### PR TITLE
fix(node): Restore eslint-disable in vendored tedious instrumentation

### DIFF
--- a/packages/node/src/integrations/tracing/tedious/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/tedious/vendored/instrumentation.ts
@@ -149,13 +149,20 @@ export class TediousInstrumentation extends InstrumentationBase<InstrumentationC
 
         const attributes: api.Attributes = {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.otel.tedious',
+          // eslint-disable-next-line typescript/no-deprecated
           [ATTR_DB_SYSTEM]: DB_SYSTEM_VALUE_MSSQL,
+          // eslint-disable-next-line typescript/no-deprecated
           [ATTR_DB_NAME]: databaseName,
           // >=4 uses `authentication` object; older versions just userName and password pair
+          // eslint-disable-next-line typescript/no-deprecated
           [ATTR_DB_USER]: this.config?.userName ?? this.config?.authentication?.options?.userName,
+          // eslint-disable-next-line typescript/no-deprecated
           [ATTR_DB_STATEMENT]: sql,
+          // eslint-disable-next-line typescript/no-deprecated
           [ATTR_DB_SQL_TABLE]: request.table,
+          // eslint-disable-next-line typescript/no-deprecated
           [ATTR_NET_PEER_NAME]: this.config?.server,
+          // eslint-disable-next-line typescript/no-deprecated
           [ATTR_NET_PEER_PORT]: this.config?.options?.port,
         };
         const span = startInactiveSpan({


### PR DESCRIPTION
The "Streamline tedious instrumentation" refactor (#21598) dropped the `/* eslint-disable */` directive from the vendored instrumentation file while keeping its imports of the deprecated semconv constants (`ATTR_DB_SYSTEM`, `ATTR_DB_NAME`, etc.).

Closes: #21614
