### PR TITLE
fix(nextjs): re-declare captureRouterTransitionStart in index.types

### DIFF
--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -28,6 +28,7 @@ export declare const consoleIntegration: typeof serverSdk.consoleIntegration;
 export declare const pinoIntegration: typeof serverSdk.pinoIntegration;
 export declare const spanStreamingIntegration: typeof clientSdk.spanStreamingIntegration;
 export declare const withStreamedSpan: typeof clientSdk.withStreamedSpan;
+export declare const captureRouterTransitionStart: typeof clientSdk.captureRouterTransitionStart;
 
 // Different implementation in server and worker
 export declare const vercelAIIntegration: typeof serverSdk.vercelAIIntegration;


### PR DESCRIPTION
Fixes #19939.

## Summary

`captureRouterTransitionStart` is exported from `./client/index.ts` and resolves correctly at runtime through the `browser` export condition (`index.client.js`). It's missing from the `types` condition entry point (`index.types.d.ts`), so static analysis tools that follow the `types` condition — `oxlint`, `eslint-plugin-import`'s `import/namespace` rule, and `tsc` from a server-condition context — report `"captureRouterTransitionStart" not found in imported namespace "@sentry/nextjs"`. The function still works at runtime; only the static-analysis surface is wrong.

## Root cause

`packages/nextjs/src/index.types.ts` carries explicit `export declare const X: typeof clientSdk.X` redeclarations for every other client-only export that needs to be visible to the types condition (`linkedErrorsIntegration`, `contextLinesIntegration`, `spanStreamingIntegration`, `withStreamedSpan`, `growthbookIntegration`, `launchDarklyIntegration`, etc.). `captureRouterTransitionStart` was added to `./client/index.ts` but not mirrored into `index.types.ts`, so it disappears from the published `.d.ts` even though it's part of the runtime client surface.

## Fix

Add the missing redeclaration alongside the other client-only exports:

```ts
export declare const captureRouterTransitionStart: typeof clientSdk.captureRouterTransitionStart;
```

Trivially correct — same shape used for the surrounding declarations.

## Note

I wasn't able to run `yarn install` / `yarn build:dev` locally to validate (disk space exhausted on my machine). CI should cover the build, types, and lint checks; happy to rebase or amend if anything surfaces.