### PR TITLE
ref(build): Switch TypeScript moduleResolution to `bundler`

### DIFF
--- a/dev-packages/node-core-integration-tests/scripts/use-ts-3_8.js
+++ b/dev-packages/node-core-integration-tests/scripts/use-ts-3_8.js
@@ -36,4 +36,9 @@ const tsConfig = require(baseTscConfigPath);
 // TS 3.8 fails build when it encounters a config option it does not understand, so we remove it :(
 delete tsConfig.compilerOptions.noUncheckedIndexedAccess;
 
+// TS 3.8 doesn't support "bundler" moduleResolution (introduced in TS 5.0)
+if (tsConfig.compilerOptions.moduleResolution === 'bundler') {
+  tsConfig.compilerOptions.moduleResolution = 'node';
+}
+
 writeFileSync(baseTscConfigPath, JSON.stringify(tsConfig, null, 2));

--- a/dev-packages/node-integration-tests/scripts/use-ts-3_8.js
+++ b/dev-packages/node-integration-tests/scripts/use-ts-3_8.js
@@ -36,4 +36,9 @@ const tsConfig = require(baseTscConfigPath);
 // TS 3.8 fails build when it encounters a config option it does not understand, so we remove it :(
 delete tsConfig.compilerOptions.noUncheckedIndexedAccess;
 
+// TS 3.8 doesn't support "bundler" moduleResolution (introduced in TS 5.0)
+if (tsConfig.compilerOptions.moduleResolution === 'bundler') {
+  tsConfig.compilerOptions.moduleResolution = 'node';
+}
+
 writeFileSync(baseTscConfigPath, JSON.stringify(tsConfig, null, 2));

--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,8 @@
       "{workspaceRoot}/*.js",
       "{workspaceRoot}/*.json",
       "{workspaceRoot}/yarn.lock",
-      "{workspaceRoot}/dev-packages/rollup-utils/**"
+      "{workspaceRoot}/dev-packages/rollup-utils/**",
+      "{workspaceRoot}/packages/typescript/**"
     ],
     "production": ["default", "!{projectRoot}/test/**/*", "!{projectRoot}/**/*.md", "!{projectRoot}/*.tgz"]
   },

--- a/packages/angular/tsconfig.ngc.json
+++ b/packages/angular/tsconfig.ngc.json
@@ -2,12 +2,34 @@
 // This tsconfig is used when building @sentry/angular with the Angular
 // compiler and `ng-packagr`. It configures a production build conforming
 // to the Angular Package Format (APF).
+//
+// Does NOT extend the shared base tsconfig because ng-packagr ships its own
+// older TypeScript that doesn't support "moduleResolution": "bundler".
 {
-  "extends": "./tsconfig.json",
+  "include": ["**/*.ts", "src/**/*"],
+  "exclude": ["patch-vitest.ts", "setup-test.ts"],
   "compilerOptions": {
-    "target": "es2020",
+    "declaration": false,
     "declarationMap": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "inlineSources": true,
+    "isolatedModules": true,
     "lib": ["DOM", "es2020"],
+    "moduleResolution": "node",
+    "noErrorTruncation": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noUncheckedIndexedAccess": true,
+    "preserveWatchOutput": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "strictBindCallApply": false,
+    "target": "es2020",
     "baseUrl": "./"
   },
   "angularCompilerOptions": {

--- a/packages/astro/tsconfig.json
+++ b/packages/astro/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "moduleResolution": "bundler"
     // package-specific options
   }
 }

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*", "test/loader.js"],
 
   "compilerOptions": {
-    "moduleResolution": "bundler",
     "lib": ["DOM", "es2020", "WebWorker"]
   }
 }

--- a/packages/cloudflare/tsconfig.json
+++ b/packages/cloudflare/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "module": "esnext",
     "types": ["node", "@cloudflare/workers-types"]
   }
 }

--- a/packages/core/tsconfig.types.json
+++ b/packages/core/tsconfig.types.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
 
   "compilerOptions": {
-    "module": "esnext",
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,

--- a/packages/core/tsconfig.types.json
+++ b/packages/core/tsconfig.types.json
@@ -3,7 +3,6 @@
 
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,

--- a/packages/deno/tsconfig.json
+++ b/packages/deno/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["./lib.deno.d.ts", "src/**/*", "example.ts"],
   "compilerOptions": {
     "lib": ["esnext"],
-    "module": "esnext",
     "target": "esnext"
   }
 }

--- a/packages/deno/tsconfig.test.json
+++ b/packages/deno/tsconfig.test.json
@@ -3,7 +3,6 @@
   "include": ["./lib.deno.d.ts", "test/**/*"],
   "compilerOptions": {
     "lib": ["esnext"],
-    "module": "esnext",
     "target": "esnext"
   }
 }

