### PR TITLE
ref: Remove unused `SENTRY_BUILD_PRESERVE_MODULES` env check from rollup configs

### DIFF
--- a/packages/browser-utils/rollup.npm.config.mjs
+++ b/packages/browser-utils/rollup.npm.config.mjs
@@ -7,10 +7,7 @@ export default makeNPMConfigVariants(
         // set exports to 'named' or 'auto' so that rollup doesn't warn
         exports: 'named',
         // set preserveModules to true because we don't want to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? true
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: true,
       },
     },
   }),

--- a/packages/browser/rollup.npm.config.mjs
+++ b/packages/browser/rollup.npm.config.mjs
@@ -9,10 +9,7 @@ export default makeNPMConfigVariants(
         // set exports to 'named' or 'auto' so that rollup doesn't warn
         exports: 'named',
         // set preserveModules to true because we don't want to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? true
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: true,
       },
     },
   }),

--- a/packages/core/rollup.npm.config.mjs
+++ b/packages/core/rollup.npm.config.mjs
@@ -20,10 +20,7 @@ const settings = {
       // set exports to 'named' or 'auto' so that rollup doesn't warn
       exports: 'named',
       // set preserveModules to true because we don't want to bundle everything into one file.
-      preserveModules:
-        process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-          ? true
-          : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+      preserveModules: true,
     },
     plugins: [
       replace({

--- a/packages/feedback/rollup.npm.config.mjs
+++ b/packages/feedback/rollup.npm.config.mjs
@@ -9,10 +9,7 @@ export default makeNPMConfigVariants(
         exports: 'named',
         // set preserveModules to false because for feedback we actually want
         // to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? false
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: false,
       },
     },
     esbuild: {

--- a/packages/opentelemetry/rollup.npm.config.mjs
+++ b/packages/opentelemetry/rollup.npm.config.mjs
@@ -10,10 +10,7 @@ export default makeNPMConfigVariants(
         // set exports to 'named' or 'auto' so that rollup doesn't warn
         exports: 'named',
         // set preserveModules to false because we want to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? false
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: false,
       },
     },
   }),

--- a/packages/profiling-node/rollup.npm.config.mjs
+++ b/packages/profiling-node/rollup.npm.config.mjs
@@ -9,10 +9,7 @@ export default makeNPMConfigVariants(
         exports: 'named',
         // set preserveModules to false because for profiling we actually want
         // to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? false
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: false,
       },
     },
   }),

--- a/packages/replay-canvas/rollup.npm.config.mjs
+++ b/packages/replay-canvas/rollup.npm.config.mjs
@@ -9,10 +9,7 @@ export default makeNPMConfigVariants(
         exports: 'named',
         // set preserveModules to false because for Replay we actually want
         // to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? false
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: false,
       },
     },
   }),

--- a/packages/replay-internal/rollup.npm.config.mjs
+++ b/packages/replay-internal/rollup.npm.config.mjs
@@ -11,10 +11,7 @@ export default makeNPMConfigVariants(
         exports: 'named',
         // set preserveModules to false because for Replay we actually want
         // to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? false
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: false,
       },
     },
   }),

--- a/packages/server-utils/rollup.npm.config.mjs
+++ b/packages/server-utils/rollup.npm.config.mjs
@@ -7,10 +7,7 @@ export default makeNPMConfigVariants(
         // set exports to 'named' or 'auto' so that rollup doesn't warn
         exports: 'named',
         // set preserveModules to true because we don't want to bundle everything into one file.
-        preserveModules:
-          process.env.SENTRY_BUILD_PRESERVE_MODULES === undefined
-            ? true
-            : Boolean(process.env.SENTRY_BUILD_PRESERVE_MODULES),
+        preserveModules: true,
       },
     },
   }),


### PR DESCRIPTION
The `SENTRY_BUILD_PRESERVE_MODULES` environment variable is never set anywhere in the codebase, so the `preserveModules` ternary in our `rollup.npm.config.mjs` files always resolved to its default (`undefined`) branch.

I _think_ we had this because we experimented with this or used this for some analysis steps back in the day, but I do not think anybodoy/anything ever sets this nowadays.

This removes the dead env check across all 9 affected packages, collapsing each ternary to the static value it always produced:

- `preserveModules: true` — `core`, `server-utils`, `browser`, `browser-utils`
- `preserveModules: false` — `opentelemetry`, `feedback`, `profiling-node`, `replay-canvas`, `replay-internal`

No behavior change: build output is identical.