### PR TITLE
ref(aws-serverless): Remove unused parts of vendored aws-sdk instrumentation

### DIFF
--- a/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
@@ -22,13 +22,11 @@
 /* eslint-disable */
 
 import { Span, SpanKind, context, trace, diag, SpanStatusCode } from '@opentelemetry/api';
-import { suppressTracing } from '@opentelemetry/core';
 import { AttributeNames } from './enums';
 import { ServicesExtensions } from './services';
 import {
   AwsSdkInstrumentationConfig,
   AwsSdkRequestHookInformation,
-  AwsSdkResponseHookInformation,
   NormalizedRequest,
   NormalizedResponse,
 } from './types';
@@ -39,8 +37,6 @@ import {
   InstrumentationNodeModuleFile,
   isWrapped,
   safeExecuteInTheMiddle,
-  SemconvStability,
-  semconvStabilityFromStr,
 } from '@opentelemetry/instrumentation';
 import type {
   MiddlewareStack,
@@ -58,7 +54,6 @@ import {
 import { propwrap } from './propwrap';
 import { RequestMetadata } from './services/ServiceExtension';
 import { ATTR_HTTP_STATUS_CODE } from './semconv';
-import { ATTR_HTTP_RESPONSE_STATUS_CODE } from '@opentelemetry/semantic-conventions';
 import { SDK_VERSION, timestampInSeconds } from '@sentry/core';
 
 const PACKAGE_NAME = '@sentry/instrumentation-aws-sdk';
@@ -70,16 +65,11 @@ type V3PluginCommand = AwsV3Command<any, any, any, any, any> & {
 
 export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentationConfig> {
   static readonly component = 'aws-sdk';
-  // need declare since initialized in callbacks from super constructor
-  declare private servicesExtensions: ServicesExtensions;
-
-  private _httpSemconvStability: SemconvStability;
-  private _dbSemconvStability: SemconvStability;
+  private servicesExtensions: ServicesExtensions;
 
   constructor(config: AwsSdkInstrumentationConfig = {}) {
     super(PACKAGE_NAME, SDK_VERSION, config);
-    this._httpSemconvStability = semconvStabilityFromStr('http', process.env.OTEL_SEMCONV_STABILITY_OPT_IN);
-    this._dbSemconvStability = semconvStabilityFromStr('database', process.env.OTEL_SEMCONV_STABILITY_OPT_IN);
+    this.servicesExtensions = new ServicesExtensions();
   }
 
   protected init(): InstrumentationModuleDefinition[] {
@@ -205,38 +195,6 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
     }
   }
 
-  private _callUserResponseHook(span: Span, response: NormalizedResponse) {
-    const { responseHook } = this.getConfig();
-    if (!responseHook) return;
-
-    const responseInfo: AwsSdkResponseHookInformation = {
-      response,
-    };
-    safeExecuteInTheMiddle(
-      () => responseHook(span, responseInfo),
-      (e: Error | undefined) => {
-        if (e) diag.error(`${AwsInstrumentation.component} instrumentation: responseHook error`, e);
-      },
-      true,
-    );
-  }
-
-  private _callUserExceptionResponseHook(span: Span, request: NormalizedRequest, err: any) {
-    const { exceptionHook } = this.getConfig();
-    if (!exceptionHook) return;
-    const requestInfo: AwsSdkRequestHookInformation = {
-      request,
-    };
-
-    safeExecuteInTheMiddle(
-      () => exceptionHook(span, requestInfo, err),
-      (e: Error | undefined) => {
-        if (e) diag.error(`${AwsInstrumentation.component} instrumentation: exceptionHook error`, e);
-      },
-      true,
-    );
-  }
-
   private _getV3ConstructStackPatch(
     moduleVersion: string | undefined,
     original: (...args: unknown[]) => MiddlewareStack<any, any>,
@@ -324,7 +282,6 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
           normalizedRequest,
           self.getConfig(),
           self._diag,
-          self._dbSemconvStability,
         );
         const startTime = timestampInSeconds();
         const span = self._startAwsV3Span(normalizedRequest, requestMetadata);
@@ -348,7 +305,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
               self._callUserPreRequestHook(span, normalizedRequest, moduleVersion);
               const resultPromise = context.with(activeContextWithSpan, () => {
                 self.servicesExtensions.requestPostSpanHook(normalizedRequest);
-                return self._callOriginalFunction(() => origHandler.call(this, command));
+                return origHandler.call(this, command);
               });
               const promiseWithResponseLogic = resultPromise
                 .then((response: any) => {
@@ -359,12 +316,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
                   const httpStatusCode = response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
-                    if (self._httpSemconvStability & SemconvStability.OLD) {
-                      span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
-                    }
-                    if (self._httpSemconvStability & SemconvStability.STABLE) {
-                      span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
-                    }
+                    span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId = response.output?.$metadata?.extendedRequestId;
@@ -388,7 +340,6 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
                     response.output = override;
                     normalizedResponse.data = override;
                   }
-                  self._callUserResponseHook(span, normalizedResponse);
                   return response;
                 })
                 .catch((err: any) => {
@@ -399,12 +350,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
                   const httpStatusCode = err?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
-                    if (self._httpSemconvStability & SemconvStability.OLD) {
-                      span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
-                    }
-                    if (self._httpSemconvStability & SemconvStability.STABLE) {
-                      span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, httpStatusCode);
-                    }
+                    span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId = err?.extendedRequestId;
@@ -417,7 +363,6 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
                     message: err.message,
                   });
                   span.recordException(err);
-                  self._callUserExceptionResponseHook(span, normalizedRequest, err);
                   throw err;
                 })
                 .finally(() => {
@@ -437,20 +382,5 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
       };
       return patchedHandler;
     };
