### PR TITLE
ref(vercel-edge): Drop unused `@opentelemetry/semantic-conventions` dependency

### DIFF
--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -46,7 +46,6 @@
   "devDependencies": {
     "@edge-runtime/types": "4.0.0",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
-    "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sentry/opentelemetry": "10.59.0"
   },
   "scripts": {


### PR DESCRIPTION
`@sentry/vercel-edge` declared `@opentelemetry/semantic-conventions` as a devDependency, but nothing in the package imports it (no usage in `src/`, tests, or build config). Remove the stale dependency.

This is the last published-package declaration of `@opentelemetry/semantic-conventions` not already covered by the ongoing migration to `@sentry/conventions` (`@sentry/node`'s remaining source imports are handled in #21635). The dependency is still required elsewhere, so `yarn.lock` is unchanged.

_Root cause_: the dependency was carried over but never used.