### PR TITLE
feat(hono): Add support for the Deno runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -998,7 +998,7 @@ jobs:
       - name: Set up Deno
         if:
           matrix.test-application == 'deno' || matrix.test-application == 'deno-streamed' || matrix.test-application ==
-          'deno-redis'
+          'deno-redis' || matrix.test-application == 'hono-4'
         uses: denoland/setup-deno@v2.0.4
         with:
           deno-version: ${{ matrix.deno-version || 'v2.8.0' }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- **feat(hono): Add support for the Deno runtime**
+
+  `@sentry/hono` now supports the Deno runtime via a new `@sentry/hono/deno` entry point.
+  Install `@sentry/deno` as a peer dependency and initialize Sentry through the `sentry()` middleware:
+
+  ```ts
+  import { Hono } from 'hono';
+  import { sentry } from '@sentry/hono/deno';
+
+  const app = new Hono();
+
+  app.use(
+    sentry(app, {
+      dsn: '__DSN__', // or Deno.env.get('SENTRY_DSN')
+      tracesSampleRate: 1.0,
+    }),
+  );
+
+  Deno.serve(app.fetch);
+  ```
+
 - **feat(core): Extract objects as structured logs in `consoleLoggingIntegration`**
 
   The `consoleLoggingIntegration` now extracts structured log attributes when the first argument is a plain object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- **feat(hono): Add support for the Deno runtime**
+- **feat(hono): Add support for the Deno runtime ([#21450](https://github.com/getsentry/sentry-javascript/pull/21450))**
 
   `@sentry/hono` now supports the Deno runtime via a new `@sentry/hono/deno` entry point.
   Install `@sentry/deno` as a peer dependency and initialize Sentry through the `sentry()` middleware:

--- a/dev-packages/e2e-tests/test-applications/hono-4/deno.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/deno.json
@@ -1,0 +1,11 @@
+{
+  "imports": {
+    "@sentry/hono": "npm:@sentry/hono",
+    "@sentry/hono/deno": "npm:@sentry/hono/deno",
+    "@sentry/deno": "npm:@sentry/deno",
+    "@sentry/core": "npm:@sentry/core",
+    "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0",
+    "hono": "npm:hono@^4.12.14"
+  },
+  "nodeModulesDir": "manual"
+}

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -7,6 +7,7 @@
     "dev:cf": "wrangler dev --var \"E2E_TEST_DSN:$E2E_TEST_DSN\" --log-level=$(test $CI && echo 'none' || echo 'log')",
     "dev:node": "node --import tsx/esm --import ./src/instrument.node.ts src/entry.node.ts",
     "dev:bun": "bun src/entry.bun.ts",
+    "dev:deno": "deno run --allow-net --allow-env --allow-read src/entry.deno.ts",
     "build": "wrangler deploy --dry-run",
     "test:build": "pnpm install && pnpm build",
     "test:assert": "TEST_ENV=production playwright test"
@@ -14,6 +15,7 @@
   "dependencies": {
     "@sentry/bun": "latest || *",
     "@sentry/cloudflare": "latest || *",
+    "@sentry/deno": "latest || *",
     "@sentry/hono": "latest || *",
     "@sentry/node": "latest || *",
     "@hono/node-server": "^1.19.10",
@@ -40,6 +42,10 @@
       {
         "assert-command": "RUNTIME=bun pnpm test:assert",
         "label": "hono-4 (bun)"
+      },
+      {
+        "assert-command": "RUNTIME=deno pnpm test:assert",
+        "label": "hono-4 (deno)"
       }
     ]
   }

--- a/dev-packages/e2e-tests/test-applications/hono-4/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/playwright.config.ts
@@ -13,6 +13,7 @@ const startCommands: Record<Runtime, string> = {
   cloudflare: `pnpm dev:cf --port ${APP_PORT}`,
   node: `pnpm dev:node`,
   bun: `pnpm dev:bun`,
+  deno: `pnpm dev:deno`,
 };
 
 const config = getPlaywrightConfig(

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/entry.deno.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/entry.deno.ts
@@ -1,0 +1,21 @@
+import { Hono } from 'hono';
+import { sentry } from '@sentry/hono/deno';
+import { addRoutes } from './routes';
+
+const app = new Hono();
+
+app.use(
+  sentry(app, {
+    dsn: Deno.env.get('E2E_TEST_DSN'),
+    environment: 'qa',
+    dataCollection: {},
+    tracesSampleRate: 1.0,
+    tunnel: 'http://localhost:3031/',
+  }),
+);
+
+addRoutes(app);
+
+const port = Number(Deno.env.get('PORT') || 38787);
+
+Deno.serve({ port }, app.fetch);

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/constants.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/constants.ts
@@ -1,5 +1,5 @@
-export type Runtime = 'cloudflare' | 'node' | 'bun';
+export type Runtime = 'cloudflare' | 'node' | 'bun' | 'deno';
 
-export const RUNTIME = (process.env.RUNTIME || 'cloudflare') as Runtime;
+export const RUNTIME = (process.env.RUNTIME || 'deno') as Runtime;
 
 export const APP_NAME = 'hono-4';

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/tracing.test.ts
@@ -45,11 +45,21 @@ test('attaches HTTP connection info to the server transaction', async ({ baseURL
   expect(data['client.address']).toEqual(expect.any(String));
   expect(data['network.peer.address']).toBe(data['client.address']);
 
+  if (RUNTIME !== 'deno') {
+    // Only exposed in `hono/deno`
+    expect(data['network.transport']).toBeUndefined();
+  } else {
+    expect(data['network.transport']).toMatch(/tcp/);
+  }
+
   if (RUNTIME === 'node' || RUNTIME === 'bun') {
     // Node (@hono/node-server) and Bun expose socket-level port and address family.
     expect(data['client.port']).toEqual(expect.any(Number));
     expect(data['network.peer.port']).toBe(data['client.port']);
     expect(data['network.type']).toMatch(/^ipv[46]$/);
+  } else if (RUNTIME === 'deno') {
+    expect(data['client.port']).toEqual(expect.any(Number));
+    expect(data['network.peer.port']).toBe(data['client.port']);
   } else if (RUNTIME === 'cloudflare') {
     // Cloudflare Workers expose no port, address family, or transport.
     // This could change in the future and checking for the absence of these fields allows us to notice if/when that happens.
@@ -59,15 +69,12 @@ test('attaches HTTP connection info to the server transaction', async ({ baseURL
   } else {
     throw new Error(`No tests for runtime: ${RUNTIME}`);
   }
-
-  // Only available in `hono/deno`
-  expect(data['network.transport']).toBeUndefined();
 });
 
 // Regression guard against connection info attributes.
 // The conninfo middleware must only *add* attributes, never replace or clear existing ones.
 // These are the baseline attributes the server transaction carries *without* the conninfo feature
-test("preserves the baseline network.* server span attributes that the SDK sends without Hono's conninfo", async ({
+test("preserves the baseline client.* and network.* server span attributes that the SDK sends without Hono's conninfo", async ({
   baseURL,
 }) => {
   const transactionPromise = waitForTransaction(APP_NAME, event => {
@@ -90,6 +97,9 @@ test("preserves the baseline network.* server span attributes that the SDK sends
     // Doesn't set net.*, network.*, or client.* attributes
   } else if (RUNTIME === 'cloudflare') {
     expect(data['network.protocol.name']).toBe('HTTP/1.1');
+  } else if (RUNTIME === 'deno') {
+    expect(data['client.address']).toEqual(expect.any(String));
+    expect(data['client.port']).toEqual(expect.any(Number));
   } else {
     throw new Error(`No tests for runtime: ${RUNTIME}`);
   }

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -6,8 +6,8 @@
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/deno",
   "author": "Sentry",
   "license": "MIT",
-  "module": "build/index.mjs",
-  "types": "build/index.d.ts",
+  "module": "build/esm/index.js",
+  "types": "build/esm/index.d.ts",
   "exports": {
     "./package.json": "./package.json",
     ".": {

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -189,6 +189,48 @@ app.use(
 serve(app);
 ```
 
+## Setup (Deno)
+
+### 1. Install Peer Dependency
+
+Additionally to `@sentry/hono`, install the `@sentry/deno` package:
+
+```bash
+npm install --save @sentry/deno
+```
+
+Make sure the installed version always stays in sync. The `@sentry/deno` package is a required peer dependency when using `@sentry/hono/deno`.
+You won't import `@sentry/deno` directly in your code, but it needs to be installed in your project.
+
+### 2. Initialize Sentry in your Hono app
+
+Initialize the Sentry Hono middleware as early as possible in your app, then serve it with `Deno.serve`:
+
+```ts
+import { Hono } from 'hono';
+import { sentry } from '@sentry/hono/deno';
+
+const app = new Hono();
+
+// Initialize Sentry middleware right after creating the app
+app.use(
+  sentry(app, {
+    dsn: '__DSN__', // or Deno.env.get('SENTRY_DSN')
+    tracesSampleRate: 1.0,
+  }),
+);
+
+// ... your routes and other middleware
+
+Deno.serve(app.fetch);
+```
+
+Run your app with the permissions Sentry needs to read environment variables and send events:
+
+```bash
+deno run --allow-net --allow-env --allow-read app.ts
+```
+
 ## Filtering errors
 
 By default, `@sentry/hono` captures 5xx errors and plain `Error` objects, and ignores 3xx/4xx HTTP errors (redirects, not-found, bad request, etc.).

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -56,6 +56,16 @@
         "types": "./build/types/index.bun.d.ts",
         "default": "./build/cjs/index.bun.js"
       }
+    },
+    "./deno": {
+      "import": {
+        "types": "./build/types/index.deno.d.ts",
+        "default": "./build/esm/index.deno.js"
+      },
+      "require": {
+        "types": "./build/types/index.deno.d.ts",
+        "default": "./build/cjs/index.deno.js"
+      }
     }
   },
   "typesVersions": {
@@ -71,6 +81,9 @@
       ],
       "build/types/index.bun.d.ts": [
         "build/types-ts3.8/index.bun.d.ts"
+      ],
+      "build/types/index.deno.d.ts": [
+        "build/types-ts3.8/index.deno.d.ts"
       ]
     }
   },
@@ -85,6 +98,7 @@
     "@cloudflare/workers-types": "^4.x",
     "@sentry/bun": "10.57.0",
     "@sentry/cloudflare": "10.57.0",
+    "@sentry/deno": "10.57.0",
     "@sentry/node": "10.57.0",
     "hono": "^4.x"
   },
@@ -96,6 +110,9 @@
       "optional": true
     },
     "@sentry/cloudflare": {
+      "optional": true
+    },
+    "@sentry/deno": {
       "optional": true
     },
     "@sentry/node": {

--- a/packages/hono/rollup.npm.config.mjs
+++ b/packages/hono/rollup.npm.config.mjs
@@ -1,7 +1,13 @@
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '@sentry-internal/rollup-utils';
 
 const baseConfig = makeBaseNPMConfig({
-  entrypoints: ['src/index.ts', 'src/index.cloudflare.ts', 'src/index.node.ts', 'src/index.bun.ts'],
+  entrypoints: [
+    'src/index.ts',
+    'src/index.cloudflare.ts',
+    'src/index.node.ts',
+    'src/index.bun.ts',
+    'src/index.deno.ts',
+  ],
   packageSpecificConfig: {
     output: {
       preserveModulesRoot: 'src',

--- a/packages/hono/src/deno/middleware.ts
+++ b/packages/hono/src/deno/middleware.ts
@@ -1,6 +1,7 @@
 import { type BaseTransportOptions, debug, type Options } from '@sentry/core';
 import { init } from './sdk';
 import type { Env, Hono, MiddlewareHandler } from 'hono';
+import { getConnInfo } from 'hono/deno';
 import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
 import { applyPatches } from '../shared/applyPatches';
 import type { SentryHonoMiddlewareOptions } from '../shared/types';
@@ -18,7 +19,7 @@ export const sentry = <E extends Env>(app: Hono<E>, options: HonoDenoOptions): M
   applyPatches(app);
 
   return async (context, next) => {
-    requestHandler(context);
+    requestHandler(context, getConnInfo);
 
     await next(); // Handler runs in between Request above ⤴ and Response below ⤵
 

--- a/packages/hono/src/deno/middleware.ts
+++ b/packages/hono/src/deno/middleware.ts
@@ -1,0 +1,27 @@
+import { type BaseTransportOptions, debug, type Options } from '@sentry/core';
+import { init } from './sdk';
+import type { Env, Hono, MiddlewareHandler } from 'hono';
+import { requestHandler, responseHandler } from '../shared/middlewareHandlers';
+import { applyPatches } from '../shared/applyPatches';
+import type { SentryHonoMiddlewareOptions } from '../shared/types';
+
+export interface HonoDenoOptions extends Options<BaseTransportOptions>, SentryHonoMiddlewareOptions {}
+
+/**
+ * Sentry middleware for Hono running in a Deno runtime environment.
+ */
+export const sentry = <E extends Env>(app: Hono<E>, options: HonoDenoOptions): MiddlewareHandler => {
+  options.debug && debug.log('Initialized Sentry Hono middleware (Deno)');
+
+  init(options);
+
+  applyPatches(app);
+
+  return async (context, next) => {
+    requestHandler(context);
+
+    await next(); // Handler runs in between Request above ⤴ and Response below ⤵
+
+    responseHandler(context, options.shouldHandleError);
+  };
+};

--- a/packages/hono/src/deno/sdk.ts
+++ b/packages/hono/src/deno/sdk.ts
@@ -6,6 +6,10 @@ import { buildFilteredIntegrations } from '../shared/buildFilteredIntegrations';
 
 /**
  * Initializes Sentry for Hono running in a Deno runtime environment.
+ *
+ * In general, it is recommended to initialize Sentry via the `sentry()` middleware, as it sets up everything by default and calls `init` internally.
+ *
+ * When manually calling `init`, add the `honoIntegration` to the `integrations` array to set up the Hono integration.
  */
 export function init(options: HonoDenoOptions): Client | undefined {
   if (getClient()) {

--- a/packages/hono/src/deno/sdk.ts
+++ b/packages/hono/src/deno/sdk.ts
@@ -3,6 +3,7 @@ import { applySdkMetadata, consoleSandbox, getClient } from '@sentry/core';
 import { init as initDeno } from '@sentry/deno';
 import type { HonoDenoOptions } from './middleware';
 import { buildFilteredIntegrations } from '../shared/buildFilteredIntegrations';
+import { LOW_QUALITY_TRANSACTION_PATTERNS } from '../shared/lowQualityTransactionPatterns';
 
 /**
  * Initializes Sentry for Hono running in a Deno runtime environment.
@@ -23,9 +24,10 @@ export function init(options: HonoDenoOptions): Client | undefined {
 
   applySdkMetadata(options, 'hono', ['hono', 'deno']);
 
-  // Remove Hono from the SDK defaults to prevent double instrumentation: @sentry/deno
   const filteredOptions: HonoDenoOptions = {
     ...options,
+    ignoreSpans: [...(options.ignoreSpans || []), ...LOW_QUALITY_TRANSACTION_PATTERNS],
+    // Remove Hono from the SDK defaults to prevent double instrumentation: @sentry/deno
     integrations: buildFilteredIntegrations(options.integrations, false),
   };
 

--- a/packages/hono/src/deno/sdk.ts
+++ b/packages/hono/src/deno/sdk.ts
@@ -1,0 +1,29 @@
+import type { Client } from '@sentry/core';
+import { applySdkMetadata, consoleSandbox, getClient } from '@sentry/core';
+import { init as initDeno } from '@sentry/deno';
+import type { HonoDenoOptions } from './middleware';
+import { buildFilteredIntegrations } from '../shared/buildFilteredIntegrations';
+
+/**
+ * Initializes Sentry for Hono running in a Deno runtime environment.
+ */
+export function init(options: HonoDenoOptions): Client | undefined {
+  if (getClient()) {
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[Sentry] Sentry is already initialized. Sentry should only be initialized once, through the `sentry()` middleware. Remove the `Sentry.init()` call, if one exists.',
+      );
+    });
+  }
+
+  applySdkMetadata(options, 'hono', ['hono', 'deno']);
+
+  // Remove Hono from the SDK defaults to prevent double instrumentation: @sentry/deno
+  const filteredOptions: HonoDenoOptions = {
+    ...options,
+    integrations: buildFilteredIntegrations(options.integrations, false),
+  };
+
+  return initDeno(filteredOptions);
+}

--- a/packages/hono/src/index.deno.ts
+++ b/packages/hono/src/index.deno.ts
@@ -1,0 +1,7 @@
+import { earlyPatchHono } from './shared/applyPatches';
+
+earlyPatchHono();
+
+export { sentry } from './deno/middleware';
+
+export * from '@sentry/deno';

--- a/packages/hono/src/index.deno.ts
+++ b/packages/hono/src/index.deno.ts
@@ -5,3 +5,5 @@ earlyPatchHono();
 export { sentry } from './deno/middleware';
 
 export * from '@sentry/deno';
+
+export { init } from './deno/sdk';

--- a/packages/hono/test/deno/middleware.test.ts
+++ b/packages/hono/test/deno/middleware.test.ts
@@ -4,6 +4,7 @@ import { Hono } from 'hono';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { sentry } from '../../src/deno/middleware';
 import { init } from '../../src/deno/sdk';
+import { LOW_QUALITY_TRANSACTION_PATTERNS } from '../../src/shared/lowQualityTransactionPatterns';
 
 vi.mock('@sentry/deno', () => ({
   init: vi.fn(),
@@ -203,6 +204,37 @@ describe('Hono Deno Middleware', () => {
       init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
       expect(initDenoMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ignoreSpans (low-quality transaction filtering)', () => {
+    it('adds default low-quality transaction patterns to ignoreSpans', () => {
+      const app = new Hono();
+      sentry(app, { dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      const callArgs = (initDenoMock as Mock).mock.calls[0]?.[0];
+      expect(callArgs.ignoreSpans).toEqual(expect.arrayContaining(LOW_QUALITY_TRANSACTION_PATTERNS));
+    });
+
+    it('preserves user-supplied ignoreSpans and appends defaults', () => {
+      const app = new Hono();
+      const userPattern = /^GET \/health$/;
+      sentry(app, {
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        ignoreSpans: [userPattern],
+      });
+
+      const callArgs = (initDenoMock as Mock).mock.calls[0]?.[0];
+      expect(callArgs.ignoreSpans[0]).toBe(userPattern);
+      expect(callArgs.ignoreSpans).toEqual(expect.arrayContaining(LOW_QUALITY_TRANSACTION_PATTERNS));
+    });
+
+    it('handles undefined ignoreSpans gracefully', () => {
+      const app = new Hono();
+      sentry(app, { dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      const callArgs = (initDenoMock as Mock).mock.calls[0]?.[0];
+      expect(callArgs.ignoreSpans).toHaveLength(LOW_QUALITY_TRANSACTION_PATTERNS.length);
     });
   });
 });

--- a/packages/hono/test/deno/middleware.test.ts
+++ b/packages/hono/test/deno/middleware.test.ts
@@ -1,0 +1,208 @@
+import * as SentryCore from '@sentry/core';
+import { SDK_VERSION } from '@sentry/core';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { sentry } from '../../src/deno/middleware';
+import { init } from '../../src/deno/sdk';
+
+vi.mock('@sentry/deno', () => ({
+  init: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+const { init: initDenoMock } = await vi.importMock<typeof import('@sentry/deno')>('@sentry/deno');
+
+vi.mock('@sentry/core', async () => {
+  const actual = await vi.importActual('@sentry/core');
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    applySdkMetadata: vi.fn(actual.applySdkMetadata),
+    getClient: vi.fn(() => undefined),
+    // Pass-through so console.warn calls inside consoleSandbox are observable in tests
+    consoleSandbox: vi.fn((cb: () => unknown) => cb()),
+  };
+});
+
+const applySdkMetadataMock = SentryCore.applySdkMetadata as Mock;
+const getClientMock = SentryCore.getClient as Mock;
+
+describe('Hono Deno Middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('sentry middleware', () => {
+    it('accepts Hono with custom env types without requiring a cast', () => {
+      type CustomEnv = { Bindings: { DATABASE_URL: string }; Variables: { userId: string } };
+      const app = new Hono<CustomEnv>();
+
+      const middleware = sentry(app, { dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      expect(typeof middleware).toBe('function');
+      expect(middleware).toHaveLength(2);
+    });
+
+    it('calls applySdkMetadata with "hono" and "deno"', () => {
+      const app = new Hono();
+      const options = {
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      };
+
+      sentry(app, options);
+
+      expect(applySdkMetadataMock).toHaveBeenCalledTimes(1);
+      expect(applySdkMetadataMock).toHaveBeenCalledWith(options, 'hono', ['hono', 'deno']);
+    });
+
+    it('calls init from @sentry/deno when no client exists yet', () => {
+      getClientMock.mockReturnValue(undefined);
+      const app = new Hono();
+      const options = {
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      };
+
+      sentry(app, options);
+
+      expect(initDenoMock).toHaveBeenCalledTimes(1);
+      expect(initDenoMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        }),
+      );
+    });
+
+    it('sets SDK metadata before calling Deno init', () => {
+      const app = new Hono();
+      const options = {
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      };
+
+      sentry(app, options);
+
+      const applySdkMetadataCallOrder = applySdkMetadataMock.mock.invocationCallOrder[0];
+      const initDenoCallOrder = (initDenoMock as Mock).mock.invocationCallOrder[0];
+
+      expect(applySdkMetadataCallOrder).toBeLessThan(initDenoCallOrder as number);
+    });
+
+    it('preserves all user options', () => {
+      const app = new Hono();
+      const options = {
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        environment: 'production',
+        sampleRate: 0.5,
+        tracesSampleRate: 1.0,
+        debug: true,
+      };
+
+      sentry(app, options);
+
+      expect(initDenoMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dsn: 'https://public@dsn.ingest.sentry.io/1337',
+          environment: 'production',
+          sampleRate: 0.5,
+          tracesSampleRate: 1.0,
+          debug: true,
+        }),
+      );
+    });
+
+    it('returns a middleware handler function', () => {
+      const app = new Hono();
+      const options = {
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      };
+
+      const middleware = sentry(app, options);
+
+      expect(middleware).toBeDefined();
+      expect(typeof middleware).toBe('function');
+      expect(middleware).toHaveLength(2); // Hono middleware takes (context, next)
+    });
+
+    it('returns an async middleware handler', () => {
+      const app = new Hono();
+      const middleware = sentry(app, {});
+
+      expect(middleware.constructor.name).toBe('AsyncFunction');
+    });
+
+    it('passes an integrations function to initDeno (never a raw array)', () => {
+      const app = new Hono();
+      sentry(app, { dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      const callArgs = (initDenoMock as Mock).mock.calls[0]?.[0];
+      expect(typeof callArgs.integrations).toBe('function');
+    });
+
+    it('includes hono SDK metadata', () => {
+      const app = new Hono();
+      const options = {
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      };
+
+      sentry(app, options);
+
+      expect(initDenoMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _metadata: expect.objectContaining({
+            sdk: expect.objectContaining({
+              name: 'sentry.javascript.hono',
+              version: SDK_VERSION,
+              packages: [
+                { name: 'npm:@sentry/hono', version: SDK_VERSION },
+                { name: 'npm:@sentry/deno', version: SDK_VERSION },
+              ],
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('double-init guard', () => {
+    it('still calls init even when Sentry is already initialized', () => {
+      const fakeClient = { getOptions: () => ({}) };
+      getClientMock.mockReturnValue(fakeClient as unknown as SentryCore.Client);
+
+      const app = new Hono();
+      sentry(app, { dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      expect(initDenoMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits a console.warn directing to remove the duplicate init call when Sentry is already initialized', () => {
+      const warnSpy = vi.spyOn(console, 'warn');
+      const fakeClient = { getOptions: () => ({}) };
+      getClientMock.mockReturnValue(fakeClient as unknown as SentryCore.Client);
+
+      const app = new Hono();
+      sentry(app, { dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Sentry is already initialized'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Remove the `Sentry.init()` call'));
+    });
+
+    it('does not emit a console.warn when no client exists yet', () => {
+      const warnSpy = vi.spyOn(console, 'warn');
+      getClientMock.mockReturnValue(undefined);
+
+      const app = new Hono();
+      sentry(app, { dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('always calls init regardless of whether a client already exists', () => {
+      getClientMock.mockReturnValue(undefined);
+
+      init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+
+      expect(initDenoMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/hono/test/deno/middleware.test.ts
+++ b/packages/hono/test/deno/middleware.test.ts
@@ -10,6 +10,12 @@ vi.mock('@sentry/deno', () => ({
   init: vi.fn(),
 }));
 
+// `hono/deno` references the `Deno` global at module-eval time, which is not defined in the
+// vitest (Node) environment.
+vi.mock('hono/deno', () => ({
+  getConnInfo: vi.fn(),
+}));
+
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 const { init: initDenoMock } = await vi.importMock<typeof import('@sentry/deno')>('@sentry/deno');
 


### PR DESCRIPTION
Adds support for the Deno Runtime with `@sentry/hono/deno` and adds an E2E test variant.

[Linear Link](https://linear.app/getsentry/issue/JS-2037/hono-add-deno-support-4-optional)
Part of this issue: https://github.com/getsentry/sentry-javascript/issues/21246

Builds on top of this (`@sentry/deno` types change):
- https://github.com/getsentry/sentry-javascript/pull/21449 