--- a/packages/effect/tsconfig.json
+++ b/packages/effect/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "bundler",
     "outDir": "build"
   },
   "include": ["src/**/*"]

--- a/packages/effect/tsconfig.json
+++ b/packages/effect/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
     "outDir": "build"
   },
   "include": ["src/**/*"]

--- a/packages/ember/tsconfig.json
+++ b/packages/ember/tsconfig.json
@@ -4,7 +4,6 @@
     "target": "es2022",
     "lib": ["DOM", "ES2022"],
     "allowJs": true,
-    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "alwaysStrict": true,
     "strictNullChecks": true,

--- a/packages/ember/tsconfig.json
+++ b/packages/ember/tsconfig.json
@@ -11,7 +11,6 @@
     "noEmitOnError": false,
     "noEmit": true,
     "baseUrl": ".",
-    "module": "esnext",
     "experimentalDecorators": true,
     "paths": {
       "dummy/tests/*": ["tests/*"],

--- a/packages/feedback/tsconfig.json
+++ b/packages/feedback/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
-
     /* Preact Config */
     "jsx": "react-jsx",
     "jsxImportSource": "preact",

--- a/packages/hono/tsconfig.json
+++ b/packages/hono/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "module": "esnext",
     "types": ["node", "@cloudflare/workers-types"]
   }
 }

--- a/packages/integration-shims/tsconfig.json
+++ b/packages/integration-shims/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "moduleResolution": "bundler"
     // package-specific options
   }
 }

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     // package-specific options
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "esnext"
   }
 }

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -5,6 +5,5 @@
 
   "compilerOptions": {
     // package-specific options
-    "module": "esnext"
   }
 }

--- a/packages/nextjs/tsconfig.test.json
+++ b/packages/nextjs/tsconfig.test.json
@@ -8,8 +8,7 @@
     "types": ["node"],
 
     // require for top-level await
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "esnext",
     "target": "es2020",
 
     // other package-specific, test-specific options

--- a/packages/nextjs/tsconfig.test.json
+++ b/packages/nextjs/tsconfig.test.json
@@ -7,8 +7,6 @@
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
     "types": ["node"],
 
-    // require for top-level await
-    "module": "esnext",
     "target": "es2020",
 
     // other package-specific, test-specific options

--- a/packages/nitro/tsconfig.json
+++ b/packages/nitro/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     // package-specific options
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "esnext"
   }
 }

--- a/packages/nitro/tsconfig.json
+++ b/packages/nitro/tsconfig.json
@@ -5,6 +5,5 @@
 
   "compilerOptions": {
     // package-specific options
-    "module": "esnext"
   }
 }

--- a/packages/node-core/tsconfig.json
+++ b/packages/node-core/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "lib": ["ES2020", "ES2021.WeakRef"],
-    "module": "esnext"
+    "lib": ["ES2020", "ES2021.WeakRef"]
   }
 }

--- a/packages/node-core/tsconfig.json
+++ b/packages/node-core/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     "lib": ["ES2020", "ES2021.WeakRef"],
-    "module": "Node16",
-    "moduleResolution": "Node16"
+    "module": "esnext"
   }
 }

--- a/packages/node-native/tsconfig.json
+++ b/packages/node-native/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "esnext",
-    "lib": ["es2020"],
     "outDir": "build",
     "types": ["node"]
   },

--- a/packages/node-native/tsconfig.json
+++ b/packages/node-native/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
     "outDir": "build",
     "types": ["node"]
   },

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -3,7 +3,5 @@
 
   "include": ["src/**/*"],
 
-  "compilerOptions": {
-    "module": "esnext"
-  }
+  "compilerOptions": {}
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -4,8 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "lib": ["es2020"],
-    "module": "Node16",
-    "moduleResolution": "Node16"
+    "module": "esnext"
   }
 }

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     // package-specific options
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "esnext"
   }
 }

--- a/packages/nuxt/tsconfig.json
+++ b/packages/nuxt/tsconfig.json
@@ -5,6 +5,5 @@
 
   "compilerOptions": {
     // package-specific options
-    "module": "esnext"
   }
 }

--- a/packages/profiling-node/tsconfig.json
+++ b/packages/profiling-node/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "module": "esnext",
-    "lib": ["es2020"],
     "outDir": "build",
     "types": ["node"]
   },

--- a/packages/profiling-node/tsconfig.json
+++ b/packages/profiling-node/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
     "outDir": "build",
     "types": ["node"]
   },

