### PR TITLE
ref(node-core): Use `@sentry/conventions`

### DIFF
--- a/packages/node-core/README.md
+++ b/packages/node-core/README.md
@@ -15,17 +15,15 @@ Unlike the `@sentry/node` SDK, this SDK comes with no OpenTelemetry auto-instrum
 - `@opentelemetry/api`
 - `@opentelemetry/core`
 - `@opentelemetry/instrumentation`
-- `@opentelemetry/resources`
 - `@opentelemetry/sdk-trace-base`
-- `@opentelemetry/semantic-conventions`.
 
 ## Installation
 
 ```bash
-npm install @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/core @opentelemetry/instrumentation @opentelemetry/resources @opentelemetry/sdk-trace-base @opentelemetry/semantic-conventions
+npm install @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/core @opentelemetry/instrumentation @opentelemetry/sdk-trace-base
 
 # Or yarn
-yarn add @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/core @opentelemetry/instrumentation @opentelemetry/resources @opentelemetry/sdk-trace-base @opentelemetry/semantic-conventions
+yarn add @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/core @opentelemetry/instrumentation @opentelemetry/sdk-trace-base
 ```
 
 ## Usage

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -81,7 +81,6 @@
     "@opentelemetry/core": "^1.30.1 || ^2.1.0",
     "@opentelemetry/instrumentation": ">=0.57.1 <1",
     "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-    "@opentelemetry/semantic-conventions": "^1.39.0",
     "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1"
   },
   "peerDependenciesMeta": {
@@ -97,14 +96,12 @@
     "@opentelemetry/sdk-trace-base": {
       "optional": true
     },
-    "@opentelemetry/semantic-conventions": {
-      "optional": true
-    },
     "@opentelemetry/exporter-trace-otlp-http": {
       "optional": true
     }
   },
   "dependencies": {
+    "@sentry/conventions": "^0.11.0",
     "@sentry/core": "10.58.0",
     "@sentry/opentelemetry": "10.58.0",
     "import-in-the-middle": "^3.0.0"
@@ -115,7 +112,6 @@
     "@opentelemetry/exporter-trace-otlp-http": "^0.214.0",
     "@opentelemetry/instrumentation": "^0.214.0",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
     "@types/node": "^18.19.1"
   },
   "scripts": {

--- a/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
@@ -4,13 +4,13 @@ import { context, SpanKind, trace } from '@opentelemetry/api';
 import type { RPCMetadata } from '@opentelemetry/core';
 import { getRPCMetadata, isTracingSuppressed, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import {
-  ATTR_HTTP_RESPONSE_STATUS_CODE,
-  ATTR_HTTP_ROUTE,
-  SEMATTRS_HTTP_STATUS_CODE,
-  SEMATTRS_NET_HOST_IP,
-  SEMATTRS_NET_HOST_PORT,
-  SEMATTRS_NET_PEER_IP,
-} from '@opentelemetry/semantic-conventions';
+  HTTP_RESPONSE_STATUS_CODE,
+  HTTP_ROUTE,
+  HTTP_STATUS_CODE,
+  NET_HOST_IP,
+  NET_HOST_PORT,
+  NET_PEER_IP,
+} from '@sentry/conventions/attributes';
 import type {
   Event,
   HttpClientRequest,
@@ -375,30 +375,25 @@ function getIncomingRequestAttributesOnResponse(
   const { statusCode, statusMessage } = response;
 
   const newAttributes: SpanAttributes = {
-    [ATTR_HTTP_RESPONSE_STATUS_CODE]: statusCode,
-    // eslint-disable-next-line deprecation/deprecation
-    [SEMATTRS_HTTP_STATUS_CODE]: statusCode,
+    [HTTP_RESPONSE_STATUS_CODE]: statusCode,
+    [HTTP_STATUS_CODE]: statusCode,
     'http.status_text': statusMessage?.toUpperCase(),
   };
 
   const rpcMetadata = getRPCMetadata(context.active());
   if (socket) {
     const { localAddress, localPort, remoteAddress, remotePort } = socket;
-    // eslint-disable-next-line deprecation/deprecation
-    newAttributes[SEMATTRS_NET_HOST_IP] = localAddress;
-    // eslint-disable-next-line deprecation/deprecation
-    newAttributes[SEMATTRS_NET_HOST_PORT] = localPort;
-    // eslint-disable-next-line deprecation/deprecation
-    newAttributes[SEMATTRS_NET_PEER_IP] = remoteAddress;
+    newAttributes[NET_HOST_IP] = localAddress;
+    newAttributes[NET_HOST_PORT] = localPort;
+    newAttributes[NET_PEER_IP] = remoteAddress;
     newAttributes['net.peer.port'] = remotePort;
   }
-  // eslint-disable-next-line deprecation/deprecation
-  newAttributes[SEMATTRS_HTTP_STATUS_CODE] = statusCode;
+  newAttributes[HTTP_STATUS_CODE] = statusCode;
   newAttributes['http.status_text'] = (statusMessage || '').toUpperCase();
 
   if (rpcMetadata?.type === RPCType.HTTP && rpcMetadata.route !== undefined) {
     const routeName = rpcMetadata.route;
-    newAttributes[ATTR_HTTP_ROUTE] = routeName;
+    newAttributes[HTTP_ROUTE] = routeName;
   }
 
   return newAttributes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,6 +7578,11 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
+"@sentry/conventions@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.0.tgz#5a324b8368dc5c141260bd8ccc684756ea3dd843"
+  integrity sha512-AQTAKeq9mDpOElDFSPymZTPZF/c50rk355mWTf5Y1ZxZJKKOBli5qTttskJyCxrE5ynNgN1KwcXoU5MRrMSRmQ==
+
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@sentry/node-cpu-profiler/-/node-cpu-profiler-2.4.2.tgz#d0ba01370545297d015df1497daf7f81e27f2ab5"


### PR DESCRIPTION
Switches `@sentry/node-core` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982