### PR TITLE
ref(vercel-edge): Remove `@opentelemetry/resources` dependency

### DIFF
--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/resources": "^2.6.1",
     "@sentry/core": "10.59.0"
   },
   "devDependencies": {

--- a/packages/vercel-edge/rollup.npm.config.mjs
+++ b/packages/vercel-edge/rollup.npm.config.mjs
@@ -73,6 +73,32 @@ export default makeNPMConfigVariants(
             }
           },
         },
+        {
+          // `@opentelemetry/sdk-trace-base` is bundled here, and its `BasicTracerProvider`
+          // statically imports `defaultResource` from `@opentelemetry/resources` as a fallback
+          // (`mergedConfig.resource ?? defaultResource()`). Sentry always supplies its own
+          // resource via `getSentryResource()`, so the fallback never runs. Shimming the import
+          // lets us drop the `@opentelemetry/resources` dependency and avoids bundling its
+          // node-only resource detectors into the edge runtime.
+          name: 'otel-resources-shim',
+          resolveId: source => (source === '@opentelemetry/resources' ? '\0otel_resources_sentry_shim' : null),
+          load: id =>
+            id === '\0otel_resources_sentry_shim'
+              ? `
+                export function defaultResource() {
+                  return {
+                    attributes: {},
+                    merge() {
+                      return this;
+                    },
+                    getRawAttributes() {
+                      return [];
+                    },
+                  };
+                }
+              `
+              : null,
+        },
       ],
     },
   }),


### PR DESCRIPTION
The bundled `BasicTracerProvider` from `@opentelemetry/sdk-trace-base` statically imports `defaultResource` from `@opentelemetry/resources` as a fallback (`mergedConfig.resource ?? defaultResource()`).But we always supply our own ownresource via `getSentryResource()`, so the fallback never runs. The import only needs to resolve.

So we shim `@opentelemetry/resources` to a tiny inlined stub during bundling so the real package is never bundled, then remove it from `dependencies`.

This also avoids pulling OTel's node-only resource detectors into the edge runtime.

Closes: #20983
