### PR TITLE
fix(sveltekit): Add `default` exports condition

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -31,6 +31,10 @@
       "node": {
         "import": "./build/esm/index.server.js",
         "require": "./build/cjs/index.server.js"
+      },
+      "default": {
+        "import": "./build/esm/index.server.js",
+        "require": "./build/cjs/index.server.js"
       }
     }
   },


### PR DESCRIPTION
Adds a `default` exports condition to the SvelteKit SDK `package.json`. The missing fallback condition caused Vercel workflows to throw errors due to a missing fitting condition. Apparently not all tools fall back to the top-level `main` and `module` entry points. We also have default conditions in NextJS and Nuxt so I think this is worth adding to the SvelteKit SDK as well.

All credits to @paoloricciuti for reporting and proposing the fix, thank you!