### PR TITLE
feat(hono): Extend peer dependency range

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -18,7 +18,7 @@
     "@sentry/deno": "latest || *",
     "@sentry/hono": "latest || *",
     "@sentry/node": "latest || *",
-    "@hono/node-server": "^1.19.10",
+    "@hono/node-server": "^2.0.5",
     "hono": "^4.12.14"
   },
   "devDependencies": {

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.x",
-    "@hono/node-server": "^1.x",
+    "@hono/node-server": "^1.x || ^2.x",
     "@sentry/bun": "10.58.0",
     "@sentry/cloudflare": "10.58.0",
     "@sentry/deno": "10.58.0",


### PR DESCRIPTION
- Extend optional peer deps to 2.x
- Move the e2e test to `@hono/node-server@2`, v1 is covered in integration tests