### PR TITLE
ref(protocol): Strictly type profile chunk platform item header

### DIFF
--- a/packages/core/src/types/envelope.ts
+++ b/packages/core/src/types/envelope.ts
@@ -89,7 +89,7 @@ type ReplayEventItemHeaders = { type: 'replay_event' };
 type ReplayRecordingItemHeaders = { type: 'replay_recording'; length: number };
 type CheckInItemHeaders = { type: 'check_in' };
 type ProfileItemHeaders = { type: 'profile' };
-type ProfileChunkItemHeaders = { type: 'profile_chunk' };
+type ProfileChunkItemHeaders = { type: 'profile_chunk'; platform: ProfileChunk['platform'] };
 type SpanItemHeaders = { type: 'span' };
 type SpanContainerItemHeaders = {
   /**


### PR DESCRIPTION
Header was already added, just adds the typing as we do consider it required (even if it's currently treated as optional in Relay).