### PR TITLE
test(cloudflare): Increasing timeout and exit with reason

### DIFF
--- a/dev-packages/cloudflare-integration-tests/runner.ts
+++ b/dev-packages/cloudflare-integration-tests/runner.ts
@@ -158,7 +158,14 @@ export function createRunner(...paths: string[]) {
 
       let envelopeCount = 0;
       const envelopeWaiters: { expected: Expected; resolve: () => void; reject: (e: unknown) => void }[] = [];
-      const { resolve: setWorkerPort, promise: workerPortPromise } = deferredPromise<number>();
+      const {
+        resolve: setWorkerPort,
+        reject: rejectWorkerPort,
+        promise: workerPortPromise,
+      } = deferredPromise<number>();
+      workerPortPromise.catch(() => {
+        // handled in `makeRequest`
+      });
       let child: ReturnType<typeof spawn> | undefined;
       let childSubWorker: ReturnType<typeof spawn> | undefined;
 
@@ -277,6 +284,10 @@ export function createRunner(...paths: string[]) {
                   resolve(parseInt(new URL(match[1]).port, 10));
                 }
               });
+
+              childProcess.on('close', (code, sig) => {
+                reject(new Error(`wrangler exited with code ${code} (signal ${sig}) before becoming ready`));
+              });
             });
           }
 
@@ -340,7 +351,10 @@ export function createRunner(...paths: string[]) {
 
           setWorkerPort(workerPort);
         })
-        .catch(e => reject(e));
+        .catch(e => {
+          rejectWorkerPort(e);
+          reject(e);
+        });
 
       return {
         completed: async function (): Promise<void> {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/test.ts
@@ -6,8 +6,7 @@ import { createRunner } from '../../../runner';
 // must appear as children of the DO transaction. The first invocation always worked;
 // the second invocation on the same DO instance previously lost its child spans
 // because the client was disposed after the first call.
-// TODO: unskip - this test is flaky, timing out in CI
-it.skip('sends child spans on repeated Durable Object calls', async ({ signal }) => {
+it('sends child spans on repeated Durable Object calls', async ({ signal }) => {
   function assertDoWorkEnvelope(envelope: unknown): void {
     const transactionEvent = (envelope as any)[1]?.[0]?.[1];
 

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/test.ts
@@ -69,8 +69,7 @@ it('handles consecutive RPC calls without throwing "RPC receiver does not implem
 // the Proxy must ensure `this` refers to the original object (not the Proxy),
 // otherwise private field access throws: "Cannot read private member from an object
 // whose class did not declare it"
-// TODO: unskip - this test is flaky, timing out in CI (#21201)
-it.skip('allows RPC methods to access private class fields', async ({ signal }) => {
+it('allows RPC methods to access private class fields', async ({ signal }) => {
   const runner = createRunner(__dirname)
     .expect(envelope => {
       const transactionEvent = envelope[1]?.[0]?.[1] as Event;

--- a/dev-packages/cloudflare-integration-tests/vite.config.mts
+++ b/dev-packages/cloudflare-integration-tests/vite.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
     },
     isolate: false,
     include: ['./suites/**/test.ts'],
-    testTimeout: 20_000,
+    testTimeout: 30_000,
     // Ensure we can see debug output when DEBUG=true
     ...(process.env.DEBUG
       ? {


### PR DESCRIPTION
Hope to have a better reasoning on #21544 and re-enabling two skipped tests.

With that PR there are two things happening

1. the timeout increases as I couldn't think of anything else other than the worker is not fast enough to spin up. 
2. When something crashes for some reason it fails fast rather than waiting for the timeout to be over, including a better error description with the code and the signal. Maybe then the reasoning is better of what is actually happening (in case it fails before)