### PR TITLE
test(cloudflare): Add mTLS instrumentation test

### DIFF
--- a/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
@@ -216,6 +216,56 @@ describe('instrumentEnv', () => {
     expect(instrumentDurableObjectNamespace).toHaveBeenCalledWith(doNamespace);
   });
 
+  describe('mTLS Fetcher bindings', () => {
+    function createMtlsFetcherProxy(mockFetch: ReturnType<typeof vi.fn>) {
+      return new Proxy(
+        { fetch: mockFetch },
+        {
+          get(target, prop) {
+            if (prop in target) {
+              return Reflect.get(target, prop);
+            }
+            return () => {};
+          },
+        },
+      );
+    }
+
+    it('does not instrument mTLS Fetcher when enableRpcTracePropagation is disabled', () => {
+      const mockFetch = vi.fn();
+      const mtlsFetcher = createMtlsFetcherProxy(mockFetch);
+      const env = { MY_CERT: mtlsFetcher };
+      const instrumented = instrumentEnv(env);
+
+      expect(instrumented.MY_CERT).toBe(mtlsFetcher);
+    });
+
+    it('preserves existing headers and response on mTLS Fetcher fetch', async () => {
+      vi.spyOn(SentryCore, '_INTERNAL_getTracingHeadersForFetchRequest').mockReturnValue({
+        Authorization: 'Bearer client-cert-token',
+        'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
+        baggage: 'sentry-environment=production',
+      });
+
+      const mockFetch = vi.fn().mockResolvedValue(new Response('mtls-response'));
+      const mtlsFetcher = createMtlsFetcherProxy(mockFetch);
+      const env = { MY_CERT: mtlsFetcher };
+      const instrumented = instrumentEnv(env, { enableRpcTracePropagation: true });
+
+      const response = await instrumented.MY_CERT.fetch('https://example.com/api', {
+        headers: { Authorization: 'Bearer client-cert-token' },
+      });
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      const headers = new Headers(init?.headers);
+
+      expect(instrumented.MY_CERT).not.toBe(mtlsFetcher);
+      expect(headers.get('Authorization')).toBe('Bearer client-cert-token');
+      expect(headers.get('sentry-trace')).toBe('12345678901234567890123456789012-1234567890123456-1');
+      expect(await response.text()).toBe('mtls-response');
+    });
+  });
+
   describe('JSRPC RPC method instrumentation', () => {
     it('does not inject Sentry RPC meta by default (enableRpcTracePropagation not set)', () => {
       vi.spyOn(SentryCore, 'getTraceData').mockReturnValue({
@@ -238,7 +288,7 @@ describe('instrumentEnv', () => {
       const env = { SERVICE: jsrpcProxy };
       const instrumented = instrumentEnv(env);
 
-      (instrumented.SERVICE as any).myRpcMethod('arg1', 42);
+      instrumented.SERVICE.myRpcMethod('arg1', 42);
 
       // Without enableRpcTracePropagation, no metadata should be injected
       expect(rpcMethod).toHaveBeenCalledWith('arg1', 42);
@@ -265,7 +315,7 @@ describe('instrumentEnv', () => {
       const env = { SERVICE: jsrpcProxy };
       const instrumented = instrumentEnv(env, { enableRpcTracePropagation: true });
 
-      (instrumented.SERVICE as any).myRpcMethod('arg1', 42);
+      instrumented.SERVICE.myRpcMethod('arg1', 42);
 
       expect(rpcMethod).toHaveBeenCalledWith('arg1', 42, {
         __sentry_rpc_meta__: {
@@ -296,7 +346,7 @@ describe('instrumentEnv', () => {
       const env = { SERVICE: jsrpcProxy };
       const instrumented = instrumentEnv(env, { enableRpcTracePropagation: true });
 
-      (instrumented.SERVICE as any).fetch('https://example.com');
+      instrumented.SERVICE.fetch('https://example.com');
 
       // fetch should use HTTP header injection, not trailing arg
       const callArgs = mockFetch.mock.calls[0];
@@ -321,7 +371,7 @@ describe('instrumentEnv', () => {
       const env = { SERVICE: jsrpcProxy };
       const instrumented = instrumentEnv(env, { enableRpcTracePropagation: true });
 
-      (instrumented.SERVICE as any).myRpcMethod('arg1');
+      instrumented.SERVICE.myRpcMethod('arg1');
 
       expect(rpcMethod).toHaveBeenCalledWith('arg1');
     });


### PR DESCRIPTION
closes #20870
closes [JS-2465](https://linear.app/getsentry/issue/JS-2465)

This adds only a unit test for mTLS. mTLS is basically just a Fetcher, but cannot be used locally with miniflare, that is why only a mocked unit test exists.

I also removed some unnecessary `any` assertions