### PR TITLE
chore: Cleanup unused imports of `@opentelemetry/core`

### DIFF
--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/instrumentation": "^0.214.0",
     "@sentry/conventions": "^0.12.0",
     "@sentry/core": "10.59.0",

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/instrumentation": "^0.214.0",
     "@sentry/browser": "10.59.0",
     "@sentry/cli": "^2.58.6",

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -45,7 +45,6 @@
   },
   "devDependencies": {
     "@edge-runtime/types": "4.0.0",
-    "@opentelemetry/core": "^2.6.1",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sentry/opentelemetry": "10.59.0"


### PR DESCRIPTION
These are not in direct use.