### PR TITLE
chore(node): Disable no-deprecated lint for deprecated attribute

### DIFF
--- a/packages/node/src/integrations/tracing/hapi/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/hapi/vendored/utils.ts
@@ -75,6 +75,7 @@ export const getRouteMetadata = (
 } => {
   const attributes: Attributes = {
     [ATTR_HTTP_ROUTE]: route.path,
+    // eslint-disable-next-line typescript/no-deprecated
     [ATTR_HTTP_METHOD]: route.method,
   };
 


### PR DESCRIPTION
Lint is failing on develop because this attribute is deprecated.