### PR TITLE
ref(opentelemetry): Use `@sentry/conventions`

### DIFF
--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -28,7 +28,6 @@ Note that `@sentry/opentelemetry` depends on the following peer dependencies:
 
 - `@opentelemetry/api` version `1.0.0` or greater
 - `@opentelemetry/core` version `1.0.0` or greater
-- `@opentelemetry/semantic-conventions` version `1.0.0` or greater
 - `@opentelemetry/sdk-trace-base` version `1.0.0` or greater, or a package that implements that, like
   `@opentelemetry/sdk-node`.
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -65,19 +65,18 @@
     "access": "public"
   },
   "dependencies": {
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-    "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-    "@opentelemetry/semantic-conventions": "^1.39.0"
+    "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.6.1",
-    "@opentelemetry/sdk-trace-base": "^2.6.1",
-    "@opentelemetry/semantic-conventions": "^1.40.0"
+    "@opentelemetry/sdk-trace-base": "^2.6.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -1,7 +1,7 @@
 import type { Baggage, Context, Span, SpanContext, TextMapGetter, TextMapSetter } from '@opentelemetry/api';
 import { context, INVALID_TRACEID, propagation, trace, TraceFlags } from '@opentelemetry/api';
 import { isTracingSuppressed, W3CBaggagePropagator } from '@opentelemetry/core';
-import { ATTR_URL_FULL, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions';
+import { HTTP_URL, URL_FULL } from '@sentry/conventions/attributes';
 import type { Client, continueTrace, DynamicSamplingContext, Scope } from '@sentry/core';
 import {
   baggageHeaderToDynamicSamplingContext,
@@ -275,9 +275,9 @@ function getExistingSentryTrace(carrier: unknown): string | string[] | undefined
  */
 function getCurrentURL(span: Span): string | undefined {
   const spanData = spanToJSON(span).data;
-  // `ATTR_URL_FULL` is the new attribute, but we still support the old one, `SEMATTRS_HTTP_URL`, for now.
+  // `URL_FULL` is the new attribute, but we still support the old one, `HTTP_URL`, for now.
   // eslint-disable-next-line typescript/no-deprecated
-  const urlAttribute = spanData[SEMATTRS_HTTP_URL] || spanData[ATTR_URL_FULL];
+  const urlAttribute = spanData[HTTP_URL] || spanData[URL_FULL];
   if (typeof urlAttribute === 'string') {
     return urlAttribute;
   }

--- a/packages/opentelemetry/src/resource.ts
+++ b/packages/opentelemetry/src/resource.ts
@@ -1,14 +1,16 @@
 import type { Attributes, AttributeValue } from '@opentelemetry/api';
 import { SDK_INFO } from '@opentelemetry/core';
-import {
-  ATTR_SERVICE_NAME,
-  ATTR_SERVICE_VERSION,
-  ATTR_TELEMETRY_SDK_LANGUAGE,
-  ATTR_TELEMETRY_SDK_NAME,
-  ATTR_TELEMETRY_SDK_VERSION,
-  SEMRESATTRS_SERVICE_NAMESPACE,
-} from '@opentelemetry/semantic-conventions';
+import { SERVICE_NAME, SERVICE_VERSION } from '@sentry/conventions/attributes';
 import { SDK_VERSION } from '@sentry/core';
+
+// These resource attributes are not (yet) part of `@sentry/conventions`, so we inline the
+// stable OTel attribute keys here as plain strings rather than depending on
+// `@opentelemetry/semantic-conventions`. The string values must match exactly, as
+// `SDK_INFO` (from `@opentelemetry/core`) is keyed by them.
+const ATTR_TELEMETRY_SDK_LANGUAGE = 'telemetry.sdk.language';
+const ATTR_TELEMETRY_SDK_NAME = 'telemetry.sdk.name';
+const ATTR_TELEMETRY_SDK_VERSION = 'telemetry.sdk.version';
+const SEMRESATTRS_SERVICE_NAMESPACE = 'service.namespace';
 
 type RawResourceAttribute = [string, AttributeValue | undefined];
 
@@ -85,13 +87,13 @@ export function getSentryResource(serviceNameFallback: string): SentryResource {
     // Lowest priority: Sentry defaults
     // eslint-disable-next-line typescript/no-deprecated
     [SEMRESATTRS_SERVICE_NAMESPACE]: 'sentry',
-    [ATTR_SERVICE_NAME]: serviceNameFallback,
+    [SERVICE_NAME]: serviceNameFallback,
     // OTEL_RESOURCE_ATTRIBUTES overrides defaults (including service.name and service.namespace)
     ...otelResourceAttrs,
     // OTEL_SERVICE_NAME explicitly overrides service.name
-    ...(otelServiceName ? { [ATTR_SERVICE_NAME]: otelServiceName } : {}),
+    ...(otelServiceName ? { [SERVICE_NAME]: otelServiceName } : {}),
     // Highest priority: Sentry SDK telemetry attrs (cannot be overridden by env vars)
-    [ATTR_SERVICE_VERSION]: SDK_VERSION,
+    [SERVICE_VERSION]: SDK_VERSION,
     [ATTR_TELEMETRY_SDK_LANGUAGE]: SDK_INFO[ATTR_TELEMETRY_SDK_LANGUAGE],
     [ATTR_TELEMETRY_SDK_NAME]: SDK_INFO[ATTR_TELEMETRY_SDK_NAME],
     [ATTR_TELEMETRY_SDK_VERSION]: SDK_INFO[ATTR_TELEMETRY_SDK_VERSION],

--- a/packages/opentelemetry/src/resource.ts
+++ b/packages/opentelemetry/src/resource.ts
@@ -3,10 +3,11 @@ import { SDK_INFO } from '@opentelemetry/core';
 import { SERVICE_NAME, SERVICE_VERSION } from '@sentry/conventions/attributes';
 import { SDK_VERSION } from '@sentry/core';
 
-// These resource attributes are not (yet) part of `@sentry/conventions`, so we inline the
+// These resource attributes are not part of `@sentry/conventions`, so we inline the
 // stable OTel attribute keys here as plain strings rather than depending on
 // `@opentelemetry/semantic-conventions`. The string values must match exactly, as
 // `SDK_INFO` (from `@opentelemetry/core`) is keyed by them.
+// This is OTEL-specific and not relevant for Sentry, and will eventually go away.
 const ATTR_TELEMETRY_SDK_LANGUAGE = 'telemetry.sdk.language';
 const ATTR_TELEMETRY_SDK_NAME = 'telemetry.sdk.name';
 const ATTR_TELEMETRY_SDK_VERSION = 'telemetry.sdk.version';

--- a/packages/opentelemetry/src/sampler.ts
+++ b/packages/opentelemetry/src/sampler.ts
@@ -4,12 +4,7 @@ import { isSpanContextValid, SpanKind, trace } from '@opentelemetry/api';
 import { TraceState } from './utils/TraceState';
 import type { Sampler, SamplingResult } from '@opentelemetry/sdk-trace-base';
 import { SamplingDecision } from '@opentelemetry/sdk-trace-base';
-import {
-  ATTR_HTTP_REQUEST_METHOD,
-  ATTR_URL_FULL,
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_URL,
-} from '@opentelemetry/semantic-conventions';
+import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_URL, URL_FULL } from '@sentry/conventions/attributes';
 import type { Client, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_safeMathRandom,
@@ -70,9 +65,9 @@ export class SentrySampler implements Sampler {
       return wrapSamplingDecision({ decision: undefined, context, spanAttributes });
     }
 
-    // `ATTR_HTTP_REQUEST_METHOD` is the new attribute, but we still support the old one, `SEMATTRS_HTTP_METHOD`, for now.
+    // `HTTP_REQUEST_METHOD` is the new attribute, but we still support the old one, `HTTP_METHOD`, for now.
     // eslint-disable-next-line typescript/no-deprecated
-    const maybeSpanHttpMethod = spanAttributes[SEMATTRS_HTTP_METHOD] || spanAttributes[ATTR_HTTP_REQUEST_METHOD];
+    const maybeSpanHttpMethod = spanAttributes[HTTP_METHOD] || spanAttributes[HTTP_REQUEST_METHOD];
 
     // If we have a http.client span that has no local parent, we never want to sample it
     // but we want to leave downstream sampling decisions up to the server.
@@ -331,9 +326,9 @@ function getBaseTraceState(context: Context, spanAttributes: SpanAttributes): Tr
   let traceState = parentContext?.traceState || new TraceState();
 
   // We always keep the URL on the trace state, so we can access it in the propagator
-  // `ATTR_URL_FULL` is the new attribute, but we still support the old one, `ATTR_HTTP_URL`, for now.
+  // `URL_FULL` is the new attribute, but we still support the old one, `HTTP_URL`, for now.
   // eslint-disable-next-line typescript/no-deprecated
-  const url = spanAttributes[SEMATTRS_HTTP_URL] || spanAttributes[ATTR_URL_FULL];
+  const url = spanAttributes[HTTP_URL] || spanAttributes[URL_FULL];
   if (url && typeof url === 'string') {
     traceState = traceState.set(SENTRY_TRACE_STATE_URL, url);
   }

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -2,7 +2,7 @@
 import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { ATTR_HTTP_RESPONSE_STATUS_CODE, SEMATTRS_HTTP_STATUS_CODE } from '@opentelemetry/semantic-conventions';
+import { HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE } from '@sentry/conventions/attributes';
 import type {
   SpanAttributes,
   SpanJSON,
@@ -295,7 +295,7 @@ export function createTransactionForOtelSpan(span: ReadableSpan): TransactionEve
     links: convertSpanLinksForEnvelope(links),
   };
 
-  const statusCode = attributes[ATTR_HTTP_RESPONSE_STATUS_CODE];
+  const statusCode = attributes[HTTP_RESPONSE_STATUS_CODE];
   const responseContext = typeof statusCode === 'number' ? { response: { status_code: statusCode } } : undefined;
 
   const transactionEvent: TransactionEvent = {
@@ -442,9 +442,9 @@ function getData(span: ReadableSpan): Record<string, unknown> {
   }
 
   // eslint-disable-next-line typescript/no-deprecated
-  const maybeHttpStatusCodeAttribute = attributes[SEMATTRS_HTTP_STATUS_CODE];
+  const maybeHttpStatusCodeAttribute = attributes[HTTP_STATUS_CODE];
   if (maybeHttpStatusCodeAttribute) {
-    data[ATTR_HTTP_RESPONSE_STATUS_CODE] = maybeHttpStatusCodeAttribute as string;
+    data[HTTP_RESPONSE_STATUS_CODE] = maybeHttpStatusCodeAttribute as string;
   }
 
   const requestData = getRequestSpanData(span);

--- a/packages/opentelemetry/src/utils/getRequestSpanData.ts
+++ b/packages/opentelemetry/src/utils/getRequestSpanData.ts
@@ -1,11 +1,6 @@
 import type { Span } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import {
-  ATTR_HTTP_REQUEST_METHOD,
-  ATTR_URL_FULL,
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_URL,
-} from '@opentelemetry/semantic-conventions';
+import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_URL, URL_FULL } from '@sentry/conventions/attributes';
 import type { SanitizedRequestData } from '@sentry/core';
 import { getSanitizedUrlString, parseUrl } from '@sentry/core';
 import { spanHasAttributes } from './spanTypes';
@@ -20,16 +15,12 @@ export function getRequestSpanData(span: Span | ReadableSpan): Partial<Sanitized
   }
 
   // eslint-disable-next-line typescript/no-deprecated
-  const maybeUrlAttribute = (span.attributes[ATTR_URL_FULL] || span.attributes[SEMATTRS_HTTP_URL]) as
-    | string
-    | undefined;
+  const maybeUrlAttribute = (span.attributes[URL_FULL] || span.attributes[HTTP_URL]) as string | undefined;
 
   const data: Partial<SanitizedRequestData> = {
     url: maybeUrlAttribute,
     // eslint-disable-next-line typescript/no-deprecated
-    'http.method': (span.attributes[ATTR_HTTP_REQUEST_METHOD] || span.attributes[SEMATTRS_HTTP_METHOD]) as
-      | string
-      | undefined,
+    'http.method': (span.attributes[HTTP_REQUEST_METHOD] || span.attributes[HTTP_METHOD]) as string | undefined,
   };
 
   // Default to GET if URL is set but method is not

--- a/packages/opentelemetry/src/utils/isSentryRequest.ts
+++ b/packages/opentelemetry/src/utils/isSentryRequest.ts
@@ -1,4 +1,4 @@
-import { ATTR_URL_FULL, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions';
+import { HTTP_URL, URL_FULL } from '@sentry/conventions/attributes';
 import { getClient, isSentryRequestUrl } from '@sentry/core';
 import type { AbstractSpan } from '../types';
 import { spanHasAttributes } from './spanTypes';
@@ -15,9 +15,9 @@ export function isSentryRequestSpan(span: AbstractSpan): boolean {
 
   const { attributes } = span;
 
-  // `ATTR_URL_FULL` is the new attribute, but we still support the old one, `ATTR_HTTP_URL`, for now.
+  // `URL_FULL` is the new attribute, but we still support the old one, `HTTP_URL`, for now.
   // eslint-disable-next-line typescript/no-deprecated
-  const httpUrl = attributes[SEMATTRS_HTTP_URL] || attributes[ATTR_URL_FULL];
+  const httpUrl = attributes[HTTP_URL] || attributes[URL_FULL];
 
   if (!httpUrl) {
     return false;

--- a/packages/opentelemetry/src/utils/mapStatus.ts
+++ b/packages/opentelemetry/src/utils/mapStatus.ts
@@ -1,9 +1,5 @@
 import { SpanStatusCode } from '@opentelemetry/api';
-import {
-  ATTR_HTTP_RESPONSE_STATUS_CODE,
-  SEMATTRS_HTTP_STATUS_CODE,
-  SEMATTRS_RPC_GRPC_STATUS_CODE,
-} from '@opentelemetry/semantic-conventions';
+import { HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE, RPC_GRPC_STATUS_CODE } from '@sentry/conventions/attributes';
 import type { SpanAttributes, SpanStatus } from '@sentry/core';
 import { getSpanStatusFromHttpCode, SPAN_STATUS_ERROR, SPAN_STATUS_OK } from '@sentry/core';
 import type { AbstractSpan } from '../types';
@@ -80,9 +76,9 @@ function inferStatusFromAttributes(attributes: SpanAttributes): SpanStatus | und
   // If the span status is UNSET, we try to infer it from HTTP or GRPC status codes.
 
   // eslint-disable-next-line typescript/no-deprecated
-  const httpCodeAttribute = attributes[ATTR_HTTP_RESPONSE_STATUS_CODE] || attributes[SEMATTRS_HTTP_STATUS_CODE];
+  const httpCodeAttribute = attributes[HTTP_RESPONSE_STATUS_CODE] || attributes[HTTP_STATUS_CODE];
   // eslint-disable-next-line typescript/no-deprecated
-  const grpcCodeAttribute = attributes[SEMATTRS_RPC_GRPC_STATUS_CODE];
+  const grpcCodeAttribute = attributes[RPC_GRPC_STATUS_CODE];
 
   const numberHttpCode =
     typeof httpCodeAttribute === 'number'

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -1,19 +1,19 @@
 import type { Attributes, AttributeValue } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import {
-  ATTR_DB_SYSTEM_NAME,
-  ATTR_HTTP_REQUEST_METHOD,
-  ATTR_HTTP_ROUTE,
-  ATTR_URL_FULL,
-  SEMATTRS_DB_STATEMENT,
-  SEMATTRS_DB_SYSTEM,
-  SEMATTRS_FAAS_TRIGGER,
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_TARGET,
-  SEMATTRS_HTTP_URL,
-  SEMATTRS_MESSAGING_SYSTEM,
-  SEMATTRS_RPC_SERVICE,
-} from '@opentelemetry/semantic-conventions';
+  DB_STATEMENT,
+  DB_SYSTEM,
+  DB_SYSTEM_NAME,
+  FAAS_TRIGGER,
+  HTTP_METHOD,
+  HTTP_REQUEST_METHOD,
+  HTTP_ROUTE,
+  HTTP_TARGET,
+  HTTP_URL,
+  MESSAGING_SYSTEM,
+  RPC_SERVICE,
+  URL_FULL,
+} from '@sentry/conventions/attributes';
 import type { SpanAttributes, TransactionSource } from '@sentry/core';
 import {
   getSanitizedUrlString,
@@ -42,13 +42,13 @@ interface SpanDescription {
 export function inferSpanData(spanName: string, attributes: SpanAttributes, kind: SpanKind): SpanDescription {
   // if http.method exists, this is an http request span
   // eslint-disable-next-line typescript/no-deprecated
-  const httpMethod = attributes[ATTR_HTTP_REQUEST_METHOD] || attributes[SEMATTRS_HTTP_METHOD];
+  const httpMethod = attributes[HTTP_REQUEST_METHOD] || attributes[HTTP_METHOD];
   if (httpMethod) {
     return descriptionForHttpMethod({ attributes, name: spanName, kind }, httpMethod);
   }
 
   // eslint-disable-next-line typescript/no-deprecated
-  const dbSystem = attributes[ATTR_DB_SYSTEM_NAME] || attributes[SEMATTRS_DB_SYSTEM];
+  const dbSystem = attributes[DB_SYSTEM_NAME] || attributes[DB_SYSTEM];
   const opIsCache =
     typeof attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'string' &&
     attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP].startsWith('cache.');
@@ -63,7 +63,7 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
 
   // If rpc.service exists then this is a rpc call span.
   // eslint-disable-next-line typescript/no-deprecated
-  const rpcService = attributes[SEMATTRS_RPC_SERVICE];
+  const rpcService = attributes[RPC_SERVICE];
   if (rpcService) {
     return {
       ...getUserUpdatedNameAndSource(spanName, attributes, 'route'),
@@ -73,7 +73,7 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
 
   // If messaging.system exists then this is a messaging system span.
   // eslint-disable-next-line typescript/no-deprecated
-  const messagingSystem = attributes[SEMATTRS_MESSAGING_SYSTEM];
+  const messagingSystem = attributes[MESSAGING_SYSTEM];
   if (messagingSystem) {
     return {
       ...getUserUpdatedNameAndSource(spanName, attributes, customSourceOrRoute),
@@ -83,7 +83,7 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
 
   // If faas.trigger exists then this is a function as a service span.
   // eslint-disable-next-line typescript/no-deprecated
-  const faasTrigger = attributes[SEMATTRS_FAAS_TRIGGER];
+  const faasTrigger = attributes[FAAS_TRIGGER];
   if (faasTrigger) {
     return {
       ...getUserUpdatedNameAndSource(spanName, attributes, customSourceOrRoute),
@@ -129,7 +129,7 @@ function descriptionForDbSystem({ attributes, name }: { attributes: Attributes; 
 
   // Use DB statement (Ex "SELECT * FROM table") if possible as description.
   // eslint-disable-next-line typescript/no-deprecated
-  const statement = attributes[SEMATTRS_DB_STATEMENT];
+  const statement = attributes[DB_STATEMENT];
 
   const description = statement ? statement.toString() : name;
 
@@ -248,12 +248,12 @@ export function getSanitizedUrl(
 } {
   // This is the relative path of the URL, e.g. /sub
   // eslint-disable-next-line typescript/no-deprecated
-  const httpTarget = attributes[SEMATTRS_HTTP_TARGET];
+  const httpTarget = attributes[HTTP_TARGET];
   // This is the full URL, including host & query params etc., e.g. https://example.com/sub?foo=bar
   // eslint-disable-next-line typescript/no-deprecated
-  const httpUrl = attributes[SEMATTRS_HTTP_URL] || attributes[ATTR_URL_FULL];
+  const httpUrl = attributes[HTTP_URL] || attributes[URL_FULL];
   // This is the normalized route name - may not always be available!
-  const httpRoute = attributes[ATTR_HTTP_ROUTE];
+  const httpRoute = attributes[HTTP_ROUTE];
 
   const parsedUrl = typeof httpUrl === 'string' ? parseUrl(httpUrl) : undefined;
   const url = parsedUrl ? getSanitizedUrlString(parsedUrl) : undefined;

--- a/packages/opentelemetry/test/resource.test.ts
+++ b/packages/opentelemetry/test/resource.test.ts
@@ -1,15 +1,15 @@
-import {
-  ATTR_SERVICE_NAME,
-  ATTR_SERVICE_VERSION,
-  ATTR_TELEMETRY_SDK_LANGUAGE,
-  ATTR_TELEMETRY_SDK_NAME,
-  ATTR_TELEMETRY_SDK_VERSION,
-  SEMRESATTRS_SERVICE_NAMESPACE,
-} from '@opentelemetry/semantic-conventions';
+import { SERVICE_NAME, SERVICE_VERSION } from '@sentry/conventions/attributes';
 import { SDK_VERSION } from '@sentry/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getSentryResource } from '../src/resource';
 import { SDK_INFO } from '@opentelemetry/core';
+
+// These resource attributes are not (yet) part of `@sentry/conventions`, so we inline the
+// stable OTel attribute keys here as plain strings (mirroring `src/resource.ts`).
+const ATTR_TELEMETRY_SDK_LANGUAGE = 'telemetry.sdk.language';
+const ATTR_TELEMETRY_SDK_NAME = 'telemetry.sdk.name';
+const ATTR_TELEMETRY_SDK_VERSION = 'telemetry.sdk.version';
+const SEMRESATTRS_SERVICE_NAMESPACE = 'service.namespace';
 
 describe('getSentryResource', () => {
   const originalEnv = process.env;
@@ -28,19 +28,19 @@ describe('getSentryResource', () => {
 
   it('uses serviceNameFallback when no env vars are set', () => {
     const resource = getSentryResource('node');
-    expect(resource.attributes[ATTR_SERVICE_NAME]).toBe('node');
+    expect(resource.attributes[SERVICE_NAME]).toBe('node');
   });
 
   it('uses OTEL_SERVICE_NAME over the fallback', () => {
     process.env['OTEL_SERVICE_NAME'] = 'my-service';
     const resource = getSentryResource('node');
-    expect(resource.attributes[ATTR_SERVICE_NAME]).toBe('my-service');
+    expect(resource.attributes[SERVICE_NAME]).toBe('my-service');
   });
 
   it('ignores empty OTEL_SERVICE_NAME and falls back to serviceNameFallback', () => {
     process.env['OTEL_SERVICE_NAME'] = '';
     const resource = getSentryResource('node');
-    expect(resource.attributes[ATTR_SERVICE_NAME]).toBe('node');
+    expect(resource.attributes[SERVICE_NAME]).toBe('node');
   });
 
   it('includes OTEL_RESOURCE_ATTRIBUTES key=value pairs', () => {
@@ -53,14 +53,14 @@ describe('getSentryResource', () => {
   it('OTEL_RESOURCE_ATTRIBUTES can override service.name (but OTEL_SERVICE_NAME takes precedence over it)', () => {
     process.env['OTEL_RESOURCE_ATTRIBUTES'] = 'service.name=from-attrs';
     const resource = getSentryResource('node');
-    expect(resource.attributes[ATTR_SERVICE_NAME]).toBe('from-attrs');
+    expect(resource.attributes[SERVICE_NAME]).toBe('from-attrs');
   });
 
   it('OTEL_SERVICE_NAME takes precedence over service.name from OTEL_RESOURCE_ATTRIBUTES', () => {
     process.env['OTEL_RESOURCE_ATTRIBUTES'] = 'service.name=from-attrs';
     process.env['OTEL_SERVICE_NAME'] = 'from-service-name';
     const resource = getSentryResource('node');
-    expect(resource.attributes[ATTR_SERVICE_NAME]).toBe('from-service-name');
+    expect(resource.attributes[SERVICE_NAME]).toBe('from-service-name');
   });
 
   it('OTEL_RESOURCE_ATTRIBUTES can override service.namespace', () => {
@@ -83,7 +83,7 @@ describe('getSentryResource', () => {
   it('Sentry SDK telemetry attrs cannot be overridden by OTEL_SERVICE_NAME (service.version)', () => {
     process.env['OTEL_RESOURCE_ATTRIBUTES'] = 'service.version=0.0.0';
     const resource = getSentryResource('node');
-    expect(resource.attributes[ATTR_SERVICE_VERSION]).toBe(SDK_VERSION);
+    expect(resource.attributes[SERVICE_VERSION]).toBe(SDK_VERSION);
   });
 
   it('always includes Sentry SDK telemetry attributes', () => {
@@ -91,7 +91,7 @@ describe('getSentryResource', () => {
     expect(resource.attributes[ATTR_TELEMETRY_SDK_LANGUAGE]).toBeDefined();
     expect(resource.attributes[ATTR_TELEMETRY_SDK_NAME]).toBeDefined();
     expect(resource.attributes[ATTR_TELEMETRY_SDK_VERSION]).toBeDefined();
-    expect(resource.attributes[ATTR_SERVICE_VERSION]).toBe(SDK_VERSION);
+    expect(resource.attributes[SERVICE_VERSION]).toBe(SDK_VERSION);
   });
 
   it('always sets service.namespace to sentry by default', () => {

--- a/packages/opentelemetry/test/sampler.test.ts
+++ b/packages/opentelemetry/test/sampler.test.ts
@@ -1,7 +1,7 @@
 import { context, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
 import { TraceState } from '../src/utils/TraceState';
 import { SamplingDecision } from '@opentelemetry/sdk-trace-base';
-import { ATTR_HTTP_REQUEST_METHOD } from '@opentelemetry/semantic-conventions';
+import { HTTP_REQUEST_METHOD } from '@sentry/conventions/attributes';
 import { generateSpanId, generateTraceId } from '@sentry/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -130,7 +130,7 @@ describe('SentrySampler', () => {
     const spanName = 'test';
     const spanKind = SpanKind.CLIENT;
     const spanAttributes = {
-      [ATTR_HTTP_REQUEST_METHOD]: 'GET',
+      [HTTP_REQUEST_METHOD]: 'GET',
     };
     const links = undefined;
 
@@ -205,7 +205,7 @@ describe('SentrySampler', () => {
       const traceId = generateTraceId();
       const spanName = 'GET /health';
       const spanKind = SpanKind.SERVER;
-      const spanAttributes = { [ATTR_HTTP_REQUEST_METHOD]: 'GET' };
+      const spanAttributes = { [HTTP_REQUEST_METHOD]: 'GET' };
 
       const actual = sampler.shouldSample(ctx, traceId, spanName, spanKind, spanAttributes, undefined);
       expect(actual.decision).toBe(SamplingDecision.NOT_RECORD);
@@ -359,7 +359,7 @@ describe('SentrySampler', () => {
       const spanName = 'GET http://example.com/api';
       const spanKind = SpanKind.CLIENT;
       const spanAttributes = {
-        [ATTR_HTTP_REQUEST_METHOD]: 'GET',
+        [HTTP_REQUEST_METHOD]: 'GET',
       };
 
       const actual = sampler.shouldSample(ctx, traceId, spanName, spanKind, spanAttributes, undefined);

--- a/packages/opentelemetry/test/spanExporter.test.ts
+++ b/packages/opentelemetry/test/spanExporter.test.ts
@@ -1,4 +1,4 @@
-import { ATTR_HTTP_RESPONSE_STATUS_CODE } from '@opentelemetry/semantic-conventions';
+import { HTTP_RESPONSE_STATUS_CODE } from '@sentry/conventions/attributes';
 import { SDK_VERSION, SEMANTIC_ATTRIBUTE_SENTRY_OP, startInactiveSpan, startSpanManual } from '@sentry/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createTransactionForOtelSpan } from '../src/spanExporter';
@@ -62,7 +62,7 @@ describe('createTransactionForOtelSpan', () => {
       startTime: 1733821670000,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
-        [ATTR_HTTP_RESPONSE_STATUS_CODE]: 200,
+        [HTTP_RESPONSE_STATUS_CODE]: 200,
       },
     });
     span.end(1733821672000);

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -2,7 +2,7 @@
 import type { Span, TimeInput } from '@opentelemetry/api';
 import { context, ROOT_CONTEXT, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
-import { SEMATTRS_HTTP_METHOD } from '@opentelemetry/semantic-conventions';
+import { HTTP_METHOD } from '@sentry/conventions/attributes';
 import type { Event, Scope } from '@sentry/core';
 import {
   getClient,
@@ -1879,36 +1879,33 @@ describe('HTTP methods (sampling)', () => {
   });
 
   it('does sample when HTTP method is other than OPTIONS or HEAD', () => {
-    const spanGET = startSpanManual({ name: 'test span', attributes: { [SEMATTRS_HTTP_METHOD]: 'GET' } }, span => {
+    const spanGET = startSpanManual({ name: 'test span', attributes: { [HTTP_METHOD]: 'GET' } }, span => {
       return span;
     });
     expect(spanIsSampled(spanGET)).toBe(true);
     expect(getSamplingDecision(spanGET.spanContext())).toBe(true);
 
-    const spanPOST = startSpanManual({ name: 'test span', attributes: { [SEMATTRS_HTTP_METHOD]: 'POST' } }, span => {
+    const spanPOST = startSpanManual({ name: 'test span', attributes: { [HTTP_METHOD]: 'POST' } }, span => {
       return span;
     });
     expect(spanIsSampled(spanPOST)).toBe(true);
     expect(getSamplingDecision(spanPOST.spanContext())).toBe(true);
 
-    const spanPUT = startSpanManual({ name: 'test span', attributes: { [SEMATTRS_HTTP_METHOD]: 'PUT' } }, span => {
+    const spanPUT = startSpanManual({ name: 'test span', attributes: { [HTTP_METHOD]: 'PUT' } }, span => {
       return span;
     });
     expect(spanIsSampled(spanPUT)).toBe(true);
     expect(getSamplingDecision(spanPUT.spanContext())).toBe(true);
 
-    const spanDELETE = startSpanManual(
-      { name: 'test span', attributes: { [SEMATTRS_HTTP_METHOD]: 'DELETE' } },
-      span => {
-        return span;
-      },
-    );
+    const spanDELETE = startSpanManual({ name: 'test span', attributes: { [HTTP_METHOD]: 'DELETE' } }, span => {
+      return span;
+    });
     expect(spanIsSampled(spanDELETE)).toBe(true);
     expect(getSamplingDecision(spanDELETE.spanContext())).toBe(true);
   });
 
   it('does not sample when HTTP method is OPTIONS', () => {
-    const span = startSpanManual({ name: 'test span', attributes: { [SEMATTRS_HTTP_METHOD]: 'OPTIONS' } }, span => {
+    const span = startSpanManual({ name: 'test span', attributes: { [HTTP_METHOD]: 'OPTIONS' } }, span => {
       return span;
     });
     expect(spanIsSampled(span)).toBe(false);
@@ -1916,7 +1913,7 @@ describe('HTTP methods (sampling)', () => {
   });
 
   it('does not sample when HTTP method is HEAD', () => {
-    const span = startSpanManual({ name: 'test span', attributes: { [SEMATTRS_HTTP_METHOD]: 'HEAD' } }, span => {
+    const span = startSpanManual({ name: 'test span', attributes: { [HTTP_METHOD]: 'HEAD' } }, span => {
       return span;
     });
     expect(spanIsSampled(span)).toBe(false);

--- a/packages/opentelemetry/test/utils/getRequestSpanData.test.ts
+++ b/packages/opentelemetry/test/utils/getRequestSpanData.test.ts
@@ -2,7 +2,7 @@
 import type { Span } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
-import { SEMATTRS_HTTP_METHOD, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions';
+import { HTTP_METHOD, HTTP_URL } from '@sentry/conventions/attributes';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getRequestSpanData } from '../../src/utils/getRequestSpanData';
 import { setupOtel } from '../helpers/initOtel';
@@ -35,8 +35,8 @@ describe('getRequestSpanData', () => {
   it('works with http span', () => {
     const span = createSpan('test-span');
     span.setAttributes({
-      [SEMATTRS_HTTP_URL]: 'http://example.com?foo=bar#baz',
-      [SEMATTRS_HTTP_METHOD]: 'GET',
+      [HTTP_URL]: 'http://example.com?foo=bar#baz',
+      [HTTP_METHOD]: 'GET',
     });
 
     const data = getRequestSpanData(span);
@@ -52,7 +52,7 @@ describe('getRequestSpanData', () => {
   it('works without method', () => {
     const span = createSpan('test-span');
     span.setAttributes({
-      [SEMATTRS_HTTP_URL]: 'http://example.com',
+      [HTTP_URL]: 'http://example.com',
     });
 
     const data = getRequestSpanData(span);
@@ -66,8 +66,8 @@ describe('getRequestSpanData', () => {
   it('works with incorrect URL', () => {
     const span = createSpan('test-span');
     span.setAttributes({
-      [SEMATTRS_HTTP_URL]: 'malformed-url-here',
-      [SEMATTRS_HTTP_METHOD]: 'GET',
+      [HTTP_URL]: 'malformed-url-here',
+      [HTTP_METHOD]: 'GET',
     });
 
     const data = getRequestSpanData(span);

--- a/packages/opentelemetry/test/utils/mapStatus.test.ts
+++ b/packages/opentelemetry/test/utils/mapStatus.test.ts
@@ -2,7 +2,7 @@
 import type { Span } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
-import { SEMATTRS_HTTP_STATUS_CODE, SEMATTRS_RPC_GRPC_STATUS_CODE } from '@opentelemetry/semantic-conventions';
+import { HTTP_STATUS_CODE, RPC_GRPC_STATUS_CODE } from '@sentry/conventions/attributes';
 import type { SpanStatus } from '@sentry/core';
 import { SPAN_STATUS_ERROR, SPAN_STATUS_OK } from '@sentry/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -70,22 +70,22 @@ describe('mapStatus', () => {
     span.setStatus({ code: 0 }); // UNSET
 
     if (httpCode) {
-      span.setAttribute(SEMATTRS_HTTP_STATUS_CODE, httpCode);
+      span.setAttribute(HTTP_STATUS_CODE, httpCode);
     }
 
     if (grpcCode) {
-      span.setAttribute(SEMATTRS_RPC_GRPC_STATUS_CODE, grpcCode);
+      span.setAttribute(RPC_GRPC_STATUS_CODE, grpcCode);
     }
 
     const actual = mapStatus(span);
     expect(actual).toEqual(expected);
   });
 
-  it('works with string SEMATTRS_HTTP_STATUS_CODE', () => {
+  it('works with string HTTP_STATUS_CODE', () => {
     const span = createSpan('test-span');
 
     span.setStatus({ code: 0 }); // UNSET
-    span.setAttribute(SEMATTRS_HTTP_STATUS_CODE, '400');
+    span.setAttribute(HTTP_STATUS_CODE, '400');
 
     const actual = mapStatus(span);
     expect(actual).toEqual({ code: SPAN_STATUS_ERROR, message: 'invalid_argument' });
@@ -117,7 +117,7 @@ describe('mapStatus', () => {
 
   it('infers error status form attributes when span already has error status without message', () => {
     const span = createSpan('test-span');
-    span.setAttribute(SEMATTRS_HTTP_STATUS_CODE, 500);
+    span.setAttribute(HTTP_STATUS_CODE, 500);
     span.setStatus({ code: 2 }); // ERROR
     expect(mapStatus(span)).toEqual({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
   });

--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -2,19 +2,19 @@
 import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import {
-  ATTR_DB_SYSTEM_NAME,
-  ATTR_HTTP_ROUTE,
-  SEMATTRS_DB_STATEMENT,
-  SEMATTRS_DB_SYSTEM,
-  SEMATTRS_FAAS_TRIGGER,
-  SEMATTRS_HTTP_HOST,
-  SEMATTRS_HTTP_METHOD,
-  SEMATTRS_HTTP_STATUS_CODE,
-  SEMATTRS_HTTP_TARGET,
-  SEMATTRS_HTTP_URL,
-  SEMATTRS_MESSAGING_SYSTEM,
-  SEMATTRS_RPC_SERVICE,
-} from '@opentelemetry/semantic-conventions';
+  DB_STATEMENT,
+  DB_SYSTEM,
+  DB_SYSTEM_NAME,
+  FAAS_TRIGGER,
+  HTTP_HOST,
+  HTTP_METHOD,
+  HTTP_ROUTE,
+  HTTP_STATUS_CODE,
+  HTTP_TARGET,
+  HTTP_URL,
+  MESSAGING_SYSTEM,
+  RPC_SERVICE,
+} from '@sentry/conventions/attributes';
 import { SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { describe, expect, it } from 'vitest';
 import {
@@ -51,7 +51,7 @@ describe('parseSpanDescription', () => {
     [
       'works with deprecated http method',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
+        [HTTP_METHOD]: 'GET',
       },
       'test name',
       SpanKind.CLIENT,
@@ -77,8 +77,8 @@ describe('parseSpanDescription', () => {
     [
       'works with db system',
       {
-        [SEMATTRS_DB_SYSTEM]: 'mysql',
-        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+        [DB_SYSTEM]: 'mysql',
+        [DB_STATEMENT]: 'SELECT * from users',
       },
       'test name',
       SpanKind.CLIENT,
@@ -92,8 +92,8 @@ describe('parseSpanDescription', () => {
       'works with db system and custom source',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_DB_SYSTEM]: 'mysql',
-        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+        [DB_SYSTEM]: 'mysql',
+        [DB_STATEMENT]: 'SELECT * from users',
       },
       'test name',
       SpanKind.CLIENT,
@@ -107,8 +107,8 @@ describe('parseSpanDescription', () => {
       'works with db system and custom source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_DB_SYSTEM]: 'mysql',
-        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+        [DB_SYSTEM]: 'mysql',
+        [DB_STATEMENT]: 'SELECT * from users',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -123,8 +123,8 @@ describe('parseSpanDescription', () => {
       'works with db system and component source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
-        [SEMATTRS_DB_SYSTEM]: 'mysql',
-        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+        [DB_SYSTEM]: 'mysql',
+        [DB_STATEMENT]: 'SELECT * from users',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -138,7 +138,7 @@ describe('parseSpanDescription', () => {
     [
       'works with db system without statement',
       {
-        [SEMATTRS_DB_SYSTEM]: 'mysql',
+        [DB_SYSTEM]: 'mysql',
       },
       'test name',
       SpanKind.CLIENT,
@@ -151,8 +151,8 @@ describe('parseSpanDescription', () => {
     [
       'works with db.system.name (stable attribute)',
       {
-        [ATTR_DB_SYSTEM_NAME]: 'postgresql',
-        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+        [DB_SYSTEM_NAME]: 'postgresql',
+        [DB_STATEMENT]: 'SELECT * from users',
       },
       'test name',
       SpanKind.CLIENT,
@@ -165,7 +165,7 @@ describe('parseSpanDescription', () => {
     [
       'works with db.system.name without statement',
       {
-        [ATTR_DB_SYSTEM_NAME]: 'postgresql',
+        [DB_SYSTEM_NAME]: 'postgresql',
       },
       'test name',
       SpanKind.CLIENT,
@@ -178,9 +178,9 @@ describe('parseSpanDescription', () => {
     [
       'prefers db.system.name over deprecated db.system',
       {
-        [ATTR_DB_SYSTEM_NAME]: 'postgresql',
-        [SEMATTRS_DB_SYSTEM]: 'mysql',
-        [SEMATTRS_DB_STATEMENT]: 'SELECT * from users',
+        [DB_SYSTEM_NAME]: 'postgresql',
+        [DB_SYSTEM]: 'mysql',
+        [DB_STATEMENT]: 'SELECT * from users',
       },
       'test name',
       SpanKind.CLIENT,
@@ -193,7 +193,7 @@ describe('parseSpanDescription', () => {
     [
       'works with rpc service',
       {
-        [SEMATTRS_RPC_SERVICE]: 'rpc-test-service',
+        [RPC_SERVICE]: 'rpc-test-service',
       },
       'test name',
       undefined,
@@ -207,7 +207,7 @@ describe('parseSpanDescription', () => {
       'works with rpc service and custom source',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_RPC_SERVICE]: 'rpc-test-service',
+        [RPC_SERVICE]: 'rpc-test-service',
       },
       'test name',
       undefined,
@@ -221,7 +221,7 @@ describe('parseSpanDescription', () => {
       'works with rpc service and custom source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_RPC_SERVICE]: 'rpc-test-service',
+        [RPC_SERVICE]: 'rpc-test-service',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -236,7 +236,7 @@ describe('parseSpanDescription', () => {
       'works with rpc service and component source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
-        [SEMATTRS_RPC_SERVICE]: 'rpc-test-service',
+        [RPC_SERVICE]: 'rpc-test-service',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -250,7 +250,7 @@ describe('parseSpanDescription', () => {
     [
       'works with messaging system',
       {
-        [SEMATTRS_MESSAGING_SYSTEM]: 'test-messaging-system',
+        [MESSAGING_SYSTEM]: 'test-messaging-system',
       },
       'test name',
       undefined,
@@ -264,7 +264,7 @@ describe('parseSpanDescription', () => {
       'works with messaging system and custom source',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_MESSAGING_SYSTEM]: 'test-messaging-system',
+        [MESSAGING_SYSTEM]: 'test-messaging-system',
       },
       'test name',
       undefined,
@@ -278,7 +278,7 @@ describe('parseSpanDescription', () => {
       'works with messaging system and custom source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_MESSAGING_SYSTEM]: 'test-messaging-system',
+        [MESSAGING_SYSTEM]: 'test-messaging-system',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -293,7 +293,7 @@ describe('parseSpanDescription', () => {
       'works with messaging system and component source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
-        [SEMATTRS_MESSAGING_SYSTEM]: 'test-messaging-system',
+        [MESSAGING_SYSTEM]: 'test-messaging-system',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -307,7 +307,7 @@ describe('parseSpanDescription', () => {
     [
       'works with faas trigger',
       {
-        [SEMATTRS_FAAS_TRIGGER]: 'test-faas-trigger',
+        [FAAS_TRIGGER]: 'test-faas-trigger',
       },
       'test name',
       undefined,
@@ -321,7 +321,7 @@ describe('parseSpanDescription', () => {
       'works with faas trigger and custom source',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_FAAS_TRIGGER]: 'test-faas-trigger',
+        [FAAS_TRIGGER]: 'test-faas-trigger',
       },
       'test name',
       undefined,
@@ -335,7 +335,7 @@ describe('parseSpanDescription', () => {
       'works with faas trigger and custom source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-        [SEMATTRS_FAAS_TRIGGER]: 'test-faas-trigger',
+        [FAAS_TRIGGER]: 'test-faas-trigger',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -350,7 +350,7 @@ describe('parseSpanDescription', () => {
       'works with faas trigger and component source and custom name',
       {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
-        [SEMATTRS_FAAS_TRIGGER]: 'test-faas-trigger',
+        [FAAS_TRIGGER]: 'test-faas-trigger',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       'test name',
@@ -385,9 +385,9 @@ describe('descriptionForHttpMethod', () => {
       'works with basic client GET',
       'GET',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path',
-        [SEMATTRS_HTTP_TARGET]: '/my-path',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path',
+        [HTTP_TARGET]: '/my-path',
       },
       'test name',
       SpanKind.CLIENT,
@@ -404,9 +404,9 @@ describe('descriptionForHttpMethod', () => {
       'works with prefetch request',
       'GET',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path',
-        [SEMATTRS_HTTP_TARGET]: '/my-path',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path',
+        [HTTP_TARGET]: '/my-path',
         'sentry.http.prefetch': true,
       },
       'test name',
@@ -424,9 +424,9 @@ describe('descriptionForHttpMethod', () => {
       'works with basic server POST',
       'POST',
       {
-        [SEMATTRS_HTTP_METHOD]: 'POST',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path',
-        [SEMATTRS_HTTP_TARGET]: '/my-path',
+        [HTTP_METHOD]: 'POST',
+        [HTTP_URL]: 'https://www.example.com/my-path',
+        [HTTP_TARGET]: '/my-path',
       },
       'test name',
       SpanKind.SERVER,
@@ -443,10 +443,10 @@ describe('descriptionForHttpMethod', () => {
       'works with client GET with route',
       'GET',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path/123',
-        [SEMATTRS_HTTP_TARGET]: '/my-path/123',
-        [ATTR_HTTP_ROUTE]: '/my-path/:id',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path/123',
+        [HTTP_TARGET]: '/my-path/123',
+        [HTTP_ROUTE]: '/my-path/:id',
       },
       'test name',
       SpanKind.CLIENT,
@@ -463,9 +463,9 @@ describe('descriptionForHttpMethod', () => {
       'works with basic client GET with SpanKind.INTERNAL',
       'GET',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path',
-        [SEMATTRS_HTTP_TARGET]: '/my-path',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path',
+        [HTTP_TARGET]: '/my-path',
       },
       'test name',
       SpanKind.INTERNAL,
@@ -482,10 +482,10 @@ describe('descriptionForHttpMethod', () => {
       "doesn't overwrite span name with source custom",
       'GET',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path/123',
-        [SEMATTRS_HTTP_TARGET]: '/my-path/123',
-        [ATTR_HTTP_ROUTE]: '/my-path/:id',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path/123',
+        [HTTP_TARGET]: '/my-path/123',
+        [HTTP_ROUTE]: '/my-path/:id',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
       },
       'test name',
@@ -503,10 +503,10 @@ describe('descriptionForHttpMethod', () => {
       'takes user-passed span name (with source custom)',
       'GET',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path/123',
-        [SEMATTRS_HTTP_TARGET]: '/my-path/123',
-        [ATTR_HTTP_ROUTE]: '/my-path/:id',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path/123',
+        [HTTP_TARGET]: '/my-path/123',
+        [HTTP_ROUTE]: '/my-path/:id',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
@@ -525,10 +525,10 @@ describe('descriptionForHttpMethod', () => {
       'takes user-passed span name (with source component)',
       'GET',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_URL]: 'https://www.example.com/my-path/123',
-        [SEMATTRS_HTTP_TARGET]: '/my-path/123',
-        [ATTR_HTTP_ROUTE]: '/my-path/:id',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path/123',
+        [HTTP_TARGET]: '/my-path/123',
+        [HTTP_ROUTE]: '/my-path/:id',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
@@ -566,11 +566,11 @@ describe('getSanitizedUrl', () => {
     [
       'uses url without query for client request',
       {
-        [SEMATTRS_HTTP_URL]: 'http://example.com/?what=true',
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_TARGET]: '/?what=true',
-        [SEMATTRS_HTTP_HOST]: 'example.com:80',
-        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+        [HTTP_URL]: 'http://example.com/?what=true',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_TARGET]: '/?what=true',
+        [HTTP_HOST]: 'example.com:80',
+        [HTTP_STATUS_CODE]: 200,
       },
       SpanKind.CLIENT,
       {
@@ -584,11 +584,11 @@ describe('getSanitizedUrl', () => {
     [
       'uses url without hash for client request',
       {
-        [SEMATTRS_HTTP_URL]: 'http://example.com/sub#hash',
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_TARGET]: '/sub#hash',
-        [SEMATTRS_HTTP_HOST]: 'example.com:80',
-        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+        [HTTP_URL]: 'http://example.com/sub#hash',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_TARGET]: '/sub#hash',
+        [HTTP_HOST]: 'example.com:80',
+        [HTTP_STATUS_CODE]: 200,
       },
       SpanKind.CLIENT,
       {
@@ -602,12 +602,12 @@ describe('getSanitizedUrl', () => {
     [
       'uses route if available for client request',
       {
-        [SEMATTRS_HTTP_URL]: 'http://example.com/?what=true',
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_TARGET]: '/?what=true',
-        [ATTR_HTTP_ROUTE]: '/my-route',
-        [SEMATTRS_HTTP_HOST]: 'example.com:80',
-        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+        [HTTP_URL]: 'http://example.com/?what=true',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_TARGET]: '/?what=true',
+        [HTTP_ROUTE]: '/my-route',
+        [HTTP_HOST]: 'example.com:80',
+        [HTTP_STATUS_CODE]: 200,
       },
       SpanKind.CLIENT,
       {
@@ -621,10 +621,10 @@ describe('getSanitizedUrl', () => {
     [
       'falls back to target for client request if url not available',
       {
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_TARGET]: '/?what=true',
-        [SEMATTRS_HTTP_HOST]: 'example.com:80',
-        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+        [HTTP_METHOD]: 'GET',
+        [HTTP_TARGET]: '/?what=true',
+        [HTTP_HOST]: 'example.com:80',
+        [HTTP_STATUS_CODE]: 200,
       },
       SpanKind.CLIENT,
       {
@@ -638,11 +638,11 @@ describe('getSanitizedUrl', () => {
     [
       'uses target without query for server request',
       {
-        [SEMATTRS_HTTP_URL]: 'http://example.com/?what=true',
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_TARGET]: '/?what=true',
-        [SEMATTRS_HTTP_HOST]: 'example.com:80',
-        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+        [HTTP_URL]: 'http://example.com/?what=true',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_TARGET]: '/?what=true',
+        [HTTP_HOST]: 'example.com:80',
+        [HTTP_STATUS_CODE]: 200,
       },
       SpanKind.SERVER,
       {
@@ -656,11 +656,11 @@ describe('getSanitizedUrl', () => {
     [
       'uses target without hash for server request',
       {
-        [SEMATTRS_HTTP_URL]: 'http://example.com/?what=true',
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_TARGET]: '/sub#hash',
-        [SEMATTRS_HTTP_HOST]: 'example.com:80',
-        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+        [HTTP_URL]: 'http://example.com/?what=true',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_TARGET]: '/sub#hash',
+        [HTTP_HOST]: 'example.com:80',
+        [HTTP_STATUS_CODE]: 200,
       },
       SpanKind.SERVER,
       {
@@ -674,12 +674,12 @@ describe('getSanitizedUrl', () => {
     [
       'uses route for server request if available',
       {
-        [SEMATTRS_HTTP_URL]: 'http://example.com/?what=true',
-        [SEMATTRS_HTTP_METHOD]: 'GET',
-        [SEMATTRS_HTTP_TARGET]: '/?what=true',
-        [ATTR_HTTP_ROUTE]: '/my-route',
-        [SEMATTRS_HTTP_HOST]: 'example.com:80',
-        [SEMATTRS_HTTP_STATUS_CODE]: 200,
+        [HTTP_URL]: 'http://example.com/?what=true',
+        [HTTP_METHOD]: 'GET',
+        [HTTP_TARGET]: '/?what=true',
+        [HTTP_ROUTE]: '/my-route',
+        [HTTP_HOST]: 'example.com:80',
+        [HTTP_STATUS_CODE]: 200,
       },
       SpanKind.SERVER,
       {


### PR DESCRIPTION
Switches `@sentry/opentelemetry` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982