### PR TITLE
feat(node): Add Vercel AI v7 tracing-channel support

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/instrument-with-pii.mjs
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  dataCollection: { genAI: { inputs: true, outputs: true } },
+  transport: loggingTransport,
+  integrations: [Sentry.vercelAIIntegration()],
+  streamGenAiSpans: true,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/instrument.mjs
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  integrations: [Sentry.vercelAIIntegration()],
+  streamGenAiSpans: true,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/scenario-error-in-tool.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/scenario-error-in-tool.mjs
@@ -1,0 +1,87 @@
+import * as Sentry from '@sentry/node';
+import { tracingChannel } from 'node:diagnostics_channel';
+
+// Mirrors the AI SDK v7 publisher from vercel/ai#15660 without depending on an unpublished npm build.
+const channel = tracingChannel('ai:telemetry');
+
+const usage = (inputTokens, outputTokens) => ({
+  inputTokens,
+  outputTokens,
+  totalTokens: inputTokens + outputTokens,
+});
+
+async function trace(type, event, execute) {
+  return channel.tracePromise(execute, { type, event });
+}
+
+async function run() {
+  await Promise.resolve();
+
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    await trace(
+      'generateText',
+      {
+        functionId: 'weather_agent',
+        provider: 'mock-provider',
+        modelId: 'mock-model-id',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'What is the weather in San Francisco?' }] }],
+      },
+      async () => {
+        await trace('step', { stepNumber: 0 }, async () => {
+          await trace(
+            'languageModelCall',
+            {
+              provider: 'mock-provider',
+              modelId: 'mock-model-id',
+              messages: [{ role: 'user', content: [{ type: 'text', text: 'What is the weather in San Francisco?' }] }],
+            },
+            async () => ({
+              finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+              usage: usage(8, 13),
+              content: [
+                {
+                  type: 'tool-call',
+                  toolCallType: 'function',
+                  toolCallId: 'call-1',
+                  toolName: 'getWeather',
+                  input: { location: 'San Francisco' },
+                },
+              ],
+              response: { id: 'response-error', modelId: 'mock-model-id' },
+            }),
+          );
+
+          await trace(
+            'executeTool',
+            {
+              toolCall: {
+                toolCallId: 'call-1',
+                toolName: 'getWeather',
+                input: { location: 'San Francisco' },
+              },
+            },
+            async () => ({
+              output: {
+                type: 'tool-error',
+                toolCallId: 'call-1',
+                toolName: 'getWeather',
+                input: { location: 'San Francisco' },
+                error: new Error('Error in tool'),
+              },
+            }),
+          );
+
+          return { finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: usage(8, 13) };
+        });
+
+        return {
+          finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+          totalUsage: usage(8, 13),
+          responseModel: 'mock-model-id',
+        };
+      },
+    );
+  });
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/scenario.mjs
@@ -1,0 +1,173 @@
+import * as Sentry from '@sentry/node';
+import { tracingChannel } from 'node:diagnostics_channel';
+
+// Mirrors the AI SDK v7 publisher from vercel/ai#15660 without depending on an unpublished npm build.
+const channel = tracingChannel('ai:telemetry');
+
+const tools = {
+  getWeather: {
+    description: 'Get the current weather for a location',
+  },
+};
+
+const usage = (inputTokens, outputTokens) => ({
+  inputTokens,
+  outputTokens,
+  totalTokens: inputTokens + outputTokens,
+});
+
+async function trace(type, event, execute) {
+  return channel.tracePromise(execute, { type, event });
+}
+
+async function languageModelCall({ inputTokens, outputTokens, finishReason, content }) {
+  return trace(
+    'languageModelCall',
+    {
+      provider: 'mock-provider',
+      modelId: 'mock-model-id',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'What is the weather in San Francisco?' }] }],
+      tools,
+    },
+    async () => ({
+      finishReason,
+      usage: usage(inputTokens, outputTokens),
+      content,
+      response: { id: `response-${inputTokens}`, modelId: 'mock-model-id' },
+    }),
+  );
+}
+
+async function runWeatherAgent() {
+  await trace(
+    'generateText',
+    {
+      functionId: 'weather_agent',
+      provider: 'mock-provider',
+      modelId: 'mock-model-id',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'What is the weather in San Francisco?' }] }],
+      tools,
+    },
+    async () => {
+      await trace('step', { stepNumber: 0 }, async () => {
+        await languageModelCall({
+          inputTokens: 10,
+          outputTokens: 20,
+          finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+          content: [
+            {
+              type: 'tool-call',
+              toolCallType: 'function',
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              input: { location: 'San Francisco' },
+            },
+          ],
+        });
+
+        await trace(
+          'executeTool',
+          {
+            toolCall: {
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              input: { location: 'San Francisco' },
+            },
+          },
+          async () => ({
+            output: {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'getWeather',
+              input: { location: 'San Francisco' },
+              output: 'Weather in San Francisco: Sunny, 72°F',
+            },
+          }),
+        );
+
+        return { finishReason: { unified: 'tool-calls', raw: 'tool_calls' }, usage: usage(10, 20) };
+      });
+
+      await trace('step', { stepNumber: 1 }, async () => {
+        await languageModelCall({
+          inputTokens: 15,
+          outputTokens: 25,
+          finishReason: { unified: 'stop', raw: 'stop' },
+          content: [{ type: 'text', text: 'The weather in San Francisco is sunny.' }],
+        });
+
+        return { finishReason: { unified: 'stop', raw: 'stop' }, usage: usage(15, 25) };
+      });
+
+      return {
+        finishReason: { unified: 'stop', raw: 'stop' },
+        totalUsage: usage(25, 45),
+        content: [{ type: 'text', text: 'The weather in San Francisco is sunny.' }],
+        responseModel: 'mock-model-id',
+      };
+    },
+  );
+}
+
+async function runStreamAgent() {
+  await trace(
+    'streamText',
+    {
+      functionId: 'stream_agent',
+      provider: 'mock-provider',
+      modelId: 'mock-model-id',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Stream a greeting' }] }],
+    },
+    async () => {
+      await trace('step', { stepNumber: 0 }, async () => {
+        await languageModelCall({
+          inputTokens: 3,
+          outputTokens: 4,
+          finishReason: { unified: 'stop', raw: 'stop' },
+          content: [{ type: 'text', text: 'Hello' }],
+        });
+
+        return { finishReason: { unified: 'stop', raw: 'stop' }, usage: usage(3, 4) };
+      });
+
+      return {
+        finishReason: { unified: 'stop', raw: 'stop' },
+        totalUsage: usage(3, 4),
+        content: [{ type: 'text', text: 'Hello' }],
+        responseModel: 'mock-model-id',
+      };
+    },
+  );
+}
+
+async function run() {
+  await Promise.resolve();
+
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    await runWeatherAgent();
+    await runStreamAgent();
+
+    await trace(
+      'embed',
+      {
+        provider: 'mock-provider',
+        modelId: 'mock-model-id',
+        value: 'embed this text',
+        recordInputs: true,
+      },
+      async () => ({ usage: { inputTokens: 7 } }),
+    );
+
+    await trace(
+      'rerank',
+      {
+        functionId: 'reranker',
+        provider: 'mock-provider',
+        modelId: 'mock-model-id',
+      },
+      async () => ({ ranking: [{ index: 1, relevanceScore: 0.9 }] }),
+    );
+  });
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v7/test.ts
@@ -1,0 +1,206 @@
+import { afterAll, describe, expect } from 'vitest';
+import {
+  GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE,
+  GEN_AI_FUNCTION_ID_ATTRIBUTE,
+  GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
+  GEN_AI_OPERATION_NAME_ATTRIBUTE,
+  GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE,
+  GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE,
+  GEN_AI_TOOL_CALL_ID_ATTRIBUTE,
+  GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE,
+  GEN_AI_TOOL_INPUT_ATTRIBUTE,
+  GEN_AI_TOOL_NAME_ATTRIBUTE,
+  GEN_AI_TOOL_OUTPUT_ATTRIBUTE,
+  GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
+} from '../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../../utils/runner';
+
+describe('Vercel AI integration (V7 tracing channel)', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('creates tracing-channel spans without recording inputs by default', async () => {
+      await createRunner()
+        .expect({ transaction: { transaction: 'main' } })
+        .expect({
+          span: container => {
+            expect(container.items).toHaveLength(11);
+
+            const weatherRoot = container.items.find(span => span.name === 'invoke_agent weather_agent');
+            expect(weatherRoot).toBeDefined();
+            expect(weatherRoot!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+            expect(weatherRoot!.attributes[GEN_AI_FUNCTION_ID_ATTRIBUTE].value).toBe('weather_agent');
+            expect(weatherRoot!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE]).toBeUndefined();
+            expect(weatherRoot!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(25);
+            expect(weatherRoot!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE].value).toBe(45);
+            expect(weatherRoot!.attributes[GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE].value).toBe(70);
+
+            const weatherSteps = container.items.filter(
+              span => span.name.startsWith('step ') && span.parent_span_id === weatherRoot!.span_id,
+            );
+            expect(weatherSteps).toHaveLength(2);
+
+            const firstStep = weatherSteps.find(span => span.name === 'step 0');
+            const secondStep = weatherSteps.find(span => span.name === 'step 1');
+            expect(firstStep).toBeDefined();
+            expect(secondStep).toBeDefined();
+
+            const firstModelCall = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.parent_span_id === firstStep!.span_id &&
+                span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value === 10,
+            );
+            expect(firstModelCall).toBeDefined();
+            expect(firstModelCall!.attributes['sentry.op'].value).toBe('gen_ai.generate_content');
+            expect(firstModelCall!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE]).toBeUndefined();
+
+            const toolSpan = container.items.find(
+              span => span.name === 'execute_tool getWeather' && span.parent_span_id === firstStep!.span_id,
+            );
+            expect(toolSpan).toBeDefined();
+            expect(toolSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+            expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+            expect(toolSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
+            expect(toolSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE]).toBeUndefined();
+
+            const secondModelCall = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.parent_span_id === secondStep!.span_id &&
+                span.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value === 15,
+            );
+            expect(secondModelCall).toBeDefined();
+
+            const streamRoot = container.items.find(span => span.name === 'invoke_agent stream_agent');
+            expect(streamRoot).toBeDefined();
+            expect(streamRoot!.attributes[GEN_AI_FUNCTION_ID_ATTRIBUTE].value).toBe('stream_agent');
+            expect(streamRoot!.attributes['gen_ai.response.streaming'].value).toBe(true);
+
+            const streamStep = container.items.find(
+              span => span.name === 'step 0' && span.parent_span_id === streamRoot!.span_id,
+            );
+            expect(streamStep).toBeDefined();
+
+            const streamModelCall = container.items.find(
+              span => span.name === 'generate_content mock-model-id' && span.parent_span_id === streamStep!.span_id,
+            );
+            expect(streamModelCall).toBeDefined();
+
+            const embeddingSpan = container.items.find(span => span.name === 'embeddings mock-model-id');
+            expect(embeddingSpan).toBeDefined();
+            expect(embeddingSpan!.attributes['sentry.op'].value).toBe('gen_ai.embeddings');
+            expect(embeddingSpan!.attributes[GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE].value).toBe('embed this text');
+            expect(embeddingSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE].value).toBe(7);
+
+            const rerankSpan = container.items.find(span => span.name === 'rerank mock-model-id');
+            expect(rerankSpan).toBeDefined();
+            expect(rerankSpan!.attributes['sentry.op'].value).toBe('gen_ai.rerank');
+            expect(rerankSpan!.attributes[GEN_AI_FUNCTION_ID_ATTRIBUTE].value).toBe('reranker');
+
+            expect(
+              container.items.some(span => span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value === 'disabled'),
+            ).toBe(false);
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
+    test('records inputs and outputs when genAI data collection is enabled', async () => {
+      await createRunner()
+        .expect({ transaction: { transaction: 'main' } })
+        .expect({
+          span: container => {
+            expect(container.items).toHaveLength(11);
+
+            const weatherRoot = container.items.find(span => span.name === 'invoke_agent weather_agent');
+            expect(weatherRoot).toBeDefined();
+            expect(weatherRoot!.attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE].value).toContain(
+              'What is the weather in San Francisco?',
+            );
+            expect(weatherRoot!.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE].value).toContain(
+              'The weather in San Francisco is sunny.',
+            );
+
+            const firstStep = container.items.find(
+              span => span.name === 'step 0' && span.parent_span_id === weatherRoot!.span_id,
+            );
+            expect(firstStep).toBeDefined();
+
+            const firstModelCall = container.items.find(
+              span => span.name === 'generate_content mock-model-id' && span.parent_span_id === firstStep!.span_id,
+            );
+            expect(firstModelCall).toBeDefined();
+            expect(firstModelCall!.attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE].value).toContain('getWeather');
+
+            const toolSpan = container.items.find(
+              span => span.name === 'execute_tool getWeather' && span.parent_span_id === firstStep!.span_id,
+            );
+            expect(toolSpan).toBeDefined();
+            expect(toolSpan!.attributes[GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE].value).toBe(
+              'Get the current weather for a location',
+            );
+            expect(toolSpan!.attributes[GEN_AI_TOOL_INPUT_ATTRIBUTE].value).toContain('San Francisco');
+            expect(toolSpan!.attributes[GEN_AI_TOOL_OUTPUT_ATTRIBUTE].value).toContain('Sunny');
+
+            const modelCallWithText = container.items.find(
+              span =>
+                span.name === 'generate_content mock-model-id' &&
+                span.attributes[GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE]?.value?.includes(
+                  'The weather in San Francisco is sunny.',
+                ),
+            );
+            expect(modelCallWithText).toBeDefined();
+            expect(modelCallWithText!.attributes[GEN_AI_OPERATION_NAME_ATTRIBUTE].value).toBe('generate_content');
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
+
+  createEsmAndCjsTests(__dirname, 'scenario-error-in-tool.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('captures tool errors from tracing-channel tool spans', async () => {
+      await createRunner()
+        .expect({ transaction: { transaction: 'main' } })
+        .expect({
+          span: container => {
+            expect(container.items).toHaveLength(4);
+
+            const toolSpan = container.items.find(span => span.name === 'execute_tool getWeather');
+            expect(toolSpan).toBeDefined();
+            expect(toolSpan!.status).toBe('error');
+            expect(toolSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+            expect(toolSpan!.attributes[GEN_AI_TOOL_NAME_ATTRIBUTE].value).toBe('getWeather');
+          },
+        })
+        .expect({
+          event: event => {
+            expect(event.exception?.values).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({
+                  type: 'Error',
+                  value: 'Error in tool',
+                }),
+              ]),
+            );
+            expect(event.tags).toEqual(
+              expect.objectContaining({
+                'vercel.ai.tool.name': 'getWeather',
+                'vercel.ai.tool.callId': 'call-1',
+              }),
+            );
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
+});

--- a/packages/core/src/server-exports.ts
+++ b/packages/core/src/server-exports.ts
@@ -23,6 +23,12 @@ export type {
   ExpressErrorMiddleware,
 } from './integrations/express/types';
 export { instrumentPostgresJsSql } from './integrations/postgresjs';
+export {
+  failVercelAiTracingChannelSpan as _INTERNAL_failVercelAiTracingChannelSpan,
+  finishVercelAiTracingChannelSpan as _INTERNAL_finishVercelAiTracingChannelSpan,
+  startVercelAiTracingChannelSpan as _INTERNAL_startVercelAiTracingChannelSpan,
+} from './tracing/vercel-ai/tracing-channel';
+export type { VercelAiTracingChannelMessage as _INTERNAL_VercelAiTracingChannelMessage } from './tracing/vercel-ai/tracing-channel';
 
 export { patchHttpModuleClient } from './integrations/http/client-patch';
 export { getHttpClientSubscriptions } from './integrations/http/client-subscriptions';

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -163,6 +163,12 @@ export * as metrics from './metrics/public-api';
 export type { MetricOptions } from './metrics/public-api';
 export { createConsolaReporter } from './integrations/consola';
 export { addVercelAiProcessors } from './tracing/vercel-ai';
+export {
+  failVercelAiTracingChannelSpan as _INTERNAL_failVercelAiTracingChannelSpan,
+  finishVercelAiTracingChannelSpan as _INTERNAL_finishVercelAiTracingChannelSpan,
+  startVercelAiTracingChannelSpan as _INTERNAL_startVercelAiTracingChannelSpan,
+} from './tracing/vercel-ai/tracing-channel';
+export type { VercelAiTracingChannelMessage as _INTERNAL_VercelAiTracingChannelMessage } from './tracing/vercel-ai/tracing-channel';
 export { _INTERNAL_getSpanContextForToolCallId, _INTERNAL_cleanupToolCallSpanContext } from './tracing/vercel-ai/utils';
 export { toolCallSpanContextMap as _INTERNAL_toolCallSpanContextMap } from './tracing/vercel-ai/constants';
 export { instrumentOpenAiClient } from './tracing/openai';

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -163,12 +163,6 @@ export * as metrics from './metrics/public-api';
 export type { MetricOptions } from './metrics/public-api';
 export { createConsolaReporter } from './integrations/consola';
 export { addVercelAiProcessors } from './tracing/vercel-ai';
-export {
-  failVercelAiTracingChannelSpan as _INTERNAL_failVercelAiTracingChannelSpan,
-  finishVercelAiTracingChannelSpan as _INTERNAL_finishVercelAiTracingChannelSpan,
-  startVercelAiTracingChannelSpan as _INTERNAL_startVercelAiTracingChannelSpan,
-} from './tracing/vercel-ai/tracing-channel';
-export type { VercelAiTracingChannelMessage as _INTERNAL_VercelAiTracingChannelMessage } from './tracing/vercel-ai/tracing-channel';
 export { _INTERNAL_getSpanContextForToolCallId, _INTERNAL_cleanupToolCallSpanContext } from './tracing/vercel-ai/utils';
 export { toolCallSpanContextMap as _INTERNAL_toolCallSpanContextMap } from './tracing/vercel-ai/constants';
 export { instrumentOpenAiClient } from './tracing/openai';

--- a/packages/core/src/tracing/ai/gen-ai-attributes.ts
+++ b/packages/core/src/tracing/ai/gen-ai-attributes.ts
@@ -170,6 +170,11 @@ export const GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE = 'gen_ai.response.tool_calls'
 export const GEN_AI_AGENT_NAME_ATTRIBUTE = 'gen_ai.agent.name';
 
 /**
+ * The Vercel AI function ID
+ */
+export const GEN_AI_FUNCTION_ID_ATTRIBUTE = 'gen_ai.function_id';
+
+/**
  * The pipeline name
  */
 export const GEN_AI_PIPELINE_NAME_ATTRIBUTE = 'gen_ai.pipeline.name';

--- a/packages/core/src/tracing/vercel-ai/index.ts
+++ b/packages/core/src/tracing/vercel-ai/index.ts
@@ -8,6 +8,7 @@ import type { Span, SpanAttributes, SpanAttributeValue, SpanJSON, StreamedSpanJS
 import { spanToJSON } from '../../utils/spanUtils';
 import {
   GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE,
+  GEN_AI_FUNCTION_ID_ATTRIBUTE,
   GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
   GEN_AI_OPERATION_NAME_ATTRIBUTE,
   GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE,
@@ -434,7 +435,7 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
 
   const functionId = attributes[AI_TELEMETRY_FUNCTION_ID_ATTRIBUTE];
   if (functionId && typeof functionId === 'string') {
-    span.setAttribute('gen_ai.function_id', functionId);
+    span.setAttribute(GEN_AI_FUNCTION_ID_ATTRIBUTE, functionId);
   }
 
   requestMessagesFromPrompt(span, attributes, enableTruncation);

--- a/packages/core/src/tracing/vercel-ai/tracing-channel.ts
+++ b/packages/core/src/tracing/vercel-ai/tracing-channel.ts
@@ -829,4 +829,8 @@ export function finishVercelAiTracingChannelSpan(span: Span, message: VercelAiTr
 export function failVercelAiTracingChannelSpan(span: Span, message: VercelAiTracingChannelMessage): void {
   const errorMessage = getErrorMessage(message.error) ?? 'AI SDK telemetry span failed';
   span.setStatus({ code: SPAN_STATUS_ERROR, message: errorMessage });
+
+  if (message.type === 'step') {
+    toolDescriptionMap.delete(spanToJSON(span).span_id);
+  }
 }

--- a/packages/core/src/tracing/vercel-ai/tracing-channel.ts
+++ b/packages/core/src/tracing/vercel-ai/tracing-channel.ts
@@ -1,0 +1,832 @@
+/* eslint-disable max-lines */
+
+import { getClient, withScope } from '../../currentScopes';
+import { captureException } from '../../exports';
+import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
+import { SPAN_STATUS_ERROR } from '../../tracing';
+import { startSpanManual } from '../../tracing/trace';
+import type { Span, SpanAttributeValue } from '../../types/span';
+import { spanToJSON } from '../../utils/spanUtils';
+import {
+  GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE,
+  GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE,
+  GEN_AI_EXECUTE_TOOL_OPERATION_ATTRIBUTE,
+  GEN_AI_FUNCTION_ID_ATTRIBUTE,
+  GEN_AI_GENERATE_CONTENT_OPERATION_ATTRIBUTE,
+  GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
+  GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE,
+  GEN_AI_INVOKE_AGENT_OPERATION_ATTRIBUTE,
+  GEN_AI_OPERATION_NAME_ATTRIBUTE,
+  GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE,
+  GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE,
+  GEN_AI_REQUEST_FREQUENCY_PENALTY_ATTRIBUTE,
+  GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE,
+  GEN_AI_REQUEST_MODEL_ATTRIBUTE,
+  GEN_AI_REQUEST_PRESENCE_PENALTY_ATTRIBUTE,
+  GEN_AI_REQUEST_STOP_SEQUENCES_ATTRIBUTE,
+  GEN_AI_REQUEST_STREAM_ATTRIBUTE,
+  GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE,
+  GEN_AI_REQUEST_TOP_K_ATTRIBUTE,
+  GEN_AI_REQUEST_TOP_P_ATTRIBUTE,
+  GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE,
+  GEN_AI_RESPONSE_ID_ATTRIBUTE,
+  GEN_AI_RESPONSE_MODEL_ATTRIBUTE,
+  GEN_AI_RESPONSE_STREAMING_ATTRIBUTE,
+  GEN_AI_RERANK_DO_RERANK_OPERATION_ATTRIBUTE,
+  GEN_AI_SYSTEM_ATTRIBUTE,
+  GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE,
+  GEN_AI_TOOL_CALL_ID_ATTRIBUTE,
+  GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE,
+  GEN_AI_TOOL_INPUT_ATTRIBUTE,
+  GEN_AI_TOOL_NAME_ATTRIBUTE,
+  GEN_AI_TOOL_OUTPUT_ATTRIBUTE,
+  GEN_AI_TOOL_TYPE_ATTRIBUTE,
+  GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE_ATTRIBUTE,
+  GEN_AI_USAGE_INPUT_TOKENS_CACHED_ATTRIBUTE,
+  GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
+} from '../ai/gen-ai-attributes';
+import { extractSystemInstructions, getJsonString, getTruncatedJsonString, shouldEnableTruncation } from '../ai/utils';
+import { toolDescriptionMap } from './constants';
+
+const ORIGIN = 'auto.vercelai.otel';
+
+export type VercelAiTracingChannelEventType =
+  | 'generateText'
+  | 'streamText'
+  | 'step'
+  | 'languageModelCall'
+  | 'executeTool'
+  | 'embed'
+  | 'rerank';
+
+/**
+ * Shape published by AI SDK v7 on `node:diagnostics_channel.tracingChannel('ai:telemetry')`.
+ * Keep this in sync with `packages/ai/src/telemetry/tracing-channel.ts` in vercel/ai.
+ */
+export interface VercelAiTracingChannelMessage {
+  type: VercelAiTracingChannelEventType;
+  event: unknown;
+  result?: unknown;
+  error?: unknown;
+}
+
+interface RecordingOptions {
+  recordInputs?: boolean;
+  recordOutputs?: boolean;
+}
+
+interface TokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  cachedInputTokens?: number;
+  cacheWriteInputTokens?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getEvent(message: VercelAiTracingChannelMessage): Record<string, unknown> {
+  return isRecord(message.event) ? message.event : {};
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function getBoolean(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function setAttributeIfDefined(
+  attributes: Record<string, SpanAttributeValue>,
+  key: string,
+  value: SpanAttributeValue | undefined,
+): void {
+  if (value !== undefined) {
+    attributes[key] = value;
+  }
+}
+
+function safeJsonStringify(value: unknown): string | undefined {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function safeGetJsonString(value: unknown, enableTruncation: boolean): string | undefined {
+  try {
+    return enableTruncation ? getTruncatedJsonString(value) : getJsonString(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function getVercelAiIntegrationOptions(): { enableTruncation?: boolean } & RecordingOptions {
+  const integration = getClient()?.getIntegrationByName('VercelAI') as
+    | { options?: { enableTruncation?: boolean } & RecordingOptions }
+    | undefined;
+  return integration?.options ?? {};
+}
+
+function resolveRecordingOption(
+  integrationOption: boolean | undefined,
+  eventOption: boolean | undefined,
+  globalOption: boolean | undefined,
+): boolean {
+  if (integrationOption === false || eventOption === false) {
+    return false;
+  }
+
+  return integrationOption ?? eventOption ?? Boolean(globalOption);
+}
+
+function getRecordingSettings(event: Record<string, unknown>): Required<RecordingOptions> {
+  const integrationOptions = getVercelAiIntegrationOptions();
+  const genAI = getClient()?.getDataCollectionOptions().genAI;
+
+  return {
+    recordInputs: resolveRecordingOption(
+      integrationOptions.recordInputs,
+      getBoolean(event.recordInputs),
+      genAI?.inputs,
+    ),
+    recordOutputs: resolveRecordingOption(
+      integrationOptions.recordOutputs,
+      getBoolean(event.recordOutputs),
+      genAI?.outputs,
+    ),
+  };
+}
+
+function getEnableTruncation(): boolean {
+  return shouldEnableTruncation(getVercelAiIntegrationOptions().enableTruncation);
+}
+
+function getFunctionId(event: Record<string, unknown>): string | undefined {
+  return getString(event.functionId);
+}
+
+function getModelId(event: Record<string, unknown>): string {
+  return getString(event.modelId) ?? 'unknown';
+}
+
+function getProvider(event: Record<string, unknown>): string | undefined {
+  return getString(event.provider);
+}
+
+function makeBaseAttributes(operationName: string): Record<string, SpanAttributeValue> {
+  return {
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: `gen_ai.${operationName}`,
+    [GEN_AI_OPERATION_NAME_ATTRIBUTE]: operationName,
+  };
+}
+
+function addFunctionId(attributes: Record<string, SpanAttributeValue>, event: Record<string, unknown>): void {
+  const functionId = getFunctionId(event);
+  if (functionId) {
+    attributes[GEN_AI_FUNCTION_ID_ATTRIBUTE] = functionId;
+  }
+}
+
+function addOperationId(attributes: Record<string, SpanAttributeValue>, event: Record<string, unknown>): void {
+  const operationId = getString(event.operationId);
+  if (operationId) {
+    attributes['vercel.ai.operationId'] = operationId;
+  }
+}
+
+function addRequestParameters(attributes: Record<string, SpanAttributeValue>, event: Record<string, unknown>): void {
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_TEMPERATURE_ATTRIBUTE, getNumber(event.temperature));
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_TOP_P_ATTRIBUTE, getNumber(event.topP));
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_TOP_K_ATTRIBUTE, getNumber(event.topK));
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_FREQUENCY_PENALTY_ATTRIBUTE, getNumber(event.frequencyPenalty));
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_PRESENCE_PENALTY_ATTRIBUTE, getNumber(event.presencePenalty));
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_MAX_TOKENS_ATTRIBUTE, getNumber(event.maxOutputTokens));
+
+  if (Array.isArray(event.stopSequences)) {
+    const stopSequences = safeJsonStringify(event.stopSequences);
+    setAttributeIfDefined(attributes, GEN_AI_REQUEST_STOP_SEQUENCES_ATTRIBUTE, stopSequences);
+  }
+}
+
+function instructionsToSystemInstructions(instructions: unknown): string | undefined {
+  if (instructions == null) {
+    return undefined;
+  }
+
+  const instructionArray = Array.isArray(instructions) ? instructions : [instructions];
+  const parts: Array<Record<string, unknown>> = [];
+
+  for (const instruction of instructionArray) {
+    if (typeof instruction === 'string') {
+      parts.push({ type: 'text', content: instruction });
+      continue;
+    }
+
+    if (!isRecord(instruction)) {
+      continue;
+    }
+
+    const content = instruction.content;
+    if (typeof content === 'string') {
+      parts.push({ type: 'text', content });
+    } else if (Array.isArray(content)) {
+      parts.push(...content.filter(isRecord));
+    }
+  }
+
+  return parts.length > 0 ? safeJsonStringify(parts) : undefined;
+}
+
+function addInputAttributes(attributes: Record<string, SpanAttributeValue>, event: Record<string, unknown>): void {
+  const enableTruncation = getEnableTruncation();
+  const systemInstructions = instructionsToSystemInstructions(event.instructions);
+  if (systemInstructions) {
+    attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE] = systemInstructions;
+  }
+
+  if (Array.isArray(event.messages)) {
+    const { systemInstructions: extractedSystemInstructions, filteredMessages } = extractSystemInstructions(
+      event.messages,
+    );
+    if (!attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE] && extractedSystemInstructions) {
+      attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE] = extractedSystemInstructions;
+    }
+
+    const messagesJson = safeGetJsonString(filteredMessages, enableTruncation);
+    if (messagesJson) {
+      attributes[GEN_AI_INPUT_MESSAGES_ATTRIBUTE] = messagesJson;
+      attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE] = Array.isArray(filteredMessages)
+        ? filteredMessages.length
+        : 1;
+    }
+  }
+}
+
+function getToolName(tool: Record<string, unknown>): string | undefined {
+  return getString(tool.name) ?? getString(tool.toolName);
+}
+
+function getToolDescription(tool: Record<string, unknown>): string | undefined {
+  return getString(tool.description);
+}
+
+function normalizeToolDefinition(tool: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(tool)) {
+    return undefined;
+  }
+
+  const name = getToolName(tool);
+  if (!name) {
+    return undefined;
+  }
+
+  return {
+    name,
+    ...(getToolDescription(tool) ? { description: getToolDescription(tool) } : {}),
+    ...(getString(tool.type) ? { type: getString(tool.type) } : { type: 'function' }),
+  };
+}
+
+function getAvailableTools(tools: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(tools)) {
+    return tools.map(normalizeToolDefinition).filter((tool): tool is Record<string, unknown> => tool !== undefined);
+  }
+
+  if (!isRecord(tools)) {
+    return [];
+  }
+
+  return Object.entries(tools).map(([name, tool]) => ({
+    name,
+    ...(isRecord(tool) && getToolDescription(tool) ? { description: getToolDescription(tool) } : {}),
+    type: 'function',
+  }));
+}
+
+function addAvailableTools(attributes: Record<string, SpanAttributeValue>, tools: unknown): void {
+  const availableTools = getAvailableTools(tools);
+  if (availableTools.length === 0) {
+    return;
+  }
+
+  const availableToolsJson = safeJsonStringify(availableTools);
+  if (availableToolsJson) {
+    attributes[GEN_AI_REQUEST_AVAILABLE_TOOLS_ATTRIBUTE] = availableToolsJson;
+  }
+}
+
+function rememberToolDescriptions(span: Span, tools: unknown): void {
+  const availableTools = getAvailableTools(tools);
+  if (availableTools.length === 0) {
+    return;
+  }
+
+  const descriptions = new Map<string, string>();
+  for (const tool of availableTools) {
+    const name = getToolName(tool);
+    const description = getToolDescription(tool);
+    if (name && description) {
+      descriptions.set(name, description);
+    }
+  }
+
+  const parentSpanId = spanToJSON(span).parent_span_id;
+  if (parentSpanId && descriptions.size > 0) {
+    toolDescriptionMap.set(parentSpanId, descriptions);
+  }
+}
+
+function applyToolDescription(span: Span, attributes: Record<string, SpanAttributeValue>): void {
+  const toolName = attributes[GEN_AI_TOOL_NAME_ATTRIBUTE];
+  const parentSpanId = spanToJSON(span).parent_span_id;
+  if (typeof toolName !== 'string' || !parentSpanId) {
+    return;
+  }
+
+  const description = toolDescriptionMap.get(parentSpanId)?.get(toolName);
+  if (description) {
+    span.setAttribute(GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE, description);
+  }
+}
+
+function getTokenCount(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (isRecord(value)) {
+    return getNumber(value.total) ?? getNumber(value.cached) ?? getNumber(value.cacheRead);
+  }
+
+  return undefined;
+}
+
+function extractUsage(usage: unknown): TokenUsage {
+  if (!isRecord(usage)) {
+    return {};
+  }
+
+  const inputTokenDetails = isRecord(usage.inputTokenDetails) ? usage.inputTokenDetails : undefined;
+  const inputTokens = getTokenCount(usage.inputTokens);
+  const outputTokens = getTokenCount(usage.outputTokens);
+
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: getTokenCount(usage.totalTokens),
+    cachedInputTokens:
+      getNumber(inputTokenDetails?.cacheReadTokens) ??
+      getNumber(inputTokenDetails?.cacheRead) ??
+      (isRecord(usage.inputTokens)
+        ? (getNumber(usage.inputTokens.cacheRead) ?? getNumber(usage.inputTokens.cached))
+        : undefined),
+    cacheWriteInputTokens:
+      getNumber(inputTokenDetails?.cacheWriteTokens) ??
+      getNumber(inputTokenDetails?.cacheWrite) ??
+      (isRecord(usage.inputTokens) ? getNumber(usage.inputTokens.cacheWrite) : undefined),
+  };
+}
+
+function setUsageAttributes(span: Span, usage: unknown): void {
+  const { inputTokens, outputTokens, totalTokens, cachedInputTokens, cacheWriteInputTokens } = extractUsage(usage);
+
+  if (inputTokens !== undefined) {
+    span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE, inputTokens);
+  }
+  if (outputTokens !== undefined) {
+    span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE, outputTokens);
+  }
+  if (totalTokens !== undefined) {
+    span.setAttribute(GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE, totalTokens);
+  } else if (inputTokens !== undefined || outputTokens !== undefined) {
+    span.setAttribute(GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE, (inputTokens ?? 0) + (outputTokens ?? 0));
+  }
+  if (cachedInputTokens !== undefined) {
+    span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS_CACHED_ATTRIBUTE, cachedInputTokens);
+  }
+  if (cacheWriteInputTokens !== undefined) {
+    span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS_CACHE_WRITE_ATTRIBUTE, cacheWriteInputTokens);
+  }
+}
+
+function normalizeFinishReason(reason: unknown): string | undefined {
+  if (typeof reason === 'string') {
+    return reason === 'tool-calls' ? 'tool_call' : reason;
+  }
+
+  if (isRecord(reason)) {
+    return normalizeFinishReason(reason.unified ?? reason.raw);
+  }
+
+  return undefined;
+}
+
+function getContentParts(content: unknown): unknown[] {
+  return Array.isArray(content) ? content : [];
+}
+
+function buildOutputMessagesFromContent(content: unknown, fallbackText?: unknown): string | undefined {
+  const parts: Array<Record<string, unknown>> = [];
+  const textParts: string[] = [];
+
+  for (const part of getContentParts(content)) {
+    if (!isRecord(part)) {
+      continue;
+    }
+
+    if (part.type === 'text' && typeof part.text === 'string') {
+      textParts.push(part.text);
+      continue;
+    }
+
+    if (part.type === 'tool-call') {
+      const input = part.input;
+      const serializedInput = typeof input === 'string' ? input : safeJsonStringify(input ?? {});
+      parts.push({
+        type: 'tool_call',
+        id: getString(part.toolCallId),
+        name: getString(part.toolName),
+        arguments: serializedInput,
+      });
+    }
+  }
+
+  if (textParts.length === 0 && typeof fallbackText === 'string' && fallbackText.length > 0) {
+    textParts.push(fallbackText);
+  }
+
+  if (textParts.length > 0) {
+    parts.unshift({ type: 'text', content: textParts.join('') });
+  }
+
+  return parts.length > 0 ? safeJsonStringify([{ role: 'assistant', parts }]) : undefined;
+}
+
+function getResult(message: VercelAiTracingChannelMessage): Record<string, unknown> | undefined {
+  return isRecord(message.result) ? message.result : undefined;
+}
+
+function getResultUsage(result: Record<string, unknown> | undefined): unknown {
+  return result?.usage ?? result?.totalUsage;
+}
+
+function getToolOutput(result: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  const output = result?.output;
+  return isRecord(output) ? output : undefined;
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return typeof error === 'string' ? error : undefined;
+}
+
+function captureToolError(span: Span, toolOutput: Record<string, unknown>): void {
+  const error = toolOutput.error;
+  if (!error) {
+    return;
+  }
+
+  const toolName = getString(toolOutput.toolName);
+  const toolCallId = getString(toolOutput.toolCallId);
+  const spanContext = span.spanContext();
+
+  withScope(scope => {
+    scope.setContext('trace', {
+      trace_id: spanContext.traceId,
+      span_id: spanContext.spanId,
+    });
+
+    if (toolName) {
+      scope.setTag('vercel.ai.tool.name', toolName);
+    }
+    if (toolCallId) {
+      scope.setTag('vercel.ai.tool.callId', toolCallId);
+    }
+    scope.setLevel('error');
+
+    captureException(error, {
+      mechanism: {
+        type: ORIGIN,
+        handled: false,
+      },
+    });
+  });
+}
+
+function startInvokeAgentSpan(message: VercelAiTracingChannelMessage): Span {
+  const event = getEvent(message);
+  const operationName = 'invoke_agent';
+  const attributes = makeBaseAttributes(operationName);
+  const functionId = getFunctionId(event);
+
+  addFunctionId(attributes, event);
+  addOperationId(attributes, event);
+  addRequestParameters(attributes, event);
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_RESPONSE_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_STREAM_ATTRIBUTE, message.type === 'streamText');
+  setAttributeIfDefined(attributes, GEN_AI_RESPONSE_STREAMING_ATTRIBUTE, message.type === 'streamText');
+
+  if (getRecordingSettings(event).recordInputs) {
+    addInputAttributes(attributes, event);
+  }
+
+  return startSpanManual(
+    {
+      name: functionId ? `invoke_agent ${functionId}` : 'invoke_agent',
+      op: GEN_AI_INVOKE_AGENT_OPERATION_ATTRIBUTE,
+      attributes,
+    },
+    span => span,
+  );
+}
+
+function startStepSpan(message: VercelAiTracingChannelMessage): Span {
+  const event = getEvent(message);
+  const attributes = makeBaseAttributes('invoke_agent');
+  const stepNumber = getNumber(event.stepNumber);
+  if (stepNumber !== undefined) {
+    attributes['vercel.ai.stepNumber'] = stepNumber;
+  }
+
+  return startSpanManual(
+    {
+      name: stepNumber !== undefined ? `step ${stepNumber}` : 'step',
+      op: GEN_AI_INVOKE_AGENT_OPERATION_ATTRIBUTE,
+      attributes,
+    },
+    span => span,
+  );
+}
+
+function startLanguageModelCallSpan(message: VercelAiTracingChannelMessage): Span {
+  const event = getEvent(message);
+  const attributes = makeBaseAttributes('generate_content');
+
+  addFunctionId(attributes, event);
+  addRequestParameters(attributes, event);
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_RESPONSE_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_SYSTEM_ATTRIBUTE, getProvider(event));
+
+  if (getRecordingSettings(event).recordInputs) {
+    addInputAttributes(attributes, event);
+    addAvailableTools(attributes, event.tools);
+  }
+
+  const modelId = getModelId(event);
+  const span = startSpanManual(
+    {
+      name: `generate_content ${modelId}`,
+      op: GEN_AI_GENERATE_CONTENT_OPERATION_ATTRIBUTE,
+      attributes,
+    },
+    startedSpan => startedSpan,
+  );
+
+  rememberToolDescriptions(span, event.tools);
+  return span;
+}
+
+function startToolSpan(message: VercelAiTracingChannelMessage): Span {
+  const event = getEvent(message);
+  const toolCall = isRecord(event.toolCall) ? event.toolCall : {};
+  const toolName = getString(toolCall.toolName) ?? 'unknown';
+  const toolCallId = getString(toolCall.toolCallId);
+  const attributes = makeBaseAttributes('execute_tool');
+
+  setAttributeIfDefined(attributes, GEN_AI_TOOL_NAME_ATTRIBUTE, toolName);
+  setAttributeIfDefined(attributes, GEN_AI_TOOL_CALL_ID_ATTRIBUTE, toolCallId);
+  setAttributeIfDefined(attributes, GEN_AI_TOOL_TYPE_ATTRIBUTE, 'function');
+
+  if (getRecordingSettings(event).recordInputs) {
+    const input = toolCall.input;
+    const serializedInput = typeof input === 'string' ? input : safeJsonStringify(input ?? {});
+    setAttributeIfDefined(attributes, GEN_AI_TOOL_INPUT_ATTRIBUTE, serializedInput);
+  }
+
+  const span = startSpanManual(
+    {
+      name: `execute_tool ${toolName}`,
+      op: GEN_AI_EXECUTE_TOOL_OPERATION_ATTRIBUTE,
+      attributes,
+    },
+    startedSpan => startedSpan,
+  );
+
+  applyToolDescription(span, attributes);
+  return span;
+}
+
+function startEmbeddingSpan(message: VercelAiTracingChannelMessage): Span {
+  const event = getEvent(message);
+  const attributes = makeBaseAttributes('embeddings');
+
+  addFunctionId(attributes, event);
+  addOperationId(attributes, event);
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_RESPONSE_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_SYSTEM_ATTRIBUTE, getProvider(event));
+
+  if (getRecordingSettings(event).recordInputs) {
+    const value = event.value;
+    const serializedValue = Array.isArray(value)
+      ? safeJsonStringify(value)
+      : safeGetJsonString(value, getEnableTruncation());
+    setAttributeIfDefined(attributes, GEN_AI_EMBEDDINGS_INPUT_ATTRIBUTE, serializedValue);
+  }
+
+  return startSpanManual(
+    {
+      name: `embeddings ${getModelId(event)}`,
+      op: GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE,
+      attributes,
+    },
+    span => span,
+  );
+}
+
+function startRerankSpan(message: VercelAiTracingChannelMessage): Span {
+  const event = getEvent(message);
+  const attributes = makeBaseAttributes('rerank');
+
+  addFunctionId(attributes, event);
+  addOperationId(attributes, event);
+  setAttributeIfDefined(attributes, GEN_AI_REQUEST_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_RESPONSE_MODEL_ATTRIBUTE, getModelId(event));
+  setAttributeIfDefined(attributes, GEN_AI_SYSTEM_ATTRIBUTE, getProvider(event));
+
+  return startSpanManual(
+    {
+      name: `rerank ${getModelId(event)}`,
+      op: GEN_AI_RERANK_DO_RERANK_OPERATION_ATTRIBUTE,
+      attributes,
+    },
+    span => span,
+  );
+}
+
+export function startVercelAiTracingChannelSpan(message: VercelAiTracingChannelMessage): Span {
+  switch (message.type) {
+    case 'generateText':
+    case 'streamText':
+      return startInvokeAgentSpan(message);
+    case 'step':
+      return startStepSpan(message);
+    case 'languageModelCall':
+      return startLanguageModelCallSpan(message);
+    case 'executeTool':
+      return startToolSpan(message);
+    case 'embed':
+      return startEmbeddingSpan(message);
+    case 'rerank':
+      return startRerankSpan(message);
+    default:
+      return startSpanManual(
+        {
+          name: 'ai telemetry',
+          op: GEN_AI_INVOKE_AGENT_OPERATION_ATTRIBUTE,
+          attributes: makeBaseAttributes('invoke_agent'),
+        },
+        span => span,
+      );
+  }
+}
+
+function finishInvokeAgentSpan(span: Span, message: VercelAiTracingChannelMessage): void {
+  const event = getEvent(message);
+  const result = getResult(message);
+
+  setUsageAttributes(span, getResultUsage(result));
+
+  const responseModel =
+    getString(result?.responseModel) ?? (isRecord(result?.response) ? getString(result.response.modelId) : undefined);
+  if (responseModel) {
+    span.setAttribute(GEN_AI_RESPONSE_MODEL_ATTRIBUTE, responseModel);
+  }
+
+  const finishReason = normalizeFinishReason(
+    result?.finishReason ?? (isRecord(result?.finalStep) ? result.finalStep.finishReason : undefined),
+  );
+  if (finishReason) {
+    span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE, JSON.stringify([finishReason]));
+  }
+
+  if (getRecordingSettings(event).recordOutputs) {
+    const outputMessages = buildOutputMessagesFromContent(result?.content, result?.text);
+    if (outputMessages) {
+      span.setAttribute(GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE, outputMessages);
+    }
+  }
+}
+
+function finishStepSpan(span: Span, message: VercelAiTracingChannelMessage): void {
+  const result = getResult(message);
+
+  setUsageAttributes(span, getResultUsage(result));
+
+  const finishReason = normalizeFinishReason(result?.finishReason);
+  if (finishReason) {
+    span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE, JSON.stringify([finishReason]));
+  }
+
+  toolDescriptionMap.delete(spanToJSON(span).span_id);
+}
+
+function finishLanguageModelCallSpan(span: Span, message: VercelAiTracingChannelMessage): void {
+  const event = getEvent(message);
+  const result = getResult(message);
+
+  setUsageAttributes(span, result?.usage);
+
+  const response = isRecord(result?.response) ? result.response : undefined;
+  const responseModel = getString(response?.modelId) ?? getModelId(event);
+  span.setAttribute(GEN_AI_RESPONSE_MODEL_ATTRIBUTE, responseModel);
+  const responseId = getString(response?.id);
+  if (responseId) {
+    span.setAttribute(GEN_AI_RESPONSE_ID_ATTRIBUTE, responseId);
+  }
+
+  const finishReason = normalizeFinishReason(result?.finishReason);
+  if (finishReason) {
+    span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE, JSON.stringify([finishReason]));
+  }
+
+  if (getRecordingSettings(event).recordOutputs) {
+    const outputMessages = buildOutputMessagesFromContent(result?.content);
+    if (outputMessages) {
+      span.setAttribute(GEN_AI_OUTPUT_MESSAGES_ATTRIBUTE, outputMessages);
+    }
+  }
+}
+
+function finishToolSpan(span: Span, message: VercelAiTracingChannelMessage): void {
+  const event = getEvent(message);
+  const result = getResult(message);
+  const toolOutput = getToolOutput(result);
+
+  if (!toolOutput) {
+    return;
+  }
+
+  if (getRecordingSettings(event).recordOutputs) {
+    const output = toolOutput.output;
+    const serializedOutput = typeof output === 'string' ? output : safeJsonStringify(output);
+    if (serializedOutput) {
+      span.setAttribute(GEN_AI_TOOL_OUTPUT_ATTRIBUTE, serializedOutput);
+    }
+  }
+
+  if (toolOutput.type === 'tool-error') {
+    const errorMessage = getErrorMessage(toolOutput.error) ?? 'Tool execution failed';
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: errorMessage });
+    captureToolError(span, toolOutput);
+  }
+}
+
+function finishEmbeddingSpan(span: Span, message: VercelAiTracingChannelMessage): void {
+  setUsageAttributes(span, getResult(message)?.usage);
+}
+
+export function finishVercelAiTracingChannelSpan(span: Span, message: VercelAiTracingChannelMessage): void {
+  switch (message.type) {
+    case 'generateText':
+    case 'streamText':
+      finishInvokeAgentSpan(span, message);
+      break;
+    case 'step':
+      finishStepSpan(span, message);
+      break;
+    case 'languageModelCall':
+      finishLanguageModelCallSpan(span, message);
+      break;
+    case 'executeTool':
+      finishToolSpan(span, message);
+      break;
+    case 'embed':
+      finishEmbeddingSpan(span, message);
+      break;
+    case 'rerank':
+      break;
+  }
+}
+
+export function failVercelAiTracingChannelSpan(span: Span, message: VercelAiTracingChannelMessage): void {
+  const errorMessage = getErrorMessage(message.error) ?? 'AI SDK telemetry span failed';
+  span.setStatus({ code: SPAN_STATUS_ERROR, message: errorMessage });
+}

