### PR TITLE
ref(aws-serverless): Use `@sentry/conventions`

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -69,7 +69,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@sentry/conventions": "^0.11.0",
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0",
     "@sentry/node-core": "10.58.0",

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -69,7 +69,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@sentry/conventions": "^0.11.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0",
     "@sentry/node-core": "10.58.0",

--- a/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
@@ -46,7 +46,7 @@ import {
 } from './utils';
 import { propwrap } from './propwrap';
 import { RequestMetadata } from './services/ServiceExtension';
-import { ATTR_HTTP_STATUS_CODE } from './semconv';
+import { HTTP_STATUS_CODE } from '@sentry/conventions/attributes';
 import { SDK_VERSION, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 
 const PACKAGE_NAME = '@sentry/instrumentation-aws-sdk';
@@ -289,8 +289,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
                   const httpStatusCode = response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
-                    // eslint-disable-next-line typescript/no-deprecated
-                    span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
+                    span.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId = response.output?.$metadata?.extendedRequestId;
@@ -318,8 +317,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
                   const httpStatusCode = err?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
-                    // eslint-disable-next-line typescript/no-deprecated
-                    span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
+                    span.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId = err?.extendedRequestId;

--- a/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
@@ -21,7 +21,7 @@
  */
 
 import { Span, SpanKind, context, trace, diag, SpanStatusCode } from '@opentelemetry/api';
-import { AttributeNames } from './enums';
+import { AWS_REQUEST_EXTENDED_ID, AWS_REQUEST_ID, CLOUD_REGION } from './enums';
 import { ServicesExtensions } from './services';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from './types';
 import {
@@ -265,7 +265,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
           Promise.resolve(regionPromise)
             .then(resolvedRegion => {
               normalizedRequest.region = resolvedRegion;
-              span.setAttribute(AttributeNames.CLOUD_REGION, resolvedRegion);
+              span.setAttribute(CLOUD_REGION, resolvedRegion);
             })
             .catch(e => {
               // there is nothing much we can do in this case.
@@ -284,17 +284,18 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
                 .then((response: any) => {
                   const requestId = response.output?.$metadata?.requestId;
                   if (requestId) {
-                    span.setAttribute(AttributeNames.AWS_REQUEST_ID, requestId);
+                    span.setAttribute(AWS_REQUEST_ID, requestId);
                   }
 
                   const httpStatusCode = response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
+                    // oxlint-disable-next-line typescript/no-deprecated
                     span.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId = response.output?.$metadata?.extendedRequestId;
                   if (extendedRequestId) {
-                    span.setAttribute(AttributeNames.AWS_REQUEST_EXTENDED_ID, extendedRequestId);
+                    span.setAttribute(AWS_REQUEST_EXTENDED_ID, extendedRequestId);
                   }
 
                   const normalizedResponse: NormalizedResponse = {
@@ -312,17 +313,18 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
                 .catch((err: any) => {
                   const requestId = err?.RequestId;
                   if (requestId) {
-                    span.setAttribute(AttributeNames.AWS_REQUEST_ID, requestId);
+                    span.setAttribute(AWS_REQUEST_ID, requestId);
                   }
 
                   const httpStatusCode = err?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
+                    // oxlint-disable-next-line typescript/no-deprecated
                     span.setAttribute(HTTP_STATUS_CODE, httpStatusCode);
                   }
 
                   const extendedRequestId = err?.extendedRequestId;
                   if (extendedRequestId) {
-                    span.setAttribute(AttributeNames.AWS_REQUEST_EXTENDED_ID, extendedRequestId);
+                    span.setAttribute(AWS_REQUEST_EXTENDED_ID, extendedRequestId);
                   }
 
                   span.setStatus({

--- a/packages/aws-serverless/src/integration/aws/vendored/enums.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/enums.ts
@@ -18,19 +18,13 @@
  * - Upstream version: @opentelemetry/instrumentation-aws-sdk@0.73.0
  */
 
-export enum AttributeNames {
-  AWS_OPERATION = 'aws.operation',
-  CLOUD_REGION = 'cloud.region',
-  AWS_SERVICE_API = 'aws.service.api',
-  AWS_SERVICE_NAME = 'aws.service.name',
-  AWS_SERVICE_IDENTIFIER = 'aws.service.identifier',
-  AWS_REQUEST_ID = 'aws.request.id',
-  AWS_REQUEST_EXTENDED_ID = 'aws.request.extended_id',
-  AWS_SIGNATURE_VERSION = 'aws.signature.version',
-
-  // TODO: Add these semantic attributes to:
-  // - https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts
-  // For S3, see specification: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/object-stores/s3.md
-  AWS_S3_BUCKET = 'aws.s3.bucket',
-  AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream.name',
-}
+export const AWS_OPERATION = 'aws.operation';
+export const CLOUD_REGION = 'cloud.region';
+export const AWS_SERVICE_API = 'aws.service.api';
+export const AWS_SERVICE_NAME = 'aws.service.name';
+export const AWS_SERVICE_IDENTIFIER = 'aws.service.identifier';
+export const AWS_REQUEST_ID = 'aws.request.id';
+export const AWS_REQUEST_EXTENDED_ID = 'aws.request.extended_id';
+export const AWS_SIGNATURE_VERSION = 'aws.signature.version';
+export const AWS_S3_BUCKET = 'aws.s3.bucket';
+export const AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream.name';

--- a/packages/aws-serverless/src/integration/aws/vendored/enums.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/enums.ts
@@ -18,13 +18,8 @@
  * - Upstream version: @opentelemetry/instrumentation-aws-sdk@0.73.0
  */
 
-export const AWS_OPERATION = 'aws.operation';
 export const CLOUD_REGION = 'cloud.region';
-export const AWS_SERVICE_API = 'aws.service.api';
-export const AWS_SERVICE_NAME = 'aws.service.name';
-export const AWS_SERVICE_IDENTIFIER = 'aws.service.identifier';
 export const AWS_REQUEST_ID = 'aws.request.id';
 export const AWS_REQUEST_EXTENDED_ID = 'aws.request.extended_id';
-export const AWS_SIGNATURE_VERSION = 'aws.signature.version';
 export const AWS_S3_BUCKET = 'aws.s3.bucket';
 export const AWS_KINESIS_STREAM_NAME = 'aws.kinesis.stream.name';

--- a/packages/aws-serverless/src/integration/aws/vendored/semconv.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/semconv.ts
@@ -252,52 +252,6 @@ export const ATTR_AWS_STEP_FUNCTIONS_ACTIVITY_ARN = 'aws.step_functions.activity
 export const ATTR_AWS_STEP_FUNCTIONS_STATE_MACHINE_ARN = 'aws.step_functions.state_machine.arn' as const;
 
 /**
- * Deprecated, use `db.namespace` instead.
- *
- * @example customers
- * @example main
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.namespace`.
- */
-export const ATTR_DB_NAME = 'db.name' as const;
-
-/**
- * Deprecated, use `db.operation.name` instead.
- *
- * @example findAndModify
- * @example HMSET
- * @example SELECT
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.operation.name`.
- */
-export const ATTR_DB_OPERATION = 'db.operation' as const;
-
-/**
- * The database statement being executed.
- *
- * @example SELECT * FROM wuser_table
- * @example SET mykey "WuValue"
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.query.text`.
- */
-export const ATTR_DB_STATEMENT = 'db.statement' as const;
-
-/**
- * Deprecated, use `db.system.name` instead.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `db.system.name`.
- */
-export const ATTR_DB_SYSTEM = 'db.system' as const;
-
-/**
  * The name of the invoked function.
  *
  * @example "my-function"
@@ -329,33 +283,6 @@ export const ATTR_FAAS_INVOKED_PROVIDER = 'faas.invoked_provider' as const;
 export const ATTR_FAAS_INVOKED_REGION = 'faas.invoked_region' as const;
 
 /**
- * The name of the operation being performed.
- *
- * @note If one of the predefined values applies, but specific system uses a different name it's **RECOMMENDED** to document it in the semantic conventions for specific GenAI system and use system-specific name in the instrumentation. If a different name is not documented, instrumentation libraries **SHOULD** use applicable predefined value.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_OPERATION_NAME = 'gen_ai.operation.name' as const;
-
-/**
- * The maximum number of tokens the model generates for a request.
- *
- * @example 100
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_MAX_TOKENS = 'gen_ai.request.max_tokens' as const;
-
-/**
- * The name of the GenAI model a request is being made to.
- *
- * @example "gpt-4"
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_MODEL = 'gen_ai.request.model' as const;
-
-/**
  * List of sequences that the model will use to stop generating further tokens.
  *
  * @example ["forest", "lived"]
@@ -363,43 +290,6 @@ export const ATTR_GEN_AI_REQUEST_MODEL = 'gen_ai.request.model' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_REQUEST_STOP_SEQUENCES = 'gen_ai.request.stop_sequences' as const;
-
-/**
- * The temperature setting for the GenAI request.
- *
- * @example 0.0
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_TEMPERATURE = 'gen_ai.request.temperature' as const;
-
-/**
- * The top_p sampling setting for the GenAI request.
- *
- * @example 1.0
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_REQUEST_TOP_P = 'gen_ai.request.top_p' as const;
-
-/**
- * Array of reasons the model stopped generating tokens, corresponding to each generation received.
- *
- * @example ["stop"]
- * @example ["stop", "length"]
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_RESPONSE_FINISH_REASONS = 'gen_ai.response.finish_reasons' as const;
-
-/**
- * Deprecated, use `gen_ai.provider.name` instead.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `gen_ai.provider.name`.
- */
-export const ATTR_GEN_AI_SYSTEM = 'gen_ai.system' as const;
 
 /**
  * The type of token being counted.
@@ -410,70 +300,6 @@ export const ATTR_GEN_AI_SYSTEM = 'gen_ai.system' as const;
  * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
  */
 export const ATTR_GEN_AI_TOKEN_TYPE = 'gen_ai.token.type' as const;
-
-/**
- * The number of tokens used in the GenAI input (prompt).
- *
- * @example 100
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_USAGE_INPUT_TOKENS = 'gen_ai.usage.input_tokens' as const;
-
-/**
- * The number of tokens used in the GenAI response (completion).
- *
- * @example 180
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = 'gen_ai.usage.output_tokens' as const;
-
-/**
- * Deprecated, use `http.response.status_code` instead.
- *
- * @example 200
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- *
- * @deprecated Replaced by `http.response.status_code`.
- */
-export const ATTR_HTTP_STATUS_CODE = 'http.status_code' as const;
-
-/**
- * The number of messages sent, received, or processed in the scope of the batching operation.
- *
- * @example 0
- * @example 1
- * @example 2
- *
- * @note Instrumentations **SHOULD NOT** set `messaging.batch.message_count` on spans that operate with a single message. When a messaging client library supports both batch and single-message API for the same operation, instrumentations **SHOULD** use `messaging.batch.message_count` for batching APIs and **SHOULD NOT** use it for single-message APIs.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_BATCH_MESSAGE_COUNT = 'messaging.batch.message_count' as const;
-
-/**
- * The message destination name
- *
- * @example MyQueue
- * @example MyTopic
- *
- * @note Destination name **SHOULD** uniquely identify a specific queue, topic or other entity within the broker. If
- * the broker doesn't have such notion, the destination name **SHOULD** uniquely identify the broker.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_DESTINATION_NAME = 'messaging.destination.name' as const;
-
-/**
- * A value used by the messaging system as an identifier for the message, represented as a string.
- *
- * @example "452a7c7c7c7048c2f887f61572b18fc2"
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_MESSAGE_ID = 'messaging.message.id' as const;
 
 /**
  * Deprecated, use `messaging.operation.type` instead.
@@ -487,45 +313,6 @@ export const ATTR_MESSAGING_MESSAGE_ID = 'messaging.message.id' as const;
  * @deprecated Replaced by `messaging.operation.type`.
  */
 export const ATTR_MESSAGING_OPERATION = 'messaging.operation' as const;
-
-/**
- * A string identifying the type of the messaging operation.
- *
- * @note If a custom value is used, it **MUST** be of low cardinality.
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_OPERATION_TYPE = 'messaging.operation.type' as const;
-
-/**
- * The messaging system as identified by the client instrumentation.
- *
- * @note The actual messaging system may differ from the one known by the client. For example, when using Kafka client libraries to communicate with Azure Event Hubs, the `messaging.system` is set to `kafka` based on the instrumentation's best knowledge.
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_MESSAGING_SYSTEM = 'messaging.system' as const;
-
-/**
- * The name of the (logical) method being called, must be equal to the $method part in the span name.
- *
- * @example "exampleMethod"
- *
- * @note This is the logical name of the method from the RPC interface perspective, which can be different from the name of any implementing method/function. The `code.function.name` attribute may be used to store the latter (e.g., method actually executing the call on the server side, RPC client stub method on the client side).
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RPC_METHOD = 'rpc.method' as const;
-
-/**
- * The full (logical) name of the service being called, including its package name, if applicable.
- *
- * @example "myservice.EchoService"
- *
- * @note This is the logical name of the service from the RPC interface perspective, which can be different from the name of any implementing class. The `code.namespace` attribute may be used to store the latter (despite the attribute name, it may include a class name; e.g., class with method actually executing the call on the server side, RPC client stub class on the client side).
- *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
- */
-export const ATTR_RPC_SERVICE = 'rpc.service' as const;
 
 /**
  * A string identifying the remoting system. See below for a list of well-known identifiers.

--- a/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
@@ -84,6 +84,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   ): RequestMetadata {
     let spanName = GEN_AI_OPERATION_NAME_VALUE_CHAT;
     const spanAttributes: Attributes = {
+      // oxlint-disable-next-line typescript/no-deprecated
       [GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
       [GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
     };
@@ -128,6 +129,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     isStream: boolean,
   ): RequestMetadata {
     const spanAttributes: Attributes = {
+      // oxlint-disable-next-line typescript/no-deprecated
       [GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
       // add operation name for InvokeModel API
     };

--- a/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
@@ -21,16 +21,18 @@
 import { Attributes, DiagLogger, diag, Span } from '@opentelemetry/api';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import {
-  ATTR_GEN_AI_SYSTEM,
-  ATTR_GEN_AI_OPERATION_NAME,
-  ATTR_GEN_AI_REQUEST_MODEL,
-  ATTR_GEN_AI_REQUEST_MAX_TOKENS,
-  ATTR_GEN_AI_REQUEST_TEMPERATURE,
-  ATTR_GEN_AI_REQUEST_TOP_P,
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_REQUEST_MAX_TOKENS,
+  GEN_AI_REQUEST_MODEL,
+  GEN_AI_REQUEST_TEMPERATURE,
+  GEN_AI_REQUEST_TOP_P,
+  GEN_AI_RESPONSE_FINISH_REASONS,
+  GEN_AI_SYSTEM,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+} from '@sentry/conventions/attributes';
+import {
   ATTR_GEN_AI_REQUEST_STOP_SEQUENCES,
-  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
-  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
-  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
   GEN_AI_OPERATION_NAME_VALUE_CHAT,
   GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
 } from '../semconv';
@@ -82,14 +84,13 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   ): RequestMetadata {
     let spanName = GEN_AI_OPERATION_NAME_VALUE_CHAT;
     const spanAttributes: Attributes = {
-      // eslint-disable-next-line typescript/no-deprecated
-      [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
-      [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
+      [GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
+      [GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
     };
 
     const modelId = request.commandInput.modelId;
     if (modelId) {
-      spanAttributes[ATTR_GEN_AI_REQUEST_MODEL] = modelId;
+      spanAttributes[GEN_AI_REQUEST_MODEL] = modelId;
       if (spanName) {
         spanName += ` ${modelId}`;
       }
@@ -99,13 +100,13 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     if (inferenceConfig) {
       const { maxTokens, temperature, topP, stopSequences } = inferenceConfig;
       if (maxTokens !== undefined) {
-        spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = maxTokens;
+        spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = maxTokens;
       }
       if (temperature !== undefined) {
-        spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = temperature;
+        spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = temperature;
       }
       if (topP !== undefined) {
-        spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = topP;
+        spanAttributes[GEN_AI_REQUEST_TOP_P] = topP;
       }
       if (stopSequences !== undefined) {
         spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = stopSequences;
@@ -127,102 +128,101 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     isStream: boolean,
   ): RequestMetadata {
     const spanAttributes: Attributes = {
-      // eslint-disable-next-line typescript/no-deprecated
-      [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
+      [GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
       // add operation name for InvokeModel API
     };
 
     const modelId = request.commandInput?.modelId;
     if (modelId) {
-      spanAttributes[ATTR_GEN_AI_REQUEST_MODEL] = modelId;
+      spanAttributes[GEN_AI_REQUEST_MODEL] = modelId;
     }
 
     if (request.commandInput?.body) {
       const requestBody = JSON.parse(request.commandInput.body);
       if (modelId.includes('amazon.titan')) {
         if (requestBody.textGenerationConfig?.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.textGenerationConfig.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.textGenerationConfig.temperature;
         }
         if (requestBody.textGenerationConfig?.topP !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.textGenerationConfig.topP;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.textGenerationConfig.topP;
         }
         if (requestBody.textGenerationConfig?.maxTokenCount !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.textGenerationConfig.maxTokenCount;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.textGenerationConfig.maxTokenCount;
         }
         if (requestBody.textGenerationConfig?.stopSequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.textGenerationConfig.stopSequences;
         }
       } else if (modelId.includes('amazon.nova')) {
         if (requestBody.inferenceConfig?.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.inferenceConfig.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.inferenceConfig.temperature;
         }
         if (requestBody.inferenceConfig?.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.inferenceConfig.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.inferenceConfig.top_p;
         }
         if (requestBody.inferenceConfig?.max_new_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.inferenceConfig.max_new_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.inferenceConfig.max_new_tokens;
         }
         if (requestBody.inferenceConfig?.stopSequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.inferenceConfig.stopSequences;
         }
       } else if (modelId.includes('anthropic.claude')) {
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
         }
         if (requestBody.stop_sequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop_sequences;
         }
       } else if (modelId.includes('meta.llama')) {
         if (requestBody.max_gen_len !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_gen_len;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_gen_len;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
         }
         // request for meta llama models does not contain stop_sequences field
       } else if (modelId.includes('cohere.command-r')) {
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.p;
         }
         if (requestBody.message !== undefined) {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          spanAttributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.message.length / 6);
+          spanAttributes[GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.message.length / 6);
         }
         if (requestBody.stop_sequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop_sequences;
         }
       } else if (modelId.includes('cohere.command')) {
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.p;
         }
         if (requestBody.prompt !== undefined) {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          spanAttributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
+          spanAttributes[GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
         }
         if (requestBody.stop_sequences !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop_sequences;
@@ -232,16 +232,16 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          spanAttributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
+          spanAttributes[GEN_AI_USAGE_INPUT_TOKENS] = Math.ceil(requestBody.prompt.length / 6);
         }
         if (requestBody.max_tokens !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
+          spanAttributes[GEN_AI_REQUEST_MAX_TOKENS] = requestBody.max_tokens;
         }
         if (requestBody.temperature !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
+          spanAttributes[GEN_AI_REQUEST_TEMPERATURE] = requestBody.temperature;
         }
         if (requestBody.top_p !== undefined) {
-          spanAttributes[ATTR_GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
+          spanAttributes[GEN_AI_REQUEST_TOP_P] = requestBody.top_p;
         }
         if (requestBody.stop !== undefined) {
           spanAttributes[ATTR_GEN_AI_REQUEST_STOP_SEQUENCES] = requestBody.stop;
@@ -309,7 +309,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
 
   private static setStopReason(span: Span, stopReason: string | undefined) {
     if (stopReason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [stopReason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [stopReason]);
     }
   }
 
@@ -317,10 +317,10 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     if (usage) {
       const { inputTokens, outputTokens } = usage;
       if (inputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, inputTokens);
+        span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, inputTokens);
       }
       if (outputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
+        span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
       }
     }
   }
@@ -332,60 +332,60 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       const responseBody = JSON.parse(decodedResponseBody);
       if (currentModelId.includes('amazon.titan')) {
         if (responseBody.inputTextTokenCount !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.inputTextTokenCount);
+          span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.inputTextTokenCount);
         }
         if (responseBody.results?.[0]?.tokenCount !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.results[0].tokenCount);
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.results[0].tokenCount);
         }
         if (responseBody.results?.[0]?.completionReason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.results[0].completionReason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.results[0].completionReason]);
         }
       } else if (currentModelId.includes('amazon.nova')) {
         if (responseBody.usage !== undefined) {
           if (responseBody.usage.inputTokens !== undefined) {
-            span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.inputTokens);
+            span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.inputTokens);
           }
           if (responseBody.usage.outputTokens !== undefined) {
-            span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.outputTokens);
+            span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.outputTokens);
           }
         }
         if (responseBody.stopReason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stopReason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stopReason]);
         }
       } else if (currentModelId.includes('anthropic.claude')) {
         if (responseBody.usage?.input_tokens !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.input_tokens);
+          span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.usage.input_tokens);
         }
         if (responseBody.usage?.output_tokens !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.output_tokens);
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.usage.output_tokens);
         }
         if (responseBody.stop_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
         }
       } else if (currentModelId.includes('meta.llama')) {
         if (responseBody.prompt_token_count !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, responseBody.prompt_token_count);
+          span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, responseBody.prompt_token_count);
         }
         if (responseBody.generation_token_count !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.generation_token_count);
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, responseBody.generation_token_count);
         }
         if (responseBody.stop_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.stop_reason]);
         }
       } else if (currentModelId.includes('cohere.command-r')) {
         if (responseBody.text !== undefined) {
           // NOTE: We approximate the token count since this value is not directly available in the body
           // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
           // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-          span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(responseBody.text.length / 6));
+          span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(responseBody.text.length / 6));
         }
         if (responseBody.finish_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.finish_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.finish_reason]);
         }
       } else if (currentModelId.includes('cohere.command')) {
         if (responseBody.generations?.[0]?.text !== undefined) {
           span.setAttribute(
-            ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+            GEN_AI_USAGE_OUTPUT_TOKENS,
             // NOTE: We approximate the token count since this value is not directly available in the body
             // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
             // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -393,12 +393,12 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
           );
         }
         if (responseBody.generations?.[0]?.finish_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.generations[0].finish_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.generations[0].finish_reason]);
         }
       } else if (currentModelId.includes('mistral')) {
         if (responseBody.outputs?.[0]?.text !== undefined) {
           span.setAttribute(
-            ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+            GEN_AI_USAGE_OUTPUT_TOKENS,
             // NOTE: We approximate the token count since this value is not directly available in the body
             // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
             // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -406,7 +406,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
           );
         }
         if (responseBody.outputs?.[0]?.stop_reason !== undefined) {
-          span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.outputs[0].stop_reason]);
+          span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [responseBody.outputs[0].stop_reason]);
         }
       }
     }
@@ -466,56 +466,56 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   private static recordNovaAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.metadata?.usage !== undefined) {
       if (parsedChunk.metadata?.usage.inputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.metadata.usage.inputTokens);
+        span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.metadata.usage.inputTokens);
       }
       if (parsedChunk.metadata?.usage.outputTokens !== undefined) {
-        span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.metadata.usage.outputTokens);
+        span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.metadata.usage.outputTokens);
       }
     }
     if (parsedChunk.messageStop?.stopReason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.messageStop.stopReason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.messageStop.stopReason]);
     }
   }
 
   private static recordClaudeAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.message?.usage?.input_tokens !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.message.usage.input_tokens);
+      span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.message.usage.input_tokens);
     }
     if (parsedChunk.message?.usage?.output_tokens !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.message.usage.output_tokens);
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.message.usage.output_tokens);
     }
     if (parsedChunk.delta?.stop_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.delta.stop_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.delta.stop_reason]);
     }
   }
 
   private static recordTitanAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.inputTextTokenCount !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.inputTextTokenCount);
+      span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.inputTextTokenCount);
     }
     if (parsedChunk.totalOutputTextTokenCount !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.totalOutputTextTokenCount);
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.totalOutputTextTokenCount);
     }
     if (parsedChunk.completionReason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.completionReason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.completionReason]);
     }
   }
   private static recordLlamaAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.prompt_token_count !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.prompt_token_count);
+      span.setAttribute(GEN_AI_USAGE_INPUT_TOKENS, parsedChunk.prompt_token_count);
     }
     if (parsedChunk.generation_token_count !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.generation_token_count);
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, parsedChunk.generation_token_count);
     }
     if (parsedChunk.stop_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.stop_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.stop_reason]);
     }
   }
 
   private static recordMistralAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.outputs?.[0]?.text !== undefined) {
       span.setAttribute(
-        ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_USAGE_OUTPUT_TOKENS,
         // NOTE: We approximate the token count since this value is not directly available in the body
         // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
         // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -523,14 +523,14 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       );
     }
     if (parsedChunk.outputs?.[0]?.stop_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.outputs[0].stop_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.outputs[0].stop_reason]);
     }
   }
 
   private static recordCohereAttributes(parsedChunk: any, span: Span) {
     if (parsedChunk.generations?.[0]?.text !== undefined) {
       span.setAttribute(
-        ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_USAGE_OUTPUT_TOKENS,
         // NOTE: We approximate the token count since this value is not directly available in the body
         // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
         // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
@@ -538,7 +538,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       );
     }
     if (parsedChunk.generations?.[0]?.finish_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.generations[0].finish_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.generations[0].finish_reason]);
     }
   }
 
@@ -547,10 +547,10 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
       // NOTE: We approximate the token count since this value is not directly available in the body
       // According to Bedrock docs they use (total_chars / 6) to approximate token count for pricing.
       // https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html
-      span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(parsedChunk.text.length / 6));
+      span.setAttribute(GEN_AI_USAGE_OUTPUT_TOKENS, Math.ceil(parsedChunk.text.length / 6));
     }
     if (parsedChunk.finish_reason !== undefined) {
-      span.setAttribute(ATTR_GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.finish_reason]);
+      span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, [parsedChunk.finish_reason]);
     }
   }
 }

--- a/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
@@ -42,11 +42,9 @@ import {
   ATTR_AWS_DYNAMODB_TABLE_COUNT,
   ATTR_AWS_DYNAMODB_TABLE_NAMES,
   ATTR_AWS_DYNAMODB_TOTAL_SEGMENTS,
-  ATTR_DB_NAME,
-  ATTR_DB_OPERATION,
-  ATTR_DB_SYSTEM,
   DB_SYSTEM_VALUE_DYNAMODB,
 } from '../semconv';
+import { DB_NAME, DB_OPERATION, DB_SYSTEM } from '@sentry/conventions/attributes';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
 
 export class DynamodbServiceExtension implements ServiceExtension {
@@ -66,12 +64,9 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     const spanAttributes: Attributes = {};
 
-    // eslint-disable-next-line typescript/no-deprecated
-    spanAttributes[ATTR_DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
-    // eslint-disable-next-line typescript/no-deprecated
-    spanAttributes[ATTR_DB_NAME] = tableName;
-    // eslint-disable-next-line typescript/no-deprecated
-    spanAttributes[ATTR_DB_OPERATION] = operation;
+    spanAttributes[DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
+    spanAttributes[DB_NAME] = tableName;
+    spanAttributes[DB_OPERATION] = operation;
 
     // normalizedRequest.commandInput.RequestItems) is undefined when no table names are returned
     // keys in this object are the table names

--- a/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
@@ -64,8 +64,11 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     const spanAttributes: Attributes = {};
 
+    // oxlint-disable-next-line typescript/no-deprecated
     spanAttributes[DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
+    // oxlint-disable-next-line typescript/no-deprecated
     spanAttributes[DB_NAME] = tableName;
+    // oxlint-disable-next-line typescript/no-deprecated
     spanAttributes[DB_OPERATION] = operation;
 
     // normalizedRequest.commandInput.RequestItems) is undefined when no table names are returned

--- a/packages/aws-serverless/src/integration/aws/vendored/services/kinesis.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/kinesis.ts
@@ -19,7 +19,7 @@
  */
 
 import { Attributes, SpanKind } from '@opentelemetry/api';
-import { AttributeNames } from '../enums';
+import { AWS_KINESIS_STREAM_NAME } from '../enums';
 import { AwsSdkInstrumentationConfig, NormalizedRequest } from '../types';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 
@@ -30,7 +30,7 @@ export class KinesisServiceExtension implements ServiceExtension {
     const spanAttributes: Attributes = {};
 
     if (streamName) {
-      spanAttributes[AttributeNames.AWS_KINESIS_STREAM_NAME] = streamName;
+      spanAttributes[AWS_KINESIS_STREAM_NAME] = streamName;
     }
 
     const isIncoming = false;

--- a/packages/aws-serverless/src/integration/aws/vendored/services/lambda.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/lambda.ts
@@ -72,7 +72,7 @@ export class LambdaServiceExtension implements ServiceExtension {
     switch (response.request.commandName) {
       case LambdaCommands.Invoke:
         {
-          // eslint-disable-next-line typescript/no-deprecated
+          // oxlint-disable-next-line typescript/no-deprecated
           span.setAttribute(ATTR_FAAS_EXECUTION, response.requestId);
         }
         break;

--- a/packages/aws-serverless/src/integration/aws/vendored/services/s3.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/s3.ts
@@ -19,7 +19,7 @@
  */
 
 import { Attributes, SpanKind } from '@opentelemetry/api';
-import { AttributeNames } from '../enums';
+import { AWS_S3_BUCKET } from '../enums';
 import { AwsSdkInstrumentationConfig, NormalizedRequest } from '../types';
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 
@@ -30,7 +30,7 @@ export class S3ServiceExtension implements ServiceExtension {
     const spanAttributes: Attributes = {};
 
     if (bucketName) {
-      spanAttributes[AttributeNames.AWS_S3_BUCKET] = bucketName;
+      spanAttributes[AWS_S3_BUCKET] = bucketName;
     }
 
     const isIncoming = false;

--- a/packages/aws-serverless/src/integration/aws/vendored/services/sns.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/sns.ts
@@ -19,7 +19,8 @@
  */
 
 import { Span, SpanKind, Attributes } from '@opentelemetry/api';
-import { ATTR_AWS_SNS_TOPIC_ARN, ATTR_MESSAGING_SYSTEM } from '../semconv';
+import { MESSAGING_SYSTEM } from '@sentry/conventions/attributes';
+import { ATTR_AWS_SNS_TOPIC_ARN } from '../semconv';
 import {
   ATTR_MESSAGING_DESTINATION,
   ATTR_MESSAGING_DESTINATION_KIND,
@@ -34,7 +35,7 @@ export class SnsServiceExtension implements ServiceExtension {
     let spanKind: SpanKind = SpanKind.CLIENT;
     let spanName = `SNS ${request.commandName}`;
     const spanAttributes: Attributes = {
-      [ATTR_MESSAGING_SYSTEM]: 'aws.sns',
+      [MESSAGING_SYSTEM]: 'aws.sns',
     };
 
     if (request.commandName === 'Publish') {

--- a/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/sqs.ts
@@ -22,14 +22,14 @@ import { SpanKind, Span, propagation, trace, ROOT_CONTEXT, Attributes } from '@o
 import { RequestMetadata, ServiceExtension } from './ServiceExtension';
 import type { SQS } from '../aws-sdk.types';
 import { AwsSdkInstrumentationConfig, NormalizedRequest, NormalizedResponse } from '../types';
-import { ATTR_URL_FULL } from '@opentelemetry/semantic-conventions';
 import {
-  ATTR_MESSAGING_BATCH_MESSAGE_COUNT,
-  ATTR_MESSAGING_DESTINATION_NAME,
-  ATTR_MESSAGING_MESSAGE_ID,
-  ATTR_MESSAGING_OPERATION_TYPE,
-  ATTR_MESSAGING_SYSTEM,
-} from '../semconv';
+  MESSAGING_BATCH_MESSAGE_COUNT,
+  MESSAGING_DESTINATION_NAME,
+  MESSAGING_MESSAGE_ID,
+  MESSAGING_OPERATION_TYPE,
+  MESSAGING_SYSTEM,
+  URL_FULL,
+} from '@sentry/conventions/attributes';
 import {
   contextGetter,
   extractPropagationContext,
@@ -45,9 +45,9 @@ export class SqsServiceExtension implements ServiceExtension {
     let spanName: string | undefined;
 
     const spanAttributes: Attributes = {
-      [ATTR_MESSAGING_SYSTEM]: 'aws_sqs',
-      [ATTR_MESSAGING_DESTINATION_NAME]: queueName,
-      [ATTR_URL_FULL]: queueUrl,
+      [MESSAGING_SYSTEM]: 'aws_sqs',
+      [MESSAGING_DESTINATION_NAME]: queueName,
+      [URL_FULL]: queueUrl,
     };
 
     let isIncoming = false;
@@ -58,7 +58,7 @@ export class SqsServiceExtension implements ServiceExtension {
           isIncoming = true;
           spanKind = SpanKind.CONSUMER;
           spanName = `${queueName} receive`;
-          spanAttributes[ATTR_MESSAGING_OPERATION_TYPE] = 'receive';
+          spanAttributes[MESSAGING_OPERATION_TYPE] = 'receive';
 
           request.commandInput.MessageAttributeNames = addPropagationFieldsToAttributeNames(
             request.commandInput.MessageAttributeNames,
@@ -109,7 +109,7 @@ export class SqsServiceExtension implements ServiceExtension {
   responseHook = (response: NormalizedResponse, span: Span) => {
     switch (response.request.commandName) {
       case 'SendMessage':
-        span.setAttribute(ATTR_MESSAGING_MESSAGE_ID, response?.data?.MessageId);
+        span.setAttribute(MESSAGING_MESSAGE_ID, response?.data?.MessageId);
         break;
 
       case 'SendMessageBatch':
@@ -119,7 +119,7 @@ export class SqsServiceExtension implements ServiceExtension {
       case 'ReceiveMessage': {
         const messages: SQS.Message[] = response?.data?.Messages || [];
 
-        span.setAttribute(ATTR_MESSAGING_BATCH_MESSAGE_COUNT, messages.length);
+        span.setAttribute(MESSAGING_BATCH_MESSAGE_COUNT, messages.length);
 
         for (const message of messages) {
           const propagatedContext = propagation.extract(
@@ -134,7 +134,7 @@ export class SqsServiceExtension implements ServiceExtension {
             span.addLink({
               context: spanContext,
               attributes: {
-                [ATTR_MESSAGING_MESSAGE_ID]: message.MessageId,
+                [MESSAGING_MESSAGE_ID]: message.MessageId,
               },
             });
           }

--- a/packages/aws-serverless/src/integration/aws/vendored/utils.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/utils.ts
@@ -19,7 +19,8 @@
  */
 
 import { Attributes, Context, context } from '@opentelemetry/api';
-import { ATTR_RPC_METHOD, ATTR_RPC_SERVICE, ATTR_RPC_SYSTEM } from './semconv';
+import { RPC_METHOD, RPC_SERVICE } from '@sentry/conventions/attributes';
+import { ATTR_RPC_SYSTEM } from './semconv';
 import { AttributeNames } from './enums';
 import { NormalizedRequest } from './types';
 
@@ -45,8 +46,8 @@ export const normalizeV3Request = (
 export const extractAttributesFromNormalizedRequest = (normalizedRequest: NormalizedRequest): Attributes => {
   return {
     [ATTR_RPC_SYSTEM]: 'aws-api',
-    [ATTR_RPC_METHOD]: normalizedRequest.commandName,
-    [ATTR_RPC_SERVICE]: normalizedRequest.serviceName,
+    [RPC_METHOD]: normalizedRequest.commandName,
+    [RPC_SERVICE]: normalizedRequest.serviceName,
     [AttributeNames.CLOUD_REGION]: normalizedRequest.region,
   };
 };

--- a/packages/aws-serverless/src/integration/aws/vendored/utils.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/utils.ts
@@ -21,7 +21,7 @@
 import { Attributes, Context, context } from '@opentelemetry/api';
 import { RPC_METHOD, RPC_SERVICE } from '@sentry/conventions/attributes';
 import { ATTR_RPC_SYSTEM } from './semconv';
-import { AttributeNames } from './enums';
+import { CLOUD_REGION } from './enums';
 import { NormalizedRequest } from './types';
 
 export const removeSuffixFromStringIfExists = (str: string, suffixToRemove: string): string => {
@@ -48,7 +48,7 @@ export const extractAttributesFromNormalizedRequest = (normalizedRequest: Normal
     [ATTR_RPC_SYSTEM]: 'aws-api',
     [RPC_METHOD]: normalizedRequest.commandName,
     [RPC_SERVICE]: normalizedRequest.serviceName,
-    [AttributeNames.CLOUD_REGION]: normalizedRequest.region,
+    [CLOUD_REGION]: normalizedRequest.region,
   };
 };
 

--- a/packages/aws-serverless/src/integration/instrumentation-aws-lambda/instrumentation.ts
+++ b/packages/aws-serverless/src/integration/instrumentation-aws-lambda/instrumentation.ts
@@ -45,17 +45,12 @@ import {
   isWrapped,
   safeExecuteInTheMiddle,
 } from '@opentelemetry/instrumentation';
-import {
-  ATTR_URL_FULL,
-  SEMATTRS_FAAS_EXECUTION,
-  SEMRESATTRS_CLOUD_ACCOUNT_ID,
-  SEMRESATTRS_FAAS_ID,
-} from '@opentelemetry/semantic-conventions';
+import { CLOUD_ACCOUNT_ID, FAAS_COLDSTART, URL_FULL } from '@sentry/conventions/attributes';
 import type { APIGatewayProxyEventHeaders, Callback, Context, Handler, StreamifyHandler } from 'aws-lambda';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { LambdaModule } from './internal-types';
-import { ATTR_FAAS_COLDSTART } from './semconv';
+import { ATTR_FAAS_EXECUTION, ATTR_FAAS_ID } from './semconv';
 import type { AwsLambdaInstrumentationConfig, EventContextExtractor } from './types';
 import { wrapHandler } from '../../sdk';
 import { SDK_VERSION } from '@sentry/core';
@@ -338,10 +333,10 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
       {
         kind: SpanKind.SERVER,
         attributes: {
-          [SEMATTRS_FAAS_EXECUTION]: context.awsRequestId,
-          [SEMRESATTRS_FAAS_ID]: context.invokedFunctionArn,
-          [SEMRESATTRS_CLOUD_ACCOUNT_ID]: AwsLambdaInstrumentation._extractAccountId(context.invokedFunctionArn),
-          [ATTR_FAAS_COLDSTART]: requestIsColdStart,
+          [ATTR_FAAS_EXECUTION]: context.awsRequestId,
+          [ATTR_FAAS_ID]: context.invokedFunctionArn,
+          [CLOUD_ACCOUNT_ID]: AwsLambdaInstrumentation._extractAccountId(context.invokedFunctionArn),
+          [FAAS_COLDSTART]: requestIsColdStart,
           ...AwsLambdaInstrumentation._extractOtherEventFields(event),
         },
       },
@@ -561,7 +556,7 @@ export class AwsLambdaInstrumentation extends InstrumentationBase<AwsLambdaInstr
     const answer: Attributes = {};
     const fullUrl = this._extractFullUrl(event);
     if (fullUrl) {
-      answer[ATTR_URL_FULL] = fullUrl;
+      answer[URL_FULL] = fullUrl;
     }
     return answer;
   }

--- a/packages/aws-serverless/src/integration/instrumentation-aws-lambda/semconv.ts
+++ b/packages/aws-serverless/src/integration/instrumentation-aws-lambda/semconv.ts
@@ -22,8 +22,15 @@
  */
 
 /**
- * A boolean that is true if the serverless function is executed for the first time (aka cold-start).
+ * The execution ID of the current function execution.
  *
- * @experimental This attribute is experimental and is subject to breaking changes in minor releases of `@opentelemetry/semantic-conventions`.
+ * @deprecated Removed from the stable semantic conventions; not present in `@sentry/conventions`, so vendored here.
  */
-export const ATTR_FAAS_COLDSTART = 'faas.coldstart';
+export const ATTR_FAAS_EXECUTION = 'faas.execution';
+
+/**
+ * The unique ID of the single function that this runtime instance executes.
+ *
+ * @deprecated Removed from the stable semantic conventions; not present in `@sentry/conventions`, so vendored here.
+ */
+export const ATTR_FAAS_ID = 'faas.id';

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@sentry/conventions": "^0.11.0",
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0"
   },

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -101,7 +101,7 @@
     }
   },
   "dependencies": {
-    "@sentry/conventions": "^0.11.0",
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0",
     "@sentry/opentelemetry": "10.58.0",
     "import-in-the-middle": "^3.0.0"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -68,7 +68,7 @@
     "@opentelemetry/instrumentation": "^0.214.0",
     "@remix-run/router": "^1.23.3",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.11.0",
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0",
     "@sentry/node": "10.58.0",
     "@sentry/react": "10.58.0",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.11.0",
+    "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.58.0"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7605,10 +7605,10 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
-"@sentry/conventions@^0.11.0":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.1.tgz#6409c71ae1f1ca4aa8a0d0affcee14aeb2713208"
-  integrity sha512-nk09uTX+e+oV2sEKsIONoBbnHzl/dQajlhz0VUrJIAE4W35g+oQp0gnbXB/+ZFJpc7v4GSVi+bP7Zri59Lq6Og==
+"@sentry/conventions@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.12.0.tgz#e963cf928ac4d1585b1dcc196e767df3ac45ca5c"
+  integrity sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g==
 
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7606,9 +7606,9 @@
     "@sentry/cli-win32-x64" "2.58.6"
 
 "@sentry/conventions@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.0.tgz#5a324b8368dc5c141260bd8ccc684756ea3dd843"
-  integrity sha512-AQTAKeq9mDpOElDFSPymZTPZF/c50rk355mWTf5Y1ZxZJKKOBli5qTttskJyCxrE5ynNgN1KwcXoU5MRrMSRmQ==
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.11.1.tgz#6409c71ae1f1ca4aa8a0d0affcee14aeb2713208"
+  integrity sha512-nk09uTX+e+oV2sEKsIONoBbnHzl/dQajlhz0VUrJIAE4W35g+oQp0gnbXB/+ZFJpc7v4GSVi+bP7Zri59Lq6Og==
 
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"


### PR DESCRIPTION
Sources span attribute keys from `@sentry/conventions/attributes` instead of the locally vendored `./semconv` constants (and direct `@opentelemetry/semantic-conventions` imports), for the attributes that have a `@sentry/conventions` equivalent. No functional change — the resolved attribute key strings are identical.

Attributes with no `@sentry/conventions` equivalent stay vendored locally: AWS-specific keys (`aws.dynamodb.*`, `aws.sns.topic.arn`, …), `faas.execution`, `faas.id`, `gen_ai.request.stop_sequences`, and `rpc.system`.

This supersedes #21491, which was opened before `develop` substantially refactored these vendored files (the `SemconvStability` dual-semconv handling was removed). Rather than rebase through those conflicts, the migration is re-authored on top of current `develop`. Unlike the previous PR, this does **not** add a `paths` override to the shared `packages/typescript/tsconfig.json` — `@sentry/conventions/attributes` resolves via the package's own `exports` map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)