### PR TITLE
ref(aws-serverless): Use `@sentry/conventions`

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -69,7 +69,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@sentry/conventions": "^0.11.0",
     "@sentry/core": "10.57.0",
     "@sentry/node": "10.57.0",
     "@sentry/node-core": "10.57.0",

--- a/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
@@ -19,6 +19,7 @@
  */
 /* eslint-disable */
 
+import { HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE } from '@sentry/conventions/attributes';
 import { Span, SpanKind, context, trace, diag, SpanStatusCode } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import { AttributeNames } from './enums';
@@ -55,8 +56,6 @@ import {
 } from './utils';
 import { propwrap } from './propwrap';
 import { RequestMetadata } from './services/ServiceExtension';
-import { ATTR_HTTP_STATUS_CODE } from './semconv';
-import { ATTR_HTTP_RESPONSE_STATUS_CODE } from '@opentelemetry/semantic-conventions';
 import { SDK_VERSION, timestampInSeconds } from '@sentry/core';
 
 const PACKAGE_NAME = '@sentry/instrumentation-aws-sdk';
@@ -332,10 +331,10 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
                   const httpStatusCode = response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
                     if (self._httpSemconvStability & SemconvStability.OLD) {
-                      span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
+                      span.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
                     }
                     if (self._httpSemconvStability & SemconvStability.STABLE) {
-                      span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
+                      span.setAttribute(HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
                     }
                   }
 
@@ -372,10 +371,10 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
                   const httpStatusCode = err?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
                     if (self._httpSemconvStability & SemconvStability.OLD) {
-                      span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
+                      span.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
                     }
                     if (self._httpSemconvStability & SemconvStability.STABLE) {
-                      span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
+                      span.setAttribute(HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
                     }
                   }
 

