### PR TITLE
ref(nestjs): Use `@sentry/conventions`

### DIFF
--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@sentry/conventions": "^0.11.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0"
   },

--- a/packages/nestjs/src/integrations/vendored/instrumentation.ts
+++ b/packages/nestjs/src/integrations/vendored/instrumentation.ts
@@ -25,7 +25,7 @@ import {
   InstrumentationNodeModuleFile,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
+import { HTTP_ROUTE } from '@sentry/conventions/attributes';
 import type { SpanAttributes } from '@sentry/core';
 import { SDK_VERSION, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 import { AttributeNames, NestType } from './enums';
@@ -170,7 +170,7 @@ function createWrapCreateHandler(moduleVersion: string | undefined) {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.otel.nestjs',
           [AttributeNames.VERSION]: moduleVersion,
           [AttributeNames.TYPE]: NestType.REQUEST_CONTEXT,
-          [ATTR_HTTP_ROUTE]: req.route?.path || req.routeOptions?.url || req.routerPath,
+          [HTTP_ROUTE]: req.route?.path || req.routeOptions?.url || req.routerPath,
           [AttributeNames.CONTROLLER]: instanceName,
           [AttributeNames.CALLBACK]: callbackName,
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,6 +7578,11 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
+"@sentry/conventions@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.0.tgz#5a324b8368dc5c141260bd8ccc684756ea3dd843"
+  integrity sha512-AQTAKeq9mDpOElDFSPymZTPZF/c50rk355mWTf5Y1ZxZJKKOBli5qTttskJyCxrE5ynNgN1KwcXoU5MRrMSRmQ==
+
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@sentry/node-cpu-profiler/-/node-cpu-profiler-2.4.2.tgz#d0ba01370545297d015df1497daf7f81e27f2ab5"


### PR DESCRIPTION
Switches `@sentry/nestjs` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982