### PR TITLE
ref(node): Set generic-pool span origin at span creation

### DIFF
--- a/packages/node/src/integrations/tracing/genericPool/index.ts
+++ b/packages/node/src/integrations/tracing/genericPool/index.ts
@@ -1,34 +1,17 @@
 import { GenericPoolInstrumentation } from './vendored/instrumentation';
 import type { IntegrationFn } from '@sentry/core';
-import { defineIntegration, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON } from '@sentry/core';
-import { generateInstrumentOnce, instrumentWhenWrapped } from '@sentry/node-core';
+import { defineIntegration } from '@sentry/core';
+import { generateInstrumentOnce } from '@sentry/node-core';
 
 const INTEGRATION_NAME = 'GenericPool';
 
 export const instrumentGenericPool = generateInstrumentOnce(INTEGRATION_NAME, () => new GenericPoolInstrumentation({}));
 
 const _genericPoolIntegration = (() => {
-  let instrumentationWrappedCallback: undefined | ((callback: () => void) => void);
-
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
-      const instrumentation = instrumentGenericPool();
-      instrumentationWrappedCallback = instrumentWhenWrapped(instrumentation);
-    },
-
-    setup(client) {
-      instrumentationWrappedCallback?.(() =>
-        client.on('spanStart', span => {
-          const spanJSON = spanToJSON(span);
-          const spanDescription = spanJSON.description;
-          const isGenericPoolSpan = spanDescription === 'generic-pool.acquire';
-
-          if (isGenericPoolSpan) {
-            span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.db.otel.generic_pool');
-          }
-        }),
-      );
+      instrumentGenericPool();
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/node/src/integrations/tracing/genericPool/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/genericPool/vendored/instrumentation.ts
@@ -21,7 +21,13 @@
 
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationBase, InstrumentationNodeModuleDefinition, isWrapped } from '@opentelemetry/instrumentation';
-import { SDK_VERSION, SPAN_STATUS_ERROR, startSpan, startSpanManual } from '@sentry/core';
+import {
+  SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SPAN_STATUS_ERROR,
+  startSpan,
+  startSpanManual,
+} from '@sentry/core';
 import type * as genericPool from './generic-pool-types';
 
 const MODULE_NAME = 'generic-pool';
@@ -102,9 +108,15 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
 
   private _acquirePatcher(original: AcquireFn) {
     return function wrapped_acquire(this: genericPool.Pool<unknown>, ...args: unknown[]) {
-      return startSpan({ name: 'generic-pool.acquire' }, () => {
-        return original.call(this, ...args) as PromiseLike<unknown>;
-      });
+      return startSpan(
+        {
+          name: 'generic-pool.acquire',
+          attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.otel.generic_pool' },
+        },
+        () => {
+          return original.call(this, ...args) as PromiseLike<unknown>;
+        },
+      );
     };
   }
 
@@ -130,24 +142,30 @@ export class GenericPoolInstrumentation extends InstrumentationBase {
         return original.call(this, cb, priority);
       }
 
-      return startSpanManual({ name: 'generic-pool.acquire' }, span => {
-        original.call(
-          this,
-          (err: unknown, client: unknown) => {
-            if (err) {
-              span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-            }
-            span.end();
-            // Not checking whether cb is a function because
-            // the original code doesn't do that either.
-            // The callback's return value is unused by generic-pool, so we don't return it.
-            if (cb) {
-              cb(err, client);
-            }
-          },
-          priority,
-        );
-      });
+      return startSpanManual(
+        {
+          name: 'generic-pool.acquire',
+          attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.otel.generic_pool' },
+        },
+        span => {
+          original.call(
+            this,
+            (err: unknown, client: unknown) => {
+              if (err) {
+                span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+              }
+              span.end();
+              // Not checking whether cb is a function because
+              // the original code doesn't do that either.
+              // The callback's return value is unused by generic-pool, so we don't return it.
+              if (cb) {
+                cb(err, client);
+              }
+            },
+            priority,
+          );
+        },
+      );
     };
   }
 }


### PR DESCRIPTION
Now that we have vendored the generic-pool instrumentation we can set these attributes directly in the instrumentation instead of registering a `client.startSpan` hook.