### PR TITLE
fix(server-utils): Avoid directly importing `tracingChannel` for Node v18 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -782,7 +782,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['18.0.0', 18, 20, 22, 24, 26]
+        node: [18, 20, 22, 24, 26]
         typescript:
           - false
         include:
@@ -811,6 +811,28 @@ jobs:
       - name: Run integration tests
         working-directory: dev-packages/node-integration-tests
         run: yarn test
+
+  job_node_v18_compat:
+    name: Node v18.0.0 Compatibility Check
+    needs: [job_get_metadata, job_build]
+    if: needs.job_build.outputs.changed_node == 'true' || github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '18.0.0'
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        with:
+          dependency_cache_key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check Node v18.0.0 compatibility
+        run: node scripts/node-v18-compat-check.js
 
   job_node_core_integration_tests:
     name:
@@ -1198,6 +1220,7 @@ jobs:
         job_deno_unit_tests,
         job_node_unit_tests,
         job_node_integration_tests,
+        job_node_v18_compat,
         job_node_core_integration_tests,
         job_cloudflare_integration_tests,
         job_bun_integration_tests,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -782,7 +782,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20, 22, 24, 26]
+        node: ['18.0.0', 18, 20, 22, 24, 26]
         typescript:
           - false
         include:

--- a/packages/server-utils/src/integrations/tracing-channel/mysql.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/mysql.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from 'node:diagnostics_channel';
+import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Span } from '@sentry/core';
 import {
   debug,
@@ -73,7 +73,7 @@ const _mysqlChannelIntegration = (() => {
     name: INTEGRATION_NAME,
     setupOnce() {
       DEBUG_BUILD && debug.log(`[orchestrion:mysql] subscribing to channel "${CHANNELS.MYSQL_QUERY}"`);
-      const queryCh = tracingChannel(CHANNELS.MYSQL_QUERY);
+      const queryCh = diagnosticsChannel.tracingChannel(CHANNELS.MYSQL_QUERY);
 
       // Each `context` object is shared across start/end/asyncStart/asyncEnd/error
       // for one call (orchestrion creates one per invocation). We key the span

--- a/scripts/node-v18-compat-check.js
+++ b/scripts/node-v18-compat-check.js
@@ -2,6 +2,6 @@
 
 // Verify the Node SDK can be loaded without errors on Node v18.0.0 (the minimum supported version).
 // This catches accidental use of Node APIs that don't exist in v18.0.0.
-require('./packages/node/build/cjs/index.js');
+require('@sentry/node');
 
 console.log('Node v18.0.0 compatibility check passed');

--- a/scripts/node-v18-compat-check.js
+++ b/scripts/node-v18-compat-check.js
@@ -1,0 +1,7 @@
+'use strict';
+
+// Verify the Node SDK can be loaded without errors on Node v18.0.0 (the minimum supported version).
+// This catches accidental use of Node APIs that don't exist in v18.0.0.
+require('./packages/node/build/cjs/index.js');
+
+console.log('Node v18.0.0 compatibility check passed');


### PR DESCRIPTION
This PR fixes another usage of `tracingChannel` which isn't supported in Node v18.0.0.

I also added a test to ensure we don't break this again at import time. 