### PR TITLE
fix(core): Set `production` as default `sentry.environment` attribute value on streamed spans

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import {
   SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
@@ -94,6 +95,10 @@ sentryTest(
             type: 'string',
             value: 'test-span',
           },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+            type: 'string',
+            value: 'production',
+          },
         },
         end_timestamp: expect.any(Number),
         is_segment: false,
@@ -126,6 +131,10 @@ sentryTest(
             type: 'string',
             value: 'test-span',
           },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+            type: 'string',
+            value: 'production',
+          },
         },
         end_timestamp: expect.any(Number),
         is_segment: false,
@@ -157,6 +166,10 @@ sentryTest(
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: {
             type: 'string',
             value: 'test-span',
+          },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+            type: 'string',
+            value: 'production',
           },
         },
         end_timestamp: expect.any(Number),
@@ -229,6 +242,10 @@ sentryTest(
           'sentry.span.source': {
             type: 'string',
             value: 'custom',
+          },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+            type: 'string',
+            value: 'production',
           },
         },
         end_timestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import {
   SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -101,6 +102,10 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
         type: 'string',
         value: 'url',
       },
+      [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+        type: 'string',
+        value: 'production',
+      },
     },
     end_timestamp: expect.any(Number),
     is_segment: true,
@@ -140,6 +145,10 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
       [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: {
         type: 'string',
         value: '/index.html',
+      },
+      [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+        type: 'string',
+        value: 'production',
       },
     },
     end_timestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import {
   SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
@@ -151,6 +152,10 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ brow
       'sentry.span.source': {
         type: 'string',
         value: 'url',
+      },
+      [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+        type: 'string',
+        value: 'production',
       },
     },
     end_timestamp: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import {
   SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
@@ -158,6 +159,10 @@ sentryTest(
         'sentry.span.source': {
           type: 'string',
           value: 'url',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+          type: 'string',
+          value: 'production',
         },
       },
       end_timestamp: expect.any(Number),

--- a/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/test.ts
@@ -1,6 +1,7 @@
 import type { Envelope, SerializedStreamedSpanContainer } from '@sentry/core';
 import {
   SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
@@ -86,6 +87,7 @@ it('sends a streamed span envelope with correct spans for a manually started spa
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: segmentName },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'manual' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
         },
         name: 'test-child-span',
         is_segment: false,
@@ -107,6 +109,7 @@ it('sends a streamed span envelope with correct spans for a manually started spa
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: segmentName },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
         },
         links: [
           {
@@ -141,6 +144,7 @@ it('sends a streamed span envelope with correct spans for a manually started spa
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: segmentName },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
         },
         name: 'test-manual-span',
         is_segment: false,
@@ -161,6 +165,7 @@ it('sends a streamed span envelope with correct spans for a manually started spa
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: segmentName },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'manual' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
         },
         name: 'test-span',
         is_segment: false,
