### PR TITLE
ci: pin oven-sh/setup-bun to a commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -508,7 +508,7 @@ jobs:
         with:
           node-version-file: 'package.json'
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: '1.3.14'
       - name: Restore caches
@@ -892,7 +892,7 @@ jobs:
         with:
           node-version-file: 'package.json'
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: '1.3.14'
       - name: Restore caches
@@ -986,7 +986,7 @@ jobs:
         if:
           contains(fromJSON('["node-exports-test-app","nextjs-16-bun", "elysia-bun", "hono-4", "bun-bytecode"]'),
           matrix.test-application)
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
         with:
           bun-version: '1.3.14'
       - name: Set up AWS SAM

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -508,7 +508,7 @@ jobs:
         with:
           node-version-file: 'package.json'
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.14'
       - name: Restore caches
@@ -892,7 +892,7 @@ jobs:
         with:
           node-version-file: 'package.json'
       - name: Set up Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.14'
       - name: Restore caches
@@ -986,7 +986,7 @@ jobs:
         if:
           contains(fromJSON('["node-exports-test-app","nextjs-16-bun", "elysia-bun", "hono-4", "bun-bytecode"]'),
           matrix.test-application)
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6  # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: '1.3.14'
       - name: Set up AWS SAM


### PR DESCRIPTION
Pins `oven-sh/setup-bun` from the mutable `v2` tag to the exact commit that tag points to today (`0c5077e51419...`) in `build.yml` (3 places), keeping a `# v2` comment. A mutable tag can be re-pointed upstream; pinning to a commit SHA makes the action immutable, the [GitHub-recommended hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for third-party actions. Dependabot (already configured here) can keep the pin current.

Pinned to this commit: https://github.com/oven-sh/setup-bun/commit/0c5077e51419868618aeaa5fe8019c62421857d6

- [ ] If you've added code that should be tested, please add tests. — N/A, CI configuration change only.
- [ ] Ensure your code lints and the test suite passes. — N/A, no application code changed; ref-only edit.
- [ ] Link an issue if there is one. — no issue; happy to open one if preferred.

Ref-only: the pinned SHA is the exact commit `v2` resolves to today, so behavior is unchanged.

A repository-specific security report with the other categories reviewed (public files only): https://www.task-bounty.com/fix-more?repo=getsentry/sentry-javascript

<sub>Prepared by TaskBounty. Glad to adjust or close if this isn't useful.</sub>