### PR TITLE
ci: Pin react-router latest and add eslint disable for deprecated attribute

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/package.json
@@ -4,18 +4,18 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@react-router/node": "latest",
-    "@react-router/serve": "latest",
+    "@react-router/node": "^7",
+    "@react-router/serve": "^7",
     "@sentry/react-router": "file:../../packed/sentry-react-router-packed.tgz",
     "ioredis": "^5.4.1",
     "isbot": "^5.1.17",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router": "latest"
+    "react-router": "^7"
   },
   "devDependencies": {
     "@playwright/test": "~1.56.0",
-    "@react-router/dev": "latest",
+    "@react-router/dev": "^7",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "18.3.1",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "react-router build",
-    "test:build-latest": "pnpm install && pnpm add react-router@latest && pnpm add @react-router/node@latest && pnpm add @react-router/serve@latest && pnpm build",
+    "test:build-latest": "pnpm install && pnpm add react-router@7 && pnpm add @react-router/node@7 && pnpm add @react-router/serve@7 && pnpm build",
     "dev": "NODE_OPTIONS='--import ./instrument.mjs' react-router dev",
     "start": "NODE_OPTIONS='--import ./instrument.mjs' react-router-serve ./build/server/index.js",
     "proxy": "node start-event-proxy.mjs",

--- a/packages/node/src/integrations/tracing/hapi/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/hapi/vendored/utils.ts
@@ -75,6 +75,7 @@ export const getRouteMetadata = (
 } => {
   const attributes: Attributes = {
     [ATTR_HTTP_ROUTE]: route.path,
+    // eslint-disable-next-line typescript/no-deprecated
     [ATTR_HTTP_METHOD]: route.method,
   };
 


### PR DESCRIPTION
CI is currently blocked with two unrelated failures:
- Linting because of a deprecated attribute in our hapi instrumentation.
- React router e2e tests because react router v8 was released.

Pinning react router and adding an eslint disable to unblock ci.