@@ -187,6 +192,7 @@ it('sends a streamed span envelope with correct spans for a manually started spa
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'http.server' },
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: { type: 'integer', value: 1 },
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: { type: 'string', value: 'route' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           'sentry.span.source': { type: 'string', value: 'route' },
           'server.address': {
             type: 'string',

--- a/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
@@ -1,5 +1,6 @@
 import {
   SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
@@ -60,6 +61,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+            [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           },
           name: 'test-child-span',
           is_segment: false,
@@ -80,6 +82,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+            [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           },
           links: [
             {
@@ -113,6 +116,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+            [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           },
           name: 'test-manual-span',
           is_segment: false,
@@ -136,6 +140,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           'process.runtime.engine.name': { type: 'string', value: 'v8' },
           'process.runtime.engine.version': { type: 'string', value: expect.any(String) },
           'app.start_time': { type: 'string', value: expect.any(String) },

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
@@ -1,5 +1,6 @@
 import {
   SDK_VERSION,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_RELEASE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
@@ -60,6 +61,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+            [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           },
           name: 'test-child-span',
           is_segment: false,
@@ -80,6 +82,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+            [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           },
           links: [
             {
@@ -113,6 +116,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+            [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           },
           name: 'test-manual-span',
           is_segment: false,
@@ -136,6 +140,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
           [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
           [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
           'process.runtime.engine.name': { type: 'string', value: 'v8' },
           'process.runtime.engine.version': { type: 'string', value: expect.any(String) },
           'app.start_time': { type: 'string', value: expect.any(String) },

--- a/packages/browser/test/integrations/spanstreaming.test.ts
+++ b/packages/browser/test/integrations/spanstreaming.test.ts
@@ -1,5 +1,9 @@
 import * as SentryCore from '@sentry/core/browser';
-import { debug, SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS } from '@sentry/core/browser';
+import {
+  debug,
+  SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT,
+  SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
+} from '@sentry/core/browser';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BrowserClient, spanStreamingIntegration } from '../../src';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
@@ -156,6 +160,10 @@ describe('spanStreamingIntegration', () => {
         'sentry.segment.name': {
           type: 'string',
           value: 'test',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+          type: 'string',
+          value: 'production',
         },
       },
     });

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -29,6 +29,7 @@ import {
 import { getCapturedScopesOnSpan } from '../utils';
 import { isStreamedBeforeSendSpanCallback } from './beforeSendSpan';
 import { scopeContextsToSpanAttributes } from './scopeContextAttributes';
+import { DEFAULT_ENVIRONMENT } from '../../constants';
 
 export type SerializedStreamedSpanWithSegmentSpan = SerializedStreamedSpan & {
   _segmentSpan: Span;
@@ -142,7 +143,7 @@ function applyCommonSpanAttributes(
   // avoid overwriting any previously set attributes (from users or potentially our SDK instrumentation)
   safeSetSpanJSONAttributes(spanJSON, {
     [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: release,
-    [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: environment,
+    [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: environment ?? DEFAULT_ENVIRONMENT,
     [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: serializedSegmentSpan.name,
     [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: serializedSegmentSpan.span_id,
     [SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME]: sdk?.sdk?.name,

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -143,7 +143,7 @@ function applyCommonSpanAttributes(
   // avoid overwriting any previously set attributes (from users or potentially our SDK instrumentation)
   safeSetSpanJSONAttributes(spanJSON, {
     [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: release,
-    [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: environment ?? DEFAULT_ENVIRONMENT,
+    [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: environment || DEFAULT_ENVIRONMENT,
     [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: serializedSegmentSpan.name,
     [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: serializedSegmentSpan.span_id,
     [SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME]: sdk?.sdk?.name,

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -232,6 +232,78 @@ describe('captureSpan', () => {
     });
   });
 
+  it('falls back to "production" environment if not provided', () => {
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+        tracesSampleRate: 1,
+        release: '1.0.0',
+        // environment: undefined,
+      }),
+    );
+    client.init();
+
+    const span = withScope(scope => {
+      scope.setClient(client);
+
+      const span = startInactiveSpan({ name: 'my-span', attributes: { 'sentry.op': 'http.client' } });
+      span.end();
+
+      return span;
+    });
+
+    expect(captureSpan(span, client)).toStrictEqual({
+      span_id: expect.stringMatching(/^[\da-f]{16}$/),
+      parent_span_id: undefined,
+      trace_id: expect.stringMatching(/^[\da-f]{32}$/),
+      links: undefined,
+      start_timestamp: expect.any(Number),
+      name: 'my-span',
+      end_timestamp: expect.any(Number),
+      status: 'ok',
+      is_segment: true,
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: {
+          type: 'string',
+          value: 'http.client',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: {
+          type: 'string',
+          value: 'manual',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: {
+          type: 'integer',
+          value: 1,
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: {
+          value: 'my-span',
+          type: 'string',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: {
+          value: span.spanContext().spanId,
+          type: 'string',
+        },
+        'sentry.span.source': {
+          value: 'custom',
+          type: 'string',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: {
+          value: 'custom',
+          type: 'string',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: {
+          value: '1.0.0',
+          type: 'string',
+        },
+        [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
+          value: 'production',
+          type: 'string',
+        },
+      },
+      _segmentSpan: span,
+    });
+  });
+
   it('adds sentry.sdk.integrations to segment spans as an array attribute', () => {
     const client = new TestClient(
       getDefaultTestClientOptions({


### PR DESCRIPTION
We set `"production"` as the default environment on events. This PR adds the same behaviour to streamed spans when applying common attributes in the `captureSpan` pipeline

closes https://github.com/getsentry/sentry-javascript/issues/21636