### PR TITLE
test: Skip nuxt-5 E2E test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
@@ -32,7 +32,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "sentryTest": {
-    "optional": true
+    "skip": true
   },
   "volta": {
     "extends": "../../package.json",


### PR DESCRIPTION
This is currently failing and polluting CI, so for now we skip it.