### PR TITLE
test(node): Make amqplib integration test order-independent

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/amqplib/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/amqplib/test.ts
@@ -31,21 +31,33 @@ describe('amqplib auto-instrumentation', () => {
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createTestRunner, test) => {
     test('should be able to send and receive messages', { timeout: 60_000 }, async () => {
+      // The producer ('root span') and consumer ('queue1 process') transactions can
+      // arrive in any order, so we collect them and assert after both are received.
+      const receivedTransactions: TransactionEvent[] = [];
+
       await createTestRunner()
         .withDockerCompose({
           workingDirectory: [__dirname],
         })
         .expect({
           transaction: (transaction: TransactionEvent) => {
-            expect(transaction.transaction).toEqual('root span');
-            expect(transaction.spans?.length).toEqual(1);
-            expect(transaction.spans![0]).toMatchObject(EXPECTED_MESSAGE_SPAN_PRODUCER);
+            receivedTransactions.push(transaction);
           },
         })
         .expect({
           transaction: (transaction: TransactionEvent) => {
-            expect(transaction.transaction).toEqual('queue1 process');
-            expect(transaction.contexts?.trace).toMatchObject(EXPECTED_MESSAGE_SPAN_CONSUMER);
+            receivedTransactions.push(transaction);
+
+            const producer = receivedTransactions.find(t => t.transaction === 'root span');
+            const consumer = receivedTransactions.find(t => t.transaction === 'queue1 process');
+
+            expect(producer).toBeDefined();
+            expect(consumer).toBeDefined();
+
+            expect(producer!.spans?.length).toEqual(1);
+            expect(producer!.spans![0]).toMatchObject(EXPECTED_MESSAGE_SPAN_PRODUCER);
+
+            expect(consumer!.contexts?.trace).toMatchObject(EXPECTED_MESSAGE_SPAN_CONSUMER);
           },
         })
         .start()


### PR DESCRIPTION
## Summary

Applies the same fix as #21534 (amqplib **v1**) to the non-versioned `amqplib auto-instrumentation` test (`suites/tracing/amqplib/test.ts`), which has the identical flaky pattern.

## Root cause

The test asserted the producer (`root span`) and consumer (`queue1 process`) transactions in a fixed order using two sequential `.expect()` callbacks. The runner matches expected envelopes strictly FIFO, but the producer and consumer are independent traces flushed independently, so their arrival order at the test server isn't guaranteed. When the consumer envelope arrived first, the first assertion (`expect(transaction.transaction).toEqual('root span')`) failed against the consumer transaction.

## Fix

Use the established collect-then-assert pattern (same as #21534 and the `kafkajs` test): push both transactions into an array, then look them up by transaction name and assert once both have arrived. All original assertions (producer name + span count + PRODUCER span shape, consumer CONSUMER trace context) are preserved — only the order dependency is removed.