### PR TITLE
test(e2e): Add `tracing` and `errors-only` modes to lighthouse test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/package.json
@@ -9,6 +9,8 @@
     "build": "vite build",
     "build:no-sentry": "vite build --mode no-sentry",
     "build:init-only": "vite build --mode init-only",
+    "build:errors-only": "vite build --mode errors-only",
+    "build:tracing": "vite build --mode tracing",
     "build:tracing-replay": "vite build --mode tracing-replay",
     "preview": "vite preview",
     "clean": "npx rimraf node_modules pnpm-lock.yaml dist",

--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
@@ -12,12 +12,28 @@ if (import.meta.env.MODE === 'tracing-replay') {
     replaysSessionSampleRate: 1.0,
     replaysOnErrorSampleRate: 1.0,
   });
+} else if (import.meta.env.MODE === 'tracing') {
+  // Tracing + errors, but no replay — isolates the replay integration's cost.
+  Sentry.init({
+    dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
+    release: 'lighthouse-fixture',
+    environment: 'qa',
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 1.0,
+  });
+} else if (import.meta.env.MODE === 'errors-only') {
+  // Default integrations only — errors are always captured, no tracing or replay.
+  Sentry.init({
+    dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
+    release: 'lighthouse-fixture',
+    environment: 'qa',
+  });
 } else if (import.meta.env.MODE === 'init-only') {
   // enabled: false makes the SDK a guaranteed no-op (no transport allocation,
   // no DSN warning). We're measuring pure SDK-loading + tree-shaking cost.
   Sentry.init({ enabled: false });
 }
-// 'no-sentry' mode: both branches above are statically dead, so Vite drops
+// 'no-sentry' mode: all branches above are statically dead, so Vite drops
 // the @sentry/react import entirely from the bundle.
 
 const root = createRoot(document.getElementById('root')!);

--- a/scripts/lighthouse-bundle-and-upload.mjs
+++ b/scripts/lighthouse-bundle-and-upload.mjs
@@ -1,11 +1,11 @@
 /**
  * Bundle the `lighthouse-react` test app for each mode (no-sentry, init-only,
- * tracing-replay) and POST the three tarballs to the Sentry Lighthouse lab
- * (https://lighthouse.sentry.gg). The lab runs Lighthouse asynchronously and
- * ships results to Sentry on its own schedule — this script exits as soon as
- * the upload succeeds.
+ * errors-only, tracing, tracing-replay) and POST the tarballs to the Sentry
+ * Lighthouse lab (https://lighthouse.sentry.gg). The lab runs Lighthouse
+ * asynchronously and ships results to Sentry on its own schedule — this script
+ * exits as soon as the upload succeeds.
  *
- * Single-app static matrix: 1 app × 3 modes = 3 cells.
+ * Single-app static matrix: 1 app × 5 modes = 5 cells.
  *
  * Zero runtime dependencies — uses Node 22 builtins (fetch, FormData, Blob) and
  * the system `tar`. Every external command is invoked via `execFileSync` with
@@ -33,7 +33,7 @@ const E2E_DIR = path.join(WORKSPACE, 'dev-packages/e2e-tests');
 
 const APP = 'lighthouse-react';
 const APP_DIR = 'lighthouse-react';
-const MODES = ['no-sentry', 'init-only', 'tracing-replay'];
+const MODES = ['no-sentry', 'init-only', 'errors-only', 'tracing', 'tracing-replay'];
 const STATIC_DIR = 'dist';
 
 async function run() {


### PR DESCRIPTION
So far, the only "sentry active" mode included a full blown errors+tracing+replay setup. This PR adds two other smaller, more common modes:

- `errors-only` 
- `tracing` (errors+tracing)

This should help us see how much latency is induced by each of these features