--- a/packages/aws-serverless/src/integration/aws/vendored/semconv.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/semconv.ts
@@ -253,52 +253,6 @@ export const ATTR_AWS_STEP_FUNCTIONS_ACTIVITY_ARN = 'aws.step_functions.activity
 export const ATTR_AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN = 'aws.step_functions.state_machine.arn' as const;
 
 /**
- * Deprecated, use `db.namespace` instead.
- *
- * @example customers
- * @example main
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.namespace`.
- */
-export const ATTR_DB_NAME = 'db.name' as const;
-
-/**
- * Deprecated, use `db.operation.name` instead.
- *
- * @example findAndModify
- * @example HMSET
- * @example SELECT
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.operation.name`.
- */
-export const ATTR_DB_OPERATION = 'db.operation' as const;
-
-/**
- * The database statement being executed.
- *
- * @example SELECT * FROM wuser_table
- * @example SET mykey "WuValue"
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.query.text`.
- */
-export const ATTR_DB_STATEMENT = 'db.statement' as const;
-
-/**
- * Deprecated, use `db.system.name` instead.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.system.name`.
- */
-export const ATTR_DB_SYSTEM = 'db.system' as const;
-
-/**
  * The name of the invoked function.
  *
  * @example "my-function"
@@ -330,33 +284,6 @@ export const ATTR_FAAS_INVOKED_PROVIDER = 'faas.invoked_provider' as const;
 export const ATTR_FAAS_INVOKED_REGION = 'faas.invoked_region' as const;
 
 /**
- * The name of the operation being performed.
- *
- * @note If one of the predefined values applies, but specific system uses a different name it's **RECOMMENDED** to document it in the semantic conventions for specific GenAI system and use system-specific name in the instrumentation. If a different name is not documented, instrumentation libraries **SHOULD** use applicable predefined value.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_OPERATION_NAME = 'gen_ai.operation.name' as const;
-
-/**
- * The maximum number of tokens the model generates for a request.
- *
- * @example 100
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_MAX_TOKENS = 'gen_ai.request.max_tokens' as const;
-
-/**
- * The name of the GenAI model a request is being made to.
- *
- * @example "gpt-4"
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_MODEL = 'gen_ai.request.model' as const;
-
-/**
  * List of sequences that the model will use to stop generating further tokens.
  *
  * @example ["forest", "lived"]
@@ -364,43 +291,6 @@ export const ATTR_GEN_AI_REQUEST_MODEL = 'gen_ai.request.model' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_STOP_SEQUENCES = 'gen_ai.request.stop_sequences' as const;
-
-/**
- * The temperature setting for the GenAI request.
- *
- * @example 0.0
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_TEMPERATURE = 'gen_ai.request.temperature' as const;
-
-/**
- * The top_p sampling setting for the GenAI request.
- *
- * @example 1.0
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_TOP_P = 'gen_ai.request.top_p' as const;
-
-/**
- * Array of reasons the model stopped generating tokens, corresponding to each generation received.
- *
- * @example ["stop"]
- * @example ["stop", "length"]
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_RESPONSE_FINISH_REASONS = 'gen_ai.response.finish_reasons' as const;
-
-/**
- * Deprecated, use `gen_ai.provider.name` instead.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `gen_ai.provider.name`.
- */
-export const ATTR_GEN_AI_SYSTEM = 'gen_ai.system' as const;
 
 /**
  * The type of token being counted.
@@ -411,70 +301,6 @@ export const ATTR_GEN_AI_SYSTEM = 'gen_ai.system' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_TOKEN_TYPE = 'gen_ai.token.type' as const;
-
-/**
- * The number of tokens used in the GenAI input (prompt).
- *
- * @example 100
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_USAGE_INPUT_TOKENS = 'gen_ai.usage.input_tokens' as const;
-
-/**
- * The number of tokens used in the GenAI response (completion).
- *
- * @example 180
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = 'gen_ai.usage.output_tokens' as const;
-
-/**
- * Deprecated, use `http.response.status_code` instead.
- *
- * @example 200
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `http.response.status_code`.
- */
-export const ATTR_HTTP_STATUS_CODE = 'http.status_code' as const;
-
-/**
- * The number of messages sent, received, or processed in the scope of the batching operation.
- *
- * @example 0
- * @example 1
- * @example 2
- *
- * @note Instrumentations **SHOULD NOT** set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations **SHOULD** use `messaging.batch.message_count` for batching APIs and **SHOULD NOT** use it for single-message APIs.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count' as const;
-
-/**
- * The message destination name
- *
- * @example MyQueue
- * @example MyTopic
- *
- * @note Destination name **SHOULD** uniquely identify a specific queue, topic or other entity within the broker. If
- * the broker doesn't have such notion, the destination name **SHOULD** uniquely identify the broker.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_DESTINATION_NAME = 'messaging.destination.name' as const;
-
-/**
- * A value used by the messaging system as an identifier for the message, represented as a string.
- *
- * @example "452a7c7c7c7048c2f887f61572b18fc2"
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_MESSAGE_ID = 'messaging.message.id' as const;
 
 /**
  * Deprecated, use `messaging.operation.type` instead.
@@ -488,45 +314,6 @@ export const ATTR_MESSAGING_MESSAGE_ID = 'messaging.message.id' as const;
  * @deprecated Replaced by `messaging.operation.type`.
  */
 export const ATTR_MESSAGING_OPERATION = 'messaging.operation' as const;
-
-/**
- * A string identifying the type of the messaging operation.
- *
- * @note If a custom value is used, it **MUST** be of low cardinality.
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_OPERATION_TYPE = 'messaging.operation.type' as const;
-
-/**
- * The messaging system as identified by the client instrumentation.
- *
- * @note The actual messaging system may differ from the one known by the client. For example, when using Kafka client libraries to communicate with Azure Event Hubs, the `messaging.system` is set to `kafka` based on the instrumentation's best knowledge.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_SYSTEM = 'messaging.system' as const;
-
-/**
- * The name of the (logical) method being called, must be equal to the $method part in the span name.
- *
- * @example "exampleMethod"
- *
- * @note This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function.name` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RPC_METHOD = 'rpc.method' as const;
-
-/**
- * The full (logical) name of the service being called, including its package name, if applicable.
- *
- * @example "myservice.EchoService"
- *
- * @note This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RPC_SERVICE = 'rpc.service' as const;
 
 /**
  * A string identifying the remoting system. See below for a list of well-known identifiers.

--- a/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
@@ -19,20 +19,22 @@
  */
 /* eslint-disable */
 
