### PR TITLE
feat(react-router): Stabilize the instrumentation API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   // → sentry.message.template: "Hello {} {}"
   ```
 
+- **feat(react-router): Stabilize the instrumentation API**
+
+  React Router's instrumentation API is now stable — the `@experimental` markers have been removed from `createSentryServerInstrumentation`, `createSentryClientInstrumentation`, and the related helpers and types.
+  The manual server wrappers `wrapServerLoader` and `wrapServerAction` are now deprecated in favor of it. Export `instrumentations = [Sentry.createSentryServerInstrumentation()]` from your `entry.server.tsx` to instrument all loaders and actions without wrapping them individually.
+
 Work in this release was contributed by @archievi, @AyaanFaisal21, and @itosa-kazu. Thank you for your contributions!
 
 ## 10.57.0

--- a/packages/react-router/src/client/createClientInstrumentation.ts
+++ b/packages/react-router/src/client/createClientInstrumentation.ts
@@ -50,7 +50,6 @@ export interface CreateSentryClientInstrumentationOptions {
 
 /**
  * Creates a Sentry client instrumentation for React Router's instrumentation API.
- * @experimental
  */
 export function createSentryClientInstrumentation(
   options: CreateSentryClientInstrumentationOptions = {},
@@ -330,7 +329,6 @@ export function createSentryClientInstrumentation(
 
 /**
  * Check if React Router's instrumentation API is being used on the client.
- * @experimental
  */
 export function isClientInstrumentationApiUsed(): boolean {
   return !!GLOBAL_WITH_FLAGS[SENTRY_CLIENT_INSTRUMENTATION_FLAG];
@@ -338,7 +336,6 @@ export function isClientInstrumentationApiUsed(): boolean {
 
 /**
  * Check if React Router's instrumentation API's navigate hook was invoked.
- * @experimental
  */
 export function isNavigateHookInvoked(): boolean {
   return !!GLOBAL_WITH_FLAGS[SENTRY_NAVIGATE_HOOK_INVOKED_FLAG];

--- a/packages/react-router/src/client/tracingIntegration.ts
+++ b/packages/react-router/src/client/tracingIntegration.ts
@@ -13,7 +13,6 @@ import { instrumentHydratedRouter } from './hydratedRouter';
 export interface ReactRouterTracingIntegrationOptions {
   /**
    * Options for React Router's instrumentation API.
-   * @experimental
    */
   instrumentationOptions?: CreateSentryClientInstrumentationOptions;
 
@@ -27,7 +26,6 @@ export interface ReactRouterTracingIntegrationOptions {
 export interface ReactRouterTracingIntegration extends Integration {
   /**
    * Client instrumentation to pass to `HydratedRouter`'s `instrumentations` prop.
-   * @experimental
    */
   readonly clientInstrumentation: ClientInstrumentation;
 }

--- a/packages/react-router/src/common/types.ts
+++ b/packages/react-router/src/common/types.ts
@@ -5,7 +5,6 @@
  * If React Router changes these types, this file must be updated.
  *
  * @see https://reactrouter.com/how-to/instrumentation
- * @experimental
  */
 
 export type InstrumentationResult = { status: 'success'; error: undefined } | { status: 'error'; error: unknown };

--- a/packages/react-router/src/server/createServerInstrumentation.ts
+++ b/packages/react-router/src/server/createServerInstrumentation.ts
@@ -37,7 +37,6 @@ export interface CreateSentryServerInstrumentationOptions {
 
 /**
  * Creates a Sentry server instrumentation for React Router's instrumentation API.
- * @experimental
  */
 export function createSentryServerInstrumentation(
   options: CreateSentryServerInstrumentationOptions = {},

--- a/packages/react-router/src/server/index.ts
+++ b/packages/react-router/src/server/index.ts
@@ -7,7 +7,9 @@ export { init } from './sdk';
 // eslint-disable-next-line deprecation/deprecation
 export { wrapSentryHandleRequest, sentryHandleRequest } from './wrapSentryHandleRequest';
 export { createSentryHandleRequest, type SentryHandleRequestOptions } from './createSentryHandleRequest';
+// eslint-disable-next-line deprecation/deprecation
 export { wrapServerAction } from './wrapServerAction';
+// eslint-disable-next-line deprecation/deprecation
 export { wrapServerLoader } from './wrapServerLoader';
 export { createSentryHandleError, type SentryHandleErrorOptions } from './createSentryHandleError';
 export { getMetaTagTransformer } from './getMetaTagTransformer';

--- a/packages/react-router/src/server/serverGlobals.ts
+++ b/packages/react-router/src/server/serverGlobals.ts
@@ -18,7 +18,6 @@ export function markInstrumentationApiUsed(): void {
 
 /**
  * Check if React Router's instrumentation API is being used on the server.
- * @experimental
  */
 export function isInstrumentationApiUsed(): boolean {
   return !!(GLOBAL_OBJ as GlobalObjWithFlag)[SENTRY_SERVER_INSTRUMENTATION_FLAG];

--- a/packages/react-router/src/server/wrapServerAction.ts
+++ b/packages/react-router/src/server/wrapServerAction.ts
@@ -26,6 +26,11 @@ let hasWarnedAboutDuplicateActionInstrumentation = false;
 
 /**
  * Wraps a React Router server action function with Sentry performance monitoring.
+ *
+ * @deprecated Use React Router's instrumentation API instead: export
+ * `instrumentations = [createSentryServerInstrumentation()]` from your `entry.server.tsx` to instrument all server
+ * actions without wrapping them individually. This manual wrapper will be removed in a future major.
+ *
  * @param options - Optional span configuration options including name, operation, description and attributes
  * @param actionFn - The server action function to wrap
  *

--- a/packages/react-router/src/server/wrapServerAction.ts
+++ b/packages/react-router/src/server/wrapServerAction.ts
@@ -24,6 +24,7 @@ type SpanOptions = {
 // Track if we've already warned about duplicate instrumentation
 let hasWarnedAboutDuplicateActionInstrumentation = false;
 
+// todo(v11): Remove this deprecated wrapper in favor of the instrumentation API (`createSentryServerInstrumentation`).
 /**
  * Wraps a React Router server action function with Sentry performance monitoring.
  *

--- a/packages/react-router/src/server/wrapServerLoader.ts
+++ b/packages/react-router/src/server/wrapServerLoader.ts
@@ -26,6 +26,11 @@ let hasWarnedAboutDuplicateLoaderInstrumentation = false;
 
 /**
  * Wraps a React Router server loader function with Sentry performance monitoring.
+ *
+ * @deprecated Use React Router's instrumentation API instead: export
+ * `instrumentations = [createSentryServerInstrumentation()]` from your `entry.server.tsx` to instrument all server
+ * loaders without wrapping them individually. This manual wrapper will be removed in a future major.
+ *
  * @param options - Optional span configuration options including name, operation, description and attributes
  * @param loaderFn - The server loader function to wrap
  *

--- a/packages/react-router/src/server/wrapServerLoader.ts
+++ b/packages/react-router/src/server/wrapServerLoader.ts
@@ -24,6 +24,7 @@ type SpanOptions = {
 // Track if we've already warned about duplicate instrumentation
 let hasWarnedAboutDuplicateLoaderInstrumentation = false;
 
+// todo(v11): Remove this deprecated wrapper in favor of the instrumentation API (`createSentryServerInstrumentation`).
 /**
  * Wraps a React Router server loader function with Sentry performance monitoring.
  *


### PR DESCRIPTION
 - Removes all `@experimental` markers from the instrumentation API and its helpers
 - Deprecates the manual server wrappers `wrapServerLoader` and `wrapServerAction`, pointing to the instrumentation API
 
 will follow up with docs+wiz

closes https://github.com/getsentry/sentry-javascript/issues/21396