### PR TITLE
chore: Add bundler-plugins to craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -149,6 +149,9 @@ targets:
   ## 7. Other Packages
   ## 7.1
   - name: npm
+    id: '@sentry/bundler-plugins'
+    includeNames: /^sentry-bundler-plugins-\d.*\.tgz$/
+  - name: npm
     id: '@sentry/typescript'
     includeNames: /^sentry-typescript-\d.*\.tgz$/
   - name: npm


### PR DESCRIPTION
Making `@sentry/bundler-plugins` releasable.