--- a/packages/core/test/lib/tracing/vercel-ai-tracing-channel.test.ts
+++ b/packages/core/test/lib/tracing/vercel-ai-tracing-channel.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { SentrySpan } from '../../../src/tracing/sentrySpan';
+import { failVercelAiTracingChannelSpan } from '../../../src/tracing/vercel-ai/tracing-channel';
+import { toolDescriptionMap } from '../../../src/tracing/vercel-ai/constants';
+
+describe('vercel-ai tracing-channel spans', () => {
+  it('cleans tool descriptions when a step span fails', () => {
+    const span = new SentrySpan({ spanId: 'step-span-id' });
+    toolDescriptionMap.set('step-span-id', new Map([['getWeather', 'Get the current weather']]));
+
+    failVercelAiTracingChannelSpan(span, {
+      type: 'step',
+      event: {},
+      error: new Error('Step failed'),
+    });
+
+    expect(toolDescriptionMap.has('step-span-id')).toBe(false);
+  });
+});

--- a/packages/node/src/integrations/tracing/vercelai/index.ts
+++ b/packages/node/src/integrations/tracing/vercelai/index.ts
@@ -3,6 +3,7 @@ import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce, type modulesIntegration } from '@sentry/node-core';
 import { INTEGRATION_NAME } from './constants';
 import { SentryVercelAiInstrumentation } from './instrumentation';
