### PR TITLE
ref(server-utils): Use `@sentry/conventions`

### DIFF
--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -39,6 +39,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@sentry/conventions": "^0.11.0",
     "@sentry/core": "10.58.0"
   },
   "scripts": {

--- a/packages/server-utils/src/redis/redis-dc-subscriber.ts
+++ b/packages/server-utils/src/redis/redis-dc-subscriber.ts
@@ -1,3 +1,10 @@
+import {
+  DB_OPERATION_BATCH_SIZE,
+  DB_QUERY_TEXT,
+  DB_SYSTEM_NAME,
+  SERVER_ADDRESS,
+  SERVER_PORT,
+} from '@sentry/conventions/attributes';
 import type { Span } from '@sentry/core';
 import {
   debug,
@@ -19,16 +26,6 @@ export const IOREDIS_DC_CHANNEL_COMMAND = 'ioredis:command';
 export const IOREDIS_DC_CHANNEL_CONNECT = 'ioredis:connect';
 
 const ORIGIN = 'auto.db.redis.diagnostic_channel';
-
-// Inlined stable semconv attribute keys — these are plain strings, no need to
-// depend on @opentelemetry/semantic-conventions for them. We use the stable
-// OTel names (matching `@sentry/core`'s postgresjs integration) rather than the
-// deprecated `db.statement`/`db.system`/`net.peer.*` forms.
-const ATTR_DB_QUERY_TEXT = 'db.query.text';
-const ATTR_DB_SYSTEM_NAME = 'db.system.name';
-const ATTR_DB_OPERATION_BATCH_SIZE = 'db.operation.batch.size';
-const ATTR_SERVER_ADDRESS = 'server.address';
-const ATTR_SERVER_PORT = 'server.port';
 const DB_SYSTEM_NAME_VALUE_REDIS = 'redis';
 
 const NOOP = (): void => {};
@@ -206,10 +203,10 @@ function setupCommandChannel<T extends RedisCommandData | IORedisCommandData>(
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis',
-          [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
-          [ATTR_DB_QUERY_TEXT]: statement,
-          ...(data.serverAddress != null ? { [ATTR_SERVER_ADDRESS]: data.serverAddress } : {}),
-          ...(data.serverPort != null ? { [ATTR_SERVER_PORT]: data.serverPort } : {}),
+          [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
+          [DB_QUERY_TEXT]: statement,
+          ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
+          ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
         },
       },
       span => span,
@@ -250,12 +247,12 @@ function setupBatchChannel(
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis',
-          [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
+          [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
           // should only include batch size greater than 1,
           // or else it isn't properly considered a "batch"
-          ...(Number(data.batchSize) > 1 ? { [ATTR_DB_OPERATION_BATCH_SIZE]: data.batchSize } : {}),
-          ...(data.serverAddress != null ? { [ATTR_SERVER_ADDRESS]: data.serverAddress } : {}),
-          ...(data.serverPort != null ? { [ATTR_SERVER_PORT]: data.serverPort } : {}),
+          ...(Number(data.batchSize) > 1 ? { [DB_OPERATION_BATCH_SIZE]: data.batchSize } : {}),
+          ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
+          ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
         },
       },
       span => span,
@@ -288,9 +285,9 @@ function setupConnectChannel(tracingChannel: RedisTracingChannelFactory, channel
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis.connect',
-          [ATTR_DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
-          ...(data.serverAddress != null ? { [ATTR_SERVER_ADDRESS]: data.serverAddress } : {}),
-          ...(data.serverPort != null ? { [ATTR_SERVER_PORT]: data.serverPort } : {}),
+          [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
+          ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
+          ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
         },
       },
       span => span,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,6 +7578,11 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
+"@sentry/conventions@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.0.tgz#5a324b8368dc5c141260bd8ccc684756ea3dd843"
+  integrity sha512-AQTAKeq9mDpOElDFSPymZTPZF/c50rk355mWTf5Y1ZxZJKKOBli5qTttskJyCxrE5ynNgN1KwcXoU5MRrMSRmQ==
+
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@sentry/node-cpu-profiler/-/node-cpu-profiler-2.4.2.tgz#d0ba01370545297d015df1497daf7f81e27f2ab5"


### PR DESCRIPTION
Switches `@sentry/server-utils` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982