+import {
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_REQUEST_MAX_TOKENS,
+  GEN_AI_REQUEST_MODEL,
+  GEN_AI_REQUEST_TEMPERATURE,
+  GEN_AI_REQUEST_TOP_P,
+  GEN_AI_RESPONSE_FINISH_REASONS,
+  GEN_AI_SYSTEM,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+} from '@sentry/conventions/attributes';
 import { Attributes, DiagLogger, diag, Histogram, Meter, Span, Tracer, ValueType } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import {
-  ATTR_GEN_AI_SYSTEM,
-  ATTR_GEN_AI_OPERATION_NAME,
-  ATTR_GEN_AI_REQUEST_MODEL,
-  ATTR_GEN_AI_REQUEST_MAX_TOKENS,
-  ATTR_GEN_AI_REQUEST_TEMPERATURE,
-  ATTR_GEN_AI_REQUEST_TOP_P,
   ATTR_GEN_AI_REQUEST_STOP_SEQUENCES,
   ATTR_GEN_AI_TOKEN_TYPE,
-  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
-  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
-  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
   GEN_AI_OPERATION_NAME_VALUE_CHAT,
   GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
   GEN_AI_TOKEN_TYPE_VALUE_INPUT,
@@ -116,13 +118,13 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   ): RequestMetadata {
     let spanName = GEN_AI_OPERATION_NAME_VALUE_CHAT;
     const spanAttributes: Attributes = {
-      [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
-      [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
+      [GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
+      [GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
     };
 
     const modelId = request.commandInput.modelId;
     if (modelId) {
-      spanAttributes[ATTR_GEN_AI_REQUEST_MODEL] = modelId;
+      spanAttributes[GEN_AI_REQUEST_MODEL] = modelId;
       if (spanName) {
         spanName += ` ${modelId}`;
       }
@@ -132,13 +134,13 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     if (inferenceConfig) {
       const { maxTokens, temperature, topP, stopSequences } = inferenceConfig;
       if (maxTokens !== undefined) {
-        spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = maxTokens;
+        spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = maxTokens;
       }
       if (temperature !== undefined) {
-        spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = temperature;
+        spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = temperature;
       }
       if (topP !== undefined) {
-        spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = topP;
+        spanAttributes[GEN_AI_REQUEST_TOP_P] = topP;
       }
       if (stopSequences !== undefined) {
         spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = stopSequences;
@@ -161,101 +163,101 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   ): RequestMetadata {
     let spanName: string | undefined;
     const spanAttributes: Attributes = {
-      [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
+      [GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
       // add operation name for InvokeModel API
     };
 
     const modelId = request.commandInput?.modelId;
     if (modelId) {
-      spanAttributes[ATTR_GEN_AI_REQUEST_MODEL] = modelId;
+      spanAttributes[GEN_AI_REQUEST_MODEL] = modelId;
     }
 
     if (request.commandInput?.body) {
       const requestBody = JSON.parse(request.commandInput.body);
       if (modelId.includes('amazon.titan')) {
         if (requestBody.textGenerationConfig?.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.textGenerationConfig.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.textGenerationConfig.temperature;
         }
         if (requestBody.textGenerationConfig?.topP !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.textGenerationConfig.topP;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.textGenerationConfig.topP;
         }
         if (requestBody.textGenerationConfig?.maxTokenCount !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.textGenerationConfig.maxTokenCount;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.textGenerationConfig.maxTokenCount;
         }
         if (requestBody.textGenerationConfig?.stopSequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.textGenerationConfig.stopSequences;
         }
       } else if (modelId.includes('amazon.nova')) {
         if (requestBody.inferenceConfig?.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.inferenceConfig.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.inferenceConfig.temperature;
         }
         if (requestBody.inferenceConfig?.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.inferenceConfig.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.inferenceConfig.top_p;
         }
         if (requestBody.inferenceConfig?.max_new_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.inferenceConfig.max_new_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.inferenceConfig.max_new_tokens;
         }
         if (requestBody.inferenceConfig?.stopSequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.inferenceConfig.stopSequences;
         }
       } else if (modelId.includes('anthropic.claude')) {
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
         }
         if (requestBody.stop_sequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop_sequences;
         }
       } else if (modelId.includes('meta.llama')) {
         if (requestBody.max_gen_len !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_gen_len;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_gen_len;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
         }
         // request for meta llama models does not contain stop_sequences field
       } else if (modelId.includes('cohere.command-r')) {
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.p;
         }
         if (requestBody.message !== undefined) {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          spanAttributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.message.length / 6);
+          spanAttributes[GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.message.length / 6);
         }
         if (requestBody.stop_sequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop_sequences;
         }
       } else if (modelId.includes('cohere.command')) {
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.p;
         }
         if (requestBody.prompt !== undefined) {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          spanAttributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
+          spanAttributes[GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
         }
         if (requestBody.stop_sequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop_sequences;
@@ -265,16 +267,16 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          spanAttributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
+          spanAttributes[GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
         }
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
         }
         if (requestBody.stop !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop;
@@ -362,15 +364,15 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
 
   private static setStopReason(span: Span, stopReason: string | undefined) {
     if (stopReason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [stopReason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [stopReason]);
     }
   }
 
   private setUsage(response: NormalizedResponse, span: Span, usage: TokenUsage | undefined, startTime: number) {
     const sharedMetricAttrs: Attributes = {
-      [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
-      [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
-      [ATTR_GEN_AI_REQUEST_MODEL]: response.request.commandInput.modelId,
+      [GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
+      [GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
+      [GEN_AI_REQUEST_MODEL]: response.request.commandInput.modelId,
     };
 
     const durationSecs = timestampInSeconds() - startTime;
@@ -379,7 +381,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     if (usage) {
       const { inputTokens, outputTokens } = usage;
       if (inputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, inputTokens);
+        span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, inputTokens);
 
         this.tokenUsage.record(inputTokens, {
           ...sharedMetricAttrs,
@@ -387,7 +389,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
         });
       }
       if (outputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
+        span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
 
         this.tokenUsage.record(outputTokens, {
           ...sharedMetricAttrs,
@@ -409,60 +411,60 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       const responseBody = JSON.parse(decodedResponseBody);
       if (currentModelId.includes('amazon.titan')) {
         if (responseBody.inputTextTokenCount !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.inputTextTokenCount);
+          span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.inputTextTokenCount);
         }
         if (responseBody.results?.[0]?.tokenCount !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.results[0].tokenCount);
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.results[0].tokenCount);
         }
         if (responseBody.results?.[0]?.completionReason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.results[0].completionReason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.results[0].completionReason]);
         }
       } else if (currentModelId.includes('amazon.nova')) {
         if (responseBody.usage !== undefined) {
           if (responseBody.usage.inputTokens !== undefined) {
-            span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.inputTokens);
+            span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.inputTokens);
           }
           if (responseBody.usage.outputTokens !== undefined) {
-            span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.outputTokens);
+            span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.outputTokens);
           }
         }
         if (responseBody.stopReason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stopReason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stopReason]);
         }
       } else if (currentModelId.includes('anthropic.claude')) {
         if (responseBody.usage?.input_tokens !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.input_tokens);
+          span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.input_tokens);
         }
         if (responseBody.usage?.output_tokens !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.output_tokens);
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.output_tokens);
         }
         if (responseBody.stop_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
         }
       } else if (currentModelId.includes('meta.llama')) {
         if (responseBody.prompt_token_count !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.prompt_token_count);
+          span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.prompt_token_count);
         }
         if (responseBody.generation_token_count !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.generation_token_count);
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.generation_token_count);
         }
         if (responseBody.stop_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
         }
       } else if (currentModelId.includes('cohere.command-r')) {
         if (responseBody.text !== undefined) {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(responseBody.text.length / 6));
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(responseBody.text.length / 6));
         }
         if (responseBody.finish_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.finish_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.finish_reason]);
         }
       } else if (currentModelId.includes('cohere.command')) {
         if (responseBody.generations?.[0]?.text !== undefined) {
           span.setAttribute(
-            ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+            GEN_AI_USAGE_OUTPUT_TOKENS,
             // NOTE: We approximate the token count since this value is not directly available in the body
             // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
             // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -470,12 +472,12 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
           );
         }
         if (responseBody.generations?.[0]?.finish_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.generations[0].finish_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.generations[0].finish_reason]);
         }
       } else if (currentModelId.includes('mistral')) {
         if (responseBody.outputs?.[0]?.text !== undefined) {
           span.setAttribute(
-            ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+            GEN_AI_USAGE_OUTPUT_TOKENS,
             // NOTE: We approximate the token count since this value is not directly available in the body
             // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
             // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -483,7 +485,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
           );
         }
         if (responseBody.outputs?.[0]?.stop_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.outputs[0].stop_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.outputs[0].stop_reason]);
         }
       }
     }