--- a/packages/react-router/test/server/wrapServerAction.test.ts
+++ b/packages/react-router/test/server/wrapServerAction.test.ts
@@ -120,7 +120,6 @@ describe('wrapServerAction', () => {
   it('should skip span creation and warn when instrumentation API is used', async () => {
     // Reset modules to get a fresh copy with unset warning flag
     vi.resetModules();
-    // @ts-expect-error - Dynamic import for module reset works at runtime but vitest's typecheck doesn't fully support it
     const { wrapServerAction: freshWrapServerAction } = await import('../../src/server/wrapServerAction');
 
     // Set the global flag indicating instrumentation API is in use

--- a/packages/react-router/test/server/wrapServerLoader.test.ts
+++ b/packages/react-router/test/server/wrapServerLoader.test.ts
@@ -120,7 +120,6 @@ describe('wrapServerLoader', () => {
   it('should skip span creation and warn when instrumentation API is used', async () => {
     // Reset modules to get a fresh copy with unset warning flag
     vi.resetModules();
-    // @ts-expect-error - Dynamic import for module reset works at runtime but vitest's typecheck doesn't fully support it
     const { wrapServerLoader: freshWrapServerLoader } = await import('../../src/server/wrapServerLoader');
 
     // Set the global flag indicating instrumentation API is in use

--- a/packages/react-router/tsconfig.json
+++ b/packages/react-router/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "moduleResolution": "bundler",
     "jsx": "react"
   }
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -6,7 +6,6 @@
   "compilerOptions": {
     "lib": ["DOM", "es2020"],
     "module": "esnext",
-    "moduleResolution": "bundler",
     // package-specific options
     "esModuleInterop": true,
     "jsx": "react"

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     "lib": ["DOM", "es2020"],
-    "module": "esnext",
     // package-specific options
     "esModuleInterop": true,
     "jsx": "react"

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "jsx": "react",
-    "module": "esnext"
+    "jsx": "react"
   }
 }

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     "jsx": "react",
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "esnext"
   }
 }

--- a/packages/remix/tsconfig.test.json
+++ b/packages/remix/tsconfig.test.json
@@ -6,8 +6,6 @@
   "compilerOptions": {
     "lib": ["DOM", "es2020"],
     "types": ["node"],
-    // Required for top-level await in tests
-    "module": "esnext",
     "target": "es2020",
 
     "esModuleInterop": true

--- a/packages/remix/tsconfig.test.json
+++ b/packages/remix/tsconfig.test.json
@@ -7,8 +7,7 @@
     "lib": ["DOM", "es2020"],
     "types": ["node"],
     // Required for top-level await in tests
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "esnext",
     "target": "es2020",
 
     "esModuleInterop": true

--- a/packages/replay-canvas/tsconfig.json
+++ b/packages/replay-canvas/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "es2020"],
-    "module": "esnext"
+    "lib": ["DOM", "es2020"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/replay-internal/tsconfig.json
+++ b/packages/replay-internal/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "es2020"],
-    "module": "esnext"
+    "lib": ["DOM", "es2020"]
   },
   "include": ["src/**/*.ts"]
 }

--- a/packages/replay-worker/tsconfig.json
+++ b/packages/replay-worker/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
     "lib": ["webworker", "scripthost"],
     "esModuleInterop": true,
     "target": "es2020",

--- a/packages/server-utils/tsconfig.json
+++ b/packages/server-utils/tsconfig.json
@@ -3,7 +3,5 @@
 
   "include": ["src/**/*"],
 
-  "compilerOptions": {
-    "lib": ["ES2020"]
-  }
+  "compilerOptions": {}
 }

--- a/packages/solidstart/tsconfig.json
+++ b/packages/solidstart/tsconfig.json
@@ -3,7 +3,5 @@
 
   "include": ["src/**/*"],
 
-  "compilerOptions": {
-    "module": "esnext"
-  }
+  "compilerOptions": {}
 }

--- a/packages/solidstart/tsconfig.json
+++ b/packages/solidstart/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "esnext"
   }
 }

