### PR TITLE
ref(nitro): Inherit base Vitest config for vendored `@sentry/conventions`

### DIFF
--- a/packages/nitro/vite.config.ts
+++ b/packages/nitro/vite.config.ts
@@ -3,6 +3,7 @@ import baseConfig from '../../vite/vite.config';
 export default {
   ...baseConfig,
   test: {
+    ...baseConfig.test,
     typecheck: {
       enabled: true,
       tsconfig: './tsconfig.test.json',

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -18,6 +18,9 @@
     "strict": true,
     "strictBindCallApply": false,
     "target": "es2020",
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@sentry/conventions/attributes": ["../../node_modules/@sentry/conventions/dist/attributes"]
+    }
   }
 }

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -5,6 +5,16 @@ export default defineConfig({
     __DEBUG_BUILD__: true,
   },
   test: {
+    server: {
+      deps: {
+        // `@sentry/conventions` is vendored into our build output (under `build/esm/node_modules/...`)
+        // as ESM `.js` files. Vitest externalizes anything under a `node_modules/` path and loads it via
+        // native `require`, which fails on Node 18 ("ES Module shipped in a CommonJS package") because
+        // Node <20.19 can't `require()` ESM. Inlining makes Vitest transform it instead, so it works on
+        // all supported Node versions. Production is unaffected (the package resolves via its exports map).
+        inline: [/@sentry[/\\]conventions/],
+      },
+    },
     coverage: {
       enabled: true,
       reportsDirectory: './coverage',


### PR DESCRIPTION
## Summary

`packages/nitro/vite.config.ts` redefined `test` wholesale, so it did not inherit the base config's `server.deps.inline` rule. Since nitro's tests load the `@sentry/node` / `@sentry/opentelemetry` builds (which vendor `@sentry/conventions` as ESM `.js`), Vitest would externalize and `require()` that ESM copy — which fails on Node 18 (no `require(esm)` support).

This spreads `...baseConfig.test` so nitro inherits the inline rule, alongside the same shared infra changes as the other `@sentry/conventions` PRs:

- `vite/vite.config.ts` — inline `@sentry/conventions` in Vitest.
- `packages/typescript/tsconfig.json` — map the `@sentry/conventions/attributes` subpath for `node` moduleResolution type builds.

Part of splitting the larger `@sentry/conventions` migration into per-package PRs.

Ref: #20982

🤖 Generated with [Claude Code](https://claude.com/claude-code)