### PR TITLE
test(node): Update mysql tests for better coverage and correctness

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/mysql/mysql-test-server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/mysql-test-server.ts
@@ -1,0 +1,87 @@
+/* eslint-disable no-bitwise */
+
+// A tiny, dependency-free MySQL server that speaks just enough of the v10 wire
+// protocol for the `mysql` client to connect and run queries. It completes the
+// handshake (so `pool.getConnection()` resolves and reaches `connection.query`)
+// and replies to every command with a success OK packet (the client treats it
+// as a 0-row result, even for `SELECT`). This gives pool queries a real,
+// successful connection to instrument — no docker / real database required.
+import net from 'node:net';
+
+// MySQL capability flags (only the ones the client checks here).
+const CLIENT_PROTOCOL_41 = 0x00000200;
+const CLIENT_SECURE_CONNECTION = 0x00008000;
+const CLIENT_PLUGIN_AUTH = 0x00080000;
+const SERVER_CAPABILITIES = CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_PLUGIN_AUTH;
+
+/** Wrap a payload in a MySQL packet: 3-byte little-endian length + 1-byte sequence id. */
+function packet(seq: number, payload: Buffer): Buffer {
+  const header = Buffer.alloc(4);
+  header.writeUIntLE(payload.length, 0, 3);
+  header.writeUInt8(seq, 3);
+  return Buffer.concat([header, payload]);
+}
+
+function initialHandshake() {
+  const scramble = Buffer.alloc(20, 1); // 20-byte auth-plugin-data (value is irrelevant — we never verify)
+  const parts = [
+    Buffer.from([0x0a]), // protocol version 10
+    Buffer.from('8.0.0-sentry-test\0', 'latin1'), // server version (NUL-terminated)
+    Buffer.from([1, 0, 0, 0]), // connection id
+    scramble.subarray(0, 8), // auth-plugin-data-part-1
+    Buffer.from([0x00]), // filler
+    Buffer.from([SERVER_CAPABILITIES & 0xff, (SERVER_CAPABILITIES >> 8) & 0xff]), // capability flags (lower)
+    Buffer.from([0x21]), // charset (utf8_general_ci)
+    Buffer.from([0x02, 0x00]), // status flags
+    Buffer.from([(SERVER_CAPABILITIES >> 16) & 0xff, (SERVER_CAPABILITIES >> 24) & 0xff]), // capability flags (upper)
+    Buffer.from([21]), // length of auth-plugin-data
+    Buffer.alloc(10, 0), // reserved
+    Buffer.concat([scramble.subarray(8), Buffer.from([0x00])]), // auth-plugin-data-part-2 (+ NUL)
+    Buffer.from('mysql_native_password\0', 'latin1'),
+  ];
+  return Buffer.concat(parts);
+}
+
+function okPacket(): Buffer {
+  // OK header, 0 affected rows, 0 insert id, status flags, 0 warnings. The client accepts this for any
+  // command — including a `SELECT` (treated as a successful 0-row result) — so spans get `status: ok`.
+  return Buffer.from([0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]);
+}
+
+function errPacket(): Buffer {
+  // ERR for queries that should fail: code 1146 (ER_NO_SUCH_TABLE), SQL state "42S02". The client
+  // surfaces this as a query error, so the span gets `status: internal_error`.
+  const head = Buffer.from([0xff, 0x7a, 0x04]); // 0xff + error code 1146 (LE)
+  const state = Buffer.from('#42S02', 'latin1');
+  const msg = Buffer.from("Table 'does_not_exist' doesn't exist", 'latin1');
+  return Buffer.concat([head, state, msg]);
+}
+
+/** Start the server on the given host/port. Returns the `net.Server` (call `.close()` to stop). */
+export function startMysqlTestServer({ host = '127.0.0.1', port = 0 } = {}) {
+  const server = net.createServer(socket => {
+    socket.on('error', () => {}); // ignore abrupt client disconnects
+    socket.write(packet(0, initialHandshake()));
+
+    let sawHandshakeResponse = false;
+    socket.on('data', (data: Buffer) => {
+      if (!sawHandshakeResponse) {
+        // First inbound packet is the client's handshake response → accept auth.
+        sawHandshakeResponse = true;
+        socket.write(packet(2, okPacket()));
+        return;
+      }
+      // Subsequent command packet: [3-byte len][1-byte seq][1-byte command][payload]. For COM_QUERY
+      // (0x03) the payload is the SQL text. Queries referencing the conventional missing table fail
+      // (so error-path tests work); every other command succeeds with an OK. The command resets the
+      // sequence, so our reply is seq 1.
+      const isQuery = data.length > 5 && data[4] === 0x03;
+      const sql = isQuery ? data.subarray(5).toString('latin1') : '';
+      socket.write(packet(1, sql.includes('does_not_exist') ? errPacket() : okPacket()));
+    });
+  });
+  // Never let a listen error crash the test process.
+  server.on('error', () => {});
+  server.listen(port, host);
+  return server;
+}

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/mysql-test-server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/mysql-test-server.ts
@@ -64,20 +64,38 @@ export function startMysqlTestServer({ host = '127.0.0.1', port = 0 } = {}) {
     socket.write(packet(0, initialHandshake()));
 
     let sawHandshakeResponse = false;
-    socket.on('data', (data: Buffer) => {
-      if (!sawHandshakeResponse) {
-        // First inbound packet is the client's handshake response → accept auth.
-        sawHandshakeResponse = true;
-        socket.write(packet(2, okPacket()));
-        return;
+    let buffered = Buffer.alloc(0);
+    socket.on('data', (chunk: Buffer) => {
+      // TCP may coalesce several packets into one `data` event or split one packet across events, so
+      // we can't assume one packet per read. Accumulate bytes and frame on the 3-byte length header,
+      // consuming only whole packets — otherwise a coalesced handshake-response + COM_QUERY would lose
+      // its tail and the client would hang.
+      buffered = buffered.length ? Buffer.concat([buffered, chunk]) : chunk;
+
+      while (buffered.length >= 4) {
+        // Packet: [3-byte LE payload length][1-byte seq][payload].
+        const payloadLength = buffered.readUIntLE(0, 3);
+        const packetLength = 4 + payloadLength;
+        if (buffered.length < packetLength) {
+          break; // rest of this packet hasn't arrived yet
+        }
+        const pkt = buffered.subarray(0, packetLength);
+        buffered = buffered.subarray(packetLength);
+
+        if (!sawHandshakeResponse) {
+          // First inbound packet is the client's handshake response → accept auth.
+          sawHandshakeResponse = true;
+          socket.write(packet(2, okPacket()));
+          continue;
+        }
+
+        // Command packet: payload is [1-byte command][args]. For COM_QUERY (0x03) the args are the SQL
+        // text. Queries referencing the conventional missing table fail (so error-path tests work);
+        // every other command succeeds with an OK. The command resets the sequence, so our reply is seq 1.
+        const isQuery = payloadLength > 1 && pkt[4] === 0x03;
+        const sql = isQuery ? pkt.subarray(5).toString('latin1') : '';
+        socket.write(packet(1, sql.includes('does_not_exist') ? errPacket() : okPacket()));
       }
-      // Subsequent command packet: [3-byte len][1-byte seq][1-byte command][payload]. For COM_QUERY
-      // (0x03) the payload is the SQL text. Queries referencing the conventional missing table fail
-      // (so error-path tests work); every other command succeeds with an OK. The command resets the
-      // sequence, so our reply is seq 1.
-      const isQuery = data.length > 5 && data[4] === 0x03;
-      const sql = isQuery ? data.subarray(5).toString('latin1') : '';
-      socket.write(packet(1, sql.includes('does_not_exist') ? errPacket() : okPacket()));
     });
   });
   // Never let a listen error crash the test process.

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/mysql-test-server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/mysql-test-server.ts
@@ -57,8 +57,15 @@ function errPacket(): Buffer {
   return Buffer.concat([head, state, msg]);
 }
 
-/** Start the server on the given host/port. Returns the `net.Server` (call `.close()` to stop). */
-export function startMysqlTestServer({ host = '127.0.0.1', port = 0 } = {}) {
+/**
+ * Start the server on the given host/port. Returns the `net.Server` (call `.close()` to stop).
+ *
+ * `host` defaults to `undefined` so the server listens on all interfaces (dual-stack). The `mysql`
+ * client connects to `localhost`, which resolves to IPv6 `::1` first — binding only to IPv4
+ * `127.0.0.1` would get `ECONNREFUSED ::1` on Node 18 (where `autoSelectFamily` is off, so it never
+ * falls back to IPv4 the way Node 20+ does).
+ */
+export function startMysqlTestServer({ host, port = 0 }: { host?: string; port?: number } = {}) {
   const server = net.createServer(socket => {
     socket.on('error', () => {}); // ignore abrupt client disconnects
     socket.write(packet(0, initialHandshake()));

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamContext.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamContext.mjs
@@ -31,11 +31,12 @@ Sentry.startSpanManual(
           // noop
         });
 
+        // Wait to ensure the query span has been finished
         setTimeout(() => {
           innerSpan.end();
           span.end();
           connection.end();
-        }, 500);
+        }, 1);
       });
     });
   },

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamContext.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamContext.mjs
@@ -23,6 +23,8 @@ Sentry.startSpanManual(
 
     // This should _not_ be the parent of the listener-child!
     Sentry.startSpanManual({ name: 'inner-span' }, innerSpan => {
+      // The instrumentation registers its own `end` listener (which finishes the query span) when
+      // `query()` is called, before this one — so by the time we run here, the query span is finished.
       query.on('end', () => {
         // A span started from inside a stream listener should be a child of the parent context that was
         // active when the query was issued (the transaction here), not of the query span itself. This
@@ -31,12 +33,9 @@ Sentry.startSpanManual(
           // noop
         });
 
-        // Wait to ensure the query span has been finished
-        setTimeout(() => {
-          innerSpan.end();
-          span.end();
-          connection.end();
-        }, 1);
+        innerSpan.end();
+        span.end();
+        connection.end();
       });
     });
   },

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamContext.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamContext.mjs
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/node';
+import mysql from 'mysql';
+
+const connection = mysql.createConnection({
+  port: Number(process.env.MYSQL_PORT),
+  user: 'root',
+  password: 'docker',
+});
+
+connection.connect(function (err) {
+  if (err) {
+    return;
+  }
+});
+
+Sentry.startSpanManual(
+  {
+    op: 'transaction',
+    name: 'Test Transaction',
+  },
+  span => {
+    const query = connection.query('SELECT 1 + 1 AS solution');
+
+    // This should _not_ be the parent of the listener-child!
+    Sentry.startSpanManual({ name: 'inner-span' }, innerSpan => {
+      query.on('end', () => {
+        // A span started from inside a stream listener should be a child of the parent context that was
+        // active when the query was issued (the transaction here), not of the query span itself. This
+        // verifies the instrumentation re-binds the streamed query's events to the parent context.
+        Sentry.startSpan({ name: 'listener-child' }, () => {
+          // noop
+        });
+
+        setTimeout(() => {
+          innerSpan.end();
+          span.end();
+          connection.end();
+        }, 500);
+      });
+    });
+  },
+);

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamError.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamError.mjs
@@ -29,11 +29,8 @@ Sentry.startSpanManual(
     });
 
     query.on('end', () => {
-      // Wait a bit to ensure the query span has been finished
-      setTimeout(() => {
-        span.end();
-        connection.end();
-      }, 1);
+      span.end();
+      connection.end();
     });
   },
 );

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamError.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamError.mjs
@@ -33,7 +33,7 @@ Sentry.startSpanManual(
       setTimeout(() => {
         span.end();
         connection.end();
-      }, 500);
+      }, 1);
     });
   },
 );

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamError.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-streamError.mjs
@@ -1,0 +1,39 @@
+import * as Sentry from '@sentry/node';
+import mysql from 'mysql';
+
+const connection = mysql.createConnection({
+  port: Number(process.env.MYSQL_PORT),
+  user: 'root',
+  password: 'docker',
+});
+
+connection.connect(function (err) {
+  if (err) {
+    return;
+  }
+});
+
+Sentry.startSpanManual(
+  {
+    op: 'transaction',
+    name: 'Test Transaction',
+  },
+  span => {
+    // Query without a callback returns a streamable `Query`. A failing query emits an `error` event
+    // (which sets the span status) followed by `end` (which ends the span).
+    const query = connection.query('SELECT * FROM does_not_exist');
+
+    // Swallow the error so it doesn't crash the process
+    query.on('error', () => {
+      // noop
+    });
+
+    query.on('end', () => {
+      // Wait a bit to ensure the query span has been finished
+      setTimeout(() => {
+        span.end();
+        connection.end();
+      }, 500);
+    });
+  },
+);

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withConnect.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withConnect.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import mysql from 'mysql';
 
 const connection = mysql.createConnection({
+  port: Number(process.env.MYSQL_PORT),
   user: 'root',
   password: 'docker',
 });

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withPool.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withPool.mjs
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/node';
 import mysql from 'mysql';
 
