### PR TITLE
feat(opentelemetry): Add SentryTracerProvider

### DIFF
--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -103,6 +103,7 @@ export {
   spanToJSON,
   spanToStreamedSpanJSON,
   spanIsSampled,
+  spanIsSentrySpan,
   spanToTraceContext,
   getSpanDescendants,
   getStatusMessage,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -13,6 +13,7 @@ export { SPAN_STATUS_ERROR, SPAN_STATUS_OK, SPAN_STATUS_UNSET } from './spanstat
 export {
   startSpan,
   startInactiveSpan,
+  _INTERNAL_startInactiveSpan,
   startSpanManual,
   continueTrace,
   withActiveSpan,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -6,6 +6,8 @@ export {
   spanShouldInferOtelSource,
   markSpanSourceAsExplicit,
   spanSourceWasExplicitlySet,
+  markSpanAsTracerProviderSpan,
+  spanIsTracerProviderSpan,
 } from './utils';
 export { startIdleSpan, TRACING_DEFAULTS } from './idleSpan';
 export { SentrySpan } from './sentrySpan';

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -4,6 +4,8 @@ export {
   getCapturedScopesOnSpan,
   markSpanForOtelSourceInference,
   spanShouldInferOtelSource,
+  markSpanSourceAsExplicit,
+  spanSourceWasExplicitlySet,
 } from './utils';
 export { startIdleSpan, TRACING_DEFAULTS } from './idleSpan';
 export { SentrySpan } from './sentrySpan';

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -22,6 +22,7 @@ export {
   suppressTracing,
   isTracingSuppressed,
   startNewTrace,
+  spanIsIgnored,
   SUPPRESS_TRACING_KEY,
 } from './trace';
 export { bindScopeToEmitter } from './bindScopeToEmitter';

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -144,7 +144,7 @@ export class SentrySpan implements Span {
    * @hidden
    * @internal
    */
-  public recordException(_exception: unknown, _time?: number | undefined): void {
+  public recordException(_exception: unknown, _time?: SpanTimeInput | undefined): void {
     // noop
   }
 

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -47,7 +47,7 @@ import { getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { logSpanEnd } from './logSpans';
 import { timedEventsToMeasurements } from './measurement';
 import { hasSpanStreamingEnabled } from './spans/hasSpanStreamingEnabled';
-import { getCapturedScopesOnSpan, spanShouldInferOtelSource } from './utils';
+import { getCapturedScopesOnSpan, markSpanSourceAsExplicit, spanShouldInferOtelSource } from './utils';
 
 const MAX_SPAN_COUNT = 1000;
 
@@ -165,6 +165,12 @@ export class SentrySpan implements Span {
       delete this._attributes[key];
     } else {
       this._attributes[key] = value;
+    }
+
+    // Setting the source on a span branded for OTel-style inference means user code is choosing it
+    // explicitly, so flag it to keep `applyOtelSpanData` from overriding it with an inferred source.
+    if (key === SEMANTIC_ATTRIBUTE_SENTRY_SOURCE && value !== undefined && spanShouldInferOtelSource(this)) {
+      markSpanSourceAsExplicit(this);
     }
 
     return this;

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -181,6 +181,20 @@ export function startInactiveSpan(options: StartSpanOptions): Span {
     return acs.startInactiveSpan(options);
   }
 
+  return _startInactiveSpanImpl(options);
+}
+
+/**
+ * Internal version of startInactiveSpan that bypasses the ACS check.
+ * Used by SentryTracerProvider to create spans without triggering recursion
+ * through ACS overrides.
+ * @hidden
+ */
+export function _INTERNAL_startInactiveSpan(options: StartSpanOptions): Span {
+  return _startInactiveSpanImpl(options);
+}
+
+function _startInactiveSpanImpl(options: StartSpanOptions): Span {
   const spanArguments = parseSentrySpanArguments(options);
   const { forceTransaction, parentSpan: customParentSpan } = options;
 

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -82,7 +82,7 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
       // Ignored root spans still need to be set on scope so that `getActiveSpan()` returns them
       // and descendants are also non-recording. Ignored child spans don't need this because
       // the parent span is already on scope.
-      if (!_isIgnoredSpan(activeSpan) || !parentSpan) {
+      if (!spanIsIgnored(activeSpan) || !parentSpan) {
         _setSpanForScope(scope, activeSpan);
       }
 
@@ -144,7 +144,7 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
 
       // We don't set ignored child spans onto the scope because there likely is an active,
       // unignored span on the scope already.
-      if (!_isIgnoredSpan(activeSpan) || !parentSpan) {
+      if (!spanIsIgnored(activeSpan) || !parentSpan) {
         _setSpanForScope(scope, activeSpan);
       }
 
@@ -665,6 +665,11 @@ function _shouldIgnoreStreamedSpan(client: Client | undefined, spanArguments: Se
   );
 }
 
-function _isIgnoredSpan(span: Span): span is SentryNonRecordingSpan {
+/**
+ * Whether a span is an ignored (`ignoreSpans`) placeholder. Such a span must not be set as the active
+ * span when it has a parent, so its children attach to that parent and get re-parented rather than
+ * dropped with it. Shared with the OTel-based provider so both span pipelines apply the same rule.
+ */
+export function spanIsIgnored(span: Span): span is SentryNonRecordingSpan {
   return spanIsNonRecordingSpan(span) && span.dropReason === 'ignored';
 }

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -12,6 +12,12 @@ const ISOLATION_SCOPE_ON_START_SPAN_FIELD = '_sentryIsolationScope';
 // so the key is shared across duplicated copies of `@sentry/core`.
 const OTEL_SOURCE_INFERENCE_SPAN_FIELD = Symbol.for('sentry.otelSourceInference');
 
+// Brand marking a span (otherwise subject to OTel-style source inference, see above) whose
+// `sentry.source` was explicitly set by user code after creation, so `applyOtelSpanData` stops
+// inferring and respects the chosen source and name. This is what tells a user-set `custom` source
+// apart from the default `custom` that `_startRootSpan` stamps on every root span.
+const OTEL_SOURCE_EXPLICITLY_SET_SPAN_FIELD = Symbol.for('sentry.otelSourceExplicitlySet');
+
 type SpanWithScopes = Span & {
   [SCOPE_ON_START_SPAN_FIELD]?: Scope;
   [ISOLATION_SCOPE_ON_START_SPAN_FIELD]?: MaybeWeakRef<Scope>;
@@ -19,6 +25,7 @@ type SpanWithScopes = Span & {
 
 type SpanWithOtelSourceInference = Span & {
   [OTEL_SOURCE_INFERENCE_SPAN_FIELD]?: boolean;
+  [OTEL_SOURCE_EXPLICITLY_SET_SPAN_FIELD]?: boolean;
 };
 
 /** Store the scope & isolation scope for a span, which can the be used when it is finished. */
@@ -56,4 +63,19 @@ export function markSpanForOtelSourceInference(span: Span): void {
 /** Whether a span is marked for OTel-style `sentry.source` inference (see {@link markSpanForOtelSourceInference}). */
 export function spanShouldInferOtelSource(span: Span): boolean {
   return (span as SpanWithOtelSourceInference)[OTEL_SOURCE_INFERENCE_SPAN_FIELD] === true;
+}
+
+/**
+ * Mark that user code explicitly set `sentry.source` on a span subject to OTel-style inference, so
+ * `applyOtelSpanData` keeps that source (and name) instead of overriding it. Set by `SentrySpan`
+ * when `setAttribute` writes the source on an already-branded span (the default `custom` source is
+ * stamped at construction, before the brand, so it doesn't trip this).
+ */
+export function markSpanSourceAsExplicit(span: Span): void {
+  addNonEnumerableProperty(span, OTEL_SOURCE_EXPLICITLY_SET_SPAN_FIELD, true);
+}
+
+/** Whether user code explicitly set `sentry.source` on a span (see {@link markSpanSourceAsExplicit}). */
+export function spanSourceWasExplicitlySet(span: Span): boolean {
+  return (span as SpanWithOtelSourceInference)[OTEL_SOURCE_EXPLICITLY_SET_SPAN_FIELD] === true;
 }

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -18,6 +18,12 @@ const OTEL_SOURCE_INFERENCE_SPAN_FIELD = Symbol.for('sentry.otelSourceInference'
 // apart from the default `custom` that `_startRootSpan` stamps on every root span.
 const OTEL_SOURCE_EXPLICITLY_SET_SPAN_FIELD = Symbol.for('sentry.otelSourceExplicitlySet');
 
+// Brand marking a span created by the `SentryTracerProvider` (i.e. via the OTel tracer) rather than
+// directly through the core span API. Such a span is handed to OTel instrumentations as an OTel span,
+// so it must become immutable after `end()` like a real OTel SDK span (see `SentrySpan.end()`). Spans
+// created directly through core (e.g. the browser SDK) are not branded and stay mutable.
+const TRACER_PROVIDER_SPAN_FIELD = Symbol.for('sentry.tracerProviderSpan');
+
 type SpanWithScopes = Span & {
   [SCOPE_ON_START_SPAN_FIELD]?: Scope;
   [ISOLATION_SCOPE_ON_START_SPAN_FIELD]?: MaybeWeakRef<Scope>;
@@ -26,6 +32,10 @@ type SpanWithScopes = Span & {
 type SpanWithOtelSourceInference = Span & {
   [OTEL_SOURCE_INFERENCE_SPAN_FIELD]?: boolean;
   [OTEL_SOURCE_EXPLICITLY_SET_SPAN_FIELD]?: boolean;
+};
+
+type SpanWithTracerProviderBrand = Span & {
+  [TRACER_PROVIDER_SPAN_FIELD]?: boolean;
 };
 
 /** Store the scope & isolation scope for a span, which can the be used when it is finished. */
@@ -78,4 +88,18 @@ export function markSpanSourceAsExplicit(span: Span): void {
 /** Whether user code explicitly set `sentry.source` on a span (see {@link markSpanSourceAsExplicit}). */
 export function spanSourceWasExplicitlySet(span: Span): boolean {
   return (span as SpanWithOtelSourceInference)[OTEL_SOURCE_EXPLICITLY_SET_SPAN_FIELD] === true;
+}
+
+/**
+ * Mark a span as created by the `SentryTracerProvider` (via the OTel tracer). Set by `SentryTracer`
+ * on every span it creates; read by `SentrySpan.end()` to seal the span against further writes once
+ * it has ended, mirroring OTel SDK spans (which are immutable after `end()`).
+ */
+export function markSpanAsTracerProviderSpan(span: Span): void {
+  addNonEnumerableProperty(span, TRACER_PROVIDER_SPAN_FIELD, true);
+}
+
+/** Whether a span was created by the `SentryTracerProvider` (see {@link markSpanAsTracerProviderSpan}). */
+export function spanIsTracerProviderSpan(span: Span): boolean {
+  return (span as SpanWithTracerProviderBrand)[TRACER_PROVIDER_SPAN_FIELD] === true;
 }

--- a/packages/core/src/types/span.ts
+++ b/packages/core/src/types/span.ts
@@ -319,5 +319,5 @@ export interface Span {
   /**
    * NOT USED IN SENTRY, only added for compliance with OTEL Span interface
    */
-  recordException(exception: unknown, time?: number): void;
+  recordException(exception: unknown, time?: SpanTimeInput): void;
 }

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -299,7 +299,7 @@ export interface OpenTelemetrySdkTraceBaseSpan extends Span {
  * Sadly, due to circular dependency checks we cannot actually import the Span class here and check for instanceof.
  * :( So instead we approximate this by checking if it has the `getSpanJSON` method.
  */
-function spanIsSentrySpan(span: Span): span is SentrySpan {
+export function spanIsSentrySpan(span: Span): span is SentrySpan {
   return typeof (span as SentrySpan).getSpanJSON === 'function';
 }
 

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -4,7 +4,7 @@ import { setCurrentClient } from '../../../src/sdk';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../../../src/semanticAttributes';
 import { SentrySpan } from '../../../src/tracing/sentrySpan';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing/spanstatus';
-import { markSpanForOtelSourceInference } from '../../../src/tracing/utils';
+import { markSpanForOtelSourceInference, spanSourceWasExplicitlySet } from '../../../src/tracing/utils';
 import type { SpanJSON } from '../../../src/types/span';
 import { spanToJSON, TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED } from '../../../src/utils/spanUtils';
 import { timestampInSeconds } from '../../../src/utils/time';
@@ -58,6 +58,36 @@ describe('SentrySpan', () => {
       const spanJson = spanToJSON(span);
       expect(spanJson.description).toEqual('new name');
       expect(spanJson.data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBeUndefined();
+    });
+  });
+
+  describe('explicit source', () => {
+    it('flags a source set on a span marked for OTel source inference as explicit', () => {
+      const span = new SentrySpan({ name: 'original name' });
+      markSpanForOtelSourceInference(span);
+      expect(spanSourceWasExplicitlySet(span)).toBe(false);
+
+      span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'custom');
+
+      expect(spanSourceWasExplicitlySet(span)).toBe(true);
+    });
+
+    it('does not flag the default source set at construction (before the inference brand) as explicit', () => {
+      const span = new SentrySpan({
+        name: 'original name',
+        attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom' },
+      });
+      markSpanForOtelSourceInference(span);
+
+      expect(spanSourceWasExplicitlySet(span)).toBe(false);
+    });
+
+    it('does not flag a source set on a span that is not marked for OTel source inference', () => {
+      const span = new SentrySpan({ name: 'original name' });
+
+      span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'custom');
+
+      expect(spanSourceWasExplicitlySet(span)).toBe(false);
     });
   });
 

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -85,6 +85,36 @@ function setupSentry() {
 A full setup example can be found in
 [node-experimental](https://github.com/getsentry/sentry-javascript/blob/develop/packages/node-experimental).
 
+## Experimental Sentry Tracer Provider
+
+`SentryTracerProvider` is an experimental minimal OpenTelemetry tracer provider which creates native Sentry spans directly.
+It is useful when code uses the global OpenTelemetry API and you do not need the full OpenTelemetry SDK span processor
+and exporter pipeline.
+
+```js
+import { trace } from '@opentelemetry/api';
+import { SentryTracerProvider } from '@sentry/opentelemetry';
+
+trace.setGlobalTracerProvider(new SentryTracerProvider());
+
+const span = trace.getTracer('example').startSpan('work');
+span.end();
+```
+
+In `@sentry/node`, this provider can be enabled with the experimental option:
+
+```js
+Sentry.init({
+  dsn: 'xxx',
+  _experiments: {
+    useSentryTracerProvider: true,
+  },
+});
+```
+
+When this provider is enabled, additional OpenTelemetry span processors are ignored because Sentry spans are created
+directly. OpenTelemetry logs and metrics are not handled by this provider.
+
 ## Links
 
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)

--- a/packages/opentelemetry/src/applyOtelSpanData.ts
+++ b/packages/opentelemetry/src/applyOtelSpanData.ts
@@ -6,6 +6,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   spanShouldInferOtelSource,
+  spanSourceWasExplicitlySet,
   spanToJSON,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
@@ -32,8 +33,13 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
   const kind = (span as SentrySpanWithOtelKind).kind ?? SpanKind.INTERNAL;
   const mayInferSource = spanShouldInferOtelSource(span);
   const hasCustomSpanName = attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME] !== undefined;
+  // We may only infer the source/name when the span is OTel-branded and user code hasn't already
+  // chosen them: either via `updateSpanName` (which sets `sentry.custom_span_name`) or by explicitly
+  // setting `sentry.source`. Without the explicit-source check we couldn't tell a user-set `custom`
+  // apart from the default `custom` stamped on every root span at span start, and would override it.
+  const canInferSource = mayInferSource && !hasCustomSpanName && !spanSourceWasExplicitlySet(span);
   const attributesForInference =
-    mayInferSource && !hasCustomSpanName && attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom'
+    canInferSource && attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom'
       ? { ...attributes, [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: undefined }
       : attributes;
   const inferred = inferSpanData(spanJSON.description || '<unknown>', attributesForInference, kind);
@@ -61,10 +67,7 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
     (options.finalizeStatus || inferred.source !== 'url') &&
     (spanJSON.parent_span_id === undefined || kind === SpanKind.SERVER);
 
-  if (
-    shouldApplyInferredSource &&
-    (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === undefined || (mayInferSource && !hasCustomSpanName))
-  ) {
+  if (shouldApplyInferredSource && (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === undefined || canInferSource)) {
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, inferred.source);
   }
 
@@ -83,7 +86,7 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
 
   if (
     inferred.description !== spanJSON.description &&
-    (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom' || (mayInferSource && !hasCustomSpanName))
+    (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom' || canInferSource)
   ) {
     span.updateName(inferred.description);
   }

--- a/packages/opentelemetry/src/applyOtelSpanData.ts
+++ b/packages/opentelemetry/src/applyOtelSpanData.ts
@@ -2,6 +2,8 @@ import { SpanKind } from '@opentelemetry/api';
 import { HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE } from '@sentry/conventions/attributes';
 import {
   addNonEnumerableProperty,
+  getClient,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -81,7 +83,8 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
 
   if (options.finalizeStatus) {
     applyOtelCompatibilityAttributes(span, attributes);
-    applyOtelSpanStatus(span, attributes, spanJSON.status);
+    const client = getClient();
+    applyOtelSpanStatus(span, attributes, spanJSON.status, !!client && hasSpanStreamingEnabled(client));
   }
 
   // Only re-infer the name for spans branded for OTel source inference (those the provider created
@@ -103,13 +106,23 @@ export function applyOtelSpanKind(span: Span, kind: SpanKind | undefined): void 
   addNonEnumerableProperty(span as SentrySpanWithOtelKind, 'kind', kind ?? SpanKind.INTERNAL);
 }
 
-function applyOtelSpanStatus(span: Span, attributes: SpanAttributes, status: string | undefined): void {
+function applyOtelSpanStatus(
+  span: Span,
+  attributes: SpanAttributes,
+  status: string | undefined,
+  spanStreamingEnabled: boolean,
+): void {
   if (status === undefined) {
     span.setStatus(inferStatusFromAttributes(attributes) || { code: SPAN_STATUS_OK });
     return;
   }
 
-  if (status !== 'ok' && !isStatusErrorMessageValid(status)) {
+  // Normalize a non-canonical error message to `internal_error` for the (non-streamed) transaction
+  // `status` field, matching the OTel SDK exporter's `mapStatus`. Skip this under span streaming: the
+  // streamed serializer preserves the raw message as `sentry.status.message` by reading the live span
+  // status, and the OTel SDK path keeps it too because `mapStatus` maps at export without mutating the
+  // span. Overwriting it here would replace that message with `internal_error`.
+  if (!spanStreamingEnabled && status !== 'ok' && !isStatusErrorMessageValid(status)) {
     span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
   }
 }

--- a/packages/opentelemetry/src/applyOtelSpanData.ts
+++ b/packages/opentelemetry/src/applyOtelSpanData.ts
@@ -1,0 +1,117 @@
+import { SpanKind } from '@opentelemetry/api';
+import { HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE } from '@sentry/conventions/attributes';
+import {
+  addNonEnumerableProperty,
+  SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  spanShouldInferOtelSource,
+  spanToJSON,
+  SPAN_STATUS_ERROR,
+  SPAN_STATUS_OK,
+} from '@sentry/core';
+import type { Span, SpanAttributes } from '@sentry/core';
+import { inferStatusFromAttributes, isStatusErrorMessageValid } from './utils/mapStatus';
+import { inferSpanData } from './utils/parseSpanDescription';
+
+type SentrySpanWithOtelKind = Span & { kind?: SpanKind };
+
+/**
+ * Backfill a native Sentry span with the data the OpenTelemetry SDK pipeline would otherwise derive
+ * from OTel semantic attributes: `sentry.op`, `sentry.source`, the span name, `otel.kind`, and status.
+ *
+ * On the OTel SDK provider this happens in the `SentrySpanProcessor`/`SentrySpanExporter` while
+ * converting `ReadableSpan`s to Sentry payloads (via `parseSpanDescription` + `mapStatus`).
+ * `SentryTracerProvider` creates native Sentry spans directly and never goes through that pipeline,
+ * so the same inference has to run here instead — once at span start, and again at span end
+ * (`finalizeStatus`, once attributes like `http.route` and the status code are available).
+ */
+export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolean } = {}): void {
+  const spanJSON = spanToJSON(span);
+  const attributes = spanJSON.data;
+  const kind = (span as SentrySpanWithOtelKind).kind ?? SpanKind.INTERNAL;
+  const mayInferSource = spanShouldInferOtelSource(span);
+  const hasCustomSpanName = attributes[SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME] !== undefined;
+  const attributesForInference =
+    mayInferSource && !hasCustomSpanName && attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'custom'
+      ? { ...attributes, [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: undefined }
+      : attributes;
+  const inferred = inferSpanData(spanJSON.description || '<unknown>', attributesForInference, kind);
+
+  if (kind !== SpanKind.INTERNAL && attributes['otel.kind'] === undefined) {
+    span.setAttribute('otel.kind', SpanKind[kind]);
+  }
+
+  if (inferred.op && attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === undefined) {
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, inferred.op);
+  }
+
+  // Don't apply 'url' source at creation time, only at span end (finalizeStatus).
+  // At creation, http.route may not be set yet, so inference falls back to 'url'.
+  // Keeping the default 'custom' source from _startRootSpan allows
+  // enhanceDscWithOpenTelemetryRootSpanName to include the transaction name in
+  // the DSC. At span end, http.route is typically available and inference returns
+  // 'route' instead. If it's still 'url', it's applied then.
+  // We also only set `source` on segment roots (spans that become transactions):
+  // those with no parent, plus SERVER spans, which are the segment root even when
+  // continuing a distributed trace (where they carry a remote `parent_span_id`).
+  const shouldApplyInferredSource =
+    inferred.source !== undefined &&
+    inferred.source !== 'custom' &&
+    (options.finalizeStatus || inferred.source !== 'url') &&
+    (spanJSON.parent_span_id === undefined || kind === SpanKind.SERVER);
+
+  if (
+    shouldApplyInferredSource &&
+    (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === undefined || (mayInferSource && !hasCustomSpanName))
+  ) {
+    span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, inferred.source);
+  }
+
+  if (inferred.data) {
+    Object.entries(inferred.data).forEach(([key, value]) => {
+      if (value !== undefined && attributes[key] === undefined) {
+        span.setAttribute(key, value);
+      }
+    });
+  }
+
+  if (options.finalizeStatus) {
+    applyOtelCompatibilityAttributes(span, attributes);
+    applyOtelSpanStatus(span, attributes, spanJSON.status);
+  }
+
+  if (
+    inferred.description !== spanJSON.description &&
+    (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom' || (mayInferSource && !hasCustomSpanName))
+  ) {
+    span.updateName(inferred.description);
+  }
+}
+
+/** Stash the OTel span kind on a Sentry span so {@link applyOtelSpanData} can read it. */
+export function applyOtelSpanKind(span: Span, kind: SpanKind | undefined): void {
+  addNonEnumerableProperty(span as SentrySpanWithOtelKind, 'kind', kind ?? SpanKind.INTERNAL);
+}
+
+function applyOtelSpanStatus(span: Span, attributes: SpanAttributes, status: string | undefined): void {
+  if (status === undefined) {
+    span.setStatus(inferStatusFromAttributes(attributes) || { code: SPAN_STATUS_OK });
+    return;
+  }
+
+  if (status !== 'ok' && !isStatusErrorMessageValid(status)) {
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+  }
+}
+
+function applyOtelCompatibilityAttributes(span: Span, attributes: SpanAttributes): void {
+  // `http.status_code` is the deprecated legacy attribute, read for backward compatibility.
+  // eslint-disable-next-line typescript/no-deprecated
+  const legacyHttpStatusCode = attributes[HTTP_STATUS_CODE];
+
+  if (attributes[HTTP_RESPONSE_STATUS_CODE] === undefined && legacyHttpStatusCode !== undefined) {
+    span.setAttribute(HTTP_RESPONSE_STATUS_CODE, legacyHttpStatusCode);
+    attributes[HTTP_RESPONSE_STATUS_CODE] = legacyHttpStatusCode;
+  }
+}

--- a/packages/opentelemetry/src/applyOtelSpanData.ts
+++ b/packages/opentelemetry/src/applyOtelSpanData.ts
@@ -84,7 +84,13 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
     applyOtelSpanStatus(span, attributes, spanJSON.status);
   }
 
+  // Only re-infer the name for spans branded for OTel source inference (those the provider created
+  // without an explicit Sentry source). A span created with an explicit source — e.g. a Sentry
+  // instrumentation calling `startSpan({ name, attributes: { 'sentry.source': 'url' } })` like the Bun
+  // server integration — already has a deliberate name and must be left alone. Renaming it would also
+  // stamp `source: 'custom'` (via `updateName`), which then leaks the URL into the DSC transaction name.
   if (
+    mayInferSource &&
     inferred.description !== spanJSON.description &&
     (attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom' || canInferSource)
   ) {

--- a/packages/opentelemetry/src/custom/client.ts
+++ b/packages/opentelemetry/src/custom/client.ts
@@ -1,9 +1,8 @@
 import type { Tracer } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
-import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import type { Client } from '@sentry/core';
 import { SDK_VERSION } from '@sentry/core';
-import type { OpenTelemetryClient as OpenTelemetryClientInterface } from '../types';
+import type { OpenTelemetryClient as OpenTelemetryClientInterface, OpenTelemetryTracerProvider } from '../types';
 
 // Typescript complains if we do not use `...args: any[]` for the mixin, with:
 // A mixin class must have a constructor with a single rest parameter of type 'any[]'.ts(2545)
@@ -23,7 +22,7 @@ export function wrapClientClass<
 >(ClientClass: ClassConstructor): WrappedClassConstructor {
   // @ts-expect-error We just assume that this is non-abstract, if you pass in an abstract class this would make it non-abstract
   class OpenTelemetryClient extends ClientClass implements OpenTelemetryClientInterface {
-    public traceProvider: BasicTracerProvider | undefined;
+    public traceProvider: OpenTelemetryTracerProvider | undefined;
     private _tracer: Tracer | undefined;
 
     public constructor(...args: any[]) {

--- a/packages/opentelemetry/src/exports.ts
+++ b/packages/opentelemetry/src/exports.ts
@@ -46,6 +46,7 @@ export { SentryPropagator, shouldPropagateTraceForUrl } from './propagator';
 export { SentrySpanProcessor } from './spanProcessor';
 export { SentrySampler, wrapSamplingDecision } from './sampler';
 export { applyOtelSpanData } from './applyOtelSpanData';
+export { backfillStreamedSpanDataFromOtel } from './utils/backfillStreamedSpanData';
 export { SentryTracerProvider } from './tracerProvider';
 export type { OpenTelemetryTracerProvider } from './types';
 

--- a/packages/opentelemetry/src/exports.ts
+++ b/packages/opentelemetry/src/exports.ts
@@ -45,8 +45,11 @@ export { wrapContextManagerClass } from './contextManager';
 export { SentryPropagator, shouldPropagateTraceForUrl } from './propagator';
 export { SentrySpanProcessor } from './spanProcessor';
 export { SentrySampler, wrapSamplingDecision } from './sampler';
+export { applyOtelSpanData } from './applyOtelSpanData';
+export { SentryTracerProvider } from './tracerProvider';
+export type { OpenTelemetryTracerProvider } from './types';
 
-export { openTelemetrySetupCheck } from './utils/setupCheck';
+export { openTelemetrySetupCheck, setIsSetup } from './utils/setupCheck';
 
 export { getSentryResource } from './resource';
 

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -24,7 +24,7 @@ import {
 import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER, SENTRY_TRACE_STATE_URL } from './constants';
 import { DEBUG_BUILD } from './debug-build';
 import { getScopesFromContext, setScopesOnContext } from './utils/contextData';
-import { getSamplingDecision } from './utils/getSamplingDecision';
+import { getSampledForPropagation, getSamplingDecision } from './utils/getSamplingDecision';
 import { makeTraceState } from './utils/makeTraceState';
 import { setIsSetup } from './utils/setupCheck';
 
@@ -173,7 +173,7 @@ export function getInjectionData(
       dynamicSamplingContext,
       traceId: spanContext.traceId,
       spanId: spanContext.spanId,
-      sampled: getSamplingDecision(spanContext), // TODO: Do we need to change something here?
+      sampled: getSampledForPropagation(span, options.client),
     };
   }
 

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -1,7 +1,7 @@
 import type { Context } from '@opentelemetry/api';
 import { ROOT_CONTEXT, trace } from '@opentelemetry/api';
 import type { ReadableSpan, Span, SpanProcessor as SpanProcessorInterface } from '@opentelemetry/sdk-trace-base';
-import type { Client, SpanAttributes, StreamedSpanJSON } from '@sentry/core';
+import type { Client } from '@sentry/core';
 import {
   addChildSpanToSpan,
   getClient,
@@ -10,17 +10,12 @@ import {
   hasSpanStreamingEnabled,
   logSpanEnd,
   logSpanStart,
-  safeSetSpanJSONAttributes,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCapturedScopesOnSpan,
-  SPAN_KIND,
-  spanKindToName,
 } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_PARENT_IS_REMOTE } from './semanticAttributes';
 import { SentrySpanExporter } from './spanExporter';
+import { backfillStreamedSpanDataFromOtel } from './utils/backfillStreamedSpanData';
 import { getScopesFromContext } from './utils/contextData';
-import { inferSpanData } from './utils/parseSpanDescription';
 import { setIsSetup } from './utils/setupCheck';
 /**
  * Converts OpenTelemetry Spans to Sentry Spans and sends them to Sentry via
@@ -109,34 +104,5 @@ export class SentrySpanProcessor implements SpanProcessorInterface {
     } else {
       this._exporter.export(span);
     }
-  }
-}
-
-/**
- * Backfill op, source, name and data on a streamed span JSON from OTel semantic conventions.
- * Mirrors the inference the {@link SentrySpanExporter} applies to non-streamed spans via `getSpanData`.
- * Explicitly set attributes are preserved via `safeSetSpanJSONAttributes`.
- */
-function backfillStreamedSpanDataFromOtel(spanJSON: StreamedSpanJSON, hint?: { spanKind?: number }): void {
-  const attributes = spanJSON.attributes;
-  if (!attributes) {
-    return;
-  }
-
-  const kind = hint?.spanKind ?? SPAN_KIND.INTERNAL;
-  const { op, description, source, data } = inferSpanData(spanJSON.name, attributes as unknown as SpanAttributes, kind);
-
-  spanJSON.name = description;
-
-  safeSetSpanJSONAttributes(spanJSON, {
-    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
-    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
-    ...data,
-  });
-
-  if (kind !== SPAN_KIND.INTERNAL) {
-    safeSetSpanJSONAttributes(spanJSON, {
-      'otel.kind': spanKindToName(kind),
-    });
   }
 }

--- a/packages/opentelemetry/src/tracer.ts
+++ b/packages/opentelemetry/src/tracer.ts
@@ -1,0 +1,153 @@
+import type { Context, Span as OpenTelemetrySpan, SpanOptions, Tracer } from '@opentelemetry/api';
+import { context, trace } from '@opentelemetry/api';
+import { isTracingSuppressed } from '@opentelemetry/core';
+import {
+  _INTERNAL_safeMathRandom,
+  _INTERNAL_setSpanForScope,
+  _INTERNAL_startInactiveSpan,
+  addChildSpanToSpan,
+  getCapturedScopesOnSpan,
+  getCurrentScope,
+  getDynamicSamplingContextFromSpan,
+  getIsolationScope,
+  markSpanForOtelSourceInference,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SentryNonRecordingSpan,
+  setCapturedScopesOnSpan,
+  startNewTrace,
+  withScope,
+} from '@sentry/core';
+import type { Span, SpanAttributes, SpanLink } from '@sentry/core';
+import { applyOtelSpanData, applyOtelSpanKind } from './applyOtelSpanData';
+import { SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY } from './constants';
+import { getSamplingDecision } from './utils/getSamplingDecision';
+
+export class SentryTracer implements Tracer {
+  /** @inheritdoc */
+  public startSpan(name: string, options: SpanOptions = {}, ctx?: Context): OpenTelemetrySpan {
+    const parentContext = ctx || context.active();
+    const parentSpan = options.root ? undefined : trace.getSpan(parentContext);
+
+    if (isTracingSuppressed(parentContext)) {
+      return this._createNonRecordingSpan(parentSpan);
+    }
+
+    const span = this._startSentrySpan(name, options, parentSpan, ctx !== undefined);
+
+    applyOtelSpanKind(span, options.kind);
+    if (options.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === undefined) {
+      markSpanForOtelSourceInference(span);
+    }
+    applyOtelSpanData(span);
+    return span as OpenTelemetrySpan;
+  }
+
+  /** @inheritdoc */
+  public startActiveSpan<F extends (span: OpenTelemetrySpan) => unknown>(name: string, fn: F): ReturnType<F>;
+  public startActiveSpan<F extends (span: OpenTelemetrySpan) => unknown>(
+    name: string,
+    options: SpanOptions,
+    fn: F,
+  ): ReturnType<F>;
+  public startActiveSpan<F extends (span: OpenTelemetrySpan) => unknown>(
+    name: string,
+    options: SpanOptions,
+    ctx: Context,
+    fn: F,
+  ): ReturnType<F>;
+  public startActiveSpan<F extends (span: OpenTelemetrySpan) => unknown>(
+    name: string,
+    optionsOrFn: SpanOptions | F,
+    contextOrFn?: Context | F,
+    fn?: F,
+  ): ReturnType<F> {
+    const options = typeof optionsOrFn === 'function' ? {} : optionsOrFn;
+    const ctx = typeof contextOrFn === 'function' || contextOrFn === undefined ? context.active() : contextOrFn;
+    const callback = (
+      typeof optionsOrFn === 'function' ? optionsOrFn : typeof contextOrFn === 'function' ? contextOrFn : fn
+    ) as F;
+
+    const span = this.startSpan(name, options, ctx);
+    let ctxWithSpan = trace.setSpan(ctx, span);
+
+    // Run the span's callback under the isolation scope captured when the span was created, so scope state
+    // used or set during the span (tags, breadcrumbs, captured errors) belongs to that span and stays
+    // isolated from other concurrent work. Without this it can land on a different isolation scope.
+    const capturedIsolationScope = getCapturedScopesOnSpan(span as unknown as Span).isolationScope;
+    if (capturedIsolationScope) {
+      ctxWithSpan = ctxWithSpan.setValue(SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY, capturedIsolationScope);
+    }
+
+    return context.with(ctxWithSpan, () => {
+      _INTERNAL_setSpanForScope(getCurrentScope(), span as unknown as Span);
+      return callback(span) as ReturnType<F>;
+    });
+  }
+
+  private _startSentrySpan(
+    name: string,
+    options: SpanOptions,
+    parentSpan: OpenTelemetrySpan | undefined,
+    hasExplicitContext: boolean,
+  ): Span {
+    const sentryOptions = {
+      name,
+      attributes: options.attributes as SpanAttributes | undefined,
+      links: options.links as SpanLink[] | undefined,
+      startTime: options.startTime,
+    };
+
+    if (options.root) {
+      return startNewTrace(() => _INTERNAL_startInactiveSpan({ ...sentryOptions, parentSpan: null }));
+    }
+
+    if (parentSpan?.spanContext().isRemote) {
+      return this._startRootSpanWithRemoteParent(sentryOptions, parentSpan);
+    }
+
+    if (parentSpan) {
+      return _INTERNAL_startInactiveSpan({ ...sentryOptions, parentSpan: parentSpan as unknown as Span });
+    }
+
+    return _INTERNAL_startInactiveSpan({
+      ...sentryOptions,
+      parentSpan: hasExplicitContext ? null : undefined,
+    });
+  }
+
+  private _startRootSpanWithRemoteParent(
+    options: Parameters<typeof _INTERNAL_startInactiveSpan>[0],
+    parentSpan: OpenTelemetrySpan,
+  ): Span {
+    const { spanId, traceId } = parentSpan.spanContext();
+    const dsc = getDynamicSamplingContextFromSpan(parentSpan as unknown as Span);
+    const sampleRand = typeof dsc.sample_rand === 'string' ? Number(dsc.sample_rand) : undefined;
+
+    return withScope(scope => {
+      scope.setPropagationContext({
+        traceId,
+        parentSpanId: spanId,
+        sampled: getSamplingDecision(parentSpan.spanContext()),
+        dsc,
+        sampleRand:
+          typeof sampleRand === 'number' && !Number.isNaN(sampleRand) ? sampleRand : _INTERNAL_safeMathRandom(),
+      });
+      _INTERNAL_setSpanForScope(scope, undefined);
+
+      return _INTERNAL_startInactiveSpan({ ...options, parentSpan: null });
+    });
+  }
+
+  private _createNonRecordingSpan(parentSpan: OpenTelemetrySpan | undefined): OpenTelemetrySpan {
+    const span = new SentryNonRecordingSpan({ traceId: parentSpan?.spanContext().traceId });
+    // Link to the parent (like core's `createChildOrRootSpan`) so `getRootSpan` and DSC
+    // resolution reach the parent. Non-recording spans no longer carry a `parentSpanId`.
+    if (parentSpan) {
+      addChildSpanToSpan(parentSpan as unknown as Span, span);
+    }
+    // Capture the scopes (mirroring `createChildOrRootSpan`) so `startActiveSpan` can
+    // fork the isolation scope onto the OTel context for work inside a suppressed span.
+    setCapturedScopesOnSpan(span, getCurrentScope(), getIsolationScope());
+    return span as OpenTelemetrySpan;
+  }
+}

--- a/packages/opentelemetry/src/tracer.ts
+++ b/packages/opentelemetry/src/tracer.ts
@@ -10,6 +10,7 @@ import {
   getCurrentScope,
   getDynamicSamplingContextFromSpan,
   getIsolationScope,
+  markSpanAsTracerProviderSpan,
   markSpanForOtelSourceInference,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SentryNonRecordingSpan,
@@ -34,6 +35,11 @@ export class SentryTracer implements Tracer {
     }
 
     const span = this._startSentrySpan(name, options, parentSpan, ctx !== undefined);
+
+    // Mark the span as provider-created so it becomes immutable after `end()` like an OTel SDK span
+    // (see `SentrySpan.end()`). Spans created directly through the core API (e.g. the browser SDK)
+    // are not marked and keep their mutable behavior.
+    markSpanAsTracerProviderSpan(span);
 
     applyOtelSpanKind(span, options.kind);
     if (options.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === undefined) {

--- a/packages/opentelemetry/src/tracer.ts
+++ b/packages/opentelemetry/src/tracer.ts
@@ -19,7 +19,7 @@ import {
 } from '@sentry/core';
 import type { Span, SpanAttributes, SpanLink } from '@sentry/core';
 import { applyOtelSpanData, applyOtelSpanKind } from './applyOtelSpanData';
-import { SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY } from './constants';
+import { SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY, SENTRY_TRACE_STATE_DSC } from './constants';
 import { getSamplingDecision } from './utils/getSamplingDecision';
 
 export class SentryTracer implements Tracer {
@@ -124,16 +124,21 @@ export class SentryTracer implements Tracer {
     options: Parameters<typeof _INTERNAL_startInactiveSpan>[0],
     parentSpan: OpenTelemetrySpan,
   ): Span {
-    const { spanId, traceId } = parentSpan.spanContext();
+    const { spanId, traceId, traceState } = parentSpan.spanContext();
     const dsc = getDynamicSamplingContextFromSpan(parentSpan as unknown as Span);
     const sampleRand = typeof dsc.sample_rand === 'string' ? Number(dsc.sample_rand) : undefined;
+
+    // Only freeze the DSC when the remote parent actually carried one (i.e. there was incoming
+    // baggage). Otherwise leave it unset so it is derived dynamically from the span — picking up the
+    // span's `transaction` name and the generated `sample_rand` — matching the OpenTelemetry SDK.
+    const hasIncomingDsc = !!traceState?.get(SENTRY_TRACE_STATE_DSC);
 
     return withScope(scope => {
       scope.setPropagationContext({
         traceId,
         parentSpanId: spanId,
         sampled: getSamplingDecision(parentSpan.spanContext()),
-        dsc,
+        dsc: hasIncomingDsc ? dsc : undefined,
         sampleRand:
           typeof sampleRand === 'number' && !Number.isNaN(sampleRand) ? sampleRand : _INTERNAL_safeMathRandom(),
       });

--- a/packages/opentelemetry/src/tracer.ts
+++ b/packages/opentelemetry/src/tracer.ts
@@ -14,6 +14,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SentryNonRecordingSpan,
   setCapturedScopesOnSpan,
+  spanIsIgnored,
   startNewTrace,
   withScope,
 } from '@sentry/core';
@@ -68,17 +69,27 @@ export class SentryTracer implements Tracer {
     ) as F;
 
     const span = this.startSpan(name, options, ctx);
-    let ctxWithSpan = trace.setSpan(ctx, span);
 
     // Run the span's callback under the isolation scope captured when the span was created, so scope state
     // used or set during the span (tags, breadcrumbs, captured errors) belongs to that span and stays
-    // isolated from other concurrent work. Without this it can land on a different isolation scope.
+    // isolated from other concurrent work. Without this it can land on a different isolation scope. This
+    // holds for ignored spans too, which run the callback without ever becoming the active span.
     const capturedIsolationScope = getCapturedScopesOnSpan(span as unknown as Span).isolationScope;
-    if (capturedIsolationScope) {
-      ctxWithSpan = ctxWithSpan.setValue(SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY, capturedIsolationScope);
+    const withCapturedIsolationScope = (contextToFork: Context): Context =>
+      capturedIsolationScope
+        ? contextToFork.setValue(SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY, capturedIsolationScope)
+        : contextToFork;
+
+    // Mirror core's `startSpan`: an ignored (`ignoreSpans`) span that has a parent must not become the
+    // active span. Otherwise its children would attach to it and, since it's non-recording, be dropped
+    // along with it (cascading the drop down the whole subtree). Leaving the parent active lets the
+    // children attach to it and get re-parented instead. An ignored root span has no parent and still
+    // becomes active, so its subtree is dropped as intended.
+    if (spanIsIgnored(span as unknown as Span) && trace.getSpan(ctx)) {
+      return context.with(withCapturedIsolationScope(ctx), () => callback(span)) as ReturnType<F>;
     }
 
-    return context.with(ctxWithSpan, () => {
+    return context.with(withCapturedIsolationScope(trace.setSpan(ctx, span)), () => {
       _INTERNAL_setSpanForScope(getCurrentScope(), span as unknown as Span);
       return callback(span) as ReturnType<F>;
     });

--- a/packages/opentelemetry/src/tracer.ts
+++ b/packages/opentelemetry/src/tracer.ts
@@ -109,10 +109,15 @@ export class SentryTracer implements Tracer {
       return _INTERNAL_startInactiveSpan({ ...sentryOptions, parentSpan: parentSpan as unknown as Span });
     }
 
-    return _INTERNAL_startInactiveSpan({
-      ...sentryOptions,
-      parentSpan: hasExplicitContext ? null : undefined,
-    });
+    // No parent span and no remote parent: this is a fresh root span. Start a new trace instead of
+    // continuing the scope's (possibly auto-generated) propagation context, matching the OpenTelemetry
+    // SDK where each root span without an incoming trace gets its own trace id.
+    return startNewTrace(() =>
+      _INTERNAL_startInactiveSpan({
+        ...sentryOptions,
+        parentSpan: hasExplicitContext ? null : undefined,
+      }),
+    );
   }
 
   private _startRootSpanWithRemoteParent(

--- a/packages/opentelemetry/src/tracerProvider.ts
+++ b/packages/opentelemetry/src/tracerProvider.ts
@@ -1,0 +1,39 @@
+import type { Tracer, TracerOptions, TracerProvider } from '@opentelemetry/api';
+import type { SpanAttributes } from '@sentry/core';
+import { SentryTracer } from './tracer';
+
+/**
+ * A minimal OpenTelemetry TracerProvider which creates native Sentry spans.
+ */
+export class SentryTracerProvider implements TracerProvider {
+  public readonly resource?: { attributes: SpanAttributes };
+
+  private readonly _tracers = new Map<string, SentryTracer>();
+
+  public constructor(options: { resource?: { attributes: SpanAttributes } } = {}) {
+    this.resource = options.resource;
+  }
+
+  /** @inheritdoc */
+  public getTracer(name: string, version?: string, options?: TracerOptions): Tracer {
+    const key = JSON.stringify([name, version, options]);
+    const cachedTracer = this._tracers.get(key);
+    if (cachedTracer) {
+      return cachedTracer;
+    }
+
+    const tracer = new SentryTracer();
+    this._tracers.set(key, tracer);
+    return tracer;
+  }
+
+  /** Compatibility with SDK tracer providers. */
+  public forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /** Compatibility with SDK tracer providers. */
+  public shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/packages/opentelemetry/src/types.ts
+++ b/packages/opentelemetry/src/types.ts
@@ -1,10 +1,15 @@
-import type { Span as WriteableSpan, SpanKind, Tracer } from '@opentelemetry/api';
+import type { Span as WriteableSpan, SpanKind, Tracer, TracerProvider } from '@opentelemetry/api';
 import type { BasicTracerProvider, ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { Scope, Span, StartSpanOptions } from '@sentry/core';
 
+export interface OpenTelemetryTracerProvider extends TracerProvider {
+  forceFlush(): Promise<void>;
+  shutdown(): Promise<void>;
+}
+
 export interface OpenTelemetryClient {
   tracer: Tracer;
-  traceProvider: BasicTracerProvider | undefined;
+  traceProvider: BasicTracerProvider | OpenTelemetryTracerProvider | undefined;
 }
 
 export interface OpenTelemetrySpanContext extends StartSpanOptions {

--- a/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
+++ b/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
@@ -20,10 +20,7 @@ import { inferSpanData } from './parseSpanDescription';
  * on the same attributes, so re-running it here is a no-op for already-inferred fields.
  */
 export function backfillStreamedSpanDataFromOtel(spanJSON: StreamedSpanJSON, hint?: { spanKind?: number }): void {
-  const attributes = spanJSON.attributes;
-  if (!attributes) {
-    return;
-  }
+  const attributes = spanJSON.attributes ?? {};
 
   const kind = hint?.spanKind ?? SPAN_KIND.INTERNAL;
   const { op, description, source, data } = inferSpanData(spanJSON.name, attributes as unknown as SpanAttributes, kind);

--- a/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
+++ b/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
@@ -1,0 +1,44 @@
+import type { SpanAttributes, StreamedSpanJSON } from '@sentry/core';
+import {
+  safeSetSpanJSONAttributes,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SPAN_KIND,
+  spanKindToName,
+} from '@sentry/core';
+import { inferSpanData } from './parseSpanDescription';
+
+/**
+ * Backfill op, source, name and data on a streamed span JSON from OTel semantic conventions.
+ * Mirrors the inference the {@link SentrySpanExporter} applies to non-streamed spans via `getSpanData`.
+ * Explicitly set attributes are preserved via `safeSetSpanJSONAttributes`.
+ *
+ * Runs as a `preprocessSpan` subscriber (streamed-only) on both span pipelines: the OTel SDK
+ * `SentrySpanProcessor` and the `SentryTracerProvider`. On the latter, `applyOtelSpanData` has already
+ * inferred most data on the native span; this fills the remaining gap (per-span `sentry.source` on
+ * child spans, which `applyOtelSpanData` only sets on segment roots). `inferSpanData` is deterministic
+ * on the same attributes, so re-running it here is a no-op for already-inferred fields.
+ */
+export function backfillStreamedSpanDataFromOtel(spanJSON: StreamedSpanJSON, hint?: { spanKind?: number }): void {
+  const attributes = spanJSON.attributes;
+  if (!attributes) {
+    return;
+  }
+
+  const kind = hint?.spanKind ?? SPAN_KIND.INTERNAL;
+  const { op, description, source, data } = inferSpanData(spanJSON.name, attributes as unknown as SpanAttributes, kind);
+
+  spanJSON.name = description;
+
+  safeSetSpanJSONAttributes(spanJSON, {
+    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
+    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
+    ...data,
+  });
+
+  if (kind !== SPAN_KIND.INTERNAL) {
+    safeSetSpanJSONAttributes(spanJSON, {
+      'otel.kind': spanKindToName(kind),
+    });
+  }
+}

--- a/packages/opentelemetry/src/utils/enhanceDscWithOpenTelemetryRootSpanName.ts
+++ b/packages/opentelemetry/src/utils/enhanceDscWithOpenTelemetryRootSpanName.ts
@@ -2,7 +2,6 @@ import type { Client } from '@sentry/core';
 import { hasSpansEnabled, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
 import { getSamplingDecision } from './getSamplingDecision';
 import { parseSpanDescription } from './parseSpanDescription';
-import { spanHasName } from './spanTypes';
 
 /**
  * Setup a DSC handler on the passed client,
@@ -24,9 +23,11 @@ export function enhanceDscWithOpenTelemetryRootSpanName(client: Client): void {
     const attributes = jsonSpan.data;
     const source = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
 
-    const { description } = spanHasName(rootSpan) ? parseSpanDescription(rootSpan) : { description: undefined };
-    if (source !== 'url' && description) {
-      dsc.transaction = description;
+    if (jsonSpan.description) {
+      const { description } = parseSpanDescription(rootSpan);
+      if (source !== 'url' && description) {
+        dsc.transaction = description;
+      }
     }
 
     // Also ensure sampling decision is correctly inferred

--- a/packages/opentelemetry/src/utils/enhanceDscWithOpenTelemetryRootSpanName.ts
+++ b/packages/opentelemetry/src/utils/enhanceDscWithOpenTelemetryRootSpanName.ts
@@ -1,6 +1,6 @@
 import type { Client } from '@sentry/core';
 import { hasSpansEnabled, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
-import { getSamplingDecision } from './getSamplingDecision';
+import { getSampledForPropagation } from './getSamplingDecision';
 import { parseSpanDescription } from './parseSpanDescription';
 
 /**
@@ -13,28 +13,30 @@ export function enhanceDscWithOpenTelemetryRootSpanName(client: Client): void {
       return;
     }
 
-    // We want to overwrite the transaction on the DSC that is created by default in core
-    // The reason for this is that we want to infer the span name, not use the initial one
-    // Otherwise, we'll get names like "GET" instead of e.g. "GET /foo"
-    // `parseSpanDescription` takes the attributes of the span into account for the name
-    // This mutates the passed-in DSC
-
     const jsonSpan = spanToJSON(rootSpan);
     const attributes = jsonSpan.data;
     const source = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
 
-    if (jsonSpan.description) {
+    const sampled = getSampledForPropagation(rootSpan, client);
+
+    // We want to overwrite the transaction on the DSC that is created by default in core, so that we
+    // infer the span name (e.g. "GET /foo" instead of "GET"); `parseSpanDescription` reads the span
+    // attributes. This mutates the passed-in DSC.
+    // A negatively sampled trace carries no transaction name in its DSC, matching the OTel SDK whose
+    // unsampled spans are nameless non-recording spans. Core derives one from the span name, so we
+    // drop it here for native (SentryTracerProvider) spans that do have a name.
+    if (sampled === false) {
+      delete dsc.transaction;
+    } else if (jsonSpan.description) {
       const { description } = parseSpanDescription(rootSpan);
       if (source !== 'url' && description) {
         dsc.transaction = description;
       }
     }
 
-    // Also ensure sampling decision is correctly inferred
-    // In core, we use `spanIsSampled`, which just looks at the trace flags
-    // but in OTEL, we use a slightly more complex logic to be able to differntiate between unsampled and deferred sampling
+    // Only write the sampling decision in tracing mode. In TwP mode it is deferred (read from the
+    // scope/incoming trace state), so we leave any value core already resolved untouched.
     if (hasSpansEnabled()) {
-      const sampled = getSamplingDecision(rootSpan.spanContext());
       dsc.sampled = sampled == undefined ? undefined : String(sampled);
     }
   });

--- a/packages/opentelemetry/src/utils/getSamplingDecision.ts
+++ b/packages/opentelemetry/src/utils/getSamplingDecision.ts
@@ -1,6 +1,13 @@
 import type { SpanContext } from '@opentelemetry/api';
 import { TraceFlags } from '@opentelemetry/api';
-import { baggageHeaderToDynamicSamplingContext } from '@sentry/core';
+import type { Client, Span } from '@sentry/core';
+import {
+  baggageHeaderToDynamicSamplingContext,
+  getRootSpan,
+  hasSpansEnabled,
+  spanIsSampled,
+  spanIsSentrySpan,
+} from '@sentry/core';
 import { SENTRY_TRACE_STATE_DSC, SENTRY_TRACE_STATE_SAMPLED_NOT_RECORDING } from '../constants';
 
 /**
@@ -39,4 +46,41 @@ export function getSamplingDecision(spanContext: SpanContext): boolean | undefin
   }
 
   return undefined;
+}
+
+/**
+ * Resolve a span's sampling decision for trace propagation, also handling native Sentry spans.
+ *
+ * Prefer the OpenTelemetry trace state via {@link getSamplingDecision}. Native Sentry spans (created
+ * by the `SentryTracerProvider`) don't carry that trace state, so when it's absent we fall back to the
+ * span's own decision via `spanIsSampled` — but only for an *explicit* decision. An explicit decision
+ * always originates at a real `SentrySpan` root (a negatively sampled root, or a child of one). A
+ * non-recording placeholder root (an orphan/suppressed span, or a TwP placeholder) and a remote span
+ * have a *deferred* decision that lives elsewhere (the scope, or the incoming trace state), so we
+ * return `undefined` and leave the decision deferred rather than wrongly asserting `-0`.
+ *
+ * TODO(v11): Once the OTel SDK provider is gone and every local span is a native Sentry span, the
+ * trace-state lookup only matters for remote (incoming) spans; the local path always reads the span's
+ * own decision, so the "native-vs-OTel-SDK span" framing can be dropped (local → span, remote → trace state).
+ */
+export function getSampledForPropagation(span: Span, client: Client | undefined): boolean | undefined {
+  const spanContext = span.spanContext();
+
+  // Prefer the OTel trace state: it carries the decision for OTel SDK spans and for remote (incoming)
+  // spans, and unambiguously separates sampled / unsampled / deferred.
+  const samplingDecision = getSamplingDecision(spanContext);
+  if (samplingDecision !== undefined) {
+    return samplingDecision;
+  }
+
+  // No trace state in it. Only read the span's own decision (`spanIsSampled`) when it's an explicit
+  // one, which lives on a native recording `SentrySpan` root (created by the SentryTracerProvider).
+  // Everything else defers: TwP (deferred), remote spans (decision is in the incoming trace state),
+  // and non-recording placeholder roots — whether a Sentry orphan/suppressed span or, on the OTel SDK
+  // path, an OpenTelemetry `NonRecordingSpan` (which `spanIsSentrySpan` also excludes).
+  if (!hasSpansEnabled(client?.getOptions()) || spanContext.isRemote || !spanIsSentrySpan(getRootSpan(span))) {
+    return undefined;
+  }
+
+  return spanIsSampled(span);
 }

--- a/packages/opentelemetry/src/utils/mapStatus.ts
+++ b/packages/opentelemetry/src/utils/mapStatus.ts
@@ -25,7 +25,7 @@ const canonicalGrpcErrorCodesMap: Record<string, SpanStatus['message']> = {
   '16': 'unauthenticated',
 } as const;
 
-const isStatusErrorMessageValid = (message: string): boolean => {
+export const isStatusErrorMessageValid = (message: string): boolean => {
   return Object.values(canonicalGrpcErrorCodesMap).includes(message as SpanStatus['message']);
 };
 
@@ -72,7 +72,7 @@ export function mapStatus(span: AbstractSpan): SpanStatus {
   }
 }
 
-function inferStatusFromAttributes(attributes: SpanAttributes): SpanStatus | undefined {
+export function inferStatusFromAttributes(attributes: SpanAttributes): SpanStatus | undefined {
   // If the span status is UNSET, we try to infer it from HTTP or GRPC status codes.
 
   // eslint-disable-next-line typescript/no-deprecated

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -14,7 +14,7 @@ import {
   RPC_SERVICE,
   URL_FULL,
 } from '@sentry/conventions/attributes';
-import type { SpanAttributes, TransactionSource } from '@sentry/core';
+import type { Span, SpanAttributes, TransactionSource } from '@sentry/core';
 import {
   getSanitizedUrlString,
   parseUrl,
@@ -22,6 +22,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  spanToJSON,
   stripUrlQueryAndFragment,
 } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION } from '../semanticAttributes';
@@ -104,10 +105,22 @@ export function inferSpanData(spanName: string, attributes: SpanAttributes, kind
  * Based on https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/7422ce2a06337f68a59b552b8c5a2ac125d6bae5/exporter/sentryexporter/sentry_exporter.go#L306
  */
 export function parseSpanDescription(span: AbstractSpan): SpanDescription {
-  const attributes = spanHasAttributes(span) ? span.attributes : {};
-  const name = spanHasName(span) ? span.name : '<unknown>';
-  const kind = getSpanKind(span);
+  let attributes: Attributes;
+  let name: string;
 
+  // TODO(v11): Once the OTel SDK provider is removed and SentryTracerProvider is the only path,
+  // every span is a native Sentry span — drop this `spanHasAttributes` (OTel ReadableSpan) branch
+  // and keep only the `spanToJSON()` path below.
+  if (spanHasAttributes(span)) {
+    attributes = span.attributes;
+    name = spanHasName(span) ? span.name : '<unknown>';
+  } else {
+    const json = typeof (span as Span).spanContext === 'function' ? spanToJSON(span as Span) : undefined;
+    attributes = json?.data || {};
+    name = spanHasName(span) ? span.name : json?.description || '<unknown>';
+  }
+
+  const kind = getSpanKind(span);
   return inferSpanData(name, attributes, kind);
 }
 

--- a/packages/opentelemetry/src/utils/setupCheck.ts
+++ b/packages/opentelemetry/src/utils/setupCheck.ts
@@ -1,4 +1,9 @@
-type OpenTelemetryElement = 'SentrySpanProcessor' | 'SentryContextManager' | 'SentryPropagator' | 'SentrySampler';
+type OpenTelemetryElement =
+  | 'SentrySpanProcessor'
+  | 'SentryContextManager'
+  | 'SentryPropagator'
+  | 'SentrySampler'
+  | 'SentryTracerProvider';
 
 const setupElements = new Set<OpenTelemetryElement>();
 

--- a/packages/opentelemetry/test/tracerProvider.test.ts
+++ b/packages/opentelemetry/test/tracerProvider.test.ts
@@ -1,0 +1,232 @@
+import { context, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
+import { suppressTracing } from '@opentelemetry/core';
+import {
+  getActiveSpan,
+  getCapturedScopesOnSpan,
+  getRootSpan,
+  spanToJSON,
+  SPAN_STATUS_ERROR,
+  SPAN_STATUS_OK,
+  startSpanManual,
+  type Span,
+  withIsolationScope,
+} from '@sentry/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SentryAsyncLocalStorageContextManager } from '../src/asyncLocalStorageContextManager';
+import { setOpenTelemetryContextAsyncContextStrategy } from '../src/asyncContextStrategy';
+import { applyOtelSpanData } from '../src/applyOtelSpanData';
+import { SentryTracerProvider } from '../src/tracerProvider';
+import { cleanupOtel } from './helpers/mockSdkInit';
+import { init as initTestClient } from './helpers/TestClient';
+
+describe('SentryTracerProvider', () => {
+  beforeEach(() => {
+    (global as { __SENTRY__?: unknown }).__SENTRY__ = {};
+    setOpenTelemetryContextAsyncContextStrategy();
+    initTestClient({ tracesSampleRate: 1 });
+    context.setGlobalContextManager(new SentryAsyncLocalStorageContextManager());
+    trace.setGlobalTracerProvider(new SentryTracerProvider());
+  });
+
+  afterEach(async () => {
+    await cleanupOtel();
+  });
+
+  it('creates Sentry spans from the global OpenTelemetry tracer', () => {
+    const span = trace.getTracer('test').startSpan('SELECT users', {
+      attributes: {
+        'db.system.name': 'postgresql',
+        'db.statement': 'SELECT * FROM users',
+      },
+    });
+
+    expect(spanToJSON(span as Span)).toEqual({
+      data: {
+        'sentry.origin': 'manual',
+        'sentry.op': 'db',
+        'sentry.sample_rate': 1,
+        'sentry.source': 'task',
+        'db.system.name': 'postgresql',
+        'db.statement': 'SELECT * FROM users',
+      },
+      description: 'SELECT * FROM users',
+      op: 'db',
+      origin: 'manual',
+      parent_span_id: undefined,
+      span_id: span.spanContext().spanId,
+      start_timestamp: expect.any(Number),
+      status: undefined,
+      timestamp: undefined,
+      trace_id: span.spanContext().traceId,
+      profile_id: undefined,
+      exclusive_time: undefined,
+      measurements: undefined,
+      is_segment: undefined,
+      segment_id: undefined,
+      links: undefined,
+    });
+  });
+
+  it('parents inactive spans to the active OpenTelemetry span', () => {
+    trace.getTracer('test').startActiveSpan('parent', parent => {
+      const child = trace.getTracer('test').startSpan('child');
+
+      expect(spanToJSON(child as Span).parent_span_id).toBe(parent.spanContext().spanId);
+    });
+  });
+
+  it('links non-recording spans to a suppressed active parent', () => {
+    trace.getTracer('test').startActiveSpan('parent', parent => {
+      const suppressedContext = suppressTracing(context.active());
+      const child = trace.getTracer('test').startSpan('child', {}, suppressedContext);
+
+      expect(child.isRecording()).toBe(false);
+      expect(spanToJSON(child as Span).trace_id).toBe(parent.spanContext().traceId);
+      // Non-recording spans no longer carry a `parent_span_id` under the scope-based
+      // sampling model; the child is instead linked to the parent's span tree.
+      expect(getRootSpan(child as Span)).toBe(getRootSpan(parent as unknown as Span));
+
+      parent.end();
+    });
+  });
+
+  it('captures scopes on suppressed spans so startActiveSpan can fork the isolation scope', () => {
+    withIsolationScope(isolationScope => {
+      const suppressedContext = suppressTracing(context.active());
+      const span = trace.getTracer('test').startSpan('child', {}, suppressedContext);
+
+      // Without captured scopes, startActiveSpan cannot fork the isolation scope onto the context.
+      expect(getCapturedScopesOnSpan(span as unknown as Span).isolationScope).toBe(isolationScope);
+    });
+  });
+
+  it('sets active OpenTelemetry spans on the Sentry scope', () => {
+    trace.getTracer('test').startActiveSpan('parent', parent => {
+      expect(getActiveSpan()).toBe(parent);
+    });
+  });
+
+  it('syncs manual OpenTelemetry context switches onto the Sentry scope', () => {
+    const tracer = trace.getTracer('test');
+
+    tracer.startActiveSpan('parent', parent => {
+      const child = tracer.startSpan('child');
+      const childContext = trace.setSpan(context.active(), child);
+
+      context.with(childContext, () => {
+        expect(getActiveSpan()).toBe(child);
+      });
+
+      expect(getActiveSpan()).toBe(parent);
+
+      child.end();
+      parent.end();
+    });
+  });
+
+  it('parents core spans to the active OpenTelemetry span', () => {
+    trace.getTracer('test').startActiveSpan('parent', parent => {
+      startSpanManual({ name: 'child' }, child => {
+        expect(spanToJSON(child).parent_span_id).toBe(parent.spanContext().spanId);
+        child.end();
+      });
+    });
+  });
+
+  it('continues remote OpenTelemetry span contexts as root Sentry spans', () => {
+    const remoteContext = trace.setSpanContext(context.active(), {
+      traceId: '12312012123120121231201212312012',
+      spanId: '1121201211212012',
+      isRemote: true,
+      traceFlags: TraceFlags.SAMPLED,
+    });
+
+    const span = trace.getTracer('test').startSpan('server', { kind: SpanKind.SERVER }, remoteContext);
+    const json = spanToJSON(span as Span);
+
+    expect(json.trace_id).toBe('12312012123120121231201212312012');
+    expect(json.parent_span_id).toBe('1121201211212012');
+    expect(json.data?.['otel.kind']).toBe('SERVER');
+  });
+
+  it('finalizes span statuses like the OpenTelemetry exporter', () => {
+    const okSpan = trace.getTracer('test').startSpan('ok');
+    applyOtelSpanData(okSpan as Span, { finalizeStatus: true });
+    expect(spanToJSON(okSpan as Span).status).toBe('ok');
+
+    const httpErrorSpan = trace.getTracer('test').startSpan('http-error');
+    httpErrorSpan.setAttribute('http.response.status_code', 500);
+    applyOtelSpanData(httpErrorSpan as Span, { finalizeStatus: true });
+    expect(spanToJSON(httpErrorSpan as Span).status).toBe('internal_error');
+
+    const legacyHttpErrorSpan = trace.getTracer('test').startSpan('legacy-http-error');
+    legacyHttpErrorSpan.setAttribute('http.status_code', 500);
+    applyOtelSpanData(legacyHttpErrorSpan as Span, { finalizeStatus: true });
+    expect(spanToJSON(legacyHttpErrorSpan as Span).status).toBe('internal_error');
+    expect(spanToJSON(legacyHttpErrorSpan as Span).data).toMatchObject({
+      'http.response.status_code': 500,
+      'http.status_code': 500,
+    });
+
+    const customErrorSpan = trace.getTracer('test').startSpan('custom-error');
+    customErrorSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'This is a custom error' });
+    applyOtelSpanData(customErrorSpan as Span, { finalizeStatus: true });
+    expect(spanToJSON(customErrorSpan as Span).status).toBe('internal_error');
+  });
+
+  it('preserves an explicit OK status when finalizing', () => {
+    const span = trace.getTracer('test').startSpan('explicit-ok');
+    span.setStatus({ code: SPAN_STATUS_OK });
+
+    applyOtelSpanData(span as Span, { finalizeStatus: true });
+
+    expect(spanToJSON(span as Span).status).toBe('ok');
+  });
+
+  it('keeps default custom source on provider-created spans', () => {
+    const span = trace.getTracer('test').startSpan('custom-source');
+    span.setAttribute('sentry.source', 'custom');
+
+    applyOtelSpanData(span as Span, { finalizeStatus: true });
+
+    expect(spanToJSON(span as Span).data?.['sentry.source']).toBe('custom');
+  });
+
+  it('infers route source, op, and name for HTTP server spans', () => {
+    const span = trace.getTracer('test').startSpan('GET', {
+      kind: SpanKind.SERVER,
+      attributes: {
+        'http.method': 'GET',
+        'http.route': '/my-path/:id',
+      },
+    });
+
+    const json = spanToJSON(span as Span);
+    expect(json.op).toBe('http.server');
+    expect(json.data?.['sentry.source']).toBe('route');
+    expect(json.description).toBe('GET /my-path/:id');
+  });
+
+  it('defers url source to span end, keeping custom for the DSC at creation', () => {
+    const span = trace.getTracer('test').startSpan('POST', {
+      kind: SpanKind.SERVER,
+      attributes: {
+        'http.method': 'POST',
+        'http.url': 'https://www.example.com/my-path',
+        'http.target': '/my-path',
+      },
+    });
+
+    // At creation op and name are inferred, but the `url` source is intentionally
+    // deferred so the default `custom` source survives for the DSC transaction name
+    // (http.route is often not available yet at this point).
+    const atCreation = spanToJSON(span as Span);
+    expect(atCreation.op).toBe('http.server');
+    expect(atCreation.description).toBe('POST /my-path');
+    expect(atCreation.data?.['sentry.source']).toBe('custom');
+
+    // At span end the inferred `url` source is applied.
+    applyOtelSpanData(span as Span, { finalizeStatus: true });
+    expect(spanToJSON(span as Span).data?.['sentry.source']).toBe('url');
+  });
+});

--- a/packages/opentelemetry/test/tracerProvider.test.ts
+++ b/packages/opentelemetry/test/tracerProvider.test.ts
@@ -192,6 +192,19 @@ describe('SentryTracerProvider', () => {
     expect(spanToJSON(span as Span).data?.['sentry.source']).toBe('custom');
   });
 
+  it('preserves a non-canonical error status message under span streaming', () => {
+    // Under streaming the streamed serializer surfaces the raw message as `sentry.status.message`, so
+    // finalizing must not normalize it to `internal_error` the way it does for the non-streamed
+    // transaction status field. Without streaming, `finalizes span statuses` covers the `internal_error` case.
+    initTestClient({ tracesSampleRate: 1, traceLifecycle: 'stream' });
+    const span = trace.getTracer('test').startSpan('db-error');
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: 'Cannot enqueue Query after fatal error.' });
+
+    applyOtelSpanData(span as Span, { finalizeStatus: true });
+
+    expect(spanToJSON(span as Span).status).toBe('Cannot enqueue Query after fatal error.');
+  });
+
   it('infers route source, op, and name for HTTP server spans', () => {
     const span = trace.getTracer('test').startSpan('GET', {
       kind: SpanKind.SERVER,

--- a/packages/opentelemetry/test/utils/setupCheck.test.ts
+++ b/packages/opentelemetry/test/utils/setupCheck.test.ts
@@ -2,7 +2,8 @@ import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SentrySampler } from '../../src/sampler';
 import { SentrySpanProcessor } from '../../src/spanProcessor';
-import { openTelemetrySetupCheck } from '../../src/utils/setupCheck';
+import { SentryTracerProvider } from '../../src/tracerProvider';
+import { openTelemetrySetupCheck, setIsSetup } from '../../src/utils/setupCheck';
 import { setupOtel } from '../helpers/initOtel';
 import { cleanupOtel } from '../helpers/mockSdkInit';
 import { getDefaultTestClientOptions, TestClient } from '../helpers/TestClient';
@@ -40,5 +41,21 @@ describe('openTelemetrySetupCheck', () => {
 
     const setup = openTelemetrySetupCheck();
     expect(setup).toEqual(['SentrySampler', 'SentrySpanProcessor']);
+  });
+
+  it('does not mark SentryTracerProvider as set up on construction', () => {
+    // Construction must not mark setup — that only happens once the provider is
+    // successfully registered as the global tracer provider. Otherwise setup
+    // validation would skip required checks even when registration failed.
+    new SentryTracerProvider();
+
+    expect(openTelemetrySetupCheck()).toEqual([]);
+  });
+
+  it('returns SentryTracerProvider setup once it is marked as set up', () => {
+    setIsSetup('SentryTracerProvider');
+
+    const setup = openTelemetrySetupCheck();
+    expect(setup).toEqual(['SentryTracerProvider']);
   });
 });


### PR DESCRIPTION
Add a minimal OpenTelemetry `TracerProvider` that creates native Sentry spans instead of bridging through the full OTel SDK.

Hooking up the tracer provider and e2e tests are in https://github.com/getsentry/sentry-javascript/pull/21680