### PR TITLE
ref(ci): Dedupe matrix test failures in CI failure reporter

### DIFF
--- a/scripts/report-ci-failures.mjs
+++ b/scripts/report-ci-failures.mjs
@@ -17,6 +17,31 @@
 
 import { readFileSync } from 'node:fs';
 
+/**
+ * Collapse matrix variants of a job name so the same test failing across the matrix dedupes to a
+ * single issue instead of one per node/TS version. We strip only version-like parenthetical groups
+ * — a bare number (e.g. node version) or a `TS x.y` bracket — leaving other parentheticals (e.g.
+ * `(nextjs-app, 20)`) intact:
+ *
+ *   "Node (22) Integration Tests"          -> "Node Integration Tests"
+ *   "Node (24) Integration Tests"          -> "Node Integration Tests"
+ *   "Node (24) (TS 3.8) Integration Tests" -> "Node Integration Tests"
+ */
+function normalizeJobName(name) {
+  return name
+    .replace(/\(\s*(?:\d+|TS\s+[\d.]+)\s*\)/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function applyVars(text, vars) {
+  let result = text;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replace(new RegExp(`\\{\\{\\s*env\\.${key}\\s*\\}\\}`, 'g'), value);
+  }
+  return result;
+}
+
 export default async function run({ github, context, core }) {
   const { owner, repo } = context.repo;
 
@@ -38,6 +63,12 @@ export default async function run({ github, context, core }) {
   // Read and parse template
   const template = readFileSync('.github/FLAKY_CI_FAILURE_TEMPLATE.md', 'utf8');
   const [, frontmatter, bodyTemplate] = template.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  const titleTemplate = frontmatter.match(/title:\s*'(.*)'/)[1];
+
+  // Titles we've already created or matched in this run, so the same flaky test failing on
+  // multiple matrix jobs within a single run doesn't open duplicate issues (the `existing` list
+  // below is fetched once and won't include issues created earlier in this same run).
+  const handledTitles = new Set();
 
   // Get existing open issues with Tests label
   const existing = await github.paginate(github.rest.issues.listForRepo, {
@@ -50,6 +81,7 @@ export default async function run({ github, context, core }) {
 
   for (const job of failedJobs) {
     const jobName = job.name;
+    const normalizedJobName = normalizeJobName(jobName);
     const jobUrl = job.html_url;
 
     // Fetch annotations from the check run to extract failed test names
@@ -76,24 +108,20 @@ export default async function run({ github, context, core }) {
 
     // Create one issue per failing test for proper deduplication
     for (const testName of testNames) {
-      const vars = {
-        JOB_NAME: jobName,
-        RUN_LINK: jobUrl,
-        TEST_NAME: testName,
-      };
+      // The title is keyed on the *normalized* job name so the same test failing across matrix
+      // variants (different node / TS versions) dedupes to a single issue.
+      const title = applyVars(titleTemplate, { JOB_NAME: normalizedJobName, TEST_NAME: testName });
+      // The body keeps the concrete job name + run link of the variant that actually failed.
+      const issueBody = applyVars(bodyTemplate, { JOB_NAME: jobName, RUN_LINK: jobUrl, TEST_NAME: testName });
 
-      let title = frontmatter.match(/title:\s*'(.*)'/)[1];
-      let issueBody = bodyTemplate;
-      for (const [key, value] of Object.entries(vars)) {
-        const pattern = new RegExp(`\\{\\{\\s*env\\.${key}\\s*\\}\\}`, 'g');
-        title = title.replace(pattern, value);
-        issueBody = issueBody.replace(pattern, value);
+      if (handledTitles.has(title)) {
+        continue;
       }
+      handledTitles.add(title);
 
       const existingIssue = existing.find(i => i.title === title);
-
       if (existingIssue) {
-        core.info(`Issue already exists for "${testName}" in ${jobName}: #${existingIssue.number}`);
+        core.info(`Issue already exists for "${testName}" in ${normalizedJobName}: #${existingIssue.number}`);
         continue;
       }
 
@@ -104,7 +132,7 @@ export default async function run({ github, context, core }) {
         body: issueBody.trim(),
         labels: ['Tests', 'Bug', 'Flaky Test'],
       });
-      core.info(`Created issue #${newIssue.data.number} for "${testName}" in ${jobName}`);
+      core.info(`Created issue #${newIssue.data.number} for "${testName}" in ${normalizedJobName}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

A flaky test usually fails on several matrix jobs in the same run (e.g. `Node (22) Integration Tests`, `Node (24) Integration Tests`, `Node (24) (TS 3.8) Integration Tests`). Because the issue title embedded the full job name, each matrix variant opened its **own** issue for what is really the same flaky test.

`report-ci-failures.mjs` now keys the issue title on a **normalized** job name with only **version-like** matrix parentheticals stripped — a bare number (node version) or a `TS x.y` bracket:

| Job name | Normalized |
| --- | --- |
| `Node (22) Integration Tests` | `Node Integration Tests` |
| `Node (24) Integration Tests` | `Node Integration Tests` |
| `Node (24) (TS 3.8) Integration Tests` | `Node Integration Tests` |

Other parentheticals are left intact, so genuinely-distinct jobs don't get merged — e.g. `E2E (nextjs-app, 20)` stays as-is.

Also dedupes titles **within a single run** — the existing-issues list is fetched once up front and wouldn't include an issue created moments earlier in the same run, so without this the second matrix job would still open a duplicate.

The issue **body** keeps the concrete job name and run link of the variant that actually failed, so the link still points at a real failing run.