### PR TITLE
ci: Assign server team as codeowner for server-utils package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 # Node/server runtimes and related packages
 /packages/node/                     @getsentry/team-javascript-sdks-server
 /packages/node-core/                @getsentry/team-javascript-sdks-server
+/packages/server-utils/             @getsentry/team-javascript-sdks-server
 /packages/node-native/              @getsentry/team-javascript-sdks-server
 /packages/profiling-node/           @getsentry/team-javascript-sdks-server
 /packages/opentelemetry/            @getsentry/team-javascript-sdks-server


### PR DESCRIPTION
Noticed that https://github.com/getsentry/sentry-javascript/pull/21490 did not assign any reviewers. Adding the server group for this package.