### PR TITLE
fix(server-utils): Remove optional `vite` peer dependency

### DIFF
--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -93,14 +93,6 @@
     "@types/node": "^18.19.1",
     "vite": "^6.4.3"
   },
-  "peerDependencies": {
-    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
-  },
-  "peerDependenciesMeta": {
-    "vite": {
-      "optional": true
-    }
-  },
   "scripts": {
     "build": "run-p build:transpile build:types",
     "build:dev": "yarn build",


### PR DESCRIPTION
Remove the (for now unused) `vite` optional peer dep. Since we never actually import from vite, this rather served documentational purposes. As it turns out, it also causes dependency duplication as reported in #21669. So I'd vote to remove this for now. No strong opinions though. We can also just widen the peer dep range to `>=3.0.0` if vite 7 and 8 are supported.

closes #21669 