### PR TITLE
ref(remix): Use `@sentry/conventions`

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -66,9 +66,9 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
     "@remix-run/router": "^1.23.3",
     "@sentry/cli": "^2.58.6",
+    "@sentry/conventions": "^0.11.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0",
     "@sentry/react": "10.58.0",

--- a/packages/remix/src/vendor/instrumentation.ts
+++ b/packages/remix/src/vendor/instrumentation.ts
@@ -32,7 +32,7 @@ import {
   InstrumentationNodeModuleFile,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { CODE_FUNCTION, HTTP_METHOD, HTTP_ROUTE, HTTP_STATUS_CODE, HTTP_URL } from '@sentry/conventions/attributes';
 import type { Params } from '@remix-run/router';
 import type * as remixRunServerRuntime from '@remix-run/server-runtime';
 import type * as remixRunServerRuntimeData from '@remix-run/server-runtime/dist/data';
@@ -192,7 +192,7 @@ export class RemixInstrumentation extends InstrumentationBase {
 
         const routePath = route?.path;
         if (span && routePath) {
-          span.setAttribute(SemanticAttributes.HTTP_ROUTE, routePath);
+          span.setAttribute(HTTP_ROUTE, routePath);
           span.updateName(`remix.request ${routePath}`);
         }
 
@@ -220,7 +220,7 @@ export class RemixInstrumentation extends InstrumentationBase {
           const span = plugin.tracer.startSpan(
             'remix.request',
             {
-              attributes: { [SemanticAttributes.CODE_FUNCTION]: 'requestHandler' },
+              attributes: { [CODE_FUNCTION]: 'requestHandler' },
             },
             opentelemetry.context.active(),
           );
@@ -256,7 +256,7 @@ export class RemixInstrumentation extends InstrumentationBase {
 
         const span = plugin.tracer.startSpan(
           `LOADER ${params.routeId}`,
-          { attributes: { [SemanticAttributes.CODE_FUNCTION]: 'loader' } },
+          { attributes: { [CODE_FUNCTION]: 'loader' } },
           opentelemetry.context.active(),
         );
 
@@ -291,7 +291,7 @@ export class RemixInstrumentation extends InstrumentationBase {
         const clonedRequest = params.request.clone();
         const span = plugin.tracer.startSpan(
           `ACTION ${params.routeId}`,
-          { attributes: { [SemanticAttributes.CODE_FUNCTION]: 'action' } },
+          { attributes: { [CODE_FUNCTION]: 'action' } },
           opentelemetry.context.active(),
         );
 
@@ -344,8 +344,8 @@ export class RemixInstrumentation extends InstrumentationBase {
 
 const addRequestAttributesToSpan = (span: Span, request: Request): void => {
   span.setAttributes({
-    [SemanticAttributes.HTTP_METHOD]: request.method,
-    [SemanticAttributes.HTTP_URL]: request.url,
+    [HTTP_METHOD]: request.method,
+    [HTTP_URL]: request.url,
   });
 };
 
@@ -362,7 +362,7 @@ const addMatchAttributesToSpan = (span: Span, match: { routeId: string; params: 
 const addResponseAttributesToSpan = (span: Span, response: Response | null): void => {
   if (response) {
     span.setAttributes({
-      [SemanticAttributes.HTTP_STATUS_CODE]: response.status,
+      [HTTP_STATUS_CODE]: response.status,
     });
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7578,6 +7578,11 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
+"@sentry/conventions@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.0.tgz#5a324b8368dc5c141260bd8ccc684756ea3dd843"
+  integrity sha512-AQTAKeq9mDpOElDFSPymZTPZF/c50rk355mWTf5Y1ZxZJKKOBli5qTttskJyCxrE5ynNgN1KwcXoU5MRrMSRmQ==
+
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@sentry/node-cpu-profiler/-/node-cpu-profiler-2.4.2.tgz#d0ba01370545297d015df1497daf7f81e27f2ab5"


### PR DESCRIPTION
Switches `@sentry/remix` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982