### PR TITLE
fix(browser): Ignore `__sentry_wrapped__` inherited from `Function.prototype`

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -79,10 +79,12 @@ export function wrap<T extends WrappableFunction, NonFunction>(
   }
 
   try {
-    // if we're dealing with a function that was previously wrapped, return
-    // the original wrapper.
-    const wrapper = (fn as WrappedFunction<T>).__sentry_wrapped__;
-    if (wrapper) {
+    // If we're dealing with a function that was previously wrapped, return the original wrapper.
+    // Check via hasOwnProperty so a `__sentry_wrapped__` inherited from a wrapped `Function.prototype`
+    // is not mistaken for a real wrapper.
+    const hasOwnWrapper = Object.prototype.hasOwnProperty.call(fn, '__sentry_wrapped__');
+    if (hasOwnWrapper) {
+      const wrapper = (fn as WrappedFunction<T>).__sentry_wrapped__;
       if (typeof wrapper === 'function') {
         return wrapper;
       } else {

--- a/packages/browser/src/integrations/browserapierrors.ts
+++ b/packages/browser/src/integrations/browserapierrors.ts
@@ -219,9 +219,13 @@ function _wrapEventTarget(target: string, integrationOptions: BrowserApiErrorsOp
        * to get rid of the initial handler and it'd stick there forever.
        */
       try {
-        const originalEventHandler = (fn as WrappedFunction).__sentry_wrapped__;
-        if (originalEventHandler) {
-          originalRemoveEventListener.call(this, eventName, originalEventHandler, options);
+        // Check via hasOwnProperty so a `__sentry_wrapped__` inherited from a wrapped
+        // `Function.prototype` doesn't cause removal of the wrong handler.
+        if (Object.prototype.hasOwnProperty.call(fn, '__sentry_wrapped__')) {
+          const originalEventHandler = (fn as WrappedFunction).__sentry_wrapped__;
+          if (originalEventHandler) {
+            originalRemoveEventListener.call(this, eventName, originalEventHandler, options);
+          }
         }
       } catch {
         // ignore, accessing __sentry_wrapped__ will throw in some Selenium environments

--- a/packages/browser/test/helpers.test.ts
+++ b/packages/browser/test/helpers.test.ts
@@ -74,6 +74,22 @@ describe('internal wrap()', () => {
     expect(wrapped.__sentry_original__).toBe(fn);
   });
 
+  it('ignores __sentry_wrapped__ inherited from Function.prototype', () => {
+    // Wrapping Function.prototype puts __sentry_wrapped__ on it, which every
+    // function then inherits. wrap() must only trust own wrapper metadata.
+    const prototypeWrapper = wrap(Function.prototype as () => unknown);
+    try {
+      const fresh = vi.fn(() => 'fresh');
+      const wrapped = wrap(fresh);
+
+      expect(wrapped).not.toBe(prototypeWrapper);
+      wrapped();
+      expect(fresh).toHaveBeenCalledTimes(1);
+    } finally {
+      delete (Function.prototype as unknown as { __sentry_wrapped__?: unknown }).__sentry_wrapped__;
+    }
+  });
+
   it('keeps original functions properties', () => {
     const fn = Object.assign(() => 1337, {
       some: 1337,


### PR DESCRIPTION
When `wrap()` is called with `Function.prototype` itself as the callback (e.g. when a library passes `Function.prototype` as a noop handler), the wrapper is attached as an own property of `Function.prototype`. Every function then inherits `__sentry_wrapped__` via the prototype chain, so subsequent `wrap()` calls returned the stale prototype wrapper instead of wrapping the fresh callback — silently breaking every event listener registered afterwards.

Check `__sentry_wrapped__` via `hasOwnProperty` in `wrap()` and in the patched `removeEventListener` so inherited wrappers are ignored.