-  }
-
-  private _callOriginalFunction<T>(originalFunction: (...args: any[]) => T): T {
-    if (this.getConfig().suppressInternalInstrumentation) {
-      return context.with(suppressTracing(context.active()), originalFunction);
-    } else {
-      return originalFunction();
-    }
-  }
-
-  override _updateMetricInstruments() {
-    if (!this.servicesExtensions) {
-      this.servicesExtensions = new ServicesExtensions();
-    }
-    this.servicesExtensions.updateMetricInstruments(this.meter);
   }
 }

--- a/packages/aws-serverless/src/integration/aws/vendored/services/MessageAttributes.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/MessageAttributes.ts
@@ -69,23 +69,13 @@ export const injectPropagationContext = (
   return attributes;
 };
 
-export const extractPropagationContext = (
-  message: SQS.Message,
-  sqsExtractContextPropagationFromPayload: boolean | undefined,
-): AwsSdkContextObject | undefined => {
+export const extractPropagationContext = (message: SQS.Message): AwsSdkContextObject | undefined => {
   const propagationFields = propagation.fields();
   const hasPropagationFields = Object.keys(message.MessageAttributes || []).some(attr =>
     propagationFields.includes(attr),
   );
   if (hasPropagationFields) {
     return message.MessageAttributes;
-  } else if (sqsExtractContextPropagationFromPayload && message.Body) {
-    try {
-      const payload = JSON.parse(message.Body);
-      return payload.MessageAttributes;
-    } catch {
-      diag.debug('failed to parse SQS payload to extract context propagation, trace might be incomplete.');
-    }
   }
   return undefined;
 };

--- a/packages/aws-serverless/src/integration/aws/vendored/services/ServiceExtension.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/ServiceExtension.ts
@@ -19,8 +19,7 @@
  */
 /* eslint-disable */
 
-import { DiagLogger, Meter, Span, SpanAttributes, SpanKind, Tracer } from '@opentelemetry/api';
-import { SemconvStability } from '@opentelemetry/instrumentation';
+import { DiagLogger, Span, SpanAttributes, SpanKind, Tracer } from '@opentelemetry/api';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
 
 export interface RequestMetadata {
@@ -41,7 +40,6 @@ export interface ServiceExtension {
     request: NormalizedRequest,
     config: AwsSdkInstrumentationConfig,
     diag: DiagLogger,
-    dbSemconvStability?: SemconvStability,
   ) => RequestMetadata;
 
   // called before request is sent, and after span is started
@@ -55,6 +53,4 @@ export interface ServiceExtension {
     config: AwsSdkInstrumentationConfig,
     startTime: number,
   ) => any | undefined;
-
-  updateMetricInstruments?: (meter: Meter) => void;
 }

--- a/packages/aws-serverless/src/integration/aws/vendored/services/ServicesExtensions.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/ServicesExtensions.ts
@@ -19,8 +19,7 @@
  */
 /* eslint-disable */
 
-import { Tracer, Span, DiagLogger, Meter } from '@opentelemetry/api';
-import { SemconvStability } from '@opentelemetry/instrumentation';
+import { Tracer, Span, DiagLogger } from '@opentelemetry/api';
 import { ServiceExtension, RequestMetadata } from './ServiceExtension';
 import { SqsServiceExtension } from './sqs';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
@@ -56,14 +55,13 @@ export class ServicesExtensions implements ServiceExtension {
     request: NormalizedRequest,
     config: AwsSdkInstrumentationConfig,
     diag: DiagLogger,
-    dbSemconvStability?: SemconvStability,
   ): RequestMetadata {
     const serviceExtension = this.services.get(request.serviceName);
     if (!serviceExtension)
       return {
         isIncoming: false,
       };
-    return serviceExtension.requestPreSpanHook(request, config, diag, dbSemconvStability);
+    return serviceExtension.requestPreSpanHook(request, config, diag);
   }
 
   requestPostSpanHook(request: NormalizedRequest) {
@@ -82,11 +80,5 @@ export class ServicesExtensions implements ServiceExtension {
     const serviceExtension = this.services.get(response.request.serviceName);
 
     return serviceExtension?.responseHook?.(response, span, tracer, config, startTime);
-  }
-
-  updateMetricInstruments(meter: Meter) {
-    for (const serviceExtension of this.services.values()) {
-      serviceExtension.updateMetricInstruments?.(meter);
-    }
   }
 }

--- a/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
@@ -19,7 +19,7 @@
  */
 /* eslint-disable */
 
-import { Attributes, DiagLogger, diag, Histogram, Meter, Span, Tracer, ValueType } from '@opentelemetry/api';
+import { Attributes, DiagLogger, diag, Span, Tracer } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import {
   ATTR_GEN_AI_SYSTEM,
@@ -29,19 +29,13 @@ import {
   ATTR_GEN_AI_REQUEST_TEMPERATURE,
   ATTR_GEN_AI_REQUEST_TOP_P,
   ATTR_GEN_AI_REQUEST_STOP_SEQUENCES,
-  ATTR_GEN_AI_TOKEN_TYPE,
   ATTR_GEN_AI_USAGE_INPUT_TOKENS,
   ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
   ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
   GEN_AI_OPERATION_NAME_VALUE_CHAT,
   GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
-  GEN_AI_TOKEN_TYPE_VALUE_INPUT,
-  GEN_AI_TOKEN_TYPE_VALUE_OUTPUT,
-  METRIC_GEN_AI_CLIENT_OPERATION_DURATION,
-  METRIC_GEN_AI_CLIENT_TOKEN_USAGE,
 } from '../semconv';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
-import { timestampInSeconds } from '@sentry/core';
 
 // Simplified types inlined from @aws-sdk/client-bedrock-runtime
 // Only the fields accessed by this instrumentation are included
@@ -58,34 +52,7 @@ interface ConverseStreamOutput {
 }
 
 export class BedrockRuntimeServiceExtension implements ServiceExtension {
-  private tokenUsage!: Histogram;
-  private operationDuration!: Histogram;
   private _diag: DiagLogger = diag;
-
-  updateMetricInstruments(meter: Meter) {
-    // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclienttokenusage
-    this.tokenUsage = meter.createHistogram(METRIC_GEN_AI_CLIENT_TOKEN_USAGE, {
-      unit: '{token}',
-      description: 'Measures number of input and output tokens used',
-      valueType: ValueType.INT,
-      advice: {
-        explicitBucketBoundaries: [
-          1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864,
-        ],
-      },
-    });
-
-    // https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/#metric-gen_aiclientoperationduration
-    this.operationDuration = meter.createHistogram(METRIC_GEN_AI_CLIENT_OPERATION_DURATION, {
-      unit: 's',
-      description: 'GenAI operation duration',
-      advice: {
-        explicitBucketBoundaries: [
-          0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92,
-        ],
-      },
-    });
-  }
 
   requestPreSpanHook(
     request: NormalizedRequest,
@@ -367,32 +334,13 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   }
 
   private setUsage(response: NormalizedResponse, span: Span, usage: TokenUsage | undefined, startTime: number) {
-    const sharedMetricAttrs: Attributes = {
-      [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
-      [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
-      [ATTR_GEN_AI_REQUEST_MODEL]: response.request.commandInput.modelId,
-    };
-
-    const durationSecs = timestampInSeconds() - startTime;
-    this.operationDuration.record(durationSecs, sharedMetricAttrs);
-
     if (usage) {
       const { inputTokens, outputTokens } = usage;
       if (inputTokens !== undefined) {
         span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, inputTokens);
-
-        this.tokenUsage.record(inputTokens, {
-          ...sharedMetricAttrs,
-          [ATTR_GEN_AI_TOKEN_TYPE]: GEN_AI_TOKEN_TYPE_VALUE_INPUT,
-        });
       }
       if (outputTokens !== undefined) {
         span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
-
-        this.tokenUsage.record(outputTokens, {
-          ...sharedMetricAttrs,
-          [ATTR_GEN_AI_TOKEN_TYPE]: GEN_AI_TOKEN_TYPE_VALUE_OUTPUT,
-        });
       }
     }
   }

--- a/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
@@ -20,13 +20,6 @@
 /* eslint-disable */
 
 import { Attributes, DiagLogger, Span, SpanKind, Tracer } from '@opentelemetry/api';
-import { SemconvStability } from '@opentelemetry/instrumentation';
-import {
-  ATTR_DB_NAMESPACE,
-  ATTR_DB_OPERATION_NAME,
-  ATTR_DB_QUERY_TEXT,
-  ATTR_DB_SYSTEM_NAME,
-} from '@opentelemetry/semantic-conventions';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import {
   ATTR_AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS,
@@ -52,9 +45,7 @@ import {
   ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS,
   ATTR_DB_NAME,
   ATTR_DB_OPERATION,
-  ATTR_DB_STATEMENT,
   ATTR_DB_SYSTEM,
-  DB_SYSTEM_NAME_VALUE_DYNAMODB,
   DB_SYSTEM_VALUE_DYNAMODB,
 } from '../semconv';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
@@ -68,7 +59,6 @@ export class DynamodbServiceExtension implements ServiceExtension {
     normalizedRequest: NormalizedRequest,
     config: AwsSdkInstrumentationConfig,
     diag: DiagLogger,
-    dbSemconvStability?: SemconvStability,
   ): RequestMetadata {
     const spanKind: SpanKind = SpanKind.CLIENT;
     let spanName: string | undefined;
@@ -78,33 +68,9 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     const spanAttributes: Attributes = {};
 
-    if (dbSemconvStability === undefined || dbSemconvStability & SemconvStability.OLD) {
-      spanAttributes[ATTR_DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
-      spanAttributes[ATTR_DB_NAME] = tableName;
-      spanAttributes[ATTR_DB_OPERATION] = operation;
-    }
-    if (dbSemconvStability !== undefined && dbSemconvStability & SemconvStability.STABLE) {
-      spanAttributes[ATTR_DB_SYSTEM_NAME] = DB_SYSTEM_NAME_VALUE_DYNAMODB;
-      spanAttributes[ATTR_DB_NAMESPACE] = tableName;
-      spanAttributes[ATTR_DB_OPERATION_NAME] = operation;
-    }
-
-    if (config.dynamoDBStatementSerializer) {
-      try {
-        const sanitizedStatement = config.dynamoDBStatementSerializer(operation, normalizedRequest.commandInput);
-
-        if (typeof sanitizedStatement === 'string') {
-          if (dbSemconvStability === undefined || dbSemconvStability & SemconvStability.OLD) {
-            spanAttributes[ATTR_DB_STATEMENT] = sanitizedStatement;
-          }
-          if (dbSemconvStability !== undefined && dbSemconvStability & SemconvStability.STABLE) {
-            spanAttributes[ATTR_DB_QUERY_TEXT] = sanitizedStatement;
-          }
-        }
-      } catch (err) {
-        diag.error('failed to sanitize DynamoDB statement', err);
-      }
-    }
+    spanAttributes[ATTR_DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
+    spanAttributes[ATTR_DB_NAME] = tableName;
+    spanAttributes[ATTR_DB_OPERATION] = operation;
 
     // normalizedRequest.commandInput.RequestItems) is undefined when no table names are returned
     // keys in this object are the table names

--- a/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
@@ -125,7 +125,7 @@ export class SqsServiceExtension implements ServiceExtension {
         for (const message of messages) {
           const propagatedContext = propagation.extract(
             ROOT_CONTEXT,
-            extractPropagationContext(message, false),
+            extractPropagationContext(message),
             contextGetter,
           );
 

--- a/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
@@ -125,7 +125,7 @@ export class SqsServiceExtension implements ServiceExtension {
         for (const message of messages) {
           const propagatedContext = propagation.extract(
             ROOT_CONTEXT,
-            extractPropagationContext(message, config.sqsExtractContextPropagationFromPayload),
+            extractPropagationContext(message, false),
             contextGetter,
           );
 

--- a/packages/aws-serverless/src/integration/aws/vendored/types.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/types.ts
@@ -49,64 +49,7 @@ export interface AwsSdkRequestCustomAttributeFunction {
   (span: Span, requestInfo: AwsSdkRequestHookInformation): void;
 }
 
-export interface AwsSdkResponseHookInformation {
-  moduleVersion?: string;
-  response: NormalizedResponse;
-}
-
-/**
- * span can be used to add custom attributes, or for any other need.
- * response is the object that is returned to the user calling the aws-sdk operation.
- * The response type and attributes on the response are client-specific.
- */
-export interface AwsSdkResponseCustomAttributeFunction {
-  (span: Span, responseInfo: AwsSdkResponseHookInformation): void;
-}
-
-/**
- * span can be used to modify the status.
- * As we have no response object, the request can be used to determine the failed aws-sdk operation.
- */
-export interface AwsSdkExceptionCustomAttributeFunction {
-  (span: Span, requestInfo: AwsSdkRequestHookInformation, err: any): void;
-}
-
-export type AwsSdkDynamoDBStatementSerializer = (operation: string, commandInput: CommandInput) => string | undefined;
-
 export interface AwsSdkInstrumentationConfig extends InstrumentationConfig {
   /** hook for adding custom attributes before request is sent to aws */
   preRequestHook?: AwsSdkRequestCustomAttributeFunction;
-
-  /** hook for adding custom attributes when response is received from aws */
-  responseHook?: AwsSdkResponseCustomAttributeFunction;
-
-  /**
-   * Hook for adding custom attributes when exception is received from aws.
-   * This hook is only available with aws sdk v3
-   */
-  exceptionHook?: AwsSdkExceptionCustomAttributeFunction;
-
-  /** custom serializer function for the db.statement attribute in DynamoDB spans */
-  dynamoDBStatementSerializer?: AwsSdkDynamoDBStatementSerializer;
-
-  /**
-   * Most aws operation use http request under the hood.
-   * if http instrumentation is enabled, each aws operation will also create
-   * an http/s child describing the communication with amazon servers.
-   * Setting the `suppressInternalInstrumentation` config value to `true` will
-   * cause the instrumentation to suppress instrumentation of underlying operations,
-   * effectively causing those http spans to be non-recordable.
-   */
-  suppressInternalInstrumentation?: boolean;
-
-  /**
-   * In some cases the context propagation headers may be found in the message payload
-   * rather than the message attribute.
-   * When this field is turned on the instrumentation will parse the payload and extract the
-   * context from there.
-   * Even if the field is on and MessageAttribute contains context propagation field are present,
-   * the MessageAttribute will get priority.
-   * By default it is off.
-   */
-  sqsExtractContextPropagationFromPayload?: boolean;
 }


### PR DESCRIPTION
First step of streamlining the vendored `@opentelemetry/instrumentation-aws-sdk` (#20944). Removes code paths the Sentry SDK never exercises — `awsIntegration` only ever sets `preRequestHook`. **No change to emitted spans**, verified by the existing dual-version (`@smithy/core` + `@smithy/middleware-stack`, ESM + CJS) integration tests and the 72 `@sentry/aws-serverless` unit tests.

## Removed

- **Unused config options + code paths:** `responseHook`, `exceptionHook`, `suppressInternalInstrumentation`, `dynamoDBStatementSerializer`, `sqsExtractContextPropagationFromPayload` (plus the now-dead hook-info types). The public `awsIntegration` never exposed these.
- **OTel metrics:** `_updateMetricInstruments`, the per-service `updateMetricInstruments` hook, and the Bedrock token-usage / operation-duration histograms — Sentry does not consume OTel metrics from this instrumentation.
- **Semconv stability dual-emission:** the `OTEL_SEMCONV_STABILITY_OPT_IN`-driven OLD-vs-STABLE branching. The STABLE branch was off by default, so the default (OLD) attribute set is unchanged (`http.status_code`, `db.system`/`db.name`/`db.operation`).

`servicesExtensions` is now initialized in the constructor (it was previously a side effect of the removed `_updateMetricInstruments` override).

Net: **+13 / −238**.

## Follow-up

A second PR will do step 3 (remove `/* eslint-disable */`, pass the type-aware linter) + step 4 (replace the OTel tracer API with Sentry's `startInactiveSpan`), on this smaller surface.

Part of #20944