### PR TITLE
feat(cloudflare): Export `init` from the SDK

### DIFF
--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -121,7 +121,7 @@ export { sentryPagesPlugin } from './pages-plugin';
 export { wrapRequestHandler } from './request';
 
 export { CloudflareClient } from './client';
-export { getDefaultIntegrations } from './sdk';
+export { getDefaultIntegrations, init } from './sdk';
 
 export { httpServerIntegration } from './integrations/httpServer';
 export { fetchIntegration } from './integrations/fetch';


### PR DESCRIPTION
## Summary

`init` is defined in [`packages/cloudflare/src/sdk.ts`](https://github.com/getsentry/sentry-javascript/blob/develop/packages/cloudflare/src/sdk.ts) but is not re-exported from the package entry point (`packages/cloudflare/src/index.ts`), unlike every other Sentry SDK package. As a result, `import { init } from '@sentry/cloudflare'` / `Sentry.init()` is unavailable to consumers even though the implementation exists.

This re-exports `init` alongside the already-exported `getDefaultIntegrations` from `./sdk`.

We've been carrying this as a local patch and would prefer to have it upstream.