### PR TITLE
chore(deps): bump react-router-6 to 6.30.4

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -67,7 +67,7 @@
     "react-router-3": "npm:react-router@3.2.0",
     "react-router-4": "npm:react-router@4.1.0",
     "react-router-5": "npm:react-router@5.3.4",
-    "react-router-6": "npm:react-router@6.30.3",
+    "react-router-6": "npm:react-router@6.30.4",
     "redux": "^4.0.5"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7048,11 +7048,6 @@
     react-router-dom "6.30.4"
     turbo-stream "2.4.1"
 
-"@remix-run/router@1.23.2":
-  version "1.23.2"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
-  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
-
 "@remix-run/router@1.23.3", "@remix-run/router@^1.23.3":
   version "1.23.3"
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
@@ -25526,12 +25521,12 @@ react-refresh@^0.14.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-"react-router-6@npm:react-router@6.30.3":
-  version "6.30.3"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
-  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
+"react-router-6@npm:react-router@6.30.4":
+  version "6.30.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
+  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
   dependencies:
-    "@remix-run/router" "1.23.2"
+    "@remix-run/router" "1.23.3"
 
 react-router-dom@6.30.4:
   version "6.30.4"


### PR DESCRIPTION
## Summary

Bumps the `react-router-6` test alias in `packages/react` from `npm:react-router@6.30.3` to `npm:react-router@6.30.4` — a patch bump that stays within the v6 line used to test React Router 6 compatibility.

Resolves [Dependabot alert #1800](https://github.com/getsentry/sentry-javascript/security/dependabot/1800) — GHSA-2j2x-hqr9-3h42 / CVE-2026-40181 (medium, open redirect via protocol-relative URL reinterpretation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
