### PR TITLE
feat(server-utils): Add tracingChannel-to-span binding

### DIFF
--- a/packages/cloudflare/src/async.ts
+++ b/packages/cloudflare/src/async.ts
@@ -2,7 +2,12 @@
 // Note: Because we are using node:async_hooks, we need to set `node_compat` in the wrangler.toml
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
-import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
+import {
+  _INTERNAL_setSpanForScope,
+  getDefaultCurrentScope,
+  getDefaultIsolationScope,
+  setAsyncContextStrategy,
+} from '@sentry/core';
 
 /**
  * Sets the async context strategy to use AsyncLocalStorage.
@@ -80,5 +85,14 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     withSetIsolationScope,
     getCurrentScope: () => getScopes().scope,
     getIsolationScope: () => getScopes().isolationScope,
+    getTracingChannelBinding: () => ({
+      asyncLocalStorage: asyncStorage,
+      getStoreWithActiveSpan: span => {
+        const scope = getScopes().scope.clone();
+        const isolationScope = getScopes().isolationScope;
+        _INTERNAL_setSpanForScope(scope, span);
+        return { scope, isolationScope };
+      },
+    }),
   });
 }

--- a/packages/cloudflare/src/async.ts
+++ b/packages/cloudflare/src/async.ts
@@ -3,7 +3,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
 import {
-  _INTERNAL_setSpanForScope,
+  _INTERNAL_createTracingChannelBinding,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
   setAsyncContextStrategy,
@@ -85,14 +85,6 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     withSetIsolationScope,
     getCurrentScope: () => getScopes().scope,
     getIsolationScope: () => getScopes().isolationScope,
-    getTracingChannelBinding: () => ({
-      asyncLocalStorage: asyncStorage,
-      getStoreWithActiveSpan: span => {
-        const scope = getScopes().scope.clone();
-        const isolationScope = getScopes().isolationScope;
-        _INTERNAL_setSpanForScope(scope, span);
-        return { scope, isolationScope };
-      },
-    }),
+    getTracingChannelBinding: () => _INTERNAL_createTracingChannelBinding(asyncStorage, getScopes),
   });
 }

--- a/packages/core/src/asyncContext/index.ts
+++ b/packages/core/src/asyncContext/index.ts
@@ -1,5 +1,7 @@
 import type { Carrier } from './../carrier';
 import { getMainCarrier, getSentryCarrier } from './../carrier';
+import type { Scope } from './../scope';
+import { _setSpanForScope } from './../utils/spanOnScope';
 import { getStackAsyncContextStrategy } from './stackStrategy';
 import type { AsyncContextStrategy, TracingChannelBinding } from './types';
 
@@ -35,4 +37,29 @@ export function getAsyncContextStrategy(carrier: Carrier): AsyncContextStrategy 
  */
 export function getTracingChannelBinding(): TracingChannelBinding | undefined {
   return getAsyncContextStrategy(getMainCarrier()).getTracingChannelBinding?.();
+}
+
+/**
+ * Build the default {@link TracingChannelBinding} shared by AsyncLocalStorage-based strategies.
+ *
+ * The ALS instance is supplied by the caller (kept as `unknown`).
+ * The binding clones the current scope, plants the span on it, and reuses the existing isolation scope.
+ *
+ * The OpenTelemetry strategy does not use this: its store value is an OTel context, not a
+ * `{ scope, isolationScope }` pair.
+ */
+export function _INTERNAL_createTracingChannelBinding(
+  asyncLocalStorage: unknown,
+  getScopes: () => { scope: Scope; isolationScope: Scope },
+): TracingChannelBinding {
+  return {
+    asyncLocalStorage,
+    getStoreWithActiveSpan: span => {
+      const { scope, isolationScope } = getScopes();
+      const activeScope = scope.clone();
+      _setSpanForScope(activeScope, span);
+
+      return { scope: activeScope, isolationScope };
+    },
+  };
 }

--- a/packages/core/src/asyncContext/index.ts
+++ b/packages/core/src/asyncContext/index.ts
@@ -1,7 +1,7 @@
 import type { Carrier } from './../carrier';
 import { getMainCarrier, getSentryCarrier } from './../carrier';
 import { getStackAsyncContextStrategy } from './stackStrategy';
-import type { AsyncContextStrategy } from './types';
+import type { AsyncContextStrategy, TracingChannelBinding } from './types';
 
 /**
  * @private Private API with no semver guarantees!
@@ -28,4 +28,11 @@ export function getAsyncContextStrategy(carrier: Carrier): AsyncContextStrategy 
 
   // Otherwise, use the default one (stack)
   return getStackAsyncContextStrategy();
+}
+
+/**
+ * Get the runtime binding needed to connect tracing channels to async context.
+ */
+export function getTracingChannelBinding(): TracingChannelBinding | undefined {
+  return getAsyncContextStrategy(getMainCarrier()).getTracingChannelBinding?.();
 }

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -12,8 +12,20 @@ import type {
 } from './../tracing/trace';
 import type { getActiveSpan } from './../utils/spanUtils';
 
+/*
+ * @private Private API with no semver guarantees!
+ *
+ * A binding object used to enable context propagation for a tracing channel against a span
+ */
 export interface TracingChannelBinding {
+  /**
+   * The ALS instance that will be bound to the channel.
+   */
   asyncLocalStorage: unknown;
+
+  /**
+   * Activates a span for the tracing channels nested invocations, the return value wi
+   */
   getStoreWithActiveSpan: (span: Span) => unknown;
 }
 

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -24,7 +24,7 @@ export interface TracingChannelBinding {
   asyncLocalStorage: unknown;
 
   /**
-   * Activates a span for the tracing channels nested invocations, the return value wi
+   * Activates a span for the tracing channels nested invocations, the return value must be the same type as the `asyncLocalStorage` inner value.
    */
   getStoreWithActiveSpan: (span: Span) => unknown;
 }

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -1,4 +1,5 @@
 import type { Scope } from '../scope';
+import type { Span } from '../types/span';
 import type { getTraceData } from '../utils/traceData';
 import type {
   continueTrace,
@@ -10,6 +11,11 @@ import type {
   withActiveSpan,
 } from './../tracing/trace';
 import type { getActiveSpan } from './../utils/spanUtils';
+
+export interface TracingChannelBinding {
+  asyncLocalStorage: unknown;
+  getStoreWithActiveSpan: (span: Span) => unknown;
+}
 
 /**
  * @private Private API with no semver guarantees!
@@ -80,4 +86,7 @@ export interface AsyncContextStrategy {
 
   /** Start a new trace, ensuring all spans in the callback share the same traceId. */
   startNewTrace?: typeof startNewTrace;
+
+  /** Get the runtime store required to bind tracing channels to an active span. */
+  getTracingChannelBinding?: () => TracingChannelBinding | undefined;
 }

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -52,6 +52,7 @@ export { getDefaultCurrentScope, getDefaultIsolationScope } from './defaultScope
 export {
   setAsyncContextStrategy,
   getTracingChannelBinding as _INTERNAL_getTracingChannelBinding,
+  _INTERNAL_createTracingChannelBinding,
 } from './asyncContext';
 export { getGlobalSingleton, getMainCarrier } from './carrier';
 export { makeSession, closeSession, updateSession } from './session';

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -4,7 +4,7 @@
 /* eslint-disable max-lines */
 
 export type { ClientClass as SentryCoreCurrentScopes } from './sdk';
-export type { AsyncContextStrategy } from './asyncContext/types';
+export type { AsyncContextStrategy, TracingChannelBinding } from './asyncContext/types';
 export type { Carrier } from './carrier';
 export type { OfflineStore, OfflineTransportOptions } from './transports/offline';
 export type { IntegrationIndex } from './integration';
@@ -49,7 +49,10 @@ export {
   hasExternalPropagationContext,
 } from './currentScopes';
 export { getDefaultCurrentScope, getDefaultIsolationScope } from './defaultScopes';
-export { setAsyncContextStrategy } from './asyncContext';
+export {
+  setAsyncContextStrategy,
+  getTracingChannelBinding as _INTERNAL_getTracingChannelBinding,
+} from './asyncContext';
 export { getGlobalSingleton, getMainCarrier } from './carrier';
 export { makeSession, closeSession, updateSession } from './session';
 export { Scope } from './scope';

--- a/packages/deno/src/async.ts
+++ b/packages/deno/src/async.ts
@@ -1,7 +1,12 @@
 // Need to use node: prefix for deno compatibility
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
-import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
+import {
+  _INTERNAL_setSpanForScope,
+  getDefaultCurrentScope,
+  getDefaultIsolationScope,
+  setAsyncContextStrategy,
+} from '@sentry/core';
 
 let installed = false;
 
@@ -88,5 +93,14 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     withSetIsolationScope,
     getCurrentScope: () => getScopes().scope,
     getIsolationScope: () => getScopes().isolationScope,
+    getTracingChannelBinding: () => ({
+      asyncLocalStorage: asyncStorage,
+      getStoreWithActiveSpan: span => {
+        const scope = getScopes().scope.clone();
+        const isolationScope = getScopes().isolationScope;
+        _INTERNAL_setSpanForScope(scope, span);
+        return { scope, isolationScope };
+      },
+    }),
   });
 }

--- a/packages/deno/src/async.ts
+++ b/packages/deno/src/async.ts
@@ -2,7 +2,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
 import {
-  _INTERNAL_setSpanForScope,
+  _INTERNAL_createTracingChannelBinding,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
   setAsyncContextStrategy,
@@ -93,14 +93,6 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     withSetIsolationScope,
     getCurrentScope: () => getScopes().scope,
     getIsolationScope: () => getScopes().isolationScope,
-    getTracingChannelBinding: () => ({
-      asyncLocalStorage: asyncStorage,
-      getStoreWithActiveSpan: span => {
-        const scope = getScopes().scope.clone();
-        const isolationScope = getScopes().isolationScope;
-        _INTERNAL_setSpanForScope(scope, span);
-        return { scope, isolationScope };
-      },
-    }),
+    getTracingChannelBinding: () => _INTERNAL_createTracingChannelBinding(asyncStorage, getScopes),
   });
 }

--- a/packages/node-core/src/light/asyncLocalStorageStrategy.ts
+++ b/packages/node-core/src/light/asyncLocalStorageStrategy.ts
@@ -1,7 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
 import {
-  _INTERNAL_setSpanForScope,
+  _INTERNAL_createTracingChannelBinding,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
   setAsyncContextStrategy,
@@ -81,14 +81,6 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     withSetIsolationScope,
     getCurrentScope: () => getScopes().scope,
     getIsolationScope: () => getScopes().isolationScope,
-    getTracingChannelBinding: () => ({
-      asyncLocalStorage: asyncStorage,
-      getStoreWithActiveSpan: span => {
-        const scope = getScopes().scope.clone();
-        const isolationScope = getScopes().isolationScope;
-        _INTERNAL_setSpanForScope(scope, span);
-        return { scope, isolationScope };
-      },
-    }),
+    getTracingChannelBinding: () => _INTERNAL_createTracingChannelBinding(asyncStorage, getScopes),
   });
 }