-const connection = mysql.createConnection({
+const pool = mysql.createPool({
   port: Number(process.env.MYSQL_PORT),
   user: 'root',
   password: 'docker',
@@ -13,10 +13,10 @@ Sentry.startSpanManual(
     name: 'Test Transaction',
   },
   span => {
-    connection.query('SELECT 1 + 1 AS solution', function () {
-      connection.query('SELECT NOW()', ['1', '2'], () => {
+    pool.query('SELECT 1 + 1 AS solution', function () {
+      pool.query('SELECT NOW()', ['1', '2'], () => {
         span.end();
-        connection.end();
+        pool.end();
       });
     });
   },

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withoutCallback.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withoutCallback.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import mysql from 'mysql';
 
 const connection = mysql.createConnection({
+  port: Number(process.env.MYSQL_PORT),
   user: 'root',
   password: 'docker',
 });

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withoutCallback.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withoutCallback.mjs
@@ -24,10 +24,7 @@ Sentry.startSpanManual(
 
     query.on('end', () => {
       query2.on('end', () => {
-        // Wait a bit to ensure the queries completed
-        setTimeout(() => {
-          span.end();
-        }, 1);
+        span.end();
       });
     });
   },

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withoutCallback.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/scenario-withoutCallback.mjs
@@ -27,7 +27,7 @@ Sentry.startSpanManual(
         // Wait a bit to ensure the queries completed
         setTimeout(() => {
           span.end();
-        }, 500);
+        }, 1);
       });
     });
   },

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/test.ts
@@ -137,6 +137,42 @@ describe('mysql auto instrumentation', () => {
           { failsOnEsm },
         );
       }
+
+      createEsmAndCjsTests(
+        __dirname,
+        'scenario-streamContext.mjs',
+        instrument,
+        (createTestRunner, test) => {
+          test('should run streamed query listeners with the parent context active', async () => {
+            await createTestRunner()
+              .withFlags(...flags)
+              .withEnv({ MYSQL_PORT: String(mysqlPort) })
+              .expect({
+                transaction: (transaction): void => {
+                  const transactionSpanId = transaction.contexts?.trace?.span_id;
+                  const spans = transaction.spans ?? [];
+                  const mysqlSpan = spans.find(span => span.description === 'SELECT 1 + 1 AS solution');
+                  const listenerSpan = spans.find(span => span.description === 'listener-child');
+                  const innerSpan = spans.find(span => span.description === 'inner-span');
+
+                  expect(transactionSpanId).toBeDefined();
+                  expect(mysqlSpan).toBeDefined();
+                  expect(listenerSpan).toBeDefined();
+                  expect(innerSpan).toBeDefined();
+
+                  // The span created inside the stream `end` listener is parented to the transaction
+                  // (the context active when the query was issued), not to the query span.
+                  expect(listenerSpan?.parent_span_id).toBe(transactionSpanId);
+                  expect(listenerSpan?.parent_span_id).not.toBe(mysqlSpan?.span_id);
+                  expect(innerSpan?.parent_span_id).toBe(transactionSpanId);
+                },
+              })
+              .start()
+              .completed();
+          });
+        },
+        { failsOnEsm },
+      );
     });
   }
 });

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/test.ts
@@ -1,15 +1,39 @@
-import { afterAll, describe, expect } from 'vitest';
+import type { AddressInfo, Server } from 'node:net';
+import { afterAll, beforeAll, describe, expect } from 'vitest';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+import { startMysqlTestServer } from './mysql-test-server';
 
 describe('mysql auto instrumentation', () => {
+  // A minimal in-process MySQL server (on a random free port) so the client's
+  // connection handshake succeeds. Without it, `createPool()` queries fail at
+  // connection acquisition — before `connection.query` runs — so the
+  // diagnostics-channel instrumentation (which hooks `connection.query`) never
+  // sees them. Queries still error (the server rejects them), so spans keep
+  // `status: internal_error` as the assertions expect. The port is passed to
+  // each scenario via the `MYSQL_PORT` env var.
+  let mysqlServer: Server;
+  let mysqlPort: number;
+  beforeAll(async () => {
+    mysqlServer = startMysqlTestServer();
+    await new Promise<void>(resolve => mysqlServer.once('listening', () => resolve()));
+    mysqlPort = (mysqlServer.address() as AddressInfo).port;
+  });
+
   afterAll(() => {
+    mysqlServer?.close();
     cleanupChildProcesses();
   });
 
   // Builds the expected transaction. When `origin` is given, the spans must also
   // carry that `sentry.origin`, which is how we assert that the
-  // diagnostics-channel instrumentation (not the OTel one) produced them.
-  function expectedTransaction(origin?: string): Record<string, unknown> {
+  // diagnostics-channel instrumentation (not the OTel one) produced them. A
+  // scenario can pass `override` to replace the default transaction expectation
+  // (e.g. the streamed-error scenario, which runs a different, failing query).
+  function expectedTransaction(
+    port: number,
+    origin: string | undefined,
+    override: Record<string, unknown> | undefined,
+  ): Record<string, unknown> {
     const span = (description: string): ReturnType<typeof expect.objectContaining> =>
       expect.objectContaining({
         description,
@@ -18,16 +42,16 @@ describe('mysql auto instrumentation', () => {
         data: expect.objectContaining({
           'db.system': 'mysql',
           'net.peer.name': 'localhost',
-          'net.peer.port': 3306,
+          'net.peer.port': port,
           'db.user': 'root',
         }),
-        // all db spans have an error status because we don't have an actual mysql DB server running for these tests
-        status: 'internal_error',
+        status: 'ok',
       });
 
     return {
       transaction: 'Test Transaction',
       spans: expect.arrayContaining([span('SELECT 1 + 1 AS solution'), span('SELECT NOW()')]),
+      ...(override ?? {}),
     };
   }
 
@@ -71,13 +95,31 @@ describe('mysql auto instrumentation', () => {
     ['scenario-withConnect.mjs', 'using connection.connect()'],
     ['scenario-withoutCallback.mjs', 'using query without callback'],
     ['scenario-withoutConnect.mjs', 'without connection.connect()'],
+    ['scenario-withPool.mjs', 'using createPool()'],
+    [
+      'scenario-streamError.mjs',
+      'streamed query error',
+      {
+        // The transaction itself succeeds (status `ok`); only the failing query's child span is errored.
+        spans: expect.arrayContaining([
+          expect.objectContaining({
+            description: 'SELECT * FROM does_not_exist',
+            op: 'db',
+            // A failing streamed query emits `error`, which marks the span as errored
+            status: 'internal_error',
+            data: expect.objectContaining({
+              'db.system': 'mysql',
+              'db.user': 'root',
+            }),
+          }),
+        ]),
+      },
+    ],
   ] as const;
 
   for (const { label, instrument, flags, origin, failsOnEsm } of CASES) {
     describe(label, () => {
-      const expected = expectedTransaction(origin);
-
-      for (const [scenario, description] of SCENARIOS) {
+      for (const [scenario, description, transactionOverride] of SCENARIOS) {
         createEsmAndCjsTests(
           __dirname,
           scenario,
@@ -85,8 +127,9 @@ describe('mysql auto instrumentation', () => {
           (createRunner, test) => {
             test(`should auto-instrument \`mysql\` package when ${description}`, async () => {
               await createRunner()
+                .withEnv({ MYSQL_PORT: String(mysqlPort) })
                 .withFlags(...flags)
-                .expect({ transaction: expected })
+                .expect({ transaction: expectedTransaction(mysqlPort, origin, transactionOverride) })
                 .start()
                 .completed();
             });

--- a/packages/server-utils/src/integrations/tracing-channel/mysql.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/mysql.ts
@@ -40,13 +40,10 @@ const ATTR_NET_PEER_PORT = 'net.peer.port';
  * `context` object. Documented here rather than imported because orchestrion's
  * runtime doesn't export it — see `node_modules/@apm-js-collab/code-transformer/lib/transforms.js`.
  *
- * `arguments` is the *live* args array the wrapper passes to the wrapped function:
- * orchestrion splices the user's callback out and inserts its own wrapper at
- * the same index before publishing `start`. We mutate that last entry again in
- * our `start` hook so the callback (and any nested `connection.query(...)`)
- * runs inside `withActiveSpan(parent, …)` — mysql v2 loses ALS state when it
- * dispatches callbacks from its socket handler, which would otherwise cause
- * nested queries to begin a fresh root trace.
+ * `arguments` is the *live* args array passed to the wrapped function: orchestrion
+ * splices the user's callback out and inserts its own wrapper at the same index
+ * before publishing `start`. The `start` hook re-wraps that entry to restore the
+ * caller's scope across mysql's async callback dispatch (see below).
  */
 interface MysqlQueryChannelContext {
   arguments: unknown[];
@@ -76,16 +73,12 @@ const _mysqlChannelIntegration = (() => {
       DEBUG_BUILD && debug.log(`[orchestrion:mysql] subscribing to channel "${CHANNELS.MYSQL_QUERY}"`);
       const queryCh = diagnosticsChannel.tracingChannel(CHANNELS.MYSQL_QUERY);
 
-      // Each `context` object is shared across start/end/asyncStart/asyncEnd/error
-      // for one call (orchestrion creates one per invocation). We key the span
-      // off the same identity. WeakMap so we don't leak if a path never reaches
-      // asyncEnd for some reason.
+      // Orchestrion creates one `context` object per call, shared across all
+      // lifecycle hooks. We key both maps off that identity; `WeakMap` so an
+      // unfinished path can't leak its entries.
       const spans = new WeakMap<object, Span>();
-
-      // The scope active when the query was issued, keyed by the same per-call
-      // `context` object. The streamable no-callback path needs it in `end`
-      // (where `ctx.result` first becomes available) to bind the returned
-      // `Query` emitter's listeners to it — see the `end` hook.
+      // The scope active when the query was issued, consumed in `end` to bind
+      // the streamed `Query` emitter's listeners to it.
       const parentScopes = new WeakMap<object, Scope>();
 
       // `subscribe()` requires all five lifecycle hooks. The orchestrion
@@ -101,18 +94,10 @@ const _mysqlChannelIntegration = (() => {
       //                                            (ctx.result is the Query
       //                                            emitter, no async events)
       //
-      // We end the span on `asyncEnd` for the two callback paths (so the span
-      // covers the full network round-trip + callback duration). For the
-      // sync-throw path, `end` finishes the span because `ctx.error` is set
-      // there. For the streamable no-callback path, `end` finishes by
-      // attaching `'end'`/`'error'` listeners to `ctx.result` (the returned
-      // `Query` emitter).
-      //
-      // The discriminator between "end fired before any error" and "end fired
-      // after a sync throw" is whether `ctx.error` is set when `end` runs —
-      // orchestrion populates it before publishing `error`. The discriminator
-      // between callback and no-callback is whether `ctx.result` is set — only
-      // the `wrapPromise` (no-callback) path stores it.
+      // Where the span closes depends on the path: `asyncEnd` for callbacks (so
+      // it spans the full round-trip + callback), or `end` for the sync-throw
+      // and streamable paths. The `end` hook tells those apart via `ctx.error`
+      // / `ctx.result` — see there.
       queryCh.subscribe({
         start(rawCtx) {
           const ctx = rawCtx as MysqlQueryChannelContext;
@@ -137,25 +122,19 @@ const _mysqlChannelIntegration = (() => {
           });
           spans.set(rawCtx, span);
 
-          // Restore the Sentry/OTel context across mysql's internal callback
-          // dispatch. The orchestrion transform has already spliced the user's
-          // callback out of `ctx.arguments` and put its own wrapper
-          // (`__apm$wrappedCb`) at the same index. mysql v2 drains callbacks
-          // from a socket data handler — by the time the response arrives, the
-          // AsyncLocalStorage store backing `getActiveSpan()` no longer
-          // reflects the caller's context. We re-wrap orchestrion's wrapper so
-          // the user's callback (and any nested `connection.query(...)` inside
-          // it) runs with the parent span active again.
-          //
-          // This must happen at `start` (we're synchronously inside the
-          // caller's `connection.query` call, so OTel context is still
-          // correct). `asyncStart`/`asyncEnd` fire from the same lost context
-          // as the callback itself, so they're too late.
+          // Capture the scope while we're still synchronously inside the
+          // caller's `connection.query` call. mysql v2 drains callbacks and
+          // emits streamed-query events from its socket data handler, where the
+          // AsyncLocalStorage store backing the active span no longer reflects
+          // the caller's context — and `asyncStart`/`asyncEnd` fire from that
+          // same lost context, so capturing has to happen now.
           const scope = getCurrentScope();
-
-          // Keep track of the scope that was active when the query was issued.
           parentScopes.set(rawCtx, scope);
 
+          // Callback path: orchestrion has spliced the user's callback out of
+          // `ctx.arguments` and put its own wrapper (`__apm$wrappedCb`) at the
+          // same index. Re-wrap it so the callback — and any nested
+          // `connection.query(...)` — runs with the captured scope active.
           if (ctx.arguments.length > 0) {
             const cbIdx = ctx.arguments.length - 1;
             const orchestrionWrappedCb = ctx.arguments[cbIdx];
@@ -184,27 +163,22 @@ const _mysqlChannelIntegration = (() => {
           // fires `asyncStart`/`asyncEnd`. The returned `Query` is an
           // `EventEmitter` that emits `'end'` on success and `'error'` on
           // failure — hook those to close the span.
-          // TODO: streaming spans aren't finished on `connection.destroy()` —
-          // mysql guarantees no further events/callbacks for a destroyed
-          // connection, so neither `'end'` nor `'error'` fires and the span
-          // never ends (it's dropped, never reported). Closing this gap needs
-          // connection-level lifecycle hooks, which the per-query channel
-          // context doesn't expose here. The `WeakMap` still prevents a leak.
+          // Note: a streamed span never finishes if the connection is destroyed
+          // mid-flight — mysql then emits neither `'end'` nor `'error'`, so the
+          // span is dropped (the `WeakMap` still prevents a leak). Closing this
+          // needs connection-level hooks the per-query context doesn't expose.
           const result = ctx.result;
           if (result && typeof result === 'object' && hasOnMethod(result)) {
             const span = spans.get(rawCtx);
             if (!span) return;
 
-            // Bind the streamed `Query`'s listeners to the scope that was active
-            // when the query was issued. mysql v2 emits `'end'`/`'error'`/
-            // `'fields'`/… from its socket data handler, where the
-            // AsyncLocalStorage store backing `getActiveSpan()` no longer
-            // reflects the caller's context. Without this, a span started inside
-            // a user's stream listener would begin a fresh root trace instead of
-            // nesting under the active parent. `bindScopeToEmitter` patches the
-            // emitter's `on`/`addListener`/… so listeners the user adds after
-            // `query()` returns inherit the scope — mirroring what
-            // `@opentelemetry/instrumentation-mysql` does via `context.bind`.
+            // Bind the captured scope to the streamed `Query` emitter: its
+            // `'end'`/`'error'`/`'fields'`/… events fire from mysql's socket
+            // handler with the caller's context lost, so without this a span
+            // started in a user's stream listener would begin a fresh root trace
+            // instead of nesting under the parent. `bindScopeToEmitter` patches
+            // `on`/`addListener`/… so listeners added after `query()` returns
+            // inherit the scope (like OTel's `context.bind`).
             const parentScope = parentScopes.get(rawCtx);
             if (parentScope) {
               bindScopeToEmitter(result, parentScope);

--- a/packages/server-utils/src/integrations/tracing-channel/mysql.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/mysql.ts
@@ -1,13 +1,14 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
-import type { IntegrationFn, Span } from '@sentry/core';
+import type { IntegrationFn, Scope, Span } from '@sentry/core';
 import {
+  bindScopeToEmitter,
   debug,
   defineIntegration,
-  getActiveSpan,
+  getCurrentScope,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   startInactiveSpan,
-  withActiveSpan,
+  withScope,
 } from '@sentry/core';
 import { DEBUG_BUILD } from '../../debug-build';
 import { CHANNELS } from '../../orchestrion/channels';
@@ -81,6 +82,12 @@ const _mysqlChannelIntegration = (() => {
       // asyncEnd for some reason.
       const spans = new WeakMap<object, Span>();
 
+      // The scope active when the query was issued, keyed by the same per-call
+      // `context` object. The streamable no-callback path needs it in `end`
+      // (where `ctx.result` first becomes available) to bind the returned
+      // `Query` emitter's listeners to it — see the `end` hook.
+      const parentScopes = new WeakMap<object, Scope>();
+
       // `subscribe()` requires all five lifecycle hooks. The orchestrion
       // `wrapAuto` transform fires events in one of four orders depending on
       // call shape:
@@ -144,14 +151,18 @@ const _mysqlChannelIntegration = (() => {
           // caller's `connection.query` call, so OTel context is still
           // correct). `asyncStart`/`asyncEnd` fire from the same lost context
           // as the callback itself, so they're too late.
-          const parentSpan = getActiveSpan();
-          if (parentSpan && ctx.arguments.length > 0) {
+          const scope = getCurrentScope();
+
+          // Keep track of the scope that was active when the query was issued.
+          parentScopes.set(rawCtx, scope);
+
+          if (ctx.arguments.length > 0) {
             const cbIdx = ctx.arguments.length - 1;
             const orchestrionWrappedCb = ctx.arguments[cbIdx];
             if (typeof orchestrionWrappedCb === 'function') {
               const wrapped = orchestrionWrappedCb as (...a: unknown[]) => unknown;
               ctx.arguments[cbIdx] = function (this: unknown, ...args: unknown[]): unknown {
-                return withActiveSpan(parentSpan, () => wrapped.apply(this, args));
+                return withScope(scope, () => wrapped.apply(this, args));
               };
             }
           }
@@ -183,6 +194,22 @@ const _mysqlChannelIntegration = (() => {
           if (result && typeof result === 'object' && hasOnMethod(result)) {
             const span = spans.get(rawCtx);
             if (!span) return;
+
+            // Bind the streamed `Query`'s listeners to the scope that was active
+            // when the query was issued. mysql v2 emits `'end'`/`'error'`/
+            // `'fields'`/… from its socket data handler, where the
+            // AsyncLocalStorage store backing `getActiveSpan()` no longer
+            // reflects the caller's context. Without this, a span started inside
+            // a user's stream listener would begin a fresh root trace instead of
+            // nesting under the active parent. `bindScopeToEmitter` patches the
+            // emitter's `on`/`addListener`/… so listeners the user adds after
+            // `query()` returns inherit the scope — mirroring what
+            // `@opentelemetry/instrumentation-mysql` does via `context.bind`.
+            const parentScope = parentScopes.get(rawCtx);
+            if (parentScope) {
+              bindScopeToEmitter(result, parentScope);
+            }
+
             result.on('error', err => {
               span.setStatus({
                 code: SPAN_STATUS_ERROR,
@@ -224,6 +251,7 @@ const _mysqlChannelIntegration = (() => {
         if (!span) return;
         span.end();
         spans.delete(rawCtx);
+        parentScopes.delete(rawCtx);
       }
     },
   };


### PR DESCRIPTION
This updates the node-integration-tests for `mysql` package for better test coverage (in preparation of https://github.com/getsentry/sentry-javascript/pull/21568), as well as also fixing some holes in the tests:

* Previously, we did not have any MySQL server, which lead to some weird quirks, e.g. spans being marked as failed because no server is found etc. This kind of skewed the results. This PR introduces a minimal, node-written MySQL server that only replies with OK/ERROR, just enough for our tests.
* Add tests for connection pooling
* Add tests for streamed query errors
* Add tests for context stability in streamed queries