### PR TITLE
fix(node): Restore eslint-disable in vendored tedious instrumentation

### DIFF
--- a/packages/node/src/integrations/tracing/tedious/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/tedious/vendored/instrumentation.ts
@@ -19,6 +19,7 @@
  * - Minor TypeScript strictness adjustments
  * - Span creation migrated to the @sentry/core API; origin folded into span creation
  */
+/* eslint-disable */
 
 import * as api from '@opentelemetry/api';
 import { EventEmitter } from 'events';


### PR DESCRIPTION
The Lint CI job (`typescript-eslint(no-deprecated)`) has been failing on `develop` since #21598. It was auto-filed as a flaky test, but the failure is deterministic.

_Root cause_: The "Streamline tedious instrumentation" refactor (#21598) removed the `/* eslint-disable */` directive from `packages/node/src/integrations/tracing/tedious/vendored/instrumentation.ts` while keeping its imports of the deprecated vendored semconv constants (`ATTR_DB_SYSTEM`, `ATTR_DB_NAME`, `ATTR_DB_USER`, `ATTR_DB_STATEMENT`, `ATTR_DB_SQL_TABLE`, `ATTR_NET_PEER_NAME`, `ATTR_NET_PEER_PORT`). Those constants carry `@deprecated` JSDoc tags copied verbatim from upstream OpenTelemetry, so without the directive the `no-deprecated` rule fires on every usage.

This restores the directive after the header block, matching the documented vendoring convention and every other vendored instrumentation file (mysql, knex, postgres, hapi, mongo). The deliberate use of the legacy `db.*`/`net.*` attribute names is unchanged.

Fixes #21614