### PR TITLE
chore: Pin OTel to <2.8.0 in ts 3.8 test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/generic-ts3.8/package.json
+++ b/dev-packages/e2e-tests/test-applications/generic-ts3.8/package.json
@@ -22,7 +22,10 @@
   },
   "pnpm": {
     "overrides": {
-      "@opentelemetry/api": "1.9.0"
+      "@opentelemetry/api": "1.9.0",
+      "@opentelemetry/core": "<2.8.0",
+      "@opentelemetry/resources": "<2.8.0",
+      "@opentelemetry/sdk-trace-base": "<2.8.0"
     }
   },
   "volta": {


### PR DESCRIPTION
`@opentelemetry/core@2.8.0` ships definition files with snytax that TS 3.8 cannot parse.

Ideally, nobody runs into this anyway but if they do the recommended workaround is to set `skipLibCheck: true` or force <2.8.0 resolutions.

This PR unblocks our CI.