### PR TITLE
fix(nextjs): Mark redirect server actions as `ok` instead of `internal_error`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -149,6 +149,9 @@ test('Should not capture "NEXT_REDIRECT" control-flow errors for server actions 
   const serverActionTransactionEvent = await serverActionTransactionPromise;
   expect(serverActionTransactionEvent).toBeDefined();
 
+  // Redirects are normal control flow, so the transaction must not be flagged as errored
+  expect(serverActionTransactionEvent.contexts?.trace?.status).toBe('ok');
+
   // By the time the server action span finishes the error should already have been sent
   expect(controlFlowErrorCaptured).toBe(false);
 });

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -10,6 +10,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SPAN_STATUS_ERROR,
+  SPAN_STATUS_OK,
   startSpan,
   withIsolationScope,
 } from '@sentry/core';
@@ -126,7 +127,11 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
                   // We don't want to report "not-found"s
                   span.setStatus({ code: SPAN_STATUS_ERROR, message: 'not_found' });
                 } else if (isRedirectNavigationError(error)) {
-                  // Don't do anything for redirects
+                  // Redirects are normal Next.js control flow, not errors. Mark the span as OK and end it
+                  // early so the surrounding `startSpan` error handler doesn't override the status to
+                  // `internal_error`
+                  span.setStatus({ code: SPAN_STATUS_OK });
+                  span.end();
                 } else {
                   span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
                   captureException(error, {


### PR DESCRIPTION
Server Actions that call `redirect()` inside `withServerActionInstrumentation` were recorded with span status `internal_error` instead of `ok`.

We now explicitly set it to `ok` and end the span in a redirect case.

closes https://github.com/getsentry/sentry-javascript/issues/21515