### PR TITLE
ref(nestjs): Set nest span op/origin at span creation

### DIFF
--- a/packages/nestjs/src/integrations/vendored/instrumentation.ts
+++ b/packages/nestjs/src/integrations/vendored/instrumentation.ts
@@ -27,7 +27,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { ATTR_HTTP_ROUTE } from '@opentelemetry/semantic-conventions';
 import type { SpanAttributes } from '@sentry/core';
-import { SDK_VERSION, startSpan } from '@sentry/core';
+import { SDK_VERSION, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 import { AttributeNames, NestType } from './enums';
 
 const PACKAGE_NAME = '@sentry/instrumentation-nestjs-core';
@@ -137,8 +137,10 @@ function createWrapNestFactoryCreate(moduleVersion?: string) {
       return startSpan(
         {
           name: 'Create Nest App',
+          op: `${NestType.APP_CREATION}.nestjs`,
           attributes: {
             ...NestInstrumentation.COMMON_ATTRIBUTES,
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.otel.nestjs',
             [AttributeNames.TYPE]: NestType.APP_CREATION,
             [AttributeNames.VERSION]: moduleVersion,
             [AttributeNames.MODULE]: nestModule.name,
@@ -165,6 +167,7 @@ function createWrapCreateHandler(moduleVersion: string | undefined) {
         const req = handlerArgs[0] as NestRequest;
         const attributes: SpanAttributes = {
           ...NestInstrumentation.COMMON_ATTRIBUTES,
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.otel.nestjs',
           [AttributeNames.VERSION]: moduleVersion,
           [AttributeNames.TYPE]: NestType.REQUEST_CONTEXT,
           [ATTR_HTTP_ROUTE]: req.route?.path || req.routeOptions?.url || req.routerPath,
@@ -173,7 +176,9 @@ function createWrapCreateHandler(moduleVersion: string | undefined) {
         };
         attributes['http.method'] = req.method;
         attributes['http.url'] = req.originalUrl || req.url;
-        return startSpan({ name: spanName, attributes }, () => handler.apply(this, handlerArgs));
+        return startSpan({ name: spanName, op: `${NestType.REQUEST_CONTEXT}.nestjs`, attributes }, () =>
+          handler.apply(this, handlerArgs),
+        );
       };
     };
   };
@@ -183,12 +188,15 @@ function createWrapHandler(moduleVersion: string | undefined, handler: AnyFn): A
   const spanName = handler.name || 'anonymous nest handler';
   const attributes: SpanAttributes = {
     ...NestInstrumentation.COMMON_ATTRIBUTES,
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.otel.nestjs',
     [AttributeNames.VERSION]: moduleVersion,
     [AttributeNames.TYPE]: NestType.REQUEST_HANDLER,
     [AttributeNames.CALLBACK]: handler.name,
   };
   const wrappedHandler = function (this: unknown, ...args: unknown[]) {
-    return startSpan({ name: spanName, attributes }, () => handler.apply(this, args));
+    return startSpan({ name: spanName, op: `${NestType.REQUEST_HANDLER}.nestjs`, attributes }, () =>
+      handler.apply(this, args),
+    );
   };
 
   if (handler.name) {

--- a/packages/nestjs/src/sdk.ts
+++ b/packages/nestjs/src/sdk.ts
@@ -1,11 +1,6 @@
 import type { Integration } from '@sentry/core';
-import {
-  applySdkMetadata,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  spanToJSON,
-} from '@sentry/core';
-import type { NodeClient, NodeOptions, Span } from '@sentry/node';
+import { applySdkMetadata } from '@sentry/core';
+import type { NodeClient, NodeOptions } from '@sentry/node';
 import { getDefaultIntegrations as getDefaultNodeIntegrations, init as nodeInit } from '@sentry/node';
 import { nestIntegration } from './integrations/nest';
 
@@ -20,34 +15,10 @@ export function init(options: NodeOptions | undefined = {}): NodeClient | undefi
 
   applySdkMetadata(opts, 'nestjs', ['nestjs', 'node']);
 
-  const client = nodeInit(opts);
-
-  if (client) {
-    client.on('spanStart', span => {
-      // The NestInstrumentation has no requestHook, so we add NestJS-specific attributes here
-      addNestSpanAttributes(span);
-    });
-  }
-
-  return client;
+  return nodeInit(opts);
 }
 
 /** Get the default integrations for the NestJS SDK. */
 export function getDefaultIntegrations(options: NodeOptions): Integration[] | undefined {
   return [nestIntegration(), ...getDefaultNodeIntegrations(options)];
-}
-
-function addNestSpanAttributes(span: Span): void {
-  const attributes = spanToJSON(span).data;
-
-  // this is one of: app_creation, request_context, handler
-  const type = attributes['nestjs.type'];
-
-  // Only set the NestJS attributes for spans that are created by the NestJS instrumentation and for spans that do not have an op already.
-  if (type && !attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]) {
-    span.setAttributes({
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.otel.nestjs',
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `${type}.nestjs`,
-    });
-  }
 }


### PR DESCRIPTION
Now that we have vendored the nestjs instrumentation we can set these attributes directly in the instrumentation instead of registering a `client.startSpan` hook.