@@ -548,56 +550,56 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   private static recordNovaAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.metadata?.usage !== undefined) {
       if (parsedChunk.metadata?.usage.inputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.metadata.usage.inputTokens);
+        span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.metadata.usage.inputTokens);
       }
       if (parsedChunk.metadata?.usage.outputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.metadata.usage.outputTokens);
+        span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.metadata.usage.outputTokens);
       }
     }
     if (parsedChunk.messageStop?.stopReason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.messageStop.stopReason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.messageStop.stopReason]);
     }
   }
 
   private static recordClaudeAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.message?.usage?.input_tokens !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.message.usage.input_tokens);
+      span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.message.usage.input_tokens);
     }
     if (parsedChunk.message?.usage?.output_tokens !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.message.usage.output_tokens);
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.message.usage.output_tokens);
     }
     if (parsedChunk.delta?.stop_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.delta.stop_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.delta.stop_reason]);
     }
   }
 
   private static recordTitanAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.inputTextTokenCount !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.inputTextTokenCount);
+      span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.inputTextTokenCount);
     }
     if (parsedChunk.totalOutputTextTokenCount !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.totalOutputTextTokenCount);
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.totalOutputTextTokenCount);
     }
     if (parsedChunk.completionReason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.completionReason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.completionReason]);
     }
   }
   private static recordLlamaAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.prompt_token_count !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.prompt_token_count);
