### PR TITLE
ref(build): Relocate vendored deps out of `node_modules` in npm builds

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -17,6 +17,7 @@ import {
   makeEsbuildPlugin,
   makeNodeResolvePlugin,
   makeProductionReplacePlugin,
+  makeRelocateVendoredModulesPlugin,
   makeRrwebBuildPlugin,
 } from './plugins/index.mjs';
 import { makePackageNodeEsm } from './plugins/make-esm-plugin.mjs';
@@ -38,6 +39,7 @@ export function makeBaseNPMConfig(options = {}) {
   } = options;
 
   const nodeResolvePlugin = makeNodeResolvePlugin();
+  const relocateVendoredModulesPlugin = makeRelocateVendoredModulesPlugin();
   const transpilePlugin = makeEsbuildPlugin(esbuild);
   const debugBuildStatementReplacePlugin = makeDebugBuildStatementReplacePlugin();
   const rrwebBuildPlugin = makeRrwebBuildPlugin({
@@ -102,7 +104,13 @@ export function makeBaseNPMConfig(options = {}) {
       },
     },
 
-    plugins: [nodeResolvePlugin, transpilePlugin, debugBuildStatementReplacePlugin, rrwebBuildPlugin],
+    plugins: [
+      relocateVendoredModulesPlugin,
+      nodeResolvePlugin,
+      transpilePlugin,
+      debugBuildStatementReplacePlugin,
+      rrwebBuildPlugin,
+    ],
 
     // don't include imported modules from outside the package in the final output
     // also treat subpath exports (e.g. `@sentry/core/browser`) as external

--- a/dev-packages/rollup-utils/plugins/npmPlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/npmPlugins.mjs
@@ -6,6 +6,7 @@
  * Replace plugin docs: https://github.com/rollup/plugins/tree/master/packages/replace
  */
 
+import fs from 'node:fs';
 import json from '@rollup/plugin-json';
 import replace from '@rollup/plugin-replace';
 import esbuild from 'rollup-plugin-esbuild';
@@ -50,6 +51,63 @@ export function makeEsbuildPlugin(esbuildOptions = {}) {
 
 export function makeJsonPlugin() {
   return json();
+}
+
+/**
+ * With `preserveModules: true`, Rollup emits bundled dependencies that resolve from `node_modules`
+ * (e.g. a vendored devDependency like `@sentry/conventions`) into an output directory literally
+ * named `node_modules`. That breaks at runtime: Node treats `node_modules` as a package-scope
+ * boundary, so the `{"type":"module"}` marker we emit at the ESM build root does NOT apply inside it.
+ * Node then loads our ESM `.js` files there as CommonJS — named imports fail with
+ * "is a CommonJS module" — and Vitest externalizes any `/node_modules/` path and `require()`s it,
+ * which additionally fails on Node 18 (no `require(esm)` support).
+ *
+ * This plugin relocates those modules to a plain `_external/` directory (still inside `src` so
+ * `preserveModules` roots them under the build root). Rollup rewrites every import specifier to the
+ * new location automatically, so the scope marker applies and the heuristics no longer fire.
+ */
+export function makeRelocateVendoredModulesPlugin() {
+  // Rollup module ids and `@rollup/plugin-node-resolve` results use OS-native separators, i.e.
+  // backslashes on Windows. Normalize every path we inspect to forward slashes before matching,
+  // otherwise `/node_modules/` never matches on Windows and the relocation silently no-ops.
+  const toPosix = p => p.split('\\').join('/');
+  const cwd = toPosix(process.cwd());
+  const NODE_MODULES = '/node_modules/';
+  const VENDOR_DIR = `${cwd}/src/_external/`;
+
+  return {
+    name: 'relocate-vendored-modules',
+    async resolveId(source, importer, options) {
+      // Ids we've already relocated resolve to themselves.
+      if (toPosix(source).startsWith(VENDOR_DIR)) return source;
+
+      // When the importer is itself a relocated module, resolve its imports (which are often
+      // relative, e.g. `./chunk.js`) against the REAL on-disk location so sibling files inside the
+      // vendored package are found — then relocate those too, preserving the package's structure.
+      const realImporter =
+        importer && toPosix(importer).startsWith(VENDOR_DIR)
+          ? this.getModuleInfo(importer)?.meta?.vendoredFrom
+          : importer;
+
+      const resolved = await this.resolve(source, realImporter, { ...options, skipSelf: true });
+      // Leave external deps and unresolved ids untouched.
+      if (!resolved || resolved.external) return resolved;
+
+      const resolvedId = toPosix(resolved.id);
+      const idx = resolvedId.lastIndexOf(NODE_MODULES);
+      if (idx === -1) return resolved;
+
+      // Map `<anywhere>/node_modules/<pkg>/<...>` -> `<cwd>/src/_external/<pkg>/<...>` and remember
+      // the real on-disk path so `load()` can read the original source.
+      const rest = resolvedId.slice(idx + NODE_MODULES.length);
+      return { id: `${VENDOR_DIR}${rest}`, meta: { vendoredFrom: resolved.id } };
+    },
+    load(id) {
+      if (!toPosix(id).startsWith(VENDOR_DIR)) return null;
+      const vendoredFrom = this.getModuleInfo(id)?.meta?.vendoredFrom;
+      return vendoredFrom ? fs.readFileSync(vendoredFrom, 'utf-8') : null;
+    },
+  };
 }
 
 /**

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -18,6 +18,9 @@
     "strict": true,
     "strictBindCallApply": false,
     "target": "es2020",
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@sentry/conventions/attributes": ["../../node_modules/@sentry/conventions/dist/attributes"]
+    }
   }
 }


### PR DESCRIPTION
## Summary

Foundational build-infra change for the `@sentry/conventions` migration. **The per-package** `@sentry/conventions` **PRs depend on this and it should merge first.**

## Root cause

With `preserveModules: true`, Rollup emits bundled dependencies that resolve from `node_modules` (e.g. the vendored `@sentry/conventions` devDependency) into an output directory literally named `node_modules` (`build/esm/node_modules/@sentry/conventions/dist/attributes.js`).

Node treats `node_modules` as a **package-scope boundary**: the `{"type":"module"}` marker we emit at the ESM build root does *not* apply inside it. Node then loads our ESM `.js` files there as **CommonJS**, so named imports fail:

```
Named export 'HTTP_TARGET' not found. The requested module '.../node_modules/@sentry/conventions/dist/attributes.js'
is a CommonJS module, which may not support all module.exports as named exports.
```

The same boundary also makes Vitest externalize the `/node_modules/` path and `require()` it, which additionally fails on Node 18 (no `require(esm)` support).

## Fix

A `relocate-vendored-modules` rollup-utils plugin moves bundled `node_modules` deps to a plain `_external/` directory (kept under `src` so `preserveModules` roots it at the build root). Rollup rewrites every import specifier to the new location automatically, so the `type:module` scope marker applies and neither the Node ESM/CJS heuristic nor Vitest's externalization fire. Modules with internal relative imports (e.g. the multi-file `@sentry/rrweb` bundle in replay) are relocated as a unit.

Also maps the `@sentry/conventions/attributes` subpath in `packages/typescript/tsconfig.json` for the repo's `node` moduleResolution type builds.

Verified with a full `yarn build:dev` (all 45 projects) and by confirming a packed `@sentry/react-router` resolves the relocated file as ESM.

Ref: getsentry/sentry-javascript#20982

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)