+import { subscribeVercelAiTracingChannel } from './tracing-channel-subscriber';
 import type { VercelAiOptions } from './types';
 
 export const instrumentVercelAi = generateInstrumentOnce(INTEGRATION_NAME, () => new SentryVercelAiInstrumentation({}));
@@ -35,6 +36,10 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
       } else {
         instrumentation?.callWhenPatched(() => addVercelAiProcessors(client));
       }
+
+      // AI SDK v7 publishes spans via node:diagnostics_channel.tracingChannel.
+      // Defer until after the Node SDK initializes the OpenTelemetry context manager.
+      void Promise.resolve().then(subscribeVercelAiTracingChannel);
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/node/src/integrations/tracing/vercelai/tracing-channel-subscriber.ts
+++ b/packages/node/src/integrations/tracing/vercelai/tracing-channel-subscriber.ts
@@ -1,0 +1,71 @@
+import type { Span as OtelSpan } from '@opentelemetry/api';
+import { tracingChannel as otelTracingChannel } from '@sentry/opentelemetry/tracing-channel';
+import type { _INTERNAL_VercelAiTracingChannelMessage, Span } from '@sentry/core';
+import {
+  _INTERNAL_failVercelAiTracingChannelSpan,
+  _INTERNAL_finishVercelAiTracingChannelSpan,
+  _INTERNAL_startVercelAiTracingChannelSpan,
+  debug,
+} from '@sentry/core';
+import { DEBUG_BUILD } from '../../../debug-build';
+
+const AI_SDK_TELEMETRY_TRACING_CHANNEL = 'ai:telemetry';
+
+interface VercelAiTracingChannelContext extends _INTERNAL_VercelAiTracingChannelMessage {
+  _sentrySpan?: OtelSpan;
+}
+
+let subscribed = false;
+
+const NOOP = (): void => {};
+
+/**
+ * Subscribe to AI SDK v7 tracing-channel spans.
+ *
+ * AI SDK v3-v6 emit OpenTelemetry spans and are handled by `addVercelAiProcessors`.
+ * AI SDK v7 emits lifecycle scopes via `node:diagnostics_channel.tracingChannel('ai:telemetry')`.
+ */
+export function subscribeVercelAiTracingChannel(): void {
+  if (subscribed) {
+    return;
+  }
+
+  subscribed = true;
+
+  try {
+    const channel = otelTracingChannel<_INTERNAL_VercelAiTracingChannelMessage>(
+      AI_SDK_TELEMETRY_TRACING_CHANNEL,
+      message => {
+        return _INTERNAL_startVercelAiTracingChannelSpan(message) as unknown as OtelSpan;
+      },
+    );
+
+    channel.subscribe({
+      start: NOOP,
+      end: NOOP,
+      asyncStart: NOOP,
+      asyncEnd: data => {
+        const context = data as VercelAiTracingChannelContext;
+        const span = context._sentrySpan as unknown as Span | undefined;
+        if (!span || context.error) {
+          return;
+        }
+
+        _INTERNAL_finishVercelAiTracingChannelSpan(span, context);
+        span.end();
+      },
+      error: data => {
+        const context = data as VercelAiTracingChannelContext;
+        const span = context._sentrySpan as unknown as Span | undefined;
+        if (!span) {
+          return;
+        }
+
+        _INTERNAL_failVercelAiTracingChannelSpan(span, context);
+        span.end();
+      },
+    });
+  } catch (error) {
+    DEBUG_BUILD && debug.log('Vercel AI tracing-channel subscription failed.', error);
+  }
+}

