### PR TITLE
fix(browser): Clean up pageload readystatechange listener

### DIFF
--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -490,14 +490,16 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
     function emitFinish(): void {
       if (optionalWindowDocument && ['interactive', 'complete'].includes(optionalWindowDocument.readyState)) {
         client.emit('idleSpanEnableAutoFinish', idleSpan);
+        // Once the finish signal has been emitted, the listener is no longer needed. Removing it here (rather than
+        // relying on `{ once: true }`) also covers the common case where the document is already loaded when the span
+        // starts, so the listener never fires and would otherwise leak together with the `idleSpan` it closes over.
+        optionalWindowDocument.removeEventListener('readystatechange', emitFinish);
       }
     }
 
     // Enable auto finish of the pageload span if users are not explicitly ending it
     if (isPageloadSpan && !enableReportPageLoaded && optionalWindowDocument) {
-      optionalWindowDocument.addEventListener('readystatechange', () => {
-        emitFinish();
-      });
+      optionalWindowDocument.addEventListener('readystatechange', emitFinish);
 
       emitFinish();
     }

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -565,6 +565,52 @@ describe('browserTracingIntegration', () => {
 
       expect(getCurrentScope().getScopeData().transactionName).toBe('test pageload span');
     });
+
+    it('removes the readystatechange listener once the auto-finish signal is emitted', () => {
+      const addEventListenerSpy = vi.spyOn(WINDOW.document!, 'addEventListener');
+      const removeEventListenerSpy = vi.spyOn(WINDOW.document!, 'removeEventListener');
+
+      const client = new BrowserClient(
+        getDefaultBrowserClientOptions({
+          tracesSampleRate: 1,
+          integrations: [browserTracingIntegration({ instrumentPageLoad: false })],
+        }),
+      );
+      setCurrentClient(client);
+      client.init();
+
+      // The document is already loaded (readyState 'complete') in the test environment, so the auto-finish signal is
+      // emitted synchronously and the listener must be cleaned up right away instead of leaking with the idle span.
+      startBrowserTracingPageLoadSpan(client, { name: 'test span' });
+
+      const addedListener = addEventListenerSpy.mock.calls.find(([type]) => type === 'readystatechange')?.[1];
+      expect(addedListener).toBeDefined();
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('readystatechange', addedListener);
+    });
+
+    it('removes the readystatechange listener when the document finishes loading later', () => {
+      const readyStateSpy = vi.spyOn(WINDOW.document!, 'readyState', 'get').mockReturnValue('loading');
+      const removeEventListenerSpy = vi.spyOn(WINDOW.document!, 'removeEventListener');
+
+      const client = new BrowserClient(
+        getDefaultBrowserClientOptions({
+          tracesSampleRate: 1,
+          integrations: [browserTracingIntegration({ instrumentPageLoad: false })],
+        }),
+      );
+      setCurrentClient(client);
+      client.init();
+
+      startBrowserTracingPageLoadSpan(client, { name: 'test span' });
+
+      // While loading, no auto-finish signal is emitted yet, so the listener is still attached.
+      expect(removeEventListenerSpy).not.toHaveBeenCalledWith('readystatechange', expect.any(Function));
+
+      readyStateSpy.mockReturnValue('complete');
+      WINDOW.document!.dispatchEvent(new dom.window.Event('readystatechange'));
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('readystatechange', expect.any(Function));
+    });
   });
 
   it('sets source to "custom" if name is changed in beforeStartSpan', () => {


### PR DESCRIPTION
The auto-finish `readystatechange` listener registered for each pageload span in `browserTracingIntegration` was never removed. Since the handler closes over the `idleSpan` (and the rest of the route-span closure), every pageload leaked a listener and kept the span it retained alive — the growing set of Sentry functions reported in #21630.

The previous handler was an anonymous arrow function, so it could not be removed via `removeEventListener`. The `{ once: true }` option suggested in the issue does not fully address the leak either: in the common case where the document is already loaded when the span starts, the listener never fires and therefore is never auto-removed.

This change passes `emitFinish` directly as the handler and removes it as soon as the auto-finish signal is emitted. This covers both cases:
- Document already loaded when the span starts → signal emitted synchronously, listener removed immediately.
- Document still loading → listener fires on the next `readystatechange`, emits, and removes itself.

Since the framework integrations (Vue, Astro, Next.js, Remix, SvelteKit, Ember) all wrap the browser package's `browserTracingIntegration`, this single fix covers them too.

### Root cause

`optionalWindowDocument.addEventListener('readystatechange', () => { emitFinish(); })` added a fresh, unremovable listener for every pageload span without ever detaching it.

Fixes #21630