### PR TITLE
ref(nextjs): Use `@sentry/conventions`

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -77,10 +77,10 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
     "@rollup/plugin-commonjs": "28.0.1",
     "@sentry/browser-utils": "10.58.0",
     "@sentry/bundler-plugin-core": "^5.3.0",
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0",
     "@sentry/opentelemetry": "10.58.0",

--- a/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
+++ b/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
@@ -1,4 +1,4 @@
-import { SEMATTRS_HTTP_TARGET } from '@opentelemetry/semantic-conventions';
+import { HTTP_TARGET } from '@sentry/conventions/attributes';
 import { getClient, GLOBAL_OBJ, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, type Span, type SpanAttributes } from '@sentry/core';
 import { isSentryRequestSpan } from '@sentry/opentelemetry';
 import { ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
@@ -54,7 +54,7 @@ function isTunnelRouteSpan(spanAttributes: Record<string, unknown>): boolean {
   }
 
   // eslint-disable-next-line typescript/no-deprecated
-  const httpTarget = spanAttributes[SEMATTRS_HTTP_TARGET];
+  const httpTarget = spanAttributes[HTTP_TARGET];
 
   if (typeof httpTarget === 'string') {
     // Extract pathname from the target (e.g., "/tunnel?o=123&p=456" -> "/tunnel")

--- a/packages/nextjs/src/common/utils/tracingUtils.ts
+++ b/packages/nextjs/src/common/utils/tracingUtils.ts
@@ -1,4 +1,4 @@
-import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
+import { HTTP_ROUTE } from '@sentry/conventions/attributes';
 import type { PropagationContext, Span, SpanAttributes } from '@sentry/core';
 import {
   debug,
@@ -177,7 +177,7 @@ export function maybeEnhanceServerComponentSpanName(
   }
 
   const segment = spanAttributes[ATTR_NEXT_SEGMENT] as string;
-  const route = rootSpanAttributes[ATTR_HTTP_ROUTE];
+  const route = rootSpanAttributes[HTTP_ROUTE];
   const enhancedName = getEnhancedResolveSegmentSpanName({ segment, route: typeof route === 'string' ? route : '' });
   activeSpan.updateName(enhancedName);
   activeSpan.setAttributes({

--- a/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
+++ b/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
@@ -1,9 +1,4 @@
-import {
-  ATTR_HTTP_REQUEST_METHOD,
-  ATTR_HTTP_ROUTE,
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_TARGET,
-} from '@opentelemetry/semantic-conventions';
+import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_ROUTE, HTTP_TARGET } from '@sentry/conventions/attributes';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, stripUrlQueryAndFragment } from '@sentry/core';
 import { ATTR_NEXT_ROUTE, ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../common/nextSpanAttributes';
 import { TRANSACTION_ATTR_SENTRY_ROUTE_BACKFILL } from '../common/span-attributes-with-logic-attached';
@@ -42,10 +37,10 @@ export function enhanceHandleRequestRootSpan(span: MutableRootSpan): void {
   }
 
   // eslint-disable-next-line typescript/no-deprecated
-  const method = attributes[SEMATTRS_HTTP_METHOD] ?? attributes[ATTR_HTTP_REQUEST_METHOD];
+  const method = attributes[HTTP_METHOD] ?? attributes[HTTP_REQUEST_METHOD];
   // eslint-disable-next-line typescript/no-deprecated
-  const target = attributes[SEMATTRS_HTTP_TARGET];
-  const route = attributes[ATTR_HTTP_ROUTE] || attributes[ATTR_NEXT_ROUTE];
+  const target = attributes[HTTP_TARGET];
+  const route = attributes[HTTP_ROUTE] || attributes[ATTR_NEXT_ROUTE];
   const spanName = attributes[ATTR_NEXT_SPAN_NAME];
 
   if (typeof method === 'string' && typeof route === 'string' && !route.startsWith('middleware')) {

--- a/packages/nextjs/src/server/handleOnSpanStart.ts
+++ b/packages/nextjs/src/server/handleOnSpanStart.ts
@@ -1,5 +1,5 @@
 import { context } from '@opentelemetry/api';
-import { ATTR_HTTP_REQUEST_METHOD, ATTR_HTTP_ROUTE, SEMATTRS_HTTP_METHOD } from '@opentelemetry/semantic-conventions';
+import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_ROUTE } from '@sentry/conventions/attributes';
 import type { Span } from '@sentry/core';
 import {
   getCapturedScopesOnSpan,
@@ -38,19 +38,19 @@ export function handleOnSpanStart(span: Span): void {
     // Only hoist the http.route attribute if the transaction doesn't already have it
     if (
       // eslint-disable-next-line typescript/no-deprecated
-      (rootSpanAttributes?.[ATTR_HTTP_REQUEST_METHOD] || rootSpanAttributes?.[SEMATTRS_HTTP_METHOD]) &&
-      !rootSpanAttributes?.[ATTR_HTTP_ROUTE]
+      (rootSpanAttributes?.[HTTP_REQUEST_METHOD] || rootSpanAttributes?.[HTTP_METHOD]) &&
+      !rootSpanAttributes?.[HTTP_ROUTE]
     ) {
       const route = spanAttributes[ATTR_NEXT_ROUTE].replace(/\/route$/, '');
       rootSpan.updateName(route);
-      rootSpan.setAttribute(ATTR_HTTP_ROUTE, route);
+      rootSpan.setAttribute(HTTP_ROUTE, route);
       // Preserving the original attribute despite internally not depending on it
       rootSpan.setAttribute(ATTR_NEXT_ROUTE, route);
 
       // Update the isolation scope's transaction name so that non-transaction events
       // (e.g. captureMessage, captureException) also get the parameterized route.
       // eslint-disable-next-line typescript/no-deprecated
-      const method = rootSpanAttributes?.[ATTR_HTTP_REQUEST_METHOD] || rootSpanAttributes?.[SEMATTRS_HTTP_METHOD];
+      const method = rootSpanAttributes?.[HTTP_REQUEST_METHOD] || rootSpanAttributes?.[HTTP_METHOD];
       if (typeof method === 'string') {
         getIsolationScope().setTransactionName(`${method} ${route}`);
       }
@@ -67,7 +67,7 @@ export function handleOnSpanStart(span: Span): void {
     const middlewareName = spanAttributes[ATTR_NEXT_SPAN_NAME];
     if (typeof middlewareName === 'string') {
       rootSpan.updateName(middlewareName);
-      rootSpan.setAttribute(ATTR_HTTP_ROUTE, middlewareName);
+      rootSpan.setAttribute(HTTP_ROUTE, middlewareName);
       rootSpan.setAttribute(ATTR_NEXT_SPAN_NAME, middlewareName);
     }
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto');

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -1,7 +1,7 @@
 // import/export got a false positive, and affects most of our index barrel files
 // can be removed once following issue is fixed: https://github.com/import-js/eslint-plugin-import/issues/703
 /* eslint-disable import/export */
-import { ATTR_URL_QUERY, SEMATTRS_HTTP_TARGET } from '@opentelemetry/semantic-conventions';
+import { HTTP_TARGET, URL_QUERY } from '@sentry/conventions/attributes';
 import type { EventProcessor } from '@sentry/core';
 import {
   applySdkMetadata,
@@ -189,14 +189,14 @@ export function init(options: NodeOptions): NodeClient | undefined {
     // We need to drop these spans.
     if (
       // eslint-disable-next-line typescript/no-deprecated
-      (typeof spanAttributes[SEMATTRS_HTTP_TARGET] === 'string' &&
+      (typeof spanAttributes[HTTP_TARGET] === 'string' &&
         // eslint-disable-next-line typescript/no-deprecated
-        spanAttributes[SEMATTRS_HTTP_TARGET].includes('sentry_key') &&
+        spanAttributes[HTTP_TARGET].includes('sentry_key') &&
         // eslint-disable-next-line typescript/no-deprecated
-        spanAttributes[SEMATTRS_HTTP_TARGET].includes('sentry_client')) ||
-      (typeof spanAttributes[ATTR_URL_QUERY] === 'string' &&
-        spanAttributes[ATTR_URL_QUERY].includes('sentry_key') &&
-        spanAttributes[ATTR_URL_QUERY].includes('sentry_client'))
+        spanAttributes[HTTP_TARGET].includes('sentry_client')) ||
+      (typeof spanAttributes[URL_QUERY] === 'string' &&
+        spanAttributes[URL_QUERY].includes('sentry_key') &&
+        spanAttributes[URL_QUERY].includes('sentry_client'))
     ) {
       samplingDecision.decision = false;
     }


### PR DESCRIPTION
Switches `@sentry/nextjs` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982