--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -1,6 +1,5 @@
-import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 import { componentTrackingPreprocessor, defaultComponentTrackingOptions } from './preprocessors';
-import type { SentryPreprocessorGroup, SentrySvelteConfigOptions, SvelteConfig } from './types';
+import type { PreprocessorGroup, SentryPreprocessorGroup, SentrySvelteConfigOptions, SvelteConfig } from './types';
 
 const defaultSentryOptions: SentrySvelteConfigOptions = {
   componentTracking: defaultComponentTrackingOptions,

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -1,6 +1,10 @@
 import MagicString from 'magic-string';
-import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
-import type { ComponentTrackingInitOptions, SentryPreprocessorGroup, TrackComponentOptions } from './types';
+import type {
+  ComponentTrackingInitOptions,
+  PreprocessorGroup,
+  SentryPreprocessorGroup,
+  TrackComponentOptions,
+} from './types';
 
 export const defaultComponentTrackingOptions: Required<ComponentTrackingInitOptions> = {
   trackComponents: true,

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,5 +1,4 @@
-import type { CompileOptions } from 'svelte/types/compiler';
-import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
+import type { CompileOptions } from 'svelte/compiler';
 
 // Adds an id property to the preprocessor object we can use to check for duplication
 // in the preprocessors array
@@ -70,3 +69,32 @@ export type TrackComponentOptions = {
    */
   componentName?: string;
 } & SpanOptions;
+
+// vendor those types from svelte/types/compiler/preprocess
+export interface Processed {
+  code: string;
+  map?: string | object;
+  dependencies?: string[];
+  toString?: () => string;
+}
+export declare type MarkupPreprocessor = (options: {
+  content: string;
+  filename?: string;
+}) => Processed | void | Promise<Processed | void>;
+export declare type Preprocessor = (options: {
+  /**
+   * The script/style tag content
+   */
+  content: string;
+  attributes: Record<string, string | boolean>;
+  /**
+   * The whole Svelte file content
+   */
+  markup: string;
+  filename?: string;
+}) => Processed | void | Promise<Processed | void>;
+export interface PreprocessorGroup {
+  markup?: MarkupPreprocessor;
+  style?: Preprocessor;
+  script?: Preprocessor;
+}

--- a/packages/sveltekit/tsconfig.json
+++ b/packages/sveltekit/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "module": "esnext"
     // package-specific options
   }
 }

--- a/packages/sveltekit/tsconfig.json
+++ b/packages/sveltekit/tsconfig.json
@@ -4,8 +4,7 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "esnext"
     // package-specific options
   }
 }

--- a/packages/tanstackstart-react/tsconfig.json
+++ b/packages/tanstackstart-react/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "bundler"
+    "module": "esnext"
   }
 }

--- a/packages/tanstackstart-react/tsconfig.json
+++ b/packages/tanstackstart-react/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
-  "compilerOptions": {
-    "module": "esnext"
-  }
+  "compilerOptions": {}
 }

--- a/packages/tanstackstart/tsconfig.json
+++ b/packages/tanstackstart/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
   "compilerOptions": {
-    "lib": ["es2020"],
-    "module": "Node16",
-    "moduleResolution": "Node16"
+    "module": "esnext"
   }
 }

--- a/packages/tanstackstart/tsconfig.json
+++ b/packages/tanstackstart/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
-  "compilerOptions": {
-    "module": "esnext"
-  }
+  "compilerOptions": {}
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -3,7 +3,5 @@
 
   "include": ["src/**/*"],
 
-  "compilerOptions": {
-    "lib": ["es2020"]
-  }
+  "compilerOptions": {}
 }

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -7,7 +7,7 @@
     "inlineSources": true,
     "isolatedModules": true,
     "lib": ["es2020"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "noErrorTruncation": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -7,6 +7,7 @@
     "inlineSources": true,
     "isolatedModules": true,
     "lib": ["es2020"],
+    "module": "esnext",
     "moduleResolution": "bundler",
     "noErrorTruncation": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     "module": "esnext",
-    "moduleResolution": "bundler",
     "lib": ["DOM", "es2020"]
   }
 }

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -4,7 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    "module": "esnext",
     "lib": ["DOM", "es2020"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,16 @@
     "declaration": false,
     "declarationMap": false,
     "skipLibCheck": true
+  },
+
+  // `*.ts` helper scripts are run with ts-node, which executes them as CommonJS. The base config's
+  // `module: esnext` / `moduleResolution: bundler` is an ESM-only combo that makes ts-node hand the
+  // `.ts` file to Node's native ESM loader (which can't load `.ts`). ts-node merges this `ts-node`
+  // key across the `extends` chain, so this single override covers every package that extends this config.
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs",
+      "moduleResolution": "node"
+    }
   }
 }


### PR DESCRIPTION
A couple of notable changes:

- Changes our module resolution strategy from `node` which is deprecated in next releases to `bundler` which better reflects our own setup.
- Changes our module baseline to `esnext` which was already being used all over.

Some changes were required for `svelte` SDK because it imported non-exportable types, I opted to vendor them instead. Also one minor exception is introduced for TypeScript 3.8 because it does not support `bundler` module resolution strategy.

replaces #21520