--- a/packages/node-core/src/light/asyncLocalStorageStrategy.ts
+++ b/packages/node-core/src/light/asyncLocalStorageStrategy.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
 import {
+  _INTERNAL_setSpanForScope,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
   setAsyncContextStrategy,
@@ -80,5 +81,14 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     withSetIsolationScope,
     getCurrentScope: () => getScopes().scope,
     getIsolationScope: () => getScopes().isolationScope,
+    getTracingChannelBinding: () => ({
+      asyncLocalStorage: asyncStorage,
+      getStoreWithActiveSpan: span => {
+        const scope = getScopes().scope.clone();
+        const isolationScope = getScopes().isolationScope;
+        _INTERNAL_setSpanForScope(scope, span);
+        return { scope, isolationScope };
+      },
+    }),
   });
 }

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,5 +1,5 @@
 import * as api from '@opentelemetry/api';
-import type { Scope, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
+import type { Scope, Span, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
 import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
 import {
   SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY,
@@ -12,6 +12,14 @@ import { getContextFromScope, getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
 import { getTraceData } from './utils/getTraceData';
 import { suppressTracing } from './utils/suppressTracing';
+
+interface ContextApi {
+  _getContextManager(): {
+    getAsyncLocalStorageLookup(): {
+      asyncLocalStorage: unknown;
+    };
+  };
+}
 
 /**
  * Sets the async context strategy to use follow the OTEL context under the hood.
@@ -108,5 +116,18 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     // The types here don't fully align, because our own `Span` type is narrower
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,
+    getTracingChannelBinding: () => {
+      try {
+        const contextManager = (api.context as unknown as ContextApi)._getContextManager();
+        const lookup = contextManager.getAsyncLocalStorageLookup();
+
+        return {
+          asyncLocalStorage: lookup.asyncLocalStorage,
+          getStoreWithActiveSpan: (span: Span) => api.trace.setSpan(api.context.active(), span as api.Span),
+        };
+      } catch {
+        return undefined;
+      }
+    },
   });
 }

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -24,4 +24,8 @@ export type {
   RedisTracingChannelSubscribers,
 } from './redis/redis-dc-subscriber';
 export { bindTracingChannelToSpan } from './tracing-channel';
-export type { SentryTracingChannel, TracingChannelPayloadWithSpan } from './tracing-channel';
+export type {
+  SentryTracingChannel,
+  TracingChannelBindingHandle,
+  TracingChannelPayloadWithSpan,
+} from './tracing-channel';

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -23,7 +23,7 @@ export type {
   RedisTracingChannelFactory,
   RedisTracingChannelSubscribers,
 } from './redis/redis-dc-subscriber';
-export { bindTracingChannelToSpan, bindTracingChannelToSpanWithLifeCycle } from './tracing-channel';
+export { bindTracingChannelToSpan } from './tracing-channel';
 export type {
   SentryTracingChannel,
   TracingChannelLifeCycleOptions,

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -23,3 +23,5 @@ export type {
   RedisTracingChannelFactory,
   RedisTracingChannelSubscribers,
 } from './redis/redis-dc-subscriber';
+export { bindTracingChannelToSpan } from './tracing-channel';
+export type { SentryTracingChannel, TracingChannelPayloadWithSpan } from './tracing-channel';

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -23,9 +23,10 @@ export type {
   RedisTracingChannelFactory,
   RedisTracingChannelSubscribers,
 } from './redis/redis-dc-subscriber';
-export { bindTracingChannelToSpan } from './tracing-channel';
+export { bindTracingChannelToSpan, bindTracingChannelToSpanWithLifeCycle } from './tracing-channel';
 export type {
   SentryTracingChannel,
+  TracingChannelLifeCycleOptions,
   TracingChannelBindingHandle,
   TracingChannelPayloadWithSpan,
 } from './tracing-channel';

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -27,9 +27,10 @@ export interface TracingChannelLifeCycleOptions<TData extends object = object> {
   beforeSpanEnd?: (span: Span, data: TracingChannelPayloadWithSpan<TData>) => void;
 
   /**
-   * Whether a thrown error is captured as a Sentry event. The span is always marked with error status regardless. Defaults to `true`.
+   * Whether a thrown error is captured as a Sentry event. The span is always marked with error status regardless. Defaults to `false`.
    * You can alternatively pass a function that sets the ExclusiveEventHintOrCaptureContext on the captured error.
-   * Set `false` for instrumentation that only annotates the span and lets the error be captured at the boundary that owns it (e.g. db spans).
+   * Set `true` for instrumentations that own the error boundary, (e.g: route handlers)
+   * For database drivers, it is not recommended to set this at all.
    */
   captureError?: boolean | ((e: unknown) => ExclusiveEventHintOrCaptureContext);
 }
@@ -98,7 +99,7 @@ export function bindTracingChannelToSpan<TData extends object>(
         return;
       }
 
-      if (opts?.captureError !== false) {
+      if (opts?.captureError) {
         captureException(data.error, getErrorHint(data.error));
       }
 

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -1,0 +1,80 @@
+import type { TracingChannel, TracingChannelSubscribers } from 'node:diagnostics_channel';
+import type { AsyncLocalStorage } from 'node:async_hooks';
+import type { Span } from '@sentry/core';
+import { _INTERNAL_getTracingChannelBinding, debug, captureException, SPAN_STATUS_ERROR } from '@sentry/core';
+import { DEBUG_BUILD } from './debug-build';
+
+export type TracingChannelPayloadWithSpan<TData extends object> = TData & {
+  _sentrySpan?: Span;
+};
+
+/*
+ * A type patch so that we don't have to handle all subscription types.
+ */
+export interface SentryTracingChannel<TData extends object = object> extends Omit<
+  TracingChannel<TData, TracingChannelPayloadWithSpan<TData>>,
+  'subscribe' | 'unsubscribe'
+> {
+  subscribe(subscribers: Partial<TracingChannelSubscribers<TracingChannelPayloadWithSpan<TData>>>): void;
+  unsubscribe(subscribers: Partial<TracingChannelSubscribers<TracingChannelPayloadWithSpan<TData>>>): void;
+}
+
+export interface TracingChannelBindingOptions {
+  lifecycle: 'auto' | 'manual';
+}
+
+const NOOP = () => {};
+
+export function bindTracingChannelToSpan<TData extends object>(
+  channel: TracingChannel<TData, TData>,
+  getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span,
+  opts?: Partial<TracingChannelBindingOptions>,
+): SentryTracingChannel<TData> {
+  const binding = _INTERNAL_getTracingChannelBinding();
+
+  if (!binding) {
+    DEBUG_BUILD && debug.log('[TracingChannel] Could not access async context binding.');
+    return channel as SentryTracingChannel<TData>;
+  }
+
+  channel.start.bindStore(
+    binding.asyncLocalStorage as AsyncLocalStorage<TData>,
+    (data: TracingChannelPayloadWithSpan<TData>) => {
+      const span = getSpan(data);
+      data._sentrySpan = span;
+
+      return binding.getStoreWithActiveSpan(span) as TData;
+    },
+  );
+
+  const sentryChannel = channel as SentryTracingChannel<TData>;
+
+  if (opts?.lifecycle === 'manual') {
+    return sentryChannel;
+  }
+
+  sentryChannel.subscribe({
+    start: NOOP,
+    asyncStart: NOOP,
+    end(data) {
+      // The operation settled synchronously (returned or threw)
+      // Presence checks because caller can return `undefined` result or throw a falsy value.
+      if ('error' in data || 'result' in data) {
+        data._sentrySpan?.end();
+      }
+    },
+    error(data) {
+      captureException(data.error, {
+        mechanism: {
+          type: 'auto.diagnostic_channels.bind_span',
+        },
+      });
+      data._sentrySpan?.setStatus({ code: SPAN_STATUS_ERROR, message: String(data.error) });
+    },
+    asyncEnd(data) {
+      data._sentrySpan?.end();
+    },
+  });
+
+  return sentryChannel;
+}

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -19,11 +19,18 @@ export interface SentryTracingChannel<TData extends object = object> extends Omi
   unsubscribe(subscribers: Partial<TracingChannelSubscribers<TracingChannelPayloadWithSpan<TData>>>): void;
 }
 
-export interface TracingChannelBindingOptions<TData extends object = object> {
+interface TracingChannelManualBindingOptions {
   /**
    * Whether the span is ended automatically (`auto`, default) or left to the caller (`manual`).
    */
-  lifecycle?: 'auto' | 'manual';
+  lifecycle: 'manual';
+}
+
+interface TracingChannelAutoBindingOptions<TData extends object = object> {
+  /**
+   * Whether the span is ended automatically (`auto`, default) or left to the caller (`manual`).
+   */
+  lifecycle?: 'auto' | undefined;
 
   /**
    * Invoked with the span and the channel context object once the traced operation completes
@@ -38,6 +45,10 @@ export interface TracingChannelBindingOptions<TData extends object = object> {
    */
   captureError?: boolean;
 }
+
+export type TracingChannelBindingOptions<TData extends object = object> =
+  | TracingChannelAutoBindingOptions<TData>
+  | TracingChannelManualBindingOptions;
 
 /** Returned by {@link bindTracingChannelToSpan}: the bound channel plus a teardown handle. */
 export interface TracingChannelBindingHandle<TData extends object = object> {
@@ -78,7 +89,7 @@ export function bindTracingChannelToSpan<TData extends object>(
     channel.start.unbindStore(asyncLocalStorage);
   };
 
-  if (opts?.lifecycle === 'manual') {
+  if (opts && 'lifecycle' in opts && opts.lifecycle === 'manual') {
     return { channel: sentryChannel, unbind: unbindStore };
   }
 
@@ -123,7 +134,7 @@ export function bindTracingChannelToSpan<TData extends object>(
 
 function endBoundSpan<TData extends object>(
   data: TracingChannelPayloadWithSpan<TData>,
-  beforeSpanEnd: TracingChannelBindingOptions<TData>['beforeSpanEnd'],
+  beforeSpanEnd: TracingChannelAutoBindingOptions<TData>['beforeSpanEnd'],
 ): void {
   const span = data._sentrySpan;
   if (!span) {

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -39,39 +39,52 @@ export interface TracingChannelBindingOptions<TData extends object = object> {
   captureError?: boolean;
 }
 
+/** Returned by {@link bindTracingChannelToSpan}: the bound channel plus a teardown handle. */
+export interface TracingChannelBindingHandle<TData extends object = object> {
+  /** The tracing channel with the span bound into async context (and, in `auto` mode, its lifecycle subscribed). */
+  channel: SentryTracingChannel<TData>;
+  /**
+   * Tears down the binding: unsubscribes the auto lifecycle handlers and unbinds the start store.
+   * Idempotent, and a no-op when no async context binding was available.
+   */
+  unbind: () => void;
+}
+
 const NOOP = (): void => {};
 
 export function bindTracingChannelToSpan<TData extends object>(
   channel: TracingChannel<TData, TData>,
   getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span,
   opts?: TracingChannelBindingOptions<TData>,
-): SentryTracingChannel<TData> {
+): TracingChannelBindingHandle<TData> {
+  const sentryChannel = channel as SentryTracingChannel<TData>;
   const binding = _INTERNAL_getTracingChannelBinding();
 
   if (!binding) {
     DEBUG_BUILD && debug.log('[TracingChannel] Could not access async context binding.');
-    return channel as SentryTracingChannel<TData>;
+    return { channel: sentryChannel, unbind: NOOP };
   }
 
-  channel.start.bindStore(
-    binding.asyncLocalStorage as AsyncLocalStorage<TData>,
-    (data: TracingChannelPayloadWithSpan<TData>) => {
-      const span = getSpan(data);
-      data._sentrySpan = span;
+  const asyncLocalStorage = binding.asyncLocalStorage as AsyncLocalStorage<TData>;
 
-      return binding.getStoreWithActiveSpan(span) as TData;
-    },
-  );
+  channel.start.bindStore(asyncLocalStorage, (data: TracingChannelPayloadWithSpan<TData>) => {
+    const span = getSpan(data);
+    data._sentrySpan = span;
 
-  const sentryChannel = channel as SentryTracingChannel<TData>;
+    return binding.getStoreWithActiveSpan(span) as TData;
+  });
+
+  const unbindStore = (): void => {
+    channel.start.unbindStore(asyncLocalStorage);
+  };
 
   if (opts?.lifecycle === 'manual') {
-    return sentryChannel;
+    return { channel: sentryChannel, unbind: unbindStore };
   }
 
   const beforeSpanEnd = opts?.beforeSpanEnd;
 
-  sentryChannel.subscribe({
+  const subscribers: Partial<TracingChannelSubscribers<TracingChannelPayloadWithSpan<TData>>> = {
     start: NOOP,
     asyncStart: NOOP,
     end(data) {
@@ -95,9 +108,17 @@ export function bindTracingChannelToSpan<TData extends object>(
     asyncEnd(data) {
       endBoundSpan(data, beforeSpanEnd);
     },
-  });
+  };
 
-  return sentryChannel;
+  sentryChannel.subscribe(subscribers);
+
+  return {
+    channel: sentryChannel,
+    unbind: () => {
+      sentryChannel.unsubscribe(subscribers);
+      unbindStore();
+    },
+  };
 }
 
 function endBoundSpan<TData extends object>(

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -59,12 +59,12 @@ const NOOP = (): void => {};
  * but should reuse the enclosing span instead of opening (and ending) their own — e.g. an agent
  * loop's per-step events, where ending a freshly opened span would close the parent prematurely.
  */
-export function bindTracingChannelToSpanWithLifeCycle<TData extends object>(
+export function bindTracingChannelToSpan<TData extends object>(
   channel: TracingChannel<TData, TData>,
   getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span | undefined,
   opts?: TracingChannelLifeCycleOptions<TData>,
 ): TracingChannelBindingHandle<TData> {
-  const handle = bindTracingChannelToSpan(channel, getSpan);
+  const handle = bindSpanToChannelStore(channel, getSpan);
 
   const beforeSpanEnd = opts?.beforeSpanEnd;
   const getErrorHint = (e: unknown): ExclusiveEventHintOrCaptureContext => {
@@ -121,12 +121,13 @@ export function bindTracingChannelToSpanWithLifeCycle<TData extends object>(
 }
 
 /**
- * Bind a span to a tracing channel so the span becomes the active async context for the traced
- * operation. The caller owns the span lifecycle and any error handling.
+ * Bind a span into the channel's async context so it becomes active for the traced operation,
+ * without managing its lifecycle. The primitive behind {@link bindTracingChannelToSpan}, which
+ * layers span-ending and error handling on top.
  *
  * `getSpan` may return `undefined` to leave the active context untouched for that payload.
  */
-export function bindTracingChannelToSpan<TData extends object>(
+function bindSpanToChannelStore<TData extends object>(
   channel: TracingChannel<TData, TData>,
   getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span | undefined,
 ): TracingChannelBindingHandle<TData> {

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -19,19 +19,7 @@ export interface SentryTracingChannel<TData extends object = object> extends Omi
   unsubscribe(subscribers: Partial<TracingChannelSubscribers<TracingChannelPayloadWithSpan<TData>>>): void;
 }
 
-interface TracingChannelManualBindingOptions {
-  /**
-   * Whether the span is ended automatically (`auto`, default) or left to the caller (`manual`).
-   */
-  lifecycle: 'manual';
-}
-
-interface TracingChannelAutoBindingOptions<TData extends object = object> {
-  /**
-   * Whether the span is ended automatically (`auto`, default) or left to the caller (`manual`).
-   */
-  lifecycle?: 'auto' | undefined;
-
+export interface TracingChannelLifeCycleOptions<TData extends object = object> {
   /**
    * Invoked with the span and the channel context object once the traced operation completes
    * Use it to enrich the span from the result/error (branch on `'error' in data` / `'result' in data`) or to run cleanup.
@@ -46,16 +34,15 @@ interface TracingChannelAutoBindingOptions<TData extends object = object> {
   captureError?: boolean | ((e: unknown) => ExclusiveEventHintOrCaptureContext);
 }
 
-export type TracingChannelBindingOptions<TData extends object = object> =
-  | TracingChannelAutoBindingOptions<TData>
-  | TracingChannelManualBindingOptions;
-
 /** Returned by {@link bindTracingChannelToSpan}: the bound channel plus a teardown handle. */
 export interface TracingChannelBindingHandle<TData extends object = object> {
-  /** The tracing channel with the span bound into async context (and, in `auto` mode, its lifecycle subscribed). */
-  channel: SentryTracingChannel<TData>;
   /**
-   * Tears down the binding: unsubscribes the auto lifecycle handlers and unbinds the start store.
+   * The tracing channel with the span bound into async context.
+   */
+  channel: SentryTracingChannel<TData>;
+
+  /**
+   * Tears down the binding: unsubscribes lifecycle handlers, when present, and unbinds the start store.
    * Idempotent, and a no-op when no async context binding was available.
    */
   unbind: () => void;
@@ -64,50 +51,22 @@ export interface TracingChannelBindingHandle<TData extends object = object> {
 const NOOP = (): void => {};
 
 /**
- * Bind a span (and, in `auto` mode, its lifecycle) to a tracing channel so the span becomes the
- * active async context for the traced operation.
+ * Bind a span and its lifecycle to a tracing channel so the span becomes the active async context
+ * for the traced operation and is ended when the operation completes.
  *
  * `getSpan` may return `undefined` to opt a payload out entirely: nothing is bound, no span is
  * tracked, and the active context is left untouched. Use it for events that ride the same channel
  * but should reuse the enclosing span instead of opening (and ending) their own — e.g. an agent
  * loop's per-step events, where ending a freshly opened span would close the parent prematurely.
  */
-export function bindTracingChannelToSpan<TData extends object>(
+export function bindTracingChannelToSpanWithLifeCycle<TData extends object>(
   channel: TracingChannel<TData, TData>,
   getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span | undefined,
-  opts?: TracingChannelBindingOptions<TData>,
+  opts?: TracingChannelLifeCycleOptions<TData>,
 ): TracingChannelBindingHandle<TData> {
-  const sentryChannel = channel as SentryTracingChannel<TData>;
-  const binding = _INTERNAL_getTracingChannelBinding();
-
-  if (!binding) {
-    DEBUG_BUILD && debug.log('[TracingChannel] Could not access async context binding.');
-    return { channel: sentryChannel, unbind: NOOP };
-  }
-
-  const asyncLocalStorage = binding.asyncLocalStorage as AsyncLocalStorage<TData>;
-
-  channel.start.bindStore(asyncLocalStorage, (data: TracingChannelPayloadWithSpan<TData>) => {
-    const span = getSpan(data);
-    if (!span) {
-      // Leave the active context untouched so nested operations keep parenting to the enclosing span.
-      return asyncLocalStorage.getStore() as TData;
-    }
-    data._sentrySpan = span;
-
-    return binding.getStoreWithActiveSpan(span) as TData;
-  });
-
-  const unbindStore = (): void => {
-    channel.start.unbindStore(asyncLocalStorage);
-  };
-
-  if (opts && 'lifecycle' in opts && opts.lifecycle === 'manual') {
-    return { channel: sentryChannel, unbind: unbindStore };
-  }
+  const handle = bindTracingChannelToSpan(channel, getSpan);
 
   const beforeSpanEnd = opts?.beforeSpanEnd;
-
   const getErrorHint = (e: unknown): ExclusiveEventHintOrCaptureContext => {
     if (typeof opts?.captureError === 'function') {
       return opts.captureError(e);
@@ -150,20 +109,63 @@ export function bindTracingChannelToSpan<TData extends object>(
     },
   };
 
-  sentryChannel.subscribe(subscribers);
+  handle.channel.subscribe(subscribers);
 
   return {
-    channel: sentryChannel,
+    channel: handle.channel,
     unbind: () => {
-      sentryChannel.unsubscribe(subscribers);
-      unbindStore();
+      handle.channel.unsubscribe(subscribers);
+      handle.unbind();
+    },
+  };
+}
+
+/**
+ * Bind a span to a tracing channel so the span becomes the active async context for the traced
+ * operation. The caller owns the span lifecycle and any error handling.
+ *
+ * `getSpan` may return `undefined` to leave the active context untouched for that payload.
+ */
+export function bindTracingChannelToSpan<TData extends object>(
+  channel: TracingChannel<TData, TData>,
+  getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span | undefined,
+): TracingChannelBindingHandle<TData> {
+  const binding = _INTERNAL_getTracingChannelBinding();
+
+  if (!binding) {
+    DEBUG_BUILD && debug.log('[TracingChannel] Could not access async context binding.');
+
+    return {
+      channel,
+      unbind: NOOP,
+    };
+  }
+
+  const asyncLocalStorage = binding.asyncLocalStorage as AsyncLocalStorage<TData>;
+
+  channel.start.bindStore(asyncLocalStorage, (data: TracingChannelPayloadWithSpan<TData>) => {
+    const span = getSpan(data);
+    if (!span) {
+      // Leave the active context untouched so nested operations keep parenting to the enclosing span.
+      return asyncLocalStorage.getStore() as TData;
+    }
+    data._sentrySpan = span;
+
+    return binding.getStoreWithActiveSpan(span) as TData;
+  });
+
+  return {
+    channel,
+    unbind: () => {
+      // Removes the store
+      channel.start.unbindStore(asyncLocalStorage);
     },
   };
 }
 
 function endBoundSpan<TData extends object>(
   data: TracingChannelPayloadWithSpan<TData>,
-  beforeSpanEnd: TracingChannelAutoBindingOptions<TData>['beforeSpanEnd'],
+  beforeSpanEnd: TracingChannelLifeCycleOptions<TData>['beforeSpanEnd'],
 ): void {
   const span = data._sentrySpan;
   if (!span) {

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -19,16 +19,32 @@ export interface SentryTracingChannel<TData extends object = object> extends Omi
   unsubscribe(subscribers: Partial<TracingChannelSubscribers<TracingChannelPayloadWithSpan<TData>>>): void;
 }
 
-export interface TracingChannelBindingOptions {
-  lifecycle: 'auto' | 'manual';
+export interface TracingChannelBindingOptions<TData extends object = object> {
+  /**
+   * Whether the span is ended automatically (`auto`, default) or left to the caller (`manual`).
+   */
+  lifecycle?: 'auto' | 'manual';
+
+  /**
+   * Invoked with the span and the channel context object once the traced operation completes
+   * Use it to enrich the span from the result/error (branch on `'error' in data` / `'result' in data`) or to run cleanup.
+   */
+  beforeSpanEnd?: (span: Span, data: TracingChannelPayloadWithSpan<TData>) => void;
+
+  /**
+   * Whether a thrown error is captured as a Sentry event. The span is always marked with error
+   * status regardless. Defaults to `true`.
+   * Set `false` for instrumentation that only annotates the span and lets the error be captured at the boundary that owns it (e.g. db spans).
+   */
+  captureError?: boolean;
 }
 
-const NOOP = () => {};
+const NOOP = (): void => {};
 
 export function bindTracingChannelToSpan<TData extends object>(
   channel: TracingChannel<TData, TData>,
   getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span,
-  opts?: Partial<TracingChannelBindingOptions>,
+  opts?: TracingChannelBindingOptions<TData>,
 ): SentryTracingChannel<TData> {
   const binding = _INTERNAL_getTracingChannelBinding();
 
@@ -53,6 +69,8 @@ export function bindTracingChannelToSpan<TData extends object>(
     return sentryChannel;
   }
 
+  const beforeSpanEnd = opts?.beforeSpanEnd;
+
   sentryChannel.subscribe({
     start: NOOP,
     asyncStart: NOOP,
@@ -60,21 +78,44 @@ export function bindTracingChannelToSpan<TData extends object>(
       // The operation settled synchronously (returned or threw)
       // Presence checks because caller can return `undefined` result or throw a falsy value.
       if ('error' in data || 'result' in data) {
-        data._sentrySpan?.end();
+        endBoundSpan(data, beforeSpanEnd);
       }
     },
     error(data) {
-      captureException(data.error, {
-        mechanism: {
-          type: 'auto.diagnostic_channels.bind_span',
-        },
-      });
-      data._sentrySpan?.setStatus({ code: SPAN_STATUS_ERROR, message: String(data.error) });
+      if (opts?.captureError !== false) {
+        captureException(data.error, {
+          mechanism: {
+            type: 'auto.diagnostic_channels.bind_span',
+            handled: false,
+          },
+        });
+      }
+      data._sentrySpan?.setStatus({ code: SPAN_STATUS_ERROR, message: getErrorMessage(data.error) });
     },
     asyncEnd(data) {
-      data._sentrySpan?.end();
+      endBoundSpan(data, beforeSpanEnd);
     },
   });
 
   return sentryChannel;
+}
+
+function endBoundSpan<TData extends object>(
+  data: TracingChannelPayloadWithSpan<TData>,
+  beforeSpanEnd: TracingChannelBindingOptions<TData>['beforeSpanEnd'],
+): void {
+  const span = data._sentrySpan;
+  if (!span) {
+    return;
+  }
+  beforeSpanEnd?.(span, data);
+  span.end();
+}
+
+/** Best-effort short message for a span status: an error-like's `message`, otherwise its string form. */
+function getErrorMessage(error: unknown): string {
+  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
+    return error.message;
+  }
+  return String(error);
 }

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -1,6 +1,6 @@
 import type { TracingChannel, TracingChannelSubscribers } from 'node:diagnostics_channel';
 import type { AsyncLocalStorage } from 'node:async_hooks';
-import type { Span } from '@sentry/core';
+import type { ExclusiveEventHintOrCaptureContext, Span } from '@sentry/core';
 import { _INTERNAL_getTracingChannelBinding, debug, captureException, SPAN_STATUS_ERROR } from '@sentry/core';
 import { DEBUG_BUILD } from './debug-build';
 
@@ -39,11 +39,11 @@ interface TracingChannelAutoBindingOptions<TData extends object = object> {
   beforeSpanEnd?: (span: Span, data: TracingChannelPayloadWithSpan<TData>) => void;
 
   /**
-   * Whether a thrown error is captured as a Sentry event. The span is always marked with error
-   * status regardless. Defaults to `true`.
+   * Whether a thrown error is captured as a Sentry event. The span is always marked with error status regardless. Defaults to `true`.
+   * You can alternatively pass a function that sets the ExclusiveEventHintOrCaptureContext on the captured error.
    * Set `false` for instrumentation that only annotates the span and lets the error be captured at the boundary that owns it (e.g. db spans).
    */
-  captureError?: boolean;
+  captureError?: boolean | ((e: unknown) => ExclusiveEventHintOrCaptureContext);
 }
 
 export type TracingChannelBindingOptions<TData extends object = object> =
@@ -63,9 +63,18 @@ export interface TracingChannelBindingHandle<TData extends object = object> {
 
 const NOOP = (): void => {};
 
+/**
+ * Bind a span (and, in `auto` mode, its lifecycle) to a tracing channel so the span becomes the
+ * active async context for the traced operation.
+ *
+ * `getSpan` may return `undefined` to opt a payload out entirely: nothing is bound, no span is
+ * tracked, and the active context is left untouched. Use it for events that ride the same channel
+ * but should reuse the enclosing span instead of opening (and ending) their own — e.g. an agent
+ * loop's per-step events, where ending a freshly opened span would close the parent prematurely.
+ */
 export function bindTracingChannelToSpan<TData extends object>(
   channel: TracingChannel<TData, TData>,
-  getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span,
+  getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span | undefined,
   opts?: TracingChannelBindingOptions<TData>,
 ): TracingChannelBindingHandle<TData> {
   const sentryChannel = channel as SentryTracingChannel<TData>;
@@ -80,6 +89,10 @@ export function bindTracingChannelToSpan<TData extends object>(
 
   channel.start.bindStore(asyncLocalStorage, (data: TracingChannelPayloadWithSpan<TData>) => {
     const span = getSpan(data);
+    if (!span) {
+      // Leave the active context untouched so nested operations keep parenting to the enclosing span.
+      return asyncLocalStorage.getStore() as TData;
+    }
     data._sentrySpan = span;
 
     return binding.getStoreWithActiveSpan(span) as TData;
@@ -95,6 +108,19 @@ export function bindTracingChannelToSpan<TData extends object>(
 
   const beforeSpanEnd = opts?.beforeSpanEnd;
 
+  const getErrorHint = (e: unknown): ExclusiveEventHintOrCaptureContext => {
+    if (typeof opts?.captureError === 'function') {
+      return opts.captureError(e);
+    }
+
+    return {
+      mechanism: {
+        type: 'auto.diagnostic_channels.bind_span',
+        handled: false,
+      },
+    };
+  };
+
   const subscribers: Partial<TracingChannelSubscribers<TracingChannelPayloadWithSpan<TData>>> = {
     start: NOOP,
     asyncStart: NOOP,
@@ -106,15 +132,18 @@ export function bindTracingChannelToSpan<TData extends object>(
       }
     },
     error(data) {
-      if (opts?.captureError !== false) {
-        captureException(data.error, {
-          mechanism: {
-            type: 'auto.diagnostic_channels.bind_span',
-            handled: false,
-          },
-        });
+      // No span was bound for this payload (`getSpan` returned undefined), so there is nothing to
+      // annotate and no instrumentation that owns capturing this error.
+      const span = data._sentrySpan;
+      if (!span) {
+        return;
       }
-      data._sentrySpan?.setStatus({ code: SPAN_STATUS_ERROR, message: getErrorMessage(data.error) });
+
+      if (opts?.captureError !== false) {
+        captureException(data.error, getErrorHint(data.error));
+      }
+
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: getErrorMessage(data.error) });
     },
     asyncEnd(data) {
       endBoundSpan(data, beforeSpanEnd);

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -130,8 +130,11 @@ export function bindTracingChannelToSpan<TData extends object>(
   channel: TracingChannel<TData, TData>,
   getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span | undefined,
 ): TracingChannelBindingHandle<TData> {
+  // Grabs the tracing channel binding defined by the AsyncContext strategy implementation
   const binding = _INTERNAL_getTracingChannelBinding();
 
+  // If no binding, then either the implementer doesn't support tracing channels or there is no active strategy
+  // Failure mode here means we would still access the channel and potentially subscribe to it, but parenting will be off.
   if (!binding) {
     DEBUG_BUILD && debug.log('[TracingChannel] Could not access async context binding.');
 
@@ -141,8 +144,14 @@ export function bindTracingChannelToSpan<TData extends object>(
     };
   }
 
+  // Grab the ALS instance, we don't really care what is in it as long as the AsyncContext strategy can use its value to figure out parenting.
   const asyncLocalStorage = binding.asyncLocalStorage as AsyncLocalStorage<TData>;
 
+  // bindStore activates the ALS for the traced call; any getStore() inside it returns the value bound for that context.
+  // 1. Produce: getStoreWithActiveSpan(span) clones the current scope, plants the span via _INTERNAL_setSpanForScope, and returns { scope, isolationScope }, the active context carrying our span.
+  // 2. Bind: the courier hands that opaque value to channel.start.bindStore(asyncLocalStorage, producer), which runs the traced op inside asyncLocalStorage.run(value, …); it never inspects the value.
+  // 3. Read: inside the op, Sentry's scope machinery calls getScopes() → asyncStorage.getStore() on that same ALS, so getCurrentScope/getIsolationScope/getActiveSpan resolve to the scope carrying our span.
+  // 4. Nest: any child span started in the traced op parents to that active span.
   channel.start.bindStore(asyncLocalStorage, (data: TracingChannelPayloadWithSpan<TData>) => {
     const span = getSpan(data);
     if (!span) {

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -176,8 +176,6 @@ describe('bindTracingChannelToSpan', () => {
   });
 
   describe('auto lifecycle ending strategy', () => {
-    const MECHANISM = { mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false } };
-
     // Returns a channel whose span we can observe, plus spies for `span.end` and `captureException`.
     function setup(name: string): {
       channel: ReturnType<typeof bindTracingChannelToSpan>['channel'];
@@ -205,7 +203,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
-    it('traceSync throw: ends the span once on `end`, sets error status, captures the exception', () => {
+    it('traceSync throw: ends the span once on `end`, sets error status, does not capture by default', () => {
       const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:sync-throw');
       const error = new Error('sync-throw');
 
@@ -220,8 +218,7 @@ describe('bindTracingChannelToSpan', () => {
 
       expect(endSpy).toHaveBeenCalledTimes(1);
       expect(spanToJSON(span).status).toBe('sync-throw');
-      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
     it('traceSync throw of a falsy value: still ends the span once on `end`', () => {
@@ -243,8 +240,7 @@ describe('bindTracingChannelToSpan', () => {
       // though the thrown value is falsy, the `error` key is present on the context object.
       expect(threw).toBe(true);
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-      expect(captureExceptionSpy).toHaveBeenCalledWith(0, MECHANISM);
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
     it('tracePromise resolve: ends the span once on `asyncEnd`, not on the early synchronous `end`', async () => {
@@ -271,7 +267,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
-    it('tracePromise reject: ends the span once on `asyncEnd`, sets error status, captures the exception', async () => {
+    it('tracePromise reject: ends the span once on `asyncEnd`, sets error status, does not capture by default', async () => {
       const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:promise-reject');
       const error = new Error('async-reject');
 
@@ -291,8 +287,7 @@ describe('bindTracingChannelToSpan', () => {
 
       expect(endSpy).toHaveBeenCalledTimes(1);
       expect(spanToJSON(span).status).toBe('async-reject');
-      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
     it('tracePromise with a synchronous throw: ends the span once on `end` (no async events follow)', () => {
@@ -310,8 +305,7 @@ describe('bindTracingChannelToSpan', () => {
 
       expect(endSpy).toHaveBeenCalledTimes(1);
       expect(spanToJSON(span).status).toBe('promise-sync-throw');
-      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
     it('traceCallback success: ends the span once on `asyncEnd`', async () => {
@@ -335,7 +329,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
-    it('traceCallback error: ends the span once on `asyncEnd`, sets error status, captures the exception', async () => {
+    it('traceCallback error: ends the span once on `asyncEnd`, sets error status, does not capture by default', async () => {
       const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:callback-error');
       const error = new Error('callback-error');
 
@@ -353,8 +347,7 @@ describe('bindTracingChannelToSpan', () => {
 
       expect(endSpy).toHaveBeenCalledTimes(1);
       expect(spanToJSON(span).status).toBe('callback-error');
-      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
     it('traceCallback with a synchronous throw: ends the span once on `end` (no async events follow)', () => {
@@ -375,8 +368,7 @@ describe('bindTracingChannelToSpan', () => {
 
       expect(endSpy).toHaveBeenCalledTimes(1);
       expect(spanToJSON(span).status).toBe('callback-sync-throw');
-      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -435,6 +427,67 @@ describe('bindTracingChannelToSpan', () => {
         mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
       });
       expect(spanToJSON(span).status).toBe('boom');
+    });
+
+    it('captures the exception on the synchronous error path when `captureError` is true', () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const error = new Error('sync-boom');
+      const { channel } = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:captureError:true-sync'),
+        () => span,
+        { captureError: true },
+      );
+
+      expect(() =>
+        channel.traceSync(
+          () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).toThrow(error);
+
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
+        mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
+      });
+      expect(spanToJSON(span).status).toBe('sync-boom');
+    });
+
+    it('captures the exception on the callback error path when `captureError` is true', async () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const error = new Error('callback-boom');
+      const { channel } = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:captureError:true-callback'),
+        () => span,
+        { captureError: true },
+      );
+
+      await new Promise<void>(done => {
+        channel.traceCallback(
+          (cb: (err: Error | null, result?: string) => void) => {
+            setTimeout(() => cb(error), 1);
+          },
+          0,
+          { operation: 'read' },
+          undefined,
+          () => done(),
+        );
+      });
+
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
+        mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
+      });
+      expect(spanToJSON(span).status).toBe('callback-boom');
     });
 
     it('captures the exception with the hint returned by a `captureError` function, passing it the thrown error', async () => {

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -20,7 +20,7 @@ import {
   startSpan,
 } from '@sentry/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { bindTracingChannelToSpanWithLifeCycle, bindTracingChannelToSpan } from '../src/tracing-channel';
+import { bindTracingChannelToSpan } from '../src/tracing-channel';
 
 interface TestStore {
   scope: Scope;
@@ -99,7 +99,7 @@ function installTestAsyncContextStrategy(): void {
   });
 }
 
-describe('bindTracingChannelToSpanWithLifeCycle', () => {
+describe('bindTracingChannelToSpan', () => {
   afterEach(() => {
     setAsyncContextStrategy(undefined);
     getCurrentScope().clear();
@@ -114,10 +114,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
 
     const span = startInactiveSpan({ name: 'channel-span' });
     const getSpan = vi.fn(() => span);
-    const { channel } = bindTracingChannelToSpanWithLifeCycle(
-      tracingChannel<{ operation: string }>('test:bind-span:data'),
-      getSpan,
-    );
+    const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:bind-span:data'), getSpan);
 
     let dataSpan: Span | undefined;
     channel.subscribe({
@@ -137,7 +134,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
     installTestAsyncContextStrategy();
 
     const span = startInactiveSpan({ name: 'channel-span' });
-    const { channel } = bindTracingChannelToSpanWithLifeCycle(
+    const { channel } = bindTracingChannelToSpan(
       tracingChannel<{ operation: string }>('test:bind-span:active'),
       () => span,
     );
@@ -159,7 +156,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
     initTestClient();
 
     const parent = startInactiveSpan({ forceTransaction: true, name: 'parent-span' });
-    const { channel } = bindTracingChannelToSpanWithLifeCycle(
+    const { channel } = bindTracingChannelToSpan(
       tracingChannel<{ operation: string }>('test:bind-span:children'),
       () => parent,
     );
@@ -183,7 +180,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
 
     // Returns a channel whose span we can observe, plus spies for `span.end` and `captureException`.
     function setup(name: string): {
-      channel: ReturnType<typeof bindTracingChannelToSpanWithLifeCycle>['channel'];
+      channel: ReturnType<typeof bindTracingChannelToSpan>['channel'];
       span: Span;
       endSpy: ReturnType<typeof vi.spyOn>;
       captureExceptionSpy: ReturnType<typeof vi.spyOn>;
@@ -193,10 +190,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const endSpy = vi.spyOn(span, 'end');
       const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
-        tracingChannel<{ operation: string }>(name),
-        () => span,
-      );
+      const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>(name), () => span);
       return { channel, span, endSpy, captureExceptionSpy };
     }
 
@@ -394,7 +388,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
 
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('db-down');
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:captureError:off'),
         () => span,
         { captureError: false },
@@ -421,7 +415,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
 
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('boom');
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:captureError:true'),
         () => span,
         { captureError: true },
@@ -451,7 +445,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('boom');
       const captureError = vi.fn(() => ({ mechanism: { type: 'auto.http.custom', handled: false } }));
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:captureError:fn'),
         () => span,
         { captureError },
@@ -483,7 +477,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('sync-boom');
       const captureError = vi.fn((e: unknown) => ({ extra: { caught: e instanceof Error } }));
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:captureError:fn-sync'),
         () => span,
         { captureError },
@@ -511,7 +505,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       let openWhenCalled: boolean | undefined;
       let receivedSpan: Span | undefined;
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:sync'),
         () => span,
         {
@@ -538,7 +532,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       initTestClient();
 
       const span = startInactiveSpan({ name: 'channel-span' });
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:async'),
         () => span,
         {
@@ -563,7 +557,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('boom');
       let sawError: unknown;
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:error'),
         () => span,
         {
@@ -587,32 +581,6 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
     });
   });
 
-  it('bindTracingChannelToSpan binds the span as active without ending it', () => {
-    installTestAsyncContextStrategy();
-    initTestClient();
-
-    const span = startInactiveSpan({ name: 'channel-span' });
-    const endSpy = vi.spyOn(span, 'end');
-    const getSpan = vi.fn(() => span);
-    const { channel } = bindTracingChannelToSpan(
-      tracingChannel<{ operation: string }>('test:lifecycle:manual'),
-      getSpan,
-    );
-
-    let activeSpan: Span | undefined;
-    channel.traceSync(
-      () => {
-        activeSpan = getActiveSpan();
-      },
-      { operation: 'read' },
-    );
-
-    expect(getSpan).toHaveBeenCalledTimes(1);
-    expect(activeSpan).toBe(span);
-    expect(endSpy).not.toHaveBeenCalled();
-    expect(spanToJSON(span).timestamp).toBeUndefined();
-  });
-
   it('returns the channel unchanged when no async context binding is available', () => {
     // No async context strategy is installed, so the binding cannot be resolved.
     const span = startInactiveSpan({ name: 'channel-span' });
@@ -620,7 +588,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
     const getSpan = vi.fn(() => span);
     const rawChannel = tracingChannel<{ operation: string }>('test:lifecycle:no-binding');
 
-    const { channel } = bindTracingChannelToSpanWithLifeCycle(rawChannel, getSpan);
+    const { channel } = bindTracingChannelToSpan(rawChannel, getSpan);
 
     expect(channel).toBe(rawChannel);
 
@@ -637,7 +605,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
     const span = startInactiveSpan({ name: 'channel-span' });
     const endSpy = vi.spyOn(span, 'end');
     const getSpan = vi.fn(() => span);
-    const { channel, unbind } = bindTracingChannelToSpanWithLifeCycle(
+    const { channel, unbind } = bindTracingChannelToSpan(
       tracingChannel<{ operation: string }>('test:lifecycle:unbind'),
       getSpan,
     );
@@ -664,10 +632,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       initTestClient();
 
       const getSpan = vi.fn(() => undefined);
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
-        tracingChannel<{ operation: string }>('test:skip:active'),
-        getSpan,
-      );
+      const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:skip:active'), getSpan);
 
       let dataSpan: Span | undefined;
       channel.subscribe({
@@ -702,7 +667,7 @@ describe('bindTracingChannelToSpanWithLifeCycle', () => {
       initTestClient();
       const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
 
-      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:skip:error'),
         () => undefined,
       );

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -1,0 +1,424 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { tracingChannel } from 'node:diagnostics_channel';
+import type { Scope, Span } from '@sentry/core';
+import * as SentryCore from '@sentry/core';
+import {
+  _INTERNAL_setSpanForScope,
+  Client,
+  createTransport,
+  getActiveSpan,
+  getCurrentScope,
+  getDefaultCurrentScope,
+  getDefaultIsolationScope,
+  getGlobalScope,
+  getIsolationScope,
+  initAndBind,
+  resolvedSyncPromise,
+  setAsyncContextStrategy,
+  spanToJSON,
+  startInactiveSpan,
+  startSpan,
+} from '@sentry/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { bindTracingChannelToSpan } from '../src/tracing-channel';
+
+interface TestStore {
+  scope: Scope;
+  isolationScope: Scope;
+}
+
+class TestClient extends Client<any> {
+  public eventFromException(): PromiseLike<any> {
+    return resolvedSyncPromise({});
+  }
+
+  public eventFromMessage(): PromiseLike<any> {
+    return resolvedSyncPromise({});
+  }
+}
+
+function initTestClient(): void {
+  initAndBind(TestClient, {
+    dsn: 'https://username@domain/123',
+    integrations: [],
+    sendClientReports: false,
+    stackParser: () => [],
+    tracesSampleRate: 1,
+    transport: () =>
+      createTransport(
+        {
+          recordDroppedEvent: () => undefined,
+        },
+        () => resolvedSyncPromise({}),
+      ),
+  });
+}
+
+function installTestAsyncContextStrategy(): void {
+  const asyncStorage = new AsyncLocalStorage<TestStore>();
+
+  function getScopes(): TestStore {
+    return (
+      asyncStorage.getStore() || {
+        scope: getDefaultCurrentScope(),
+        isolationScope: getDefaultIsolationScope(),
+      }
+    );
+  }
+
+  setAsyncContextStrategy({
+    withScope: callback => {
+      const scope = getScopes().scope.clone();
+      const isolationScope = getScopes().isolationScope;
+      return asyncStorage.run({ scope, isolationScope }, () => callback(scope));
+    },
+    withSetScope: (scope, callback) => {
+      const isolationScope = getScopes().isolationScope;
+      return asyncStorage.run({ scope, isolationScope }, () => callback(scope));
+    },
+    withIsolationScope: callback => {
+      const scope = getScopes().scope;
+      const isolationScope = getScopes().isolationScope.clone();
+      return asyncStorage.run({ scope, isolationScope }, () => callback(isolationScope));
+    },
+    withSetIsolationScope: (isolationScope, callback) => {
+      const scope = getScopes().scope;
+      return asyncStorage.run({ scope, isolationScope }, () => callback(isolationScope));
+    },
+    getCurrentScope: () => getScopes().scope,
+    getIsolationScope: () => getScopes().isolationScope,
+    getTracingChannelBinding: () => ({
+      asyncLocalStorage: asyncStorage,
+      getStoreWithActiveSpan: span => {
+        const scope = getScopes().scope.clone();
+        const isolationScope = getScopes().isolationScope;
+        _INTERNAL_setSpanForScope(scope, span);
+        return { scope, isolationScope };
+      },
+    }),
+  });
+}
+
+describe('bindTracingChannelToSpan', () => {
+  afterEach(() => {
+    setAsyncContextStrategy(undefined);
+    getCurrentScope().clear();
+    getCurrentScope().setClient(undefined);
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+    vi.clearAllMocks();
+  });
+
+  it('calls the span callback on start and stores the span on data', () => {
+    installTestAsyncContextStrategy();
+
+    const span = startInactiveSpan({ name: 'channel-span' });
+    const getSpan = vi.fn(() => span);
+    const channel = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:bind-span:data'), getSpan);
+
+    let dataSpan: Span | undefined;
+    channel.subscribe({
+      end: data => {
+        dataSpan = data._sentrySpan;
+      },
+    });
+
+    channel.traceSync(() => undefined, { operation: 'read' });
+
+    expect(getSpan).toHaveBeenCalledTimes(1);
+    expect(getSpan).toHaveBeenCalledWith(expect.objectContaining({ operation: 'read', _sentrySpan: span }));
+    expect(dataSpan).toBe(span);
+  });
+
+  it('sets the returned span as active inside the traced operation', () => {
+    installTestAsyncContextStrategy();
+
+    const span = startInactiveSpan({ name: 'channel-span' });
+    const channel = bindTracingChannelToSpan(
+      tracingChannel<{ operation: string }>('test:bind-span:active'),
+      () => span,
+    );
+
+    let activeSpan: Span | undefined;
+
+    channel.traceSync(
+      () => {
+        activeSpan = getActiveSpan();
+      },
+      { operation: 'read' },
+    );
+
+    expect(activeSpan).toBe(span);
+  });
+
+  it('parents child spans created inside the traced operation to the bound span', () => {
+    installTestAsyncContextStrategy();
+    initTestClient();
+
+    const parent = startInactiveSpan({ forceTransaction: true, name: 'parent-span' });
+    const channel = bindTracingChannelToSpan(
+      tracingChannel<{ operation: string }>('test:bind-span:children'),
+      () => parent,
+    );
+
+    let childParentSpanId: string | undefined;
+
+    channel.traceSync(
+      () => {
+        startSpan({ name: 'child-span' }, child => {
+          childParentSpanId = spanToJSON(child).parent_span_id;
+        });
+      },
+      { operation: 'read' },
+    );
+
+    expect(childParentSpanId).toBe(parent.spanContext().spanId);
+  });
+
+  describe('auto lifecycle ending strategy', () => {
+    const MECHANISM = { mechanism: { type: 'auto.diagnostic_channels.bind_span' } };
+
+    // Returns a channel whose span we can observe, plus spies for `span.end` and `captureException`.
+    function setup(name: string): {
+      channel: ReturnType<typeof bindTracingChannelToSpan>;
+      span: Span;
+      endSpy: ReturnType<typeof vi.spyOn>;
+      captureExceptionSpy: ReturnType<typeof vi.spyOn>;
+    } {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const endSpy = vi.spyOn(span, 'end');
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+      const channel = bindTracingChannelToSpan(tracingChannel<{ operation: string }>(name), () => span);
+      return { channel, span, endSpy, captureExceptionSpy };
+    }
+
+    it('traceSync success: ends the span once on `end`', () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:sync-ok');
+
+      channel.traceSync(() => undefined, { operation: 'read' });
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).status).toBeUndefined();
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+    });
+
+    it('traceSync throw: ends the span once on `end`, sets error status, captures the exception', () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:sync-throw');
+      const error = new Error('sync-throw');
+
+      expect(() =>
+        channel.traceSync(
+          () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).toThrow(error);
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).status).toBe('Error: sync-throw');
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+    });
+
+    it('traceSync throw of a falsy value: still ends the span once on `end`', () => {
+      const { channel, endSpy, captureExceptionSpy } = setup('test:lifecycle:sync-throw-falsy');
+
+      let threw = false;
+      try {
+        channel.traceSync(
+          () => {
+            throw 0;
+          },
+          { operation: 'read' },
+        );
+      } catch {
+        threw = true;
+      }
+
+      // No async events follow a synchronous throw, so the span must be ended on `end` — even
+      // though the thrown value is falsy, the `error` key is present on the context object.
+      expect(threw).toBe(true);
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(0, MECHANISM);
+    });
+
+    it('tracePromise resolve: ends the span once on `asyncEnd`, not on the early synchronous `end`', async () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:promise-ok');
+
+      let resolveOperation: (value: string) => void;
+      const promise = channel.tracePromise(
+        () =>
+          new Promise<string>(resolve => {
+            resolveOperation = resolve;
+          }),
+        { operation: 'read' },
+      );
+
+      // The synchronous `end` event has already fired here, but the span must stay open until the promise settles.
+      expect(endSpy).not.toHaveBeenCalled();
+
+      resolveOperation!('ok');
+      await promise;
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).status).toBeUndefined();
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+    });
+
+    it('tracePromise reject: ends the span once on `asyncEnd`, sets error status, captures the exception', async () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:promise-reject');
+      const error = new Error('async-reject');
+
+      let rejectOperation: (reason: Error) => void;
+      const promise = channel.tracePromise(
+        () =>
+          new Promise<string>((_resolve, reject) => {
+            rejectOperation = reject;
+          }),
+        { operation: 'read' },
+      );
+
+      expect(endSpy).not.toHaveBeenCalled();
+
+      rejectOperation!(error);
+      await expect(promise).rejects.toThrow(error);
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).status).toBe('Error: async-reject');
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+    });
+
+    it('tracePromise with a synchronous throw: ends the span once on `end` (no async events follow)', () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:promise-sync-throw');
+      const error = new Error('promise-sync-throw');
+
+      expect(() =>
+        channel.tracePromise(
+          () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).toThrow(error);
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).status).toBe('Error: promise-sync-throw');
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+    });
+
+    it('traceCallback success: ends the span once on `asyncEnd`', async () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:callback-ok');
+
+      await new Promise<void>(done => {
+        channel.traceCallback(
+          (cb: (err: Error | null, result?: string) => void) => {
+            setTimeout(() => cb(null, 'ok'), 1);
+          },
+          0,
+          { operation: 'read' },
+          undefined,
+          () => done(),
+        );
+      });
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).status).toBeUndefined();
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+    });
+
+    it('traceCallback error: ends the span once on `asyncEnd`, sets error status, captures the exception', async () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:callback-error');
+      const error = new Error('callback-error');
+
+      await new Promise<void>(done => {
+        channel.traceCallback(
+          (cb: (err: Error | null, result?: string) => void) => {
+            setTimeout(() => cb(error), 1);
+          },
+          0,
+          { operation: 'read' },
+          undefined,
+          () => done(),
+        );
+      });
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).status).toBe('Error: callback-error');
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+    });
+
+    it('traceCallback with a synchronous throw: ends the span once on `end` (no async events follow)', () => {
+      const { channel, span, endSpy, captureExceptionSpy } = setup('test:lifecycle:callback-sync-throw');
+      const error = new Error('callback-sync-throw');
+
+      expect(() =>
+        channel.traceCallback(
+          () => {
+            throw error;
+          },
+          0,
+          { operation: 'read' },
+          undefined,
+          () => undefined,
+        ),
+      ).toThrow(error);
+
+      expect(endSpy).toHaveBeenCalledTimes(1);
+      expect(spanToJSON(span).status).toBe('Error: callback-sync-throw');
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+    });
+  });
+
+  it('manual lifecycle: binds the span as active but does not end it automatically', () => {
+    installTestAsyncContextStrategy();
+    initTestClient();
+
+    const span = startInactiveSpan({ name: 'channel-span' });
+    const endSpy = vi.spyOn(span, 'end');
+    const getSpan = vi.fn(() => span);
+    const channel = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:lifecycle:manual'), getSpan, {
+      lifecycle: 'manual',
+    });
+
+    let activeSpan: Span | undefined;
+    channel.traceSync(
+      () => {
+        activeSpan = getActiveSpan();
+      },
+      { operation: 'read' },
+    );
+
+    expect(getSpan).toHaveBeenCalledTimes(1);
+    expect(activeSpan).toBe(span);
+    expect(endSpy).not.toHaveBeenCalled();
+    expect(spanToJSON(span).timestamp).toBeUndefined();
+  });
+
+  it('returns the channel unchanged when no async context binding is available', () => {
+    // No async context strategy is installed, so the binding cannot be resolved.
+    const span = startInactiveSpan({ name: 'channel-span' });
+    const endSpy = vi.spyOn(span, 'end');
+    const getSpan = vi.fn(() => span);
+    const rawChannel = tracingChannel<{ operation: string }>('test:lifecycle:no-binding');
+
+    const channel = bindTracingChannelToSpan(rawChannel, getSpan);
+
+    expect(channel).toBe(rawChannel);
+
+    channel.traceSync(() => undefined, { operation: 'read' });
+
+    expect(getSpan).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -407,6 +407,94 @@ describe('bindTracingChannelToSpan', () => {
       expect(spanToJSON(span).status).toBe('db-down');
       expect(spanToJSON(span).timestamp).toBeDefined();
     });
+
+    it('captures the exception with the default mechanism when `captureError` is true', async () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const error = new Error('boom');
+      const { channel } = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:captureError:true'),
+        () => span,
+        { captureError: true },
+      );
+
+      await expect(
+        channel.tracePromise(
+          async () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).rejects.toThrow(error);
+
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
+        mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
+      });
+      expect(spanToJSON(span).status).toBe('boom');
+    });
+
+    it('captures the exception with the hint returned by a `captureError` function, passing it the thrown error', async () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const error = new Error('boom');
+      const captureError = vi.fn(() => ({ mechanism: { type: 'auto.http.custom', handled: false } }));
+      const { channel } = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:captureError:fn'),
+        () => span,
+        { captureError },
+      );
+
+      await expect(
+        channel.tracePromise(
+          async () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).rejects.toThrow(error);
+
+      expect(captureError).toHaveBeenCalledTimes(1);
+      expect(captureError).toHaveBeenCalledWith(error);
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
+        mechanism: { type: 'auto.http.custom', handled: false },
+      });
+      expect(spanToJSON(span).status).toBe('boom');
+    });
+
+    it('uses the default mechanism when `captureError` is a function on the synchronous error path', () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const error = new Error('sync-boom');
+      const captureError = vi.fn((e: unknown) => ({ extra: { caught: e instanceof Error } }));
+      const { channel } = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:captureError:fn-sync'),
+        () => span,
+        { captureError },
+      );
+
+      expect(() =>
+        channel.traceSync(
+          () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).toThrow(error);
+
+      expect(captureError).toHaveBeenCalledWith(error);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error, { extra: { caught: true } });
+    });
   });
 
   describe('beforeSpanEnd', () => {
@@ -565,5 +653,65 @@ describe('bindTracingChannelToSpan', () => {
 
     // Idempotent.
     expect(() => unbind()).not.toThrow();
+  });
+
+  describe('getSpan returns undefined', () => {
+    it('skips binding and lifecycle, leaving the enclosing span as the active parent', () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+
+      const getSpan = vi.fn(() => undefined);
+      const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:skip:active'), getSpan);
+
+      let dataSpan: Span | undefined;
+      channel.subscribe({
+        end: data => {
+          dataSpan = data._sentrySpan;
+        },
+      });
+
+      let enclosingSpanId: string | undefined;
+      let childParentSpanId: string | undefined;
+      startSpan({ forceTransaction: true, name: 'enclosing-span' }, enclosing => {
+        enclosingSpanId = enclosing.spanContext().spanId;
+        channel.traceSync(
+          () => {
+            startSpan({ name: 'child-span' }, child => {
+              childParentSpanId = spanToJSON(child).parent_span_id;
+            });
+          },
+          { operation: 'read' },
+        );
+      });
+
+      expect(getSpan).toHaveBeenCalledTimes(1);
+      // No span was stamped onto the payload, so the lifecycle handlers have nothing to end.
+      expect(dataSpan).toBeUndefined();
+      // The context is left untouched, so children still parent to the enclosing span.
+      expect(childParentSpanId).toBe(enclosingSpanId);
+    });
+
+    it('does not capture the exception on the error path when no span was bound', async () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const { channel } = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:skip:error'),
+        () => undefined,
+      );
+
+      const error = new Error('boom');
+      await expect(
+        channel.tracePromise(
+          async () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).rejects.toThrow(error);
+
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -176,7 +176,7 @@ describe('bindTracingChannelToSpan', () => {
   });
 
   describe('auto lifecycle ending strategy', () => {
-    const MECHANISM = { mechanism: { type: 'auto.diagnostic_channels.bind_span' } };
+    const MECHANISM = { mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false } };
 
     // Returns a channel whose span we can observe, plus spies for `span.end` and `captureException`.
     function setup(name: string): {
@@ -219,7 +219,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('Error: sync-throw');
+      expect(spanToJSON(span).status).toBe('sync-throw');
       expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
     });
@@ -290,7 +290,7 @@ describe('bindTracingChannelToSpan', () => {
       await expect(promise).rejects.toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('Error: async-reject');
+      expect(spanToJSON(span).status).toBe('async-reject');
       expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
     });
@@ -309,7 +309,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('Error: promise-sync-throw');
+      expect(spanToJSON(span).status).toBe('promise-sync-throw');
       expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
     });
@@ -352,7 +352,7 @@ describe('bindTracingChannelToSpan', () => {
       });
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('Error: callback-error');
+      expect(spanToJSON(span).status).toBe('callback-error');
       expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
     });
@@ -374,9 +374,122 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('Error: callback-sync-throw');
+      expect(spanToJSON(span).status).toBe('callback-sync-throw');
       expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, MECHANISM);
+    });
+  });
+
+  describe('captureError', () => {
+    it('does not capture the exception when `captureError` is false, but still sets error status', async () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const error = new Error('db-down');
+      const channel = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:captureError:off'),
+        () => span,
+        { captureError: false },
+      );
+
+      await expect(
+        channel.tracePromise(
+          async () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).rejects.toThrow(error);
+
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+      expect(spanToJSON(span).status).toBe('db-down');
+      expect(spanToJSON(span).timestamp).toBeDefined();
+    });
+  });
+
+  describe('beforeSpanEnd', () => {
+    it('runs with the span still open so enrichment lands, then the span is ended (sync)', () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      let openWhenCalled: boolean | undefined;
+      let receivedSpan: Span | undefined;
+      const channel = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:beforeSpanEnd:sync'),
+        () => span,
+        {
+          beforeSpanEnd(s, data) {
+            receivedSpan = s;
+            openWhenCalled = spanToJSON(s).timestamp === undefined;
+            expect(data._sentrySpan).toBe(s);
+            expect('result' in data).toBe(true);
+            s.setAttribute('enriched', true);
+          },
+        },
+      );
+
+      channel.traceSync(() => undefined, { operation: 'read' });
+
+      expect(receivedSpan).toBe(span);
+      expect(openWhenCalled).toBe(true);
+      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).data.enriched).toBe(true);
+    });
+
+    it('runs before the span is ended on async completion', async () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const channel = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:beforeSpanEnd:async'),
+        () => span,
+        {
+          beforeSpanEnd(s) {
+            expect(spanToJSON(s).timestamp).toBeUndefined();
+            s.setAttribute('enriched', true);
+          },
+        },
+      );
+
+      await channel.tracePromise(async () => 'ok', { operation: 'read' });
+
+      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).data.enriched).toBe(true);
+    });
+
+    it('runs on the error path with the error on the context object', async () => {
+      installTestAsyncContextStrategy();
+      initTestClient();
+      vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+
+      const span = startInactiveSpan({ name: 'channel-span' });
+      const error = new Error('boom');
+      let sawError: unknown;
+      const channel = bindTracingChannelToSpan(
+        tracingChannel<{ operation: string }>('test:beforeSpanEnd:error'),
+        () => span,
+        {
+          beforeSpanEnd(_s, data) {
+            sawError = (data as { error?: unknown }).error;
+          },
+        },
+      );
+
+      await expect(
+        channel.tracePromise(
+          async () => {
+            throw error;
+          },
+          { operation: 'read' },
+        ),
+      ).rejects.toThrow(error);
+
+      expect(sawError).toBe(error);
+      expect(spanToJSON(span).timestamp).toBeDefined();
     });
   });
 

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -114,7 +114,7 @@ describe('bindTracingChannelToSpan', () => {
 
     const span = startInactiveSpan({ name: 'channel-span' });
     const getSpan = vi.fn(() => span);
-    const channel = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:bind-span:data'), getSpan);
+    const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:bind-span:data'), getSpan);
 
     let dataSpan: Span | undefined;
     channel.subscribe({
@@ -134,7 +134,7 @@ describe('bindTracingChannelToSpan', () => {
     installTestAsyncContextStrategy();
 
     const span = startInactiveSpan({ name: 'channel-span' });
-    const channel = bindTracingChannelToSpan(
+    const { channel } = bindTracingChannelToSpan(
       tracingChannel<{ operation: string }>('test:bind-span:active'),
       () => span,
     );
@@ -156,7 +156,7 @@ describe('bindTracingChannelToSpan', () => {
     initTestClient();
 
     const parent = startInactiveSpan({ forceTransaction: true, name: 'parent-span' });
-    const channel = bindTracingChannelToSpan(
+    const { channel } = bindTracingChannelToSpan(
       tracingChannel<{ operation: string }>('test:bind-span:children'),
       () => parent,
     );
@@ -180,7 +180,7 @@ describe('bindTracingChannelToSpan', () => {
 
     // Returns a channel whose span we can observe, plus spies for `span.end` and `captureException`.
     function setup(name: string): {
-      channel: ReturnType<typeof bindTracingChannelToSpan>;
+      channel: ReturnType<typeof bindTracingChannelToSpan>['channel'];
       span: Span;
       endSpy: ReturnType<typeof vi.spyOn>;
       captureExceptionSpy: ReturnType<typeof vi.spyOn>;
@@ -190,7 +190,7 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const endSpy = vi.spyOn(span, 'end');
       const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
-      const channel = bindTracingChannelToSpan(tracingChannel<{ operation: string }>(name), () => span);
+      const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>(name), () => span);
       return { channel, span, endSpy, captureExceptionSpy };
     }
 
@@ -388,7 +388,7 @@ describe('bindTracingChannelToSpan', () => {
 
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('db-down');
-      const channel = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:captureError:off'),
         () => span,
         { captureError: false },
@@ -417,7 +417,7 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       let openWhenCalled: boolean | undefined;
       let receivedSpan: Span | undefined;
-      const channel = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:sync'),
         () => span,
         {
@@ -444,7 +444,7 @@ describe('bindTracingChannelToSpan', () => {
       initTestClient();
 
       const span = startInactiveSpan({ name: 'channel-span' });
-      const channel = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:async'),
         () => span,
         {
@@ -469,7 +469,7 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('boom');
       let sawError: unknown;
-      const channel = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpan(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:error'),
         () => span,
         {
@@ -500,9 +500,13 @@ describe('bindTracingChannelToSpan', () => {
     const span = startInactiveSpan({ name: 'channel-span' });
     const endSpy = vi.spyOn(span, 'end');
     const getSpan = vi.fn(() => span);
-    const channel = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:lifecycle:manual'), getSpan, {
-      lifecycle: 'manual',
-    });
+    const { channel } = bindTracingChannelToSpan(
+      tracingChannel<{ operation: string }>('test:lifecycle:manual'),
+      getSpan,
+      {
+        lifecycle: 'manual',
+      },
+    );
 
     let activeSpan: Span | undefined;
     channel.traceSync(
@@ -525,7 +529,7 @@ describe('bindTracingChannelToSpan', () => {
     const getSpan = vi.fn(() => span);
     const rawChannel = tracingChannel<{ operation: string }>('test:lifecycle:no-binding');
 
-    const channel = bindTracingChannelToSpan(rawChannel, getSpan);
+    const { channel } = bindTracingChannelToSpan(rawChannel, getSpan);
 
     expect(channel).toBe(rawChannel);
 
@@ -533,5 +537,33 @@ describe('bindTracingChannelToSpan', () => {
 
     expect(getSpan).not.toHaveBeenCalled();
     expect(endSpy).not.toHaveBeenCalled();
+  });
+
+  it('unbind detaches the binding: getSpan no longer runs and the span is no longer ended', () => {
+    installTestAsyncContextStrategy();
+    initTestClient();
+
+    const span = startInactiveSpan({ name: 'channel-span' });
+    const endSpy = vi.spyOn(span, 'end');
+    const getSpan = vi.fn(() => span);
+    const { channel, unbind } = bindTracingChannelToSpan(
+      tracingChannel<{ operation: string }>('test:lifecycle:unbind'),
+      getSpan,
+    );
+
+    // Sanity: while bound, the span is created and ended.
+    channel.traceSync(() => undefined, { operation: 'read' });
+    expect(getSpan).toHaveBeenCalledTimes(1);
+    expect(endSpy).toHaveBeenCalledTimes(1);
+
+    unbind();
+
+    // After unbind, neither the start store nor the lifecycle handlers fire.
+    channel.traceSync(() => undefined, { operation: 'read' });
+    expect(getSpan).toHaveBeenCalledTimes(1);
+    expect(endSpy).toHaveBeenCalledTimes(1);
+
+    // Idempotent.
+    expect(() => unbind()).not.toThrow();
   });
 });

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -20,7 +20,7 @@ import {
   startSpan,
 } from '@sentry/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { bindTracingChannelToSpan } from '../src/tracing-channel';
+import { bindTracingChannelToSpanWithLifeCycle, bindTracingChannelToSpan } from '../src/tracing-channel';
 
 interface TestStore {
   scope: Scope;
@@ -99,7 +99,7 @@ function installTestAsyncContextStrategy(): void {
   });
 }
 
-describe('bindTracingChannelToSpan', () => {
+describe('bindTracingChannelToSpanWithLifeCycle', () => {
   afterEach(() => {
     setAsyncContextStrategy(undefined);
     getCurrentScope().clear();
@@ -114,7 +114,10 @@ describe('bindTracingChannelToSpan', () => {
 
     const span = startInactiveSpan({ name: 'channel-span' });
     const getSpan = vi.fn(() => span);
-    const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:bind-span:data'), getSpan);
+    const { channel } = bindTracingChannelToSpanWithLifeCycle(
+      tracingChannel<{ operation: string }>('test:bind-span:data'),
+      getSpan,
+    );
 
     let dataSpan: Span | undefined;
     channel.subscribe({
@@ -134,7 +137,7 @@ describe('bindTracingChannelToSpan', () => {
     installTestAsyncContextStrategy();
 
     const span = startInactiveSpan({ name: 'channel-span' });
-    const { channel } = bindTracingChannelToSpan(
+    const { channel } = bindTracingChannelToSpanWithLifeCycle(
       tracingChannel<{ operation: string }>('test:bind-span:active'),
       () => span,
     );
@@ -156,7 +159,7 @@ describe('bindTracingChannelToSpan', () => {
     initTestClient();
 
     const parent = startInactiveSpan({ forceTransaction: true, name: 'parent-span' });
-    const { channel } = bindTracingChannelToSpan(
+    const { channel } = bindTracingChannelToSpanWithLifeCycle(
       tracingChannel<{ operation: string }>('test:bind-span:children'),
       () => parent,
     );
@@ -180,7 +183,7 @@ describe('bindTracingChannelToSpan', () => {
 
     // Returns a channel whose span we can observe, plus spies for `span.end` and `captureException`.
     function setup(name: string): {
-      channel: ReturnType<typeof bindTracingChannelToSpan>['channel'];
+      channel: ReturnType<typeof bindTracingChannelToSpanWithLifeCycle>['channel'];
       span: Span;
       endSpy: ReturnType<typeof vi.spyOn>;
       captureExceptionSpy: ReturnType<typeof vi.spyOn>;
@@ -190,7 +193,10 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const endSpy = vi.spyOn(span, 'end');
       const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
-      const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>(name), () => span);
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+        tracingChannel<{ operation: string }>(name),
+        () => span,
+      );
       return { channel, span, endSpy, captureExceptionSpy };
     }
 
@@ -388,7 +394,7 @@ describe('bindTracingChannelToSpan', () => {
 
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('db-down');
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:captureError:off'),
         () => span,
         { captureError: false },
@@ -415,7 +421,7 @@ describe('bindTracingChannelToSpan', () => {
 
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('boom');
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:captureError:true'),
         () => span,
         { captureError: true },
@@ -445,7 +451,7 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('boom');
       const captureError = vi.fn(() => ({ mechanism: { type: 'auto.http.custom', handled: false } }));
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:captureError:fn'),
         () => span,
         { captureError },
@@ -477,7 +483,7 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('sync-boom');
       const captureError = vi.fn((e: unknown) => ({ extra: { caught: e instanceof Error } }));
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:captureError:fn-sync'),
         () => span,
         { captureError },
@@ -505,7 +511,7 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       let openWhenCalled: boolean | undefined;
       let receivedSpan: Span | undefined;
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:sync'),
         () => span,
         {
@@ -532,7 +538,7 @@ describe('bindTracingChannelToSpan', () => {
       initTestClient();
 
       const span = startInactiveSpan({ name: 'channel-span' });
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:async'),
         () => span,
         {
@@ -557,7 +563,7 @@ describe('bindTracingChannelToSpan', () => {
       const span = startInactiveSpan({ name: 'channel-span' });
       const error = new Error('boom');
       let sawError: unknown;
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:beforeSpanEnd:error'),
         () => span,
         {
@@ -581,7 +587,7 @@ describe('bindTracingChannelToSpan', () => {
     });
   });
 
-  it('manual lifecycle: binds the span as active but does not end it automatically', () => {
+  it('bindTracingChannelToSpan binds the span as active without ending it', () => {
     installTestAsyncContextStrategy();
     initTestClient();
 
@@ -591,9 +597,6 @@ describe('bindTracingChannelToSpan', () => {
     const { channel } = bindTracingChannelToSpan(
       tracingChannel<{ operation: string }>('test:lifecycle:manual'),
       getSpan,
-      {
-        lifecycle: 'manual',
-      },
     );
 
     let activeSpan: Span | undefined;
@@ -617,7 +620,7 @@ describe('bindTracingChannelToSpan', () => {
     const getSpan = vi.fn(() => span);
     const rawChannel = tracingChannel<{ operation: string }>('test:lifecycle:no-binding');
 
-    const { channel } = bindTracingChannelToSpan(rawChannel, getSpan);
+    const { channel } = bindTracingChannelToSpanWithLifeCycle(rawChannel, getSpan);
 
     expect(channel).toBe(rawChannel);
 
@@ -634,7 +637,7 @@ describe('bindTracingChannelToSpan', () => {
     const span = startInactiveSpan({ name: 'channel-span' });
     const endSpy = vi.spyOn(span, 'end');
     const getSpan = vi.fn(() => span);
-    const { channel, unbind } = bindTracingChannelToSpan(
+    const { channel, unbind } = bindTracingChannelToSpanWithLifeCycle(
       tracingChannel<{ operation: string }>('test:lifecycle:unbind'),
       getSpan,
     );
@@ -661,7 +664,10 @@ describe('bindTracingChannelToSpan', () => {
       initTestClient();
 
       const getSpan = vi.fn(() => undefined);
-      const { channel } = bindTracingChannelToSpan(tracingChannel<{ operation: string }>('test:skip:active'), getSpan);
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
+        tracingChannel<{ operation: string }>('test:skip:active'),
+        getSpan,
+      );
 
       let dataSpan: Span | undefined;
       channel.subscribe({
@@ -696,7 +702,7 @@ describe('bindTracingChannelToSpan', () => {
       initTestClient();
       const captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
 
-      const { channel } = bindTracingChannelToSpan(
+      const { channel } = bindTracingChannelToSpanWithLifeCycle(
         tracingChannel<{ operation: string }>('test:skip:error'),
         () => undefined,
       );


### PR DESCRIPTION
This abstracts away our tracing channels consumption into a utility that:

- Activates a span for the tracing channel lifecycle
- Manages the span across the entire lifecycle
  - Sets errors on the error channel
  - Correctly ends the span at the correct timing whether the traced call is sync or async
- Allows span/error enrichment and overrides

This util can be consumed uniformly across all of our server-side runtimes, I will create a stacked PR that refactors our code to use it, showcasing Nitro, Redis, and Deno adoption of that util.

## How Does it work

By adding a `TracingChannelBinding` getters on our AsyncContextStrategy (ACS) implementations that implements a pair of fields:

```ts
export interface TracingChannelBinding {
  asyncLocalStorage: unknown;
  getStoreWithActiveSpan: (span: Span) => unknown;
}
```

The exact return type doesn't matter as long as the ACS can use it to properly parent scopes and nested async contexts. We have two implementations so far:

1. Our own that uses the `{ scope, isolationScope }` pair.
2. OTel that uses the OTel API context.


To illustrate this more, we can walk the round-trip:

1. `getStoreWithActiveSpan(span)` clones the current scope, returns `{ scope, isolationScope }`.
2. The courier `bindTracingChannelToSpan` takes that opaque value and hands it to `channel.start.bindStore`. Under the hood the channel does `asyncLocalStorage.run(producedValue, () => …the traced operation…). The courier never checks the value, it just drops it into the right ALS.
3. Anywhere inside the traced async operation, Sentry's scope machinery calls `getScopes()` which is `asyncStorage.getStore()` will get the ALS instance the courier bound into. So `getCurrentScope()`, `getIsolationScope()`, and `getActiveSpan()` all resolve to the scope carrying our span. Any child span started in that operation parents to it. That's the nesting.

So there are three parties, not two:

- Producer (getStoreWithActiveSpan), ACS owns it, knows the shape, builds it.
- Courier (bindTracingChannelToSpan), opaque, it shouldn't know what's in there.
- Reader (getScopes/scope APIs) ACS owns, knows the shape, reads it back.

So it's pretty type safe given the courier never checks the value, which it shouldn't because there is no guarantee what the ACS has put on it. That's also why the OTel strategy can return a Context instead.

```mermaid
flowchart TB
    subgraph Strategy["async context strategy (per-runtime impl — owns the store shape)"]
        Producer["PRODUCE<br/>getStoreWithActiveSpan(span)<br/>clone scope + plant span<br/>→ ALS impl: { scope, isolationScope }<br/>→ OTel impl: Context"]
        Reader["READ<br/>getScopes() / getCurrentScope()<br/>getActiveSpan()<br/>reads store back out"]
    end

    ALS["AsyncLocalStorage (binding.asyncLocalStorage)<br/>the shared pipe — same instance on both sides"]

    Courier["COURIER — bindTracingChannelToSpan<br/>strategy-blind, never inspects (TValue = unknown)<br/>channel.start.bindStore(binding.asyncLocalStorage, data ⇒ getStoreWithActiveSpan(span))"]

    Op["traced async operation<br/>start child span → parents to bound span ✓"]

    Producer -->|"produced store"| ALS
    Courier -->|"als.run(store, op)"| ALS
    ALS -->|"als.getStore()"| Op
    Op -.->|"getCurrentScope / getActiveSpan"| Reader
    Reader -.->|"resolves to scope carrying our span"| Op
```

## Lifecycle Management

After testing across several node releases (20 -> 26), I locked down the strategy that we can rely on to make this reliable and predictable. 

1. always start at `start` lifecycle event, this is emitted always and is reliable.
4. Use `error` For capturing exceptions and setting error span status, always reliable.
5. When `end` is emitted:
    1. If `error` is present on the context object, end the span immediatly, there won’t be any async events coming up, the function threw in the sync part, so there is no async part to execute.
    2. If `result` is present on the context object, end the span immediately, there won’t be any async events coming up. The function returned in the sync part or is sync trace itself. Use `in` or `hasOwnProperty` , Do not use `undefined` checks as the function can return nothing.
    3. Otherwise NO-OP, there is an async lifecycle events coming up.
6. When `asyncStart` is emitted: Do nothing, this event has no value for us.
7. When `asyncEnd` is emitted: Just end the span.