--- a/packages/node/src/integrations/tracing/vercelai/tracing-channel-subscriber.ts
+++ b/packages/node/src/integrations/tracing/vercelai/tracing-channel-subscriber.ts
@@ -1,12 +1,13 @@
 import type { Span as OtelSpan } from '@opentelemetry/api';
 import { tracingChannel as otelTracingChannel } from '@sentry/opentelemetry/tracing-channel';
-import type { _INTERNAL_VercelAiTracingChannelMessage, Span } from '@sentry/core';
+import type { Span } from '@sentry/core';
+import { debug } from '@sentry/core';
+import type { _INTERNAL_VercelAiTracingChannelMessage } from '@sentry/core/server';
 import {
   _INTERNAL_failVercelAiTracingChannelSpan,
   _INTERNAL_finishVercelAiTracingChannelSpan,
   _INTERNAL_startVercelAiTracingChannelSpan,
-  debug,
-} from '@sentry/core';
+} from '@sentry/core/server';
 import { DEBUG_BUILD } from '../../../debug-build';
 
 const AI_SDK_TELEMETRY_TRACING_CHANNEL = 'ai:telemetry';


### PR DESCRIPTION
Adds Vercel AI SDK v7 tracing support by subscribing to `node:diagnostics_channel.tracingChannel('ai:telemetry')` and mapping those lifecycle messages to Sentry `gen_ai` spans.

The existing OTel span processor path remains in place for AI SDK v3-v6. The new v7 coverage verifies span hierarchy, PII gating, streaming, embeddings, rerank, and tool errors.

Refs vercel/ai#15660