### PR TITLE
test(node): Increase cron integration test timeout to 60s

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/cron/cron/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/cron/cron/test.ts
@@ -5,7 +5,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('cron instrumentation', { timeout: 30_000 }, async () => {
+test('cron instrumentation', { timeout: 60_000 }, async () => {
   await createRunner(__dirname, 'scenario.ts')
     .expect({
       check_in: {

--- a/dev-packages/node-integration-tests/suites/cron/cron/test.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/test.ts
@@ -5,7 +5,7 @@ afterAll(() => {
   cleanupChildProcesses();
 });
 
-test('cron instrumentation', { timeout: 30_000 }, async () => {
+test('cron instrumentation', { timeout: 60_000 }, async () => {
   await createRunner(__dirname, 'scenario.ts')
     .withMockSentryServer()
     .expect({


### PR DESCRIPTION
closes #21623
closes #21667

In [the previous PR](https://github.com/getsentry/sentry-javascript/pull/20586) the `setTimeout` and this timeout have both been increased., so it could be that that was the reason for the timeout, everything just got delayed.

If this is getting flaky one more time then there might be another issue somewhere.
