### PR TITLE
chore: Change deprecation/deprecation to oxlint equivalent

### DIFF
--- a/.oxlintrc.base.json
+++ b/.oxlintrc.base.json
@@ -36,7 +36,8 @@
     "no-unsafe-optional-chaining": "off",
     "no-eval": "off",
     "no-import-assign": "off",
-    "typescript/no-duplicate-type-constituents": "off"
+    "typescript/no-duplicate-type-constituents": "off",
+    "typescript/no-deprecated": "error"
   },
   "overrides": [
     {
@@ -101,7 +102,8 @@
         "typescript/no-misused-spread": "off",
         "typescript/require-array-sort-compare": "off",
         "typescript/no-base-to-string": "off",
-        "typescript/await-thenable": "off"
+        "typescript/await-thenable": "off",
+        "typescript/no-deprecated": "off"
       }
     },
     {

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -35,7 +35,7 @@ export function getDefaultIntegrations(_options: BrowserOptions = {}): Integrati
   //  - https://github.com/getsentry/sentry-javascript/issues/2744
   return [
     // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -65,6 +65,7 @@ export {
   winterCGHeadersToDict,
   graphqlIntegration,
   hapiIntegration,
+  // eslint-disable-next-line typescript/no-deprecated
   honoIntegration,
   httpIntegration,
   httpServerIntegration,
@@ -127,6 +128,7 @@ export {
   setupConnectErrorHandler,
   setupExpressErrorHandler,
   setupHapiErrorHandler,
+  // eslint-disable-next-line typescript/no-deprecated
   setupHonoErrorHandler,
   setupKoaErrorHandler,
   setUser,

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -13,10 +13,10 @@ export {
   addIntegration,
   amqplibIntegration,
   anthropicAIIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
   googleGenAIIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   captureCheckIn,
   captureConsoleIntegration,
@@ -69,7 +69,7 @@ export {
   httpIntegration,
   httpServerIntegration,
   httpServerSpansIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -29,7 +29,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           clientInitPath,
           serverInitPath,
           autoInstrumentation,
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line typescript/no-deprecated
           sourceMapsUploadOptions,
           sourcemaps,
           // todo(v11): Extract `release` build time option here - cannot be done currently, because it conflicts with the `DeprecatedRuntimeOptions` type
@@ -64,7 +64,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
         };
 
         const sourceMapsNeeded = sdkEnabled.client || sdkEnabled.server;
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         const { unstable_sentryVitePluginOptions: deprecatedVitePluginOptions, ...uploadOptions } =
           sourceMapsUploadOptions || {};
 
@@ -76,7 +76,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
         const shouldUploadSourcemaps =
           (sourceMapsNeeded &&
             sourcemaps?.disable !== true &&
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line typescript/no-deprecated
             uploadOptions?.enabled) ??
           true;
 
@@ -87,7 +87,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           let updatedFilesToDeleteAfterUpload: string[] | undefined = undefined;
 
           if (
-            // eslint-disable-next-line deprecation/deprecation
+            // eslint-disable-next-line typescript/no-deprecated
             typeof uploadOptions?.filesToDeleteAfterUpload === 'undefined' &&
             typeof sourcemaps?.filesToDeleteAfterUpload === 'undefined' &&
             computedSourceMapSettings.previousUserSourceMapSetting === 'unset'
@@ -112,15 +112,15 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                 sentryVitePlugin({
                   applicationKey,
                   // Priority: top-level options > deprecated options > env vars
-                  // eslint-disable-next-line deprecation/deprecation
+                  // eslint-disable-next-line typescript/no-deprecated
                   org: org ?? uploadOptions.org ?? env.SENTRY_ORG,
-                  // eslint-disable-next-line deprecation/deprecation
+                  // eslint-disable-next-line typescript/no-deprecated
                   project: project ?? uploadOptions.project ?? env.SENTRY_PROJECT,
-                  // eslint-disable-next-line deprecation/deprecation
+                  // eslint-disable-next-line typescript/no-deprecated
                   authToken: authToken ?? uploadOptions.authToken ?? env.SENTRY_AUTH_TOKEN,
                   url: sentryUrl ?? env.SENTRY_URL,
                   headers,
-                  // eslint-disable-next-line deprecation/deprecation
+                  // eslint-disable-next-line typescript/no-deprecated
                   telemetry: telemetry ?? uploadOptions.telemetry ?? true,
                   silent: silent ?? false,
                   errorHandler,
@@ -133,11 +133,11 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                   debug: debug ?? false,
                   sourcemaps: {
                     ...sourcemaps,
-                    // eslint-disable-next-line deprecation/deprecation
+                    // eslint-disable-next-line typescript/no-deprecated
                     assets: sourcemaps?.assets ?? uploadOptions.assets ?? [getSourcemapsAssetsGlob(config)],
                     filesToDeleteAfterUpload:
                       sourcemaps?.filesToDeleteAfterUpload ??
-                      // eslint-disable-next-line deprecation/deprecation
+                      // eslint-disable-next-line typescript/no-deprecated
                       uploadOptions?.filesToDeleteAfterUpload ??
                       updatedFilesToDeleteAfterUpload,
                     ...unstableMerged_sentryVitePluginOptions?.sourcemaps,

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -194,9 +194,9 @@ export type SentryOptions = Omit<BuildTimeOptionsBase, 'release'> &
      * @deprecated This option was deprecated. Please move the options to the top-level configuration.
      * See the migration guide in the SourceMapsOptions type documentation.
      */
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     sourceMapsUploadOptions?: SourceMapsOptions;
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
   } & DeprecatedRuntimeOptions;
 
 /**

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -47,9 +47,9 @@ export {
   instrumentLangChainEmbeddings,
   httpHeadersToSpanAttributes,
   winterCGHeadersToDict,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   consoleIntegration,
   httpIntegration,
@@ -69,7 +69,7 @@ export {
   localVariablesIntegration,
   requestDataIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
@@ -175,6 +175,6 @@ export { awsIntegration } from './integration/aws';
 export { awsLambdaIntegration } from './integration/awslambda';
 
 export { getDefaultIntegrations, init } from './init';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { tryPatchHandler, wrapHandler } from './sdk';
 export type { WrapperOptions } from './sdk';

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -122,7 +122,9 @@ export {
   createSentryWinstonTransport,
   hapiIntegration,
   setupHapiErrorHandler,
+  // eslint-disable-next-line typescript/no-deprecated
   honoIntegration,
+  // eslint-disable-next-line typescript/no-deprecated
   setupHonoErrorHandler,
   spotlightIntegration,
   initOpenTelemetry,

--- a/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/aws-sdk.ts
@@ -289,6 +289,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
                   const httpStatusCode = response.output?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
+                    // eslint-disable-next-line typescript/no-deprecated
                     span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
                   }
 
@@ -317,6 +318,7 @@ export class AwsInstrumentation extends InstrumentationBase<AwsSdkInstrumentatio
 
                   const httpStatusCode = err?.$metadata?.httpStatusCode;
                   if (httpStatusCode) {
+                    // eslint-disable-next-line typescript/no-deprecated
                     span.setAttribute(ATTR_HTTP_STATUS_CODE, httpStatusCode);
                   }
 

--- a/packages/aws-serverless/src/integration/aws/vendored/services/ServiceExtension.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/ServiceExtension.ts
@@ -28,6 +28,7 @@ export interface RequestMetadata {
   // the ServiceExtension must end the span itself, generally by wrapping the stream and ending after it is
   // consumed.
   isStream?: boolean;
+  // eslint-disable-next-line typescript/no-deprecated
   spanAttributes?: SpanAttributes;
   spanKind?: SpanKind;
   spanName?: string;

--- a/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/bedrock-runtime.ts
@@ -82,6 +82,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
   ): RequestMetadata {
     let spanName = GEN_AI_OPERATION_NAME_VALUE_CHAT;
     const spanAttributes: Attributes = {
+      // eslint-disable-next-line typescript/no-deprecated
       [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
       [ATTR_GEN_AI_OPERATION_NAME]: GEN_AI_OPERATION_NAME_VALUE_CHAT,
     };
@@ -126,6 +127,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
     isStream: boolean,
   ): RequestMetadata {
     const spanAttributes: Attributes = {
+      // eslint-disable-next-line typescript/no-deprecated
       [ATTR_GEN_AI_SYSTEM]: GEN_AI_SYSTEM_VALUE_AWS_BEDROCK,
       // add operation name for InvokeModel API
     };

--- a/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/dynamodb.ts
@@ -66,8 +66,11 @@ export class DynamodbServiceExtension implements ServiceExtension {
 
     const spanAttributes: Attributes = {};
 
+    // eslint-disable-next-line typescript/no-deprecated
     spanAttributes[ATTR_DB_SYSTEM] = DB_SYSTEM_VALUE_DYNAMODB;
+    // eslint-disable-next-line typescript/no-deprecated
     spanAttributes[ATTR_DB_NAME] = tableName;
+    // eslint-disable-next-line typescript/no-deprecated
     spanAttributes[ATTR_DB_OPERATION] = operation;
 
     // normalizedRequest.commandInput.RequestItems) is undefined when no table names are returned

--- a/packages/aws-serverless/src/integration/aws/vendored/services/lambda.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/lambda.ts
@@ -72,6 +72,7 @@ export class LambdaServiceExtension implements ServiceExtension {
     switch (response.request.commandName) {
       case LambdaCommands.Invoke:
         {
+          // eslint-disable-next-line typescript/no-deprecated
           span.setAttribute(ATTR_FAAS_EXECUTION, response.requestId);
         }
         break;

--- a/packages/aws-serverless/src/integration/aws/vendored/services/sns.ts
+++ b/packages/aws-serverless/src/integration/aws/vendored/services/sns.ts
@@ -40,12 +40,15 @@ export class SnsServiceExtension implements ServiceExtension {
     if (request.commandName === 'Publish') {
       spanKind = SpanKind.PRODUCER;
 
+      // eslint-disable-next-line typescript/no-deprecated
       spanAttributes[ATTR_MESSAGING_DESTINATION_KIND] = MESSAGING_DESTINATION_KIND_VALUE_TOPIC;
       const { TopicArn, TargetArn, PhoneNumber } = request.commandInput;
+      // eslint-disable-next-line typescript/no-deprecated
       spanAttributes[ATTR_MESSAGING_DESTINATION] = this.extractDestinationName(TopicArn, TargetArn, PhoneNumber);
       // ToDO: Use ATTR_MESSAGING_DESTINATION_NAME when implemented
       spanAttributes['messaging.destination.name'] = TopicArn || TargetArn || PhoneNumber || 'unknown';
 
+      // eslint-disable-next-line typescript/no-deprecated
       spanName = `${PhoneNumber ? 'phone_number' : spanAttributes[ATTR_MESSAGING_DESTINATION]} send`;
     }
 

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -168,7 +168,7 @@ export function wrapHandler<TEvent, TResult>(
 ): Handler<TEvent, TResult> | StreamifyHandler<TEvent, TResult> {
   const START_TIME = performance.now();
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   if (typeof wrapOptions.startTrace !== 'undefined') {
     consoleSandbox(() => {
       // eslint-disable-next-line no-console

--- a/packages/browser-utils/src/getNativeImplementation.ts
+++ b/packages/browser-utils/src/getNativeImplementation.ts
@@ -40,7 +40,7 @@ export function getNativeImplementation<T extends keyof CacheableImplementations
   }
 
   const document = WINDOW.document;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   if (document && typeof document.createElement === 'function') {
     try {
       const sandbox = document.createElement('iframe');

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -12,11 +12,13 @@ export {
   startTrackingInteractions,
   startTrackingLongTasks,
   startTrackingLongAnimationFrames,
+  // eslint-disable-next-line typescript/no-deprecated
   startTrackingWebVitals,
   startTrackingINP,
   registerInpInteractionListener,
 } from './metrics/browserMetrics';
 
+// eslint-disable-next-line typescript/no-deprecated
 export { elementTimingIntegration, startTrackingElementTiming } from './metrics/elementTiming';
 
 export { extractNetworkProtocol } from './metrics/utils';

--- a/packages/browser-utils/src/metrics/utils.ts
+++ b/packages/browser-utils/src/metrics/utils.ts
@@ -220,7 +220,7 @@ export function listenForWebVitalReportEvents(
     collected = true;
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   onHidden(() => {
     _runCollectorCallbackOnce('pagehide');
   });

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -107,7 +107,7 @@ export class BrowserClient extends Client<BrowserClientOptions> {
     const { sendClientReports, enableLogs, _experiments, enableMetrics: enableMetricsOption } = this._options;
 
     // todo(v11): Remove the experimental flag
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     const enableMetrics = enableMetricsOption ?? _experiments?.enableMetrics ?? true;
 
     // Flush logs and metrics when page becomes hidden (e.g., tab switch, navigation)

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -306,7 +306,7 @@ export function eventFromUnknownInput(
       addExceptionTypeValue(event, message);
     }
     if ('code' in domException) {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       event.tags = { ...event.tags, 'DOMException.code': `${domException.code}` };
     }
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -58,7 +58,7 @@ export {
   withScope,
   withIsolationScope,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   dedupeIntegration,

--- a/packages/browser/src/integrations/httpclient.ts
+++ b/packages/browser/src/integrations/httpclient.ts
@@ -433,7 +433,7 @@ function _getDataCollectionSettings() {
   // collect headers/cookies with deny-list filtering even without sendDefaultPii).
   const options = client.getOptions();
   if (options.dataCollection == null) {
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     const enabled = Boolean(options.sendDefaultPii);
     return { cookies: enabled, requestHeaders: enabled, responseHeaders: enabled };
   }

--- a/packages/browser/src/integrations/webVitals.ts
+++ b/packages/browser/src/integrations/webVitals.ts
@@ -50,6 +50,7 @@ export const webVitalsIntegration = defineIntegration((options: WebVitalsOptions
       const recordLcpStandaloneSpans =
         spanStreamingEnabled || ignored.has('lcp') ? undefined : enableStandaloneLcpSpans || false;
 
+      // eslint-disable-next-line typescript/no-deprecated
       const finalizeWebVitals = startTrackingWebVitals({
         recordClsStandaloneSpans,
         recordLcpStandaloneSpans,

--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -33,7 +33,7 @@ const _browserProfilingIntegration = (() => {
         options.profileLifecycle = 'manual';
       }
 
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       if (hasLegacyProfiling(options) && !options.profilesSampleRate) {
         DEBUG_BUILD && debug.log('[Profiling] Profiling disabled, no profiling options found.');
         return;

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -651,7 +651,7 @@ export function shouldProfileSpanLegacy(span: Span): boolean {
     return false;
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const profilesSampleRate = (options as BrowserOptions).profilesSampleRate as
     | BrowserOptions['profilesSampleRate']
     | boolean;
@@ -729,7 +729,7 @@ export function shouldProfileSession(options: BrowserOptions): boolean {
  * Checks if legacy profiling is configured.
  */
 export function hasLegacyProfiling(options: BrowserOptions): boolean {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   return typeof options.profilesSampleRate !== 'undefined';
 }
 

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -32,7 +32,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
    */
   return [
     // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -390,6 +390,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
     markBackgroundSpan,
     traceFetch,
     traceXHR,
+    // eslint-disable-next-line typescript/no-deprecated
     trackFetchStreamPerformance,
     shouldCreateSpanForRequest,
     enableHTTPTimings,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -141,7 +141,9 @@ export {
   processSessionIntegration,
   hapiIntegration,
   setupHapiErrorHandler,
+  // eslint-disable-next-line typescript/no-deprecated
   honoIntegration,
+  // eslint-disable-next-line typescript/no-deprecated
   setupHonoErrorHandler,
   spotlightIntegration,
   initOpenTelemetry,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -70,9 +70,9 @@ export {
   instrumentLangChainEmbeddings,
   httpHeadersToSpanAttributes,
   winterCGHeadersToDict,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   consoleIntegration,
   httpIntegration,
@@ -91,7 +91,7 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
@@ -191,7 +191,7 @@ export {
 
 export type { BunOptions } from './types';
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { BunClient } from './client';
 export { getDefaultIntegrations, init } from './sdk';
 export { bunServerIntegration } from './integrations/bunserver';

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -32,7 +32,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   return [
     // Common
     // TODO(v11): Replace with eventFiltersIntegration once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),

--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -126,7 +126,9 @@ export function instrumentDurableObjectWithSentry<
 
       // If `instrumentPrototypeMethods` was passed as an array (deprecated),
       // only the listed method names should be instrumented.
+      // eslint-disable-next-line typescript/no-deprecated
       const instrumentPrototypeMethods = Array.isArray(options.instrumentPrototypeMethods)
+        // eslint-disable-next-line typescript/no-deprecated
         ? options.instrumentPrototypeMethods
         : undefined;
       const allowSet = instrumentPrototypeMethods ? new Set(instrumentPrototypeMethods) : null;

--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -128,8 +128,8 @@ export function instrumentDurableObjectWithSentry<
       // only the listed method names should be instrumented.
       // eslint-disable-next-line typescript/no-deprecated
       const instrumentPrototypeMethods = Array.isArray(options.instrumentPrototypeMethods)
-        // eslint-disable-next-line typescript/no-deprecated
-        ? options.instrumentPrototypeMethods
+        ? // eslint-disable-next-line typescript/no-deprecated
+          options.instrumentPrototypeMethods
         : undefined;
       const allowSet = instrumentPrototypeMethods ? new Set(instrumentPrototypeMethods) : null;
 

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -125,8 +125,10 @@ export { getDefaultIntegrations } from './sdk';
 export { httpServerIntegration } from './integrations/httpServer';
 export { fetchIntegration } from './integrations/fetch';
 export { vercelAIIntegration } from './integrations/tracing/vercelai';
+// eslint-disable-next-line typescript/no-deprecated
 export { honoIntegration } from './integrations/hono';
 
+// eslint-disable-next-line typescript/no-deprecated
 export { instrumentD1WithSentry } from './instrumentations/worker/instrumentD1';
 
 export { instrumentWorkflowWithSentry } from './workflows';

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -71,7 +71,7 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   instrumentOpenAiClient,
   instrumentGoogleGenAIClient,

--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -27,14 +27,14 @@ export function getDefaultIntegrations(options: CloudflareOptions): Integration[
   // TODO(v11): Drop this transitional gating and let `requestDataIntegration` rely on the resolved
   // `dataCollection` defaults directly. Until then, preserve the historical Cloudflare behavior of not
   // attaching cookies unless the user explicitly opts in via `sendDefaultPii` or `dataCollection.cookies`.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const cookiesEnabled = options.sendDefaultPii || options.dataCollection?.cookies != null;
   return [
     // The Dedupe integration should not be used in workflows because we want to
     // capture all step failures, even if they are the same error.
     ...(options.enableDedupe === false ? [] : [dedupeIntegration()]),
     // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),

--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -40,6 +40,7 @@ export function getDefaultIntegrations(options: CloudflareOptions): Integration[
     conversationIdIntegration(),
     linkedErrorsIntegration(),
     fetchIntegration(),
+    // eslint-disable-next-line typescript/no-deprecated
     honoIntegration(),
     httpServerIntegration(),
     requestDataIntegration(cookiesEnabled ? undefined : { include: { cookies: false } }),

--- a/packages/cloudflare/src/utils/rpcOptions.ts
+++ b/packages/cloudflare/src/utils/rpcOptions.ts
@@ -13,6 +13,7 @@ import { DEBUG_BUILD } from '../debug-build';
  * @returns The effective setting for RPC trace propagation
  */
 export function getEffectiveRpcPropagation(options: CloudflareOptions): boolean {
+  // eslint-disable-next-line typescript/no-deprecated
   const { enableRpcTracePropagation, instrumentPrototypeMethods } = options;
 
   // If the new option is explicitly set, use it

--- a/packages/core/src/browser-exports.ts
+++ b/packages/core/src/browser-exports.ts
@@ -6,7 +6,7 @@
 export {
   getComponentName,
   getLocationHref,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   htmlTreeAsString,
 } from './utils/browser';
 export { supportsDOMError, supportsHistory, supportsNativeFetch, supportsReportingObserver } from './utils/supports';

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -257,7 +257,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
 
     // Backfill enableLogs option from _experiments.enableLogs
     // TODO(v11): Remove or change default value
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     this._options.enableLogs = this._options.enableLogs ?? this._options._experiments?.enableLogs;
 
     // Setup log flushing with weight and timeout tracking
@@ -266,7 +266,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     }
 
     // todo(v11): Remove the experimental flag
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     const enableMetrics = this._options.enableMetrics ?? this._options._experiments?.enableMetrics ?? true;
 
     // Setup metric flushing with weight and timeout tracking

--- a/packages/core/src/integrations/express/index.ts
+++ b/packages/core/src/integrations/express/index.ts
@@ -103,6 +103,7 @@ export function patchExpressModule(
   let getOptions: () => ExpressIntegrationOptions;
   let moduleExports: ExpressModuleExport;
   if (!maybeGetOptions && isLegacyOptions(optionsOrExports)) {
+    // eslint-disable-next-line typescript/no-deprecated
     const { express, ...options } = optionsOrExports;
     moduleExports = express;
     getOptions = () => options;

--- a/packages/core/src/integrations/mcp-server/handlers.ts
+++ b/packages/core/src/integrations/mcp-server/handlers.ts
@@ -132,6 +132,7 @@ function captureHandlerError(error: Error, methodName: keyof MCPServerInstance, 
  * @param serverInstance - MCP server instance
  */
 export function wrapToolHandlers(serverInstance: MCPServerInstance): void {
+  // eslint-disable-next-line typescript/no-deprecated
   if (typeof serverInstance.tool === 'function') wrapMethodHandler(serverInstance, 'tool');
   if (typeof serverInstance.registerTool === 'function') wrapMethodHandler(serverInstance, 'registerTool');
 }
@@ -142,6 +143,7 @@ export function wrapToolHandlers(serverInstance: MCPServerInstance): void {
  * @param serverInstance - MCP server instance
  */
 export function wrapResourceHandlers(serverInstance: MCPServerInstance): void {
+  // eslint-disable-next-line typescript/no-deprecated
   if (typeof serverInstance.resource === 'function') wrapMethodHandler(serverInstance, 'resource');
   if (typeof serverInstance.registerResource === 'function') wrapMethodHandler(serverInstance, 'registerResource');
 }
@@ -152,6 +154,7 @@ export function wrapResourceHandlers(serverInstance: MCPServerInstance): void {
  * @param serverInstance - MCP server instance
  */
 export function wrapPromptHandlers(serverInstance: MCPServerInstance): void {
+  // eslint-disable-next-line typescript/no-deprecated
   if (typeof serverInstance.prompt === 'function') wrapMethodHandler(serverInstance, 'prompt');
   if (typeof serverInstance.registerPrompt === 'function') wrapMethodHandler(serverInstance, 'registerPrompt');
 }

--- a/packages/core/src/metrics/internal.ts
+++ b/packages/core/src/metrics/internal.ts
@@ -176,7 +176,7 @@ export function _INTERNAL_captureMetric(beforeMetric: Metric, options?: Internal
   const { _experiments, enableMetrics, beforeSendMetric } = client.getOptions();
 
   // todo(v11): Remove the experimental flag
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const metricsEnabled = enableMetrics ?? _experiments?.enableMetrics ?? true;
 
   if (!metricsEnabled) {
@@ -191,7 +191,7 @@ export function _INTERNAL_captureMetric(beforeMetric: Metric, options?: Internal
   client.emit('processMetric', enrichedMetric);
 
   // todo(v11): Remove the experimental `beforeSendMetric`
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const beforeSendCallback = beforeSendMetric || _experiments?.beforeSendMetric;
   const processedMetric = beforeSendCallback ? beforeSendCallback(enrichedMetric) : enrichedMetric;
 

--- a/packages/core/src/server-exports.ts
+++ b/packages/core/src/server-exports.ts
@@ -15,6 +15,7 @@ export { vercelWaitUntil } from './utils/vercelWaitUntil';
 export { flushIfServerless } from './utils/flushIfServerless';
 export { callFrameToStackFrame, watchdogTimer } from './utils/anr';
 export { safeUnref as _INTERNAL_safeUnref } from './utils/timer';
+// eslint-disable-next-line typescript/no-deprecated
 export { patchExpressModule, setupExpressErrorHandler, expressErrorHandler } from './integrations/express/index';
 export type {
   ExpressIntegrationOptions,

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -83,7 +83,7 @@ export { parameterize, fmt } from './utils/parameterize';
 export type { HandleTunnelRequestOptions } from './utils/tunnel';
 export { handleTunnelRequest } from './utils/tunnel';
 export { addAutoIpAddressToSession } from './utils/ipAddress';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { addAutoIpAddressToUser } from './utils/ipAddress';
 export {
   convertSpanLinksForEnvelope,
@@ -126,7 +126,7 @@ export type { MaxRequestBodySize } from './utils/request';
 export { DEFAULT_ENVIRONMENT, DEV_ENVIRONMENT } from './constants';
 export { addBreadcrumb } from './breadcrumbs';
 export { functionToStringIntegration } from './integrations/functiontostring';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { inboundFiltersIntegration } from './integrations/eventFilters';
 export { eventFiltersIntegration } from './integrations/eventFilters';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
@@ -147,7 +147,7 @@ export { conversationIdIntegration } from './integrations/conversationId';
 export { profiler } from './profiling';
 // eslint thinks the entire function is deprecated (while only one overload is actually deprecated)
 // Therefore:
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { instrumentFetchRequest, _INTERNAL_getTracingHeadersForFetchRequest } from './fetch';
 export { captureFeedback } from './feedback';
 export type { ReportDialogOptions } from './report-dialog';
@@ -192,7 +192,7 @@ export type {
   GoogleGenAIOptions,
   GoogleGenAIInstrumentedMethod,
 } from './tracing/google-genai/types';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export type { GoogleGenAIIstrumentedMethod } from './tracing/google-genai/types';
 export { SpanBuffer } from './tracing/spans/spanBuffer';
 export { hasSpanStreamingEnabled } from './tracing/spans/hasSpanStreamingEnabled';
@@ -208,7 +208,7 @@ export {
 export { applyAggregateErrorsToEvent } from './utils/aggregate-errors';
 export { getBreadcrumbLogLevelFromHttpStatusCode } from './utils/breadcrumb-log-level';
 export { dsnFromString, dsnToString, makeDsn } from './utils/dsn';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { SentryError } from './utils/error';
 export { GLOBAL_OBJ } from './utils/worldwide';
 export type { InternalGlobal } from './utils/worldwide';
@@ -220,7 +220,7 @@ export { addHandler, maybeInstrument, resetInstrumentationHandlers, triggerHandl
 export {
   isDOMError,
   isDOMException,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   isElement,
   isError,
   isErrorEvent,
@@ -231,10 +231,10 @@ export {
   isPrimitive,
   isRegExp,
   isString,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   isSyntheticEvent,
   isThenable,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   isVueViewModel,
 } from './utils/is';
 export { isBrowser } from './utils/isBrowser';
@@ -255,7 +255,7 @@ export { setNormalizationDepthOverrideHint, setSkipNormalizationHint } from './u
 export {
   addNonEnumerableProperty,
   convertToPlainObject,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   dropUndefinedKeys,
   extractExceptionKeysForMessage,
   fill,
@@ -281,9 +281,9 @@ export {
   isNativeFunction,
   supportsDOMException,
   supportsErrorEvent,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   supportsFetch,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   supportsReferrerPolicy,
 } from './utils/supports';
 export { SyncPromise, rejectedSyncPromise, resolvedSyncPromise } from './utils/syncpromise';
@@ -491,7 +491,7 @@ export type {
   MetricType,
   SerializedMetric,
   SerializedMetricContainer,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   SerializedMetricAttributeValue,
 } from './types/metric';
 export type { TimedEvent } from './types/timedEvent';

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -179,10 +179,12 @@ export type { LangChainOptions, LangChainIntegration } from './tracing/langchain
 export { instrumentStateGraphCompile, instrumentCreateReactAgent, instrumentLangGraph } from './tracing/langgraph';
 export { LANGGRAPH_INTEGRATION_NAME } from './tracing/langgraph/constants';
 export type { LangGraphOptions, LangGraphIntegration, CompiledGraph } from './tracing/langgraph/types';
+// eslint-disable-next-line typescript/no-deprecated
 export type { OpenAiClient, OpenAiOptions, InstrumentedMethod } from './tracing/openai/types';
 export type {
   AnthropicAiClient,
   AnthropicAiOptions,
+  // eslint-disable-next-line typescript/no-deprecated
   AnthropicAiInstrumentedMethod,
   AnthropicAiResponse,
 } from './tracing/anthropic-ai/types';

--- a/packages/core/src/utils/supports.ts
+++ b/packages/core/src/utils/supports.ts
@@ -122,7 +122,7 @@ export function supportsNativeFetch(): boolean {
   // so create a "pure" iframe to see if that has native fetch
   let result = false;
   const doc = WINDOW.document;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   if (doc && typeof (doc.createElement as unknown) === 'function') {
     try {
       const sandbox = doc.createElement('iframe');

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -113,7 +113,7 @@ function getBrowserTimeOrigin(): number | undefined {
   // Also as of writing, performance.timing is not available in Web Workers in mainstream browsers, so it is not always
   // a valid fallback. In the absence of an initial time provided by the browser, fallback to the current time from the
   // Date API.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const navigationStart = performance.timing?.navigationStart;
   if (typeof navigationStart === 'number') {
     const navigationStartDelta = Math.abs(navigationStart + performanceNow - dateNow);

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -410,7 +410,7 @@ function createUndefinedIsNotAnObjectEvent(evaluatingStr: string): Event {
 }
 
 describe.each([
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   ['InboundFilters', inboundFiltersIntegration],
   ['EventFilters', eventFiltersIntegration],
 ])('%s', (_, integrationFn) => {

--- a/packages/core/test/lib/utils/object.test.ts
+++ b/packages/core/test/lib/utils/object.test.ts
@@ -166,7 +166,7 @@ describe('extractExceptionKeysForMessage()', () => {
   });
 });
 
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable typescript/no-deprecated */
 describe('dropUndefinedKeys()', () => {
   test('simple case', () => {
     expect(
@@ -312,7 +312,7 @@ describe('dropUndefinedKeys()', () => {
     expect(droppedChicken.lays[0] === droppedChicken).toBe(true);
   });
 });
-/* eslint-enable deprecation/deprecation */
+/* eslint-enable typescript/no-deprecated */
 
 describe('objectify()', () => {
   describe('stringifies nullish values', () => {

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -66,7 +66,7 @@ export {
   startSpanManual,
   startNewTrace,
   suppressTracing,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -36,7 +36,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   return [
     // Common
     // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     inboundFiltersIntegration(),
     requestDataIntegration(),
     functionToStringIntegration(),

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -48,9 +48,9 @@ export {
   instrumentLangChainEmbeddings,
   httpHeadersToSpanAttributes,
   winterCGHeadersToDict,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   consoleIntegration,
   httpIntegration,
@@ -69,7 +69,7 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -119,7 +119,9 @@ export {
   processSessionIntegration,
   hapiIntegration,
   setupHapiErrorHandler,
+  // eslint-disable-next-line typescript/no-deprecated
   honoIntegration,
+  // eslint-disable-next-line typescript/no-deprecated
   setupHonoErrorHandler,
   spotlightIntegration,
   initOpenTelemetry,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -120,7 +120,9 @@ export {
   processSessionIntegration,
   hapiIntegration,
   setupHapiErrorHandler,
+  // eslint-disable-next-line typescript/no-deprecated
   honoIntegration,
+  // eslint-disable-next-line typescript/no-deprecated
   setupHonoErrorHandler,
   spotlightIntegration,
   initOpenTelemetry,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -47,9 +47,9 @@ export {
   instrumentLangChainEmbeddings,
   httpHeadersToSpanAttributes,
   winterCGHeadersToDict,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   consoleIntegration,
   httpIntegration,
@@ -70,7 +70,7 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,

--- a/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
+++ b/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
@@ -53,7 +53,7 @@ function isTunnelRouteSpan(spanAttributes: Record<string, unknown>): boolean {
     return false;
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const httpTarget = spanAttributes[SEMATTRS_HTTP_TARGET];
 
   if (typeof httpTarget === 'string') {

--- a/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
+++ b/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
@@ -66,7 +66,7 @@ export function constructTurbopackConfig({
   // so it is safe even for node_modules with strict initialization order.
   // We only exclude Next.js build polyfills which contain non-standard syntax that causes
   // parse errors when any code is prepended (Turbopack re-parses the loader output).
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const applicationKey = userSentryOptions?.applicationKey ?? userSentryOptions?._experimental?.turbopackApplicationKey;
   if (applicationKey && nextJsVersion && supportsTurbopackRuleCondition(nextJsVersion)) {
     newConfig.rules = safelyAddTurbopackRule(newConfig.rules, {

--- a/packages/nextjs/src/config/withSentryConfig/deprecatedWebpackOptions.ts
+++ b/packages/nextjs/src/config/withSentryConfig/deprecatedWebpackOptions.ts
@@ -35,7 +35,7 @@ export function migrateDeprecatedWebpackOptions(userSentryOptions: SentryBuildOp
     return message;
   };
 
-  /* eslint-disable deprecation/deprecation */
+  /* eslint-disable typescript/no-deprecated */
   // Migrate each deprecated option to the new path, but only if the new path isn't already set
   webpack.autoInstrumentServerFunctions = withDeprecatedFallback(
     webpack.autoInstrumentServerFunctions,

--- a/packages/nextjs/src/config/withSentryConfig/getFinalConfigObjectUtils.ts
+++ b/packages/nextjs/src/config/withSentryConfig/getFinalConfigObjectUtils.ts
@@ -93,7 +93,7 @@ export function maybeCreateRouteManifest(
   userSentryOptions: SentryBuildOptions,
 ): RouteManifest | undefined {
   // Handle deprecated option with warning
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   if (userSentryOptions.disableManifestInjection) {
     // eslint-disable-next-line no-console
     console.warn(
@@ -107,7 +107,7 @@ export function maybeCreateRouteManifest(
   }
 
   // Still check the deprecated option if the new option is not set
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   if (userSentryOptions.routeManifestInjection === undefined && userSentryOptions.disableManifestInjection) {
     return undefined;
   }

--- a/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
+++ b/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
@@ -41,9 +41,9 @@ export function enhanceHandleRequestRootSpan(span: MutableRootSpan): void {
     span.setName(stripUrlQueryAndFragment(currentName));
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const method = attributes[SEMATTRS_HTTP_METHOD] ?? attributes[ATTR_HTTP_REQUEST_METHOD];
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const target = attributes[SEMATTRS_HTTP_TARGET];
   const route = attributes[ATTR_HTTP_ROUTE] || attributes[ATTR_NEXT_ROUTE];
   const spanName = attributes[ATTR_NEXT_SPAN_NAME];

--- a/packages/nextjs/src/server/handleOnSpanStart.ts
+++ b/packages/nextjs/src/server/handleOnSpanStart.ts
@@ -37,7 +37,7 @@ export function handleOnSpanStart(span: Span): void {
   if (typeof spanAttributes?.[ATTR_NEXT_ROUTE] === 'string') {
     // Only hoist the http.route attribute if the transaction doesn't already have it
     if (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       (rootSpanAttributes?.[ATTR_HTTP_REQUEST_METHOD] || rootSpanAttributes?.[SEMATTRS_HTTP_METHOD]) &&
       !rootSpanAttributes?.[ATTR_HTTP_ROUTE]
     ) {
@@ -49,7 +49,7 @@ export function handleOnSpanStart(span: Span): void {
 
       // Update the isolation scope's transaction name so that non-transaction events
       // (e.g. captureMessage, captureException) also get the parameterized route.
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       const method = rootSpanAttributes?.[ATTR_HTTP_REQUEST_METHOD] || rootSpanAttributes?.[SEMATTRS_HTTP_METHOD];
       if (typeof method === 'string') {
         getIsolationScope().setTransactionName(`${method} ${route}`);

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -188,11 +188,11 @@ export function init(options: NodeOptions): NodeClient | undefined {
     // because we didn't get the chance to do `suppressTracing`, since this happens outside of userland.
     // We need to drop these spans.
     if (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       (typeof spanAttributes[SEMATTRS_HTTP_TARGET] === 'string' &&
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         spanAttributes[SEMATTRS_HTTP_TARGET].includes('sentry_key') &&
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         spanAttributes[SEMATTRS_HTTP_TARGET].includes('sentry_client')) ||
       (typeof spanAttributes[ATTR_URL_QUERY] === 'string' &&
         spanAttributes[ATTR_URL_QUERY].includes('sentry_key') &&

--- a/packages/nextjs/test/config/withSentry.test.ts
+++ b/packages/nextjs/test/config/withSentry.test.ts
@@ -23,7 +23,7 @@ describe('withSentry', () => {
         this.end();
       },
       end: function (this: AugmentedNextApiResponse) {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         this.finished = true;
         // @ts-expect-error This is a mock
         this.writableEnded = true;

--- a/packages/node-core/src/index.ts
+++ b/packages/node-core/src/index.ts
@@ -34,9 +34,9 @@ export {
 } from '@sentry/opentelemetry';
 
 // Deprecated exports (do not add to common-exports.ts)
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { anrIntegration, disableAnrDetectionForCallback } from './integrations/anr';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { inboundFiltersIntegration } from '@sentry/core';
 
 export type { ExclusiveEventHintOrCaptureContext, CaptureContext } from '@sentry/core';

--- a/packages/node-core/src/integrations/anr/common.ts
+++ b/packages/node-core/src/integrations/anr/common.ts
@@ -71,7 +71,7 @@ export interface AnrIntegrationOptions {
   appRootPath: string | undefined;
 }
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export interface WorkerStartData extends AnrIntegrationOptions {
   debug: boolean;
   sdkMetadata: SdkMetadata;

--- a/packages/node-core/src/integrations/anr/index.ts
+++ b/packages/node-core/src/integrations/anr/index.ts
@@ -63,7 +63,7 @@ const INTEGRATION_NAME = 'Anr';
 
 type AnrInternal = { startWorker: () => void; stopWorker: () => void };
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 const _anrIntegration = ((options: Partial<AnrIntegrationOptions> = {}) => {
   if (NODE_VERSION.major < 16 || (NODE_VERSION.major === 16 && NODE_VERSION.minor < 17)) {
     throw new Error('ANR detection requires Node 16.17.0 or later');
@@ -112,7 +112,7 @@ const _anrIntegration = ((options: Partial<AnrIntegrationOptions> = {}) => {
   } as Integration & AnrInternal;
 }) satisfies IntegrationFn;
 
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 type AnrReturn = (options?: Partial<AnrIntegrationOptions>) => Integration & AnrInternal;
 
 /**
@@ -160,7 +160,7 @@ export const anrIntegration = defineIntegration(_anrIntegration) as AnrReturn;
  */
 async function _startWorker(
   client: NodeClient,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   integrationOptions: Partial<AnrIntegrationOptions>,
 ): Promise<() => void> {
   const dsn = client.getDsn();

--- a/packages/node-core/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node-core/src/integrations/http/SentryHttpInstrumentation.ts
@@ -180,7 +180,7 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
         options.outgoingRequestHook?.(span, request);
         // We monkey-patch `req.once('response'), which is used to trigger
         // the callback of the request, so that it runs in the active context
-        // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
+        // eslint-disable-next-line @typescript-eslint/unbound-method, typescript/no-deprecated
         const originalOnce = request.once;
 
         const newOnce = new Proxy(originalOnce, {
@@ -199,7 +199,7 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
           },
         });
 
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         request.once = newOnce;
       },
       outgoingResponseHook(span, response) {

--- a/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
@@ -103,7 +103,7 @@ const _httpServerSpansIntegration = ((options: HttpServerSpansIntegrationOptions
   ];
 
   const { onSpanCreated } = options;
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const { requestHook, responseHook, applyCustomAttributesOnSpan } = options.instrumentation ?? {};
 
   return {

--- a/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
@@ -376,6 +376,7 @@ function getIncomingRequestAttributesOnResponse(
 
   const newAttributes: SpanAttributes = {
     [HTTP_RESPONSE_STATUS_CODE]: statusCode,
+    // eslint-disable-next-line typescript/no-deprecated
     [HTTP_STATUS_CODE]: statusCode,
     'http.status_text': statusMessage?.toUpperCase(),
   };
@@ -383,11 +384,15 @@ function getIncomingRequestAttributesOnResponse(
   const rpcMetadata = getRPCMetadata(context.active());
   if (socket) {
     const { localAddress, localPort, remoteAddress, remotePort } = socket;
+    // eslint-disable-next-line typescript/no-deprecated
     newAttributes[NET_HOST_IP] = localAddress;
+    // eslint-disable-next-line typescript/no-deprecated
     newAttributes[NET_HOST_PORT] = localPort;
+    // eslint-disable-next-line typescript/no-deprecated
     newAttributes[NET_PEER_IP] = remoteAddress;
     newAttributes['net.peer.port'] = remotePort;
   }
+  // eslint-disable-next-line typescript/no-deprecated
   newAttributes[HTTP_STATUS_CODE] = statusCode;
   newAttributes['http.status_text'] = (statusMessage || '').toUpperCase();
 

--- a/packages/node-core/src/sdk/index.ts
+++ b/packages/node-core/src/sdk/index.ts
@@ -51,7 +51,7 @@ export function getDefaultIntegrations(): Integration[] {
   return [
     // Common
     // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),

--- a/packages/node-core/test/transports/http.test.ts
+++ b/packages/node-core/test/transports/http.test.ts
@@ -61,7 +61,7 @@ function setupTestServer(
     res.end();
 
     // also terminate socket because keepalive hangs connection a bit
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     res.connection?.end();
   });
 

--- a/packages/node-core/test/transports/https.test.ts
+++ b/packages/node-core/test/transports/https.test.ts
@@ -47,7 +47,7 @@ function setupTestServer(
     res.end();
 
     // also terminate socket because keepalive hangs connection a bit
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     res.connection?.end();
   });
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -72,7 +72,7 @@ export {
   withMonitor,
   requestDataIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
@@ -182,9 +182,9 @@ export {
   modulesIntegration,
   onUncaughtExceptionIntegration,
   onUnhandledRejectionIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   spotlightIntegration,
   childProcessIntegration,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -15,6 +15,7 @@ export { postgresIntegration } from './integrations/tracing/postgres';
 export { postgresJsIntegration } from './integrations/tracing/postgresjs';
 export { prismaIntegration } from './integrations/tracing/prisma';
 export { hapiIntegration, setupHapiErrorHandler } from './integrations/tracing/hapi';
+// eslint-disable-next-line typescript/no-deprecated
 export { honoIntegration, setupHonoErrorHandler } from './integrations/tracing/hono';
 export { koaIntegration, setupKoaErrorHandler } from './integrations/tracing/koa';
 export { connectIntegration, setupConnectErrorHandler } from './integrations/tracing/connect';

--- a/packages/node/src/integrations/tracing/fastify/v3/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/fastify/v3/instrumentation.ts
@@ -265,7 +265,7 @@ export class FastifyInstrumentationV3 extends InstrumentationBase<FastifyInstrum
       const spanAttributes: Attributes = {
         [AttributeNames.PLUGIN_NAME]: this.pluginName,
         [AttributeNames.FASTIFY_TYPE]: FastifyTypes.REQUEST_HANDLER,
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         [SEMATTRS_HTTP_ROUTE]: anyRequest.routeOptions
           ? anyRequest.routeOptions.url // since fastify@4.10.0
           : request.routerPath,

--- a/packages/node/src/integrations/tracing/index.ts
+++ b/packages/node/src/integrations/tracing/index.ts
@@ -36,6 +36,7 @@ export function getAutoPerformanceIntegrations(): Integration[] {
     expressIntegration(),
     fastifyIntegration(),
     graphqlIntegration(),
+    // eslint-disable-next-line typescript/no-deprecated
     honoIntegration(),
     mongoIntegration(),
     mongooseIntegration(),

--- a/packages/node/src/integrations/tracing/mongoose/vendored/mongoose.ts
+++ b/packages/node/src/integrations/tracing/mongoose/vendored/mongoose.ts
@@ -308,7 +308,9 @@ export class MongooseInstrumentation extends InstrumentationBase<Instrumentation
   private _startSpan(collection: mongoose.Collection, modelName: string, operation: string, parentSpan?: Span): Span {
     const attributes: SpanAttributes = {
       ...getAttributesFromCollection(collection),
+      // eslint-disable-next-line typescript/no-deprecated
       [ATTR_DB_OPERATION]: operation,
+      // eslint-disable-next-line typescript/no-deprecated
       [ATTR_DB_SYSTEM]: 'mongoose', // keep for backwards compatibility
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
     };

--- a/packages/node/src/integrations/tracing/mongoose/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/mongoose/vendored/utils.ts
@@ -33,10 +33,15 @@ import {
 
 export function getAttributesFromCollection(collection: Collection): SpanAttributes {
   return {
+    // eslint-disable-next-line typescript/no-deprecated
     [ATTR_DB_MONGODB_COLLECTION]: collection.name,
+    // eslint-disable-next-line typescript/no-deprecated
     [ATTR_DB_NAME]: collection.conn.name,
+    // eslint-disable-next-line typescript/no-deprecated
     [ATTR_DB_USER]: collection.conn.user,
+    // eslint-disable-next-line typescript/no-deprecated
     [ATTR_NET_PEER_NAME]: collection.conn.host,
+    // eslint-disable-next-line typescript/no-deprecated
     [ATTR_NET_PEER_PORT]: collection.conn.port,
   };
 }

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -26,7 +26,7 @@ export function setupSourceMaps(
 
   const isDebug = moduleOptions.debug;
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const sourceMapsUploadOptions = moduleOptions.sourceMapsUploadOptions || {};
 
   const sourceMapsEnabled =
@@ -34,7 +34,7 @@ export function setupSourceMaps(
       ? false
       : moduleOptions.sourcemaps?.disable === false
         ? true
-        : // eslint-disable-next-line deprecation/deprecation
+        : // eslint-disable-next-line typescript/no-deprecated
           (sourceMapsUploadOptions.enabled ?? true);
 
   // In case we overwrite the source map settings, we default to deleting the files
@@ -64,7 +64,7 @@ export function setupSourceMaps(
 
         if (
           !moduleOptions.sourcemaps?.filesToDeleteAfterUpload &&
-          // eslint-disable-next-line deprecation/deprecation
+          // eslint-disable-next-line typescript/no-deprecated
           !sourceMapsUploadOptions.sourcemaps?.filesToDeleteAfterUpload
         ) {
           // eslint-disable-next-line no-console
@@ -139,7 +139,7 @@ export function getPluginOptions(
   moduleOptions: SentryNuxtModuleOptions,
   shouldDeleteFilesFallback?: { client: boolean; server: boolean },
 ): SentryVitePluginOptions | SentryRollupPluginOptions {
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const sourceMapsUploadOptions = moduleOptions.sourceMapsUploadOptions || {};
 
   const shouldDeleteFilesAfterUpload = shouldDeleteFilesFallback?.client || shouldDeleteFilesFallback?.server;
@@ -152,12 +152,12 @@ export function getPluginOptions(
 
   // Check for filesToDeleteAfterUpload in new location first, then deprecated location
   const sourcemapsOptions = moduleOptions.sourcemaps || {};
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const deprecatedSourcemapsOptions = sourceMapsUploadOptions.sourcemaps || {};
 
   const filesToDeleteAfterUpload =
     sourcemapsOptions.filesToDeleteAfterUpload ??
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     deprecatedSourcemapsOptions.filesToDeleteAfterUpload;
 
   if (typeof filesToDeleteAfterUpload === 'undefined' && shouldDeleteFilesAfterUpload && moduleOptions.debug) {
@@ -172,25 +172,25 @@ export function getPluginOptions(
 
   return {
     applicationKey: moduleOptions.applicationKey,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     org: moduleOptions.org ?? sourceMapsUploadOptions.org ?? process.env.SENTRY_ORG,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     project: moduleOptions.project ?? sourceMapsUploadOptions.project ?? process.env.SENTRY_PROJECT,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     authToken: moduleOptions.authToken ?? sourceMapsUploadOptions.authToken ?? process.env.SENTRY_AUTH_TOKEN,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     telemetry: moduleOptions.telemetry ?? sourceMapsUploadOptions.telemetry ?? true,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     url: moduleOptions.sentryUrl ?? sourceMapsUploadOptions.url ?? process.env.SENTRY_URL,
     headers: moduleOptions.headers,
     debug: moduleOptions.debug ?? false,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     silent: moduleOptions.silent ?? sourceMapsUploadOptions.silent ?? false,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     errorHandler: moduleOptions.errorHandler ?? sourceMapsUploadOptions.errorHandler,
     bundleSizeOptimizations: moduleOptions.bundleSizeOptimizations, // todo: test if this can be overridden by the user
     release: {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       name: moduleOptions.release?.name ?? sourceMapsUploadOptions.release?.name,
       // Support all release options from BuildTimeOptionsBase
       ...moduleOptions.release,
@@ -208,9 +208,9 @@ export function getPluginOptions(
       // The server/client files are in different places depending on the nitro preset (e.g. '.output/server' or '.netlify/functions-internal/server')
       // We cannot determine automatically how the build folder looks like (depends on the preset), so we have to accept that source maps are uploaded multiple times (with the vitePlugin for Nuxt and the rollupPlugin for Nitro).
       // If we could know where the server/client assets are located, we could do something like this (based on the Nitro preset): isNitro ? ['./.output/server/**/*'] : ['./.output/public/**/*'],
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       assets: sourcemapsOptions.assets ?? deprecatedSourcemapsOptions.assets ?? undefined,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       ignore: sourcemapsOptions.ignore ?? deprecatedSourcemapsOptions.ignore ?? undefined,
       filesToDeleteAfterUpload: filesToDeleteAfterUpload
         ? filesToDeleteAfterUpload

--- a/packages/opentelemetry/src/exports.ts
+++ b/packages/opentelemetry/src/exports.ts
@@ -40,6 +40,7 @@ export { suppressTracing } from './utils/suppressTracing';
 export { setupEventContextTrace } from './setupEventContextTrace';
 
 export { setOpenTelemetryContextAsyncContextStrategy } from './asyncContextStrategy';
+// eslint-disable-next-line typescript/no-deprecated
 export { wrapContextManagerClass } from './contextManager';
 
 export { SentryPropagator, shouldPropagateTraceForUrl } from './propagator';

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -276,7 +276,7 @@ function getExistingSentryTrace(carrier: unknown): string | string[] | undefined
 function getCurrentURL(span: Span): string | undefined {
   const spanData = spanToJSON(span).data;
   // `ATTR_URL_FULL` is the new attribute, but we still support the old one, `SEMATTRS_HTTP_URL`, for now.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const urlAttribute = spanData[SEMATTRS_HTTP_URL] || spanData[ATTR_URL_FULL];
   if (typeof urlAttribute === 'string') {
     return urlAttribute;

--- a/packages/opentelemetry/src/resource.ts
+++ b/packages/opentelemetry/src/resource.ts
@@ -83,7 +83,7 @@ export function getSentryResource(serviceNameFallback: string): SentryResource {
 
   return new SentryResource({
     // Lowest priority: Sentry defaults
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     [SEMRESATTRS_SERVICE_NAMESPACE]: 'sentry',
     [ATTR_SERVICE_NAME]: serviceNameFallback,
     // OTEL_RESOURCE_ATTRIBUTES overrides defaults (including service.name and service.namespace)

--- a/packages/opentelemetry/src/sampler.ts
+++ b/packages/opentelemetry/src/sampler.ts
@@ -71,7 +71,7 @@ export class SentrySampler implements Sampler {
     }
 
     // `ATTR_HTTP_REQUEST_METHOD` is the new attribute, but we still support the old one, `SEMATTRS_HTTP_METHOD`, for now.
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     const maybeSpanHttpMethod = spanAttributes[SEMATTRS_HTTP_METHOD] || spanAttributes[ATTR_HTTP_REQUEST_METHOD];
 
     // If we have a http.client span that has no local parent, we never want to sample it
@@ -332,7 +332,7 @@ function getBaseTraceState(context: Context, spanAttributes: SpanAttributes): Tr
 
   // We always keep the URL on the trace state, so we can access it in the propagator
   // `ATTR_URL_FULL` is the new attribute, but we still support the old one, `ATTR_HTTP_URL`, for now.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const url = spanAttributes[SEMATTRS_HTTP_URL] || spanAttributes[ATTR_URL_FULL];
   if (url && typeof url === 'string') {
     traceState = traceState.set(SENTRY_TRACE_STATE_URL, url);

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -441,7 +441,7 @@ function getData(span: ReadableSpan): Record<string, unknown> {
     data['otel.kind'] = SpanKind[span.kind];
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const maybeHttpStatusCodeAttribute = attributes[SEMATTRS_HTTP_STATUS_CODE];
   if (maybeHttpStatusCodeAttribute) {
     data[ATTR_HTTP_RESPONSE_STATUS_CODE] = maybeHttpStatusCodeAttribute as string;

--- a/packages/opentelemetry/src/utils/getRequestSpanData.ts
+++ b/packages/opentelemetry/src/utils/getRequestSpanData.ts
@@ -19,14 +19,14 @@ export function getRequestSpanData(span: Span | ReadableSpan): Partial<Sanitized
     return {};
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const maybeUrlAttribute = (span.attributes[ATTR_URL_FULL] || span.attributes[SEMATTRS_HTTP_URL]) as
     | string
     | undefined;
 
   const data: Partial<SanitizedRequestData> = {
     url: maybeUrlAttribute,
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     'http.method': (span.attributes[ATTR_HTTP_REQUEST_METHOD] || span.attributes[SEMATTRS_HTTP_METHOD]) as
       | string
       | undefined,

--- a/packages/opentelemetry/src/utils/isSentryRequest.ts
+++ b/packages/opentelemetry/src/utils/isSentryRequest.ts
@@ -16,7 +16,7 @@ export function isSentryRequestSpan(span: AbstractSpan): boolean {
   const { attributes } = span;
 
   // `ATTR_URL_FULL` is the new attribute, but we still support the old one, `ATTR_HTTP_URL`, for now.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const httpUrl = attributes[SEMATTRS_HTTP_URL] || attributes[ATTR_URL_FULL];
 
   if (!httpUrl) {

--- a/packages/opentelemetry/src/utils/mapStatus.ts
+++ b/packages/opentelemetry/src/utils/mapStatus.ts
@@ -79,9 +79,9 @@ export function mapStatus(span: AbstractSpan): SpanStatus {
 function inferStatusFromAttributes(attributes: SpanAttributes): SpanStatus | undefined {
   // If the span status is UNSET, we try to infer it from HTTP or GRPC status codes.
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const httpCodeAttribute = attributes[ATTR_HTTP_RESPONSE_STATUS_CODE] || attributes[SEMATTRS_HTTP_STATUS_CODE];
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const grpcCodeAttribute = attributes[SEMATTRS_RPC_GRPC_STATUS_CODE];
 
   const numberHttpCode =

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -41,13 +41,13 @@ interface SpanDescription {
  */
 export function inferSpanData(spanName: string, attributes: SpanAttributes, kind: SpanKind): SpanDescription {
   // if http.method exists, this is an http request span
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const httpMethod = attributes[ATTR_HTTP_REQUEST_METHOD] || attributes[SEMATTRS_HTTP_METHOD];
   if (httpMethod) {
     return descriptionForHttpMethod({ attributes, name: spanName, kind }, httpMethod);
   }
 
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const dbSystem = attributes[ATTR_DB_SYSTEM_NAME] || attributes[SEMATTRS_DB_SYSTEM];
   const opIsCache =
     typeof attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'string' &&
@@ -62,7 +62,7 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
   const customSourceOrRoute = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom' ? 'custom' : 'route';
 
   // If rpc.service exists then this is a rpc call span.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const rpcService = attributes[SEMATTRS_RPC_SERVICE];
   if (rpcService) {
     return {
@@ -72,7 +72,7 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
   }
 
   // If messaging.system exists then this is a messaging system span.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const messagingSystem = attributes[SEMATTRS_MESSAGING_SYSTEM];
   if (messagingSystem) {
     return {
@@ -82,7 +82,7 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
   }
 
   // If faas.trigger exists then this is a function as a service span.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const faasTrigger = attributes[SEMATTRS_FAAS_TRIGGER];
   if (faasTrigger) {
     return {
@@ -128,7 +128,7 @@ function descriptionForDbSystem({ attributes, name }: { attributes: Attributes; 
   }
 
   // Use DB statement (Ex "SELECT * FROM table") if possible as description.
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const statement = attributes[SEMATTRS_DB_STATEMENT];
 
   const description = statement ? statement.toString() : name;
@@ -247,10 +247,10 @@ export function getSanitizedUrl(
   hasRoute: boolean;
 } {
   // This is the relative path of the URL, e.g. /sub
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const httpTarget = attributes[SEMATTRS_HTTP_TARGET];
   // This is the full URL, including host & query params etc., e.g. https://example.com/sub?foo=bar
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   const httpUrl = attributes[SEMATTRS_HTTP_URL] || attributes[ATTR_URL_FULL];
   // This is the normalized route name - may not always be available!
   const httpRoute = attributes[ATTR_HTTP_ROUTE];

--- a/packages/opentelemetry/test/resource.test.ts
+++ b/packages/opentelemetry/test/resource.test.ts
@@ -66,7 +66,7 @@ describe('getSentryResource', () => {
   it('OTEL_RESOURCE_ATTRIBUTES can override service.namespace', () => {
     process.env['OTEL_RESOURCE_ATTRIBUTES'] = 'service.namespace=my-namespace';
     const resource = getSentryResource('node');
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     expect(resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE]).toBe('my-namespace');
   });
 
@@ -96,7 +96,7 @@ describe('getSentryResource', () => {
 
   it('always sets service.namespace to sentry by default', () => {
     const resource = getSentryResource('node');
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     expect(resource.attributes[SEMRESATTRS_SERVICE_NAMESPACE]).toBe('sentry');
   });
 

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable typescript/no-deprecated */
 import type { Span, TimeInput } from '@opentelemetry/api';
 import { context, ROOT_CONTEXT, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';

--- a/packages/opentelemetry/test/utils/getRequestSpanData.test.ts
+++ b/packages/opentelemetry/test/utils/getRequestSpanData.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable typescript/no-deprecated */
 import type { Span } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';

--- a/packages/opentelemetry/test/utils/mapStatus.test.ts
+++ b/packages/opentelemetry/test/utils/mapStatus.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable typescript/no-deprecated */
 import type { Span } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';

--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable typescript/no-deprecated */
 import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import {

--- a/packages/profiling-node/src/spanProfileUtils.ts
+++ b/packages/profiling-node/src/spanProfileUtils.ts
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable typescript/no-deprecated */
 import type { CustomSamplingContext, Span } from '@sentry/core';
 import { debug, spanIsSampled, spanToJSON, uuid4 } from '@sentry/core';
 import type { NodeClient } from '@sentry/node';

--- a/packages/react-router/src/server/index.ts
+++ b/packages/react-router/src/server/index.ts
@@ -4,12 +4,12 @@
 export * from '@sentry/node';
 
 export { init } from './sdk';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { wrapSentryHandleRequest, sentryHandleRequest } from './wrapSentryHandleRequest';
 export { createSentryHandleRequest, type SentryHandleRequestOptions } from './createSentryHandleRequest';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { wrapServerAction } from './wrapServerAction';
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export { wrapServerLoader } from './wrapServerLoader';
 export { createSentryHandleError, type SentryHandleErrorOptions } from './createSentryHandleError';
 export { getMetaTagTransformer } from './getMetaTagTransformer';

--- a/packages/react-router/src/server/instrumentation/reactRouter.ts
+++ b/packages/react-router/src/server/instrumentation/reactRouter.ts
@@ -112,7 +112,7 @@ export class ReactRouterInstrumentation extends InstrumentationBase<Instrumentat
               // So we force this to be a more sensible name here
               // TODO: try to set derived parameterized route from build here (args[0])
               const spanData = spanToJSON(rootSpan);
-              // eslint-disable-next-line deprecation/deprecation
+              // eslint-disable-next-line typescript/no-deprecated
               const target = spanData.data[SEMATTRS_HTTP_TARGET] || url.pathname;
               updateSpanName(rootSpan, `${request.method} ${target}`);
               rootSpan.setAttributes({

--- a/packages/react-router/src/server/wrapServerAction.ts
+++ b/packages/react-router/src/server/wrapServerAction.ts
@@ -72,7 +72,7 @@ export function wrapServerAction<T>(
       const root = getRootSpan(active);
       const spanData = spanToJSON(root);
       if (spanData.origin === 'auto.http.otel.http') {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         const target = spanData.data[SEMATTRS_HTTP_TARGET];
 
         if (target) {

--- a/packages/react-router/src/server/wrapServerLoader.ts
+++ b/packages/react-router/src/server/wrapServerLoader.ts
@@ -73,7 +73,7 @@ export function wrapServerLoader<T>(
       const root = getRootSpan(active);
       const spanData = spanToJSON(root);
       if (spanData.origin === 'auto.http.otel.http') {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         const target = spanData.data[SEMATTRS_HTTP_TARGET];
 
         if (target) {

--- a/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
+++ b/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
@@ -48,7 +48,7 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
       ...unstableSentryVitePluginOptions?.sourcemaps,
       ...sentryConfig.sourcemaps,
       ...sourceMapsUploadOptions,
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       disable: sourceMapsUploadOptions?.enabled === false ? true : sentryConfig.sourcemaps?.disable,
     },
     release: {

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -93,7 +93,7 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -8,9 +8,9 @@ export {
   addEventProcessor,
   addIntegration,
   amqplibIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   captureCheckIn,
   captureConsoleIntegration,
@@ -54,7 +54,7 @@ export {
   httpIntegration,
   httpServerIntegration,
   httpServerSpansIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,

--- a/packages/remix/src/vendor/instrumentation.ts
+++ b/packages/remix/src/vendor/instrumentation.ts
@@ -1,4 +1,4 @@
-/* eslint-disable deprecation/deprecation */
+/* eslint-disable typescript/no-deprecated */
 /* eslint-disable jsdoc/require-jsdoc */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable import/no-named-as-default-member */

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -11,9 +11,9 @@ export {
   addEventProcessor,
   addIntegration,
   amqplibIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   captureCheckIn,
   captureConsoleIntegration,
@@ -57,7 +57,7 @@ export {
   httpIntegration,
   httpServerIntegration,
   httpServerSpansIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -56,7 +56,7 @@ function _instrumentPageload(client: Client): void {
   }
 
   // TODO(v11): require svelte 5 or newer to switch to `page` from `$app/state`
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   page.subscribe(page => {
     if (!page) {
       return;
@@ -79,7 +79,7 @@ function _instrumentNavigations(client: Client): void {
   let routingSpan: Span | undefined;
 
   // TODO(v11): require svelte 5 or newer to switch to `navigating` from `$app/state`
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   navigating.subscribe(navigation => {
     if (!navigation) {
       // `navigating` emits a 'null' value when the navigation is completed.

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -9,9 +9,9 @@ export {
   addEventProcessor,
   addIntegration,
   amqplibIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   anrIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   disableAnrDetectionForCallback,
   captureCheckIn,
   captureConsoleIntegration,
@@ -54,7 +54,7 @@ export {
   getTraceMetaTags,
   graphqlIntegration,
   hapiIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -96,14 +96,14 @@ export function generateVitePluginOptions(
   // Source Maps
   if (svelteKitPluginOptions.autoUploadSourceMaps && process.env.NODE_ENV !== 'development') {
     const {
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       unstable_sentryVitePluginOptions: deprecated_unstableSourceMapUploadOptions,
       ...deprecatedSourceMapUploadOptions
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
     } = svelteKitPluginOptions.sourceMapsUploadOptions || {};
 
     const {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars,deprecation/deprecation
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars,typescript/no-deprecated
       sourceMapsUploadOptions: _filtered1,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       unstable_sentryVitePluginOptions: _filtered2,
@@ -135,14 +135,14 @@ export function generateVitePluginOptions(
 
     // Handle sourcemaps options - merge deprecated and new, with new taking precedence
     if (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       deprecatedSourceMapUploadOptions.sourcemaps ||
       svelteKitPluginOptions.sourcemaps ||
       deprecated_unstableSourceMapUploadOptions?.sourcemaps ||
       unstable_sentryVitePluginOptions?.sourcemaps
     ) {
       sentryVitePluginsOptions.sourcemaps = {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         ...deprecatedSourceMapUploadOptions.sourcemaps,
         ...svelteKitPluginOptions.sourcemaps,
         // Also handle nested deprecated options from unstable plugin options
@@ -153,14 +153,14 @@ export function generateVitePluginOptions(
 
     // Handle release options - merge deprecated and new, with new taking precedence
     if (
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       deprecatedSourceMapUploadOptions.release ||
       svelteKitPluginOptions.release ||
       deprecated_unstableSourceMapUploadOptions?.release ||
       unstable_sentryVitePluginOptions?.release
     ) {
       sentryVitePluginsOptions.release = {
-        // eslint-disable-next-line deprecation/deprecation
+        // eslint-disable-next-line typescript/no-deprecated
         ...deprecatedSourceMapUploadOptions.release,
         ...svelteKitPluginOptions.release,
         // Also handle nested deprecated options from unstable plugin options

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -61,7 +61,7 @@ export function getHooksFileName(svelteConfig: Config, hookType: 'client' | 'ser
   // `files` is deprecated in favour of unchangeable file names. Once it is removed, only the
   // fallback will be necessary. We can remove the curstom files path once we drop support
   // for that version range (presumably sveltekit 2).
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   return svelteConfig.kit?.files?.hooks?.[hookType] || `src/hooks.${hookType}`;
 }
 

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -43,7 +43,7 @@ export {
   getSpanStatusFromHttpCode,
   getTraceData,
   getTraceMetaTags,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   isInitialized,
   isEnabled,

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -119,7 +119,7 @@ describe('browserTracingIntegration', () => {
     // We emit an update to the `page` store to simulate the SvelteKit router lifecycle
     // TODO(v11): switch to `page` from `$app/state`
     // @ts-expect-error - page is a writable but the types say it's just readable
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     page.set({ route: { id: 'testRoute' } });
 
     // This should update the transaction name with the parameterized route:
@@ -155,7 +155,7 @@ describe('browserTracingIntegration', () => {
     // We emit an update to the `page` store to simulate the SvelteKit router lifecycle
     // TODO(v11): switch to `page` from `$app/state`
     // @ts-expect-error - page is a writable but the types say it's just readable
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     page.set({ route: { id: 'testRoute/:id' } });
 
     // This should update the transaction name with the parameterized route:
@@ -173,7 +173,7 @@ describe('browserTracingIntegration', () => {
     // We emit an update to the `navigating` store to simulate the SvelteKit navigation lifecycle
     // TODO(v11): switch to `navigating` from `$app/state`
     // @ts-expect-error - page is a writable but the types say it's just readable
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     navigating.set({
       from: { route: { id: '/users' }, url: { pathname: '/users' } },
       to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
@@ -193,7 +193,7 @@ describe('browserTracingIntegration', () => {
     // We emit an update to the `navigating` store to simulate the SvelteKit navigation lifecycle
     // TODO(v11): switch to `navigating` from `$app/state`
     // @ts-expect-error - page is a writable but the types say it's just readable
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     navigating.set({
       from: { route: { id: '/users' }, url: { pathname: '/users' } },
       to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
@@ -229,7 +229,7 @@ describe('browserTracingIntegration', () => {
     // We emit `null` here to simulate the end of the navigation lifecycle
     // TODO(v11): switch to `navigating` from `$app/state`
     // @ts-expect-error - navigating is a writable but the types say it's just readable
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     navigating.set(null);
 
     expect(routingSpanEndSpy).toHaveBeenCalledTimes(1);
@@ -246,7 +246,7 @@ describe('browserTracingIntegration', () => {
       // We emit an update to the `navigating` store to simulate the SvelteKit navigation lifecycle
       // TODO(v11): switch to `navigating` from `$app/state`
       // @ts-expect-error - navigating is a writable but the types say it's just readable
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       navigating.set({
         from: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
         to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
@@ -264,7 +264,7 @@ describe('browserTracingIntegration', () => {
 
       // TODO(v11): switch to `navigating` from `$app/state`
       // @ts-expect-error - navigating is a writable but the types say it's just readable
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       navigating.set({
         from: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
         to: { route: { id: '/users/[id]' }, url: { pathname: '/users/223412' } },
@@ -305,7 +305,7 @@ describe('browserTracingIntegration', () => {
 
       // TODO(v11): switch to `navigating` from `$app/state`
       // @ts-expect-error - navigating is a writable but the types say it's just readable
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       navigating.set({
         to: { route: {}, url: { pathname: '/' } },
       });

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -30,7 +30,7 @@ function getSentrySvelteKitPlugins(options?: Parameters<typeof sentrySvelteKit>[
       authToken: 'token',
       org: 'org',
       project: 'project',
-      // eslint-disable-next-line deprecation/deprecation
+      // eslint-disable-next-line typescript/no-deprecated
       ...options?.sourceMapsUploadOptions,
     },
     ...options,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -191,7 +191,7 @@ export type FetchBreadcrumbHint = FetchBreadcrumbHint_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type XhrBreadcrumbHint = XhrBreadcrumbHint_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export type Client<O extends ClientOptions = ClientOptions<BaseTransportOptions>> = Client_imported<O>;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type ClientReport = ClientReport_imported;
@@ -300,7 +300,7 @@ export type Extras = Extras_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type Integration = Integration_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export type IntegrationFn<IntegrationType = Integration> = IntegrationFn_imported<IntegrationType>;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type Mechanism = Mechanism_imported;
@@ -313,10 +313,10 @@ export type Primitive = Primitive_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type WorkerLocation = WorkerLocation_imported;
 /** @deprecated This type has been moved to `@sentry/core`. */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export type ClientOptions<TO extends BaseTransportOptions = BaseTransportOptions> = ClientOptions_imported<TO>;
 /** @deprecated This type has been moved to `@sentry/core`. */
-// eslint-disable-next-line deprecation/deprecation
+// eslint-disable-next-line typescript/no-deprecated
 export type Options<TO extends BaseTransportOptions = BaseTransportOptions> = Options_imported<TO>;
 /** @deprecated This type has been moved to `@sentry/core`. */
 export type Package = Package_imported;

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -68,7 +68,7 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
+  // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   instrumentOpenAiClient,
   instrumentLangGraph,

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -169,6 +169,7 @@ export function setupOtel(client: VercelEdgeClient): void {
     ],
   });
 
+  // eslint-disable-next-line typescript/no-deprecated
   const SentryContextManager = wrapContextManagerClass(AsyncLocalStorageContextManager);
 
   trace.setGlobalTracerProvider(provider);

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -50,7 +50,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   return [
     dedupeIntegration(),
     // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line typescript/no-deprecated
     inboundFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),


### PR DESCRIPTION
Apparently `deprecation/deprecation` didn't work properly in oxlint. This PR enables `typescript/no-deprecated` and changed it everywhere. 

There were also 53 missing disabled lines, which I added in this commit: https://github.com/getsentry/sentry-javascript/commit/42139b1168f3c3918fa405455b9babadedc25760