### PR TITLE
fix(nextjs): Register safe random ID context at module load

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/app/capture-metadata/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/app/capture-metadata/page.tsx
@@ -1,0 +1,15 @@
+import { captureException } from '@sentry/nextjs';
+import type { Metadata } from 'next';
+
+/**
+ * Calling captureException synchronously inside generateMetadata
+ * during `next build` prerender (cacheComponents). uuid4 -> crypto.randomUUID() runs
+ */
+export const generateMetadata = (): Metadata => {
+  captureException(new Error('diagnostic: data missing for this page'));
+  return { title: 'capture-metadata' };
+};
+
+export default function Page() {
+  return <h1>capture-metadata</h1>;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/tests/cacheComponents.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/tests/cacheComponents.spec.ts
@@ -80,3 +80,10 @@ test('Should generate metadata async', async ({ page }) => {
   await expect(page.locator('#todos-fetched')).toHaveText('Todos fetched: 5');
   await expect(page).toHaveTitle('Product: 1');
 });
+
+test('Should prerender a page that captures an exception in generateMetadata', async ({ page }) => {
+  await page.goto('/capture-metadata');
+
+  await expect(page).toHaveTitle('capture-metadata');
+  await expect(page.locator('h1')).toHaveText('capture-metadata');
+});

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -42,6 +42,9 @@ const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   _sentryRelease?: string;
 };
 
+// Call at module level so `next build` prerender workers still register the runner without `init`
+prepareSafeIdGeneratorContext();
+
 /**
  * A passthrough error boundary for the server that doesn't depend on any react. Error boundaries don't catch SSR errors
  * so they should simply be a passthrough.


### PR DESCRIPTION
`captureException()` (and any `uuid4()` call) inside a prerendered route fails `next build` with `cacheComponents: true`

Build workers still import the SDK (for `captureException` etc.), so the runner gets registered with a clean snapshot captured at module load — outside any prerender scope. The `init()` call is kept so the runtime path re-captures a fresh snapshot at `register()` time.

closes #21510