### PR TITLE
ref(tanstackstart-react): Use `@sentry/conventions`

### DIFF
--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -64,8 +64,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sentry/browser-utils": "10.58.0",
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0",
     "@sentry/react": "10.58.0",

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -1,4 +1,4 @@
-import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
+import { HTTP_ROUTE } from '@sentry/conventions/attributes';
 import {
   escapeStringForRegex,
   getActiveSpan,
@@ -54,13 +54,13 @@ export function updateSpanWithRouteParametrization(method: string, pathname: str
 
   const rootSpan = getRootSpan(activeSpan);
   const rootSpanData = spanToJSON(rootSpan).data;
-  if (rootSpanData?.[ATTR_HTTP_ROUTE]) {
+  if (rootSpanData?.[HTTP_ROUTE]) {
     return;
   }
 
   const transactionName = `${method} ${matchedPattern}`;
   updateSpanName(rootSpan, transactionName);
-  rootSpan.setAttribute(ATTR_HTTP_ROUTE, matchedPattern);
+  rootSpan.setAttribute(HTTP_ROUTE, matchedPattern);
   rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
   getCurrentScope().setTransactionName(transactionName);
 }


### PR DESCRIPTION
Switches `@sentry/tanstackstart-react` to source span/attribute keys from `@sentry/conventions`, added as a regular runtime `dependency` and externalized at build time (resolved at runtime by the consumer's installed copy). No functional change — the attribute values are identical.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982