+      span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.prompt_token_count);
     }
     if (parsedChunk.generation_token_count !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.generation_token_count);
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.generation_token_count);
     }
     if (parsedChunk.stop_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.stop_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.stop_reason]);
     }
   }
 
   private static recordMistralAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.outputs?.[0]?.text !== undefined) {
       span.setAttribute(
-        ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_USAGE_OUTPUT_TOKENS,
         // NOTE: We approximate the token count since this value is not directly available in the body
         // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
         // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -605,14 +607,14 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       );
     }
     if (parsedChunk.outputs?.[0]?.stop_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.outputs[0].stop_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.outputs[0].stop_reason]);
     }
   }
 
   private static recordCohereAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.generations?.[0]?.text !== undefined) {
       span.setAttribute(
-        ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_USAGE_OUTPUT_TOKENS,
         // NOTE: We approximate the token count since this value is not directly available in the body
         // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
         // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -620,7 +622,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       );
     }
     if (parsedChunk.generations?.[0]?.finish_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.generations[0].finish_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.generations[0].finish_reason]);
     }
   }
 
@@ -629,10 +631,10 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       // NOTE: We approximate the token count since this value is not directly available in the body
       // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
       // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(parsedChunk.text.length / 6));
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(parsedChunk.text.length / 6));
     }
     if (parsedChunk.finish_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.finish_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.finish_reason]);
     }
   }
 }

--- a/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
@@ -19,14 +19,18 @@
  */
 /* eslint-disable */
 
+import {
+  DB_NAME,
+  DB_NAMESPACE,
+  DB_OPERATION,
+  DB_OPERATION_NAME,
+  DB_QUERY_TEXT,
+  DB_STATEMENT,
+  DB_SYSTEM,
+  DB_SYSTEM_NAME,
+} from '@sentry/conventions/attributes';
 import { Attributes, DiagLogger, Span, SpanKind, Tracer } from '@opentelemetry/api';
 import { SemconvStability } from '@opentelemetry/instrumentation';
-import {
-  ATTR_DB_NAMESPACE,
-  ATTR_DB_OPERATION_NAME,
-  ATTR_DB_QUERY_TEXT,
-  ATTR_DB_SYSTEM_NAME,
-} from '@opentelemetry/semantic-conventions';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import {
   ATTR_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
@@ -50,10 +54,6 @@ import {
   ATTR_AWS_DYNAMODB_TABLE_COUNT,
   ATTR_AWS_DYNAMODB_TABLE_NAMES,
   ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS,
-  ATTR_DB_NAME,
-  ATTR_DB_OPERATION,
-  ATTR_DB_STATEMENT,
-  ATTR_DB_SYSTEM,
   DB_SYSTEM_NAME_VALUE_DYNAMODB,
   DB_SYSTEM_VALUE_DYNAMODB,
 } from '../semconv';
@@ -79,14 +79,14 @@ export class DynamodbServiceExtension implements ServiceExtension {
     const spanAttributes: Attributes = {};
 
     if (dbSemconvStability === undefined || dbSemconvStability & SemconvStability.OLD) {
-      spanAttributes[ATTR_DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
-      spanAttributes[ATTR_DB_NAME] = tableName;
-      spanAttributes[ATTR_DB_OPERATION] = operation;
+      spanAttributes[DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
+      spanAttributes[DB_NAME] = tableName;
+      spanAttributes[DB_OPERATION] = operation;
     }
     if (dbSemconvStability !== undefined && dbSemconvStability & SemconvStability.STABLE) {
-      spanAttributes[ATTR_DB_SYSTEM_NAME] = DB_SYSTEM_NAME_VALUE_DYNAMODB;
-      spanAttributes[ATTR_DB_NAMESPACE] = tableName;
-      spanAttributes[ATTR_DB_OPERATION_NAME] = operation;
+      spanAttributes[DB_SYSTEM_NAME] = DB_SYSTEM_NAME_VALUE_DYNAMODB;
+      spanAttributes[DB_NAMESPACE] = tableName;
+      spanAttributes[DB_OPERATION_NAME] = operation;
     }
 
     if (config.dynamoDBStatementSerializer) {
@@ -95,10 +95,10 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
         if (typeof sanitizedStatement === 'string') {
           if (dbSemconvStability === undefined || dbSemconvStability & SemconvStability.OLD) {
-            spanAttributes[ATTR_DB_STATEMENT] = sanitizedStatement;
+            spanAttributes[DB_STATEMENT] = sanitizedStatement;
           }
           if (dbSemconvStability !== undefined && dbSemconvStability & SemconvStability.STABLE) {
-            spanAttributes[ATTR_DB_QUERY_TEXT] = sanitizedStatement;
+            spanAttributes[DB_QUERY_TEXT] = sanitizedStatement;
           }
         }
       } catch (err) {

--- a/packages/aws-serverless/src/integration/aws/vendored/services/sns.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/sns.ts
@@ -19,8 +19,9 @@
  */
 /* eslint-disable */
 
+import { MESSAGING_SYSTEM } from '@sentry/conventions/attributes';
 import { Span, Tracer, SpanKind, Attributes } from '@opentelemetry/api';
-import { ATTR_AWS_SNS_TOPIC_ARN, ATTR_MESSAGING_SYSTEM } from '../semconv';
+import { ATTR_AWS_SNS_TOPIC_ARN } from '../semconv';
 import {
   ATTR_MESSAGING_DESTINATION,
   ATTR_MESSAGING_DESTINATION_KIND,
@@ -35,7 +36,7 @@ export class SnsServiceExtension implements ServiceExtension {
     let spanKind: SpanKind = SpanKind.CLIENT;
     let spanName = `SNS ${request.commandName}`;
     const spanAttributes: Attributes = {
-      [ATTR_MESSAGING_SYSTEM]: 'aws.sns',
+      [MESSAGING_SYSTEM]: 'aws.sns',
     };
 
     if (request.commandName === 'Publish') {

--- a/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
@@ -19,18 +19,18 @@
  */
 /* eslint-disable */
 
+import {
+  MESSAGING_BATCH_MESSAGE_COUNT,
+  MESSAGING_DESTINATION_NAME,
+  MESSAGING_MESSAGE_ID,
+  MESSAGING_OPERATION_TYPE,
+  MESSAGING_SYSTEM,
+  URL_FULL,
+} from '@sentry/conventions/attributes';
 import { Tracer, SpanKind, Span, propagation, trace, ROOT_CONTEXT, Attributes } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import type { SQS } from '../aws-sdk.types';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
-import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
-import {
-  ATTR_MESSAGING_BATCH_MESSAGE_COUNT,
-  ATTR_MESSAGING_DESTINATION_NAME,
-  ATTR_MESSAGING_MESSAGE_ID,
-  ATTR_MESSAGING_OPERATION_TYPE,
-  ATTR_MESSAGING_SYSTEM,
-} from '../semconv';
 import {
   contextGetter,
   extractPropagationContext,
@@ -46,9 +46,9 @@ export class SqsServiceExtension implements ServiceExtension {
     let spanName: string | undefined;
 
     const spanAttributes: Attributes = {
-      [ATTR_MESSAGING_SYSTEM]: 'aws_sqs',
-      [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
-      [ATTR_URL_FULL]: queueUrl,
+      [MESSAGING_SYSTEM]: 'aws_sqs',
+      [MESSAGING_DESTINATION_NAME]: queueName,
+      [URL_FULL]: queueUrl,
     };
 
     let isIncoming = false;
@@ -59,7 +59,7 @@ export class SqsServiceExtension implements ServiceExtension {
           isIncoming = true;
           spanKind = SpanKind.CONSUMER;
           spanName = `${queueName} receive`;
-          spanAttributes[ATTR_MESSAGING_OPERATION_TYPE] = 'receive';
+          spanAttributes[MESSAGING_OPERATION_TYPE] = 'receive';
 
           request.commandInput.MessageAttributeNames = addPropagationFieldsToAttributeNames(
             request.commandInput.MessageAttributeNames,
@@ -110,7 +110,7 @@ export class SqsServiceExtension implements ServiceExtension {
   responseHook = (response: NormalizedResponse, span: Span, _tracer: Tracer, config: AwsSdkInstrumentationConfig) => {
     switch (response.request.commandName) {
       case 'SendMessage':
-        span.setAttribute(ATTR_MESSAGING_MESSAGE_ID, response?.data?.MessageId);
+        span.setAttribute(MESSAGING_MESSAGE_ID, response?.data?.MessageId);
         break;
 
       case 'SendMessageBatch':
@@ -120,7 +120,7 @@ export class SqsServiceExtension implements ServiceExtension {
       case 'ReceiveMessage': {
         const messages: SQS.Message[] = response?.data?.Messages || [];
 
-        span.setAttribute(ATTR_MESSAGING_BATCH_MESSAGE_COUNT, messages.length);
+        span.setAttribute(MESSAGING_BATCH_MESSAGE_COUNT, messages.length);
 
         for (const message of messages) {
           const propagatedContext = propagation.extract(
@@ -135,7 +135,7 @@ export class SqsServiceExtension implements ServiceExtension {
             span.addLink({
               context: spanContext,
               attributes: {
-                [ATTR_MESSAGING_MESSAGE_ID]: message.MessageId,
+                [MESSAGING_MESSAGE_ID]: message.MessageId,
               },
             });
           }

--- a/packages/aws-serverless/src/integration/aws/vendored/utils.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/utils.ts
@@ -19,8 +19,9 @@
  */
 /* eslint-disable */
 
+import { RPC_METHOD, RPC_SERVICE } from '@sentry/conventions/attributes';
 import { Attributes, Context, context } from '@opentelemetry/api';
-import { ATTR_RPC_METHOD, ATTR_RPC_SERVICE, ATTR_RPC_SYSTEM } from './semconv';
+import { ATTR_RPC_SYSTEM } from './semconv';
 import { AttributeNames } from './enums';
 import { NormalizedRequest } from './types';
 
@@ -46,8 +47,8 @@ export const normalizeV3Request = (
 export const extractAttributesFromNormalizedRequest = (normalizedRequest: NormalizedRequest): Attributes => {
   return {
     [ATTR_RPC_SYSTEM]: 'aws-api',
-    [ATTR_RPC_METHOD]: normalizedRequest.commandName,
-    [ATTR_RPC_SERVICE]: normalizedRequest.serviceName,
+    [RPC_METHOD]: normalizedRequest.commandName,
+    [RPC_SERVICE]: normalizedRequest.serviceName,
     [AttributeNames.CLOUD_REGION]: normalizedRequest.region,
   };
 };

--- a/packages/aws-serverless/src/integration/instrumentation-aws-lambda/instrumentation.ts
+++ b/packages/aws-serverless/src/integration/instrumentation-aws-lambda/instrumentation.ts
@@ -45,17 +45,12 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import {
-  ATTR_URL_FULL,
-  SEMATTRS_FAAS_EXECUTION,
-  SEMRESATTRS_CLOUD_ACCOUNT_ID,
-  SEMRESATTRS_FAAS_ID,
-} from '@opentelemetry/semantic-conventions';
+import { CLOUD_ACCOUNT_ID, FAAS_COLDSTART, URL_FULL } from '@sentry/conventions/attributes';
 import type { APIGatewayProxyEventHeaders, Callback, Context, Handler, StreamifyHandler } from 'aws-lambda';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { LambdaModule } from './internal-types';
-import { ATTR_FAAS_COLDSTART } from './semconv';
+import { ATTR_FAAS_EXECUTION, ATTR_FAAS_ID } from './semconv';
 import type { AwsLambdaInstrumentationConfig, EventContextExtractor } from './types';
 import { wrapHandler } from '../../sdk';
 import { SDK_VERSION } from '@sentry/core';
@@ -338,10 +333,10 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
       {
         kind: SpanKind.SERVER,
         attributes: {
-          [SEMATTRS_FAAS_EXECUTION]: context.awsRequestId,
-          [SEMRESATTRS_FAAS_ID]: context.invokedFunctionArn,
-          [SEMRESATTRS_CLOUD_ACCOUNT_ID]: AwsLambdaInstrumentation._extractAccountId(context.invokedFunctionArn),
-          [ATTR_FAAS_COLDSTART]: requestIsColdStart,
+          [ATTR_FAAS_EXECUTION]: context.awsRequestId,
+          [ATTR_FAAS_ID]: context.invokedFunctionArn,
+          [CLOUD_ACCOUNT_ID]: AwsLambdaInstrumentation._extractAccountId(context.invokedFunctionArn),
+          [FAAS_COLDSTART]: requestIsColdStart,
           ...AwsLambdaInstrumentation._extractOtherEventFields(event),
         },
       },
@@ -561,7 +556,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     const answer: Attributes = {};
     const fullUrl = this._extractFullUrl(event);
     if (fullUrl) {
-      answer[ATTR_URL_FULL] = fullUrl;
+      answer[URL_FULL] = fullUrl;
     }
     return answer;
   }

--- a/packages/aws-serverless/src/integration/instrumentation-aws-lambda/semconv.ts
+++ b/packages/aws-serverless/src/integration/instrumentation-aws-lambda/semconv.ts
@@ -22,8 +22,15 @@
  */
 
 /**
- * A boolean that is true if the serverless function is executed for the first time (aka cold-start).
+ * The execution ID of the current function execution.
  *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ * @deprecated Removed from the stable semantic conventions; not present in `@sentry/conventions`, so vendored here.
  */
-export const ATTR_FAAS_COLDSTART = 'faas.coldstart';
+export const ATTR_FAAS_EXECUTION = 'faas.execution';
+
+/**
+ * The unique ID of the single function that this runtime instance executes.
+ *
+ * @deprecated Removed from the stable semantic conventions; not present in `@sentry/conventions`, so vendored here.
+ */
+export const ATTR_FAAS_ID = 'faas.id';

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -18,6 +18,9 @@
     "strict": true,
     "strictBindCallApply": false,
     "target": "es2020",
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@sentry/conventions/attributes": ["../../node_modules/@sentry/conventions/dist/attributes"]
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,6 +7578,11 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
+"@sentry/conventions@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.0.tgz#5a324b8368dc5c141260bd8ccc684756ea3dd843"
+  integrity sha512-AQTAKeq9mDpOElDFSPymZTPZF/c50rk355mWTf5Y1ZxZJKKOBli5qTttskJyCxrE5ynNgN1KwcXoU5MRrMSRmQ==
+
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@sentry/node-cpu-profiler/-/node-cpu-profiler-2.4.2.tgz#d0ba01370545297d015df1497daf7f81e27f2ab5"


### PR DESCRIPTION
## Summary

Switches `@sentry/aws-serverless` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Also maps the `@sentry/conventions/attributes` subpath in `packages/typescript/tsconfig.json` for the repo's `node` moduleResolution type builds.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982