### PR TITLE
feat(core): Add top-level `Sentry.setAttribute(s)` APIs

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/logger/scopeAttributes/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/logger/scopeAttributes/subject.js
@@ -8,8 +8,8 @@ Sentry.getGlobalScope().setAttribute('array_attr', [1, 2, 3]);
 // global scope, log attribute
 Sentry.logger.info('log_after_global_scope', { log_attr: 'log_attr_2' });
 
-Sentry.withIsolationScope(isolationScope => {
-  isolationScope.setAttribute('isolation_scope_1_attr', { value: 100, unit: 'millisecond' });
+Sentry.withIsolationScope(() => {
+  Sentry.setAttribute('isolation_scope_1_attr', { value: 100, unit: 'millisecond' });
 
   // global scope, isolation scope, log attribute
   Sentry.logger.info('log_with_isolation_scope', { log_attr: 'log_attr_3' });

--- a/dev-packages/browser-integration-tests/suites/public-api/metrics/simple/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/metrics/simple/subject.js
@@ -9,10 +9,8 @@ Sentry.startSpan({ name: 'test-span', op: 'test' }, () => {
 Sentry.setUser({ id: 'user-123', email: 'test@example.com', username: 'testuser' });
 Sentry.metrics.count('test.user.counter', 1, { attributes: { action: 'click' } });
 
-Sentry.withScope(scope => {
-  scope.setAttribute('scope_attribute_1', 1);
-  scope.setAttributes({ scope_attribute_2: { value: 'test' }, scope_attribute_3: { value: 38, unit: 'gigabyte' } });
-  Sentry.metrics.count('test.scope.attributes.counter', 1, { attributes: { action: 'click' } });
-});
+Sentry.setAttribute('scope_attribute_1', 1);
+Sentry.setAttributes({ scope_attribute_2: { value: 'test' }, scope_attribute_3: { value: 38, unit: 'gigabyte' } });
+Sentry.metrics.count('test.scope.attributes.counter', 1, { attributes: { action: 'click' } });
 
 Sentry.flush();

--- a/dev-packages/node-core-integration-tests/suites/public-api/metrics/scenario.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/metrics/scenario.ts
@@ -25,11 +25,9 @@ async function run(): Promise<void> {
   Sentry.setUser({ id: 'user-123', email: 'test@example.com', username: 'testuser' });
   Sentry.metrics.count('test.user.counter', 1, { attributes: { action: 'click' } });
 
-  Sentry.withScope(scope => {
-    scope.setAttribute('scope_attribute_1', 1);
-    scope.setAttributes({ scope_attribute_2: { value: 'test' }, scope_attribute_3: { value: 38, unit: 'gigabyte' } });
-    Sentry.metrics.count('test.scope.attributes.counter', 1, { attributes: { action: 'click' } });
-  });
+  Sentry.setAttribute('scope_attribute_1', 1);
+  Sentry.setAttributes({ scope_attribute_2: { value: 'test' }, scope_attribute_3: { value: 38, unit: 'gigabyte' } });
+  Sentry.metrics.count('test.scope.attributes.counter', 1, { attributes: { action: 'click' } });
 
   await Sentry.flush();
 }

--- a/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
@@ -20,8 +20,8 @@ async function run(): Promise<void> {
   // global scope, log attribute
   Sentry.logger.info('log_after_global_scope', { log_attr: 'log_attr_2' }, {});
 
-  Sentry.withIsolationScope(isolationScope => {
-    isolationScope.setAttribute('isolation_scope_1_attr', { value: 100, unit: 'millisecond' });
+  Sentry.withIsolationScope(() => {
+    Sentry.setAttribute('isolation_scope_1_attr', { value: 100, unit: 'millisecond' });
 
     // global scope, isolation scope, log attribute
     Sentry.logger.info('log_with_isolation_scope', { log_attr: 'log_attr_3' }, {});

--- a/dev-packages/node-integration-tests/suites/public-api/metrics/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/metrics/scenario.ts
@@ -22,11 +22,9 @@ async function run(): Promise<void> {
   Sentry.setUser({ id: 'user-123', email: 'test@example.com', username: 'testuser' });
   Sentry.metrics.count('test.user.counter', 1, { attributes: { action: 'click' } });
 
-  Sentry.withScope(scope => {
-    scope.setAttribute('scope_attribute_1', 1);
-    scope.setAttributes({ scope_attribute_2: { value: 'test' }, scope_attribute_3: { value: 38, unit: 'gigabyte' } });
-    Sentry.metrics.count('test.scope.attributes.counter', 1, { attributes: { action: 'click' } });
-  });
+  Sentry.setAttribute('scope_attribute_1', 1);
+  Sentry.setAttributes({ scope_attribute_2: { value: 'test' }, scope_attribute_3: { value: 38, unit: 'gigabyte' } });
+  Sentry.metrics.count('test.scope.attributes.counter', 1, { attributes: { action: 'click' } });
 
   await Sentry.flush();
 }

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -125,6 +125,8 @@ export {
   setMeasurement,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setupConnectErrorHandler,
   setupExpressErrorHandler,
   setupHapiErrorHandler,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -30,6 +30,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -53,6 +53,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   setConversationId,
   withScope,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -53,6 +53,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -49,6 +49,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   setConversationId,
   getSpanStatusFromHttpCode,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -1,3 +1,4 @@
+import type { AttributeObject, RawAttribute, RawAttributes } from './attributes';
 import { getClient, getCurrentScope, getIsolationScope, withIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { CaptureContext } from './scope';
@@ -101,6 +102,52 @@ export function setTags(tags: { [key: string]: Primitive }): void {
  */
 export function setTag(key: string, value: Primitive): void {
   getIsolationScope().setTag(key, value);
+}
+
+/**
+ * Sets attributes on the isolation scope.
+ *
+ * These attributes are applied to logs, metrics and streamed spans.
+ *
+ * Supported attribute value types are `string`, `number`, `boolean`, `string[]`, `number[]` and `boolean[]`.
+ *
+ * @param attributes - The attributes to set on the scope, as key-value pairs.
+ *
+ * @example
+ * ```typescript
+ * Sentry.setAttributes({
+ *   is_admin: true,
+ *   payment_selection: 'credit_card',
+ *   render_duration: 150,
+ * });
+ * ```
+ */
+export function setAttributes<T extends Record<string, unknown>>(attributes: RawAttributes<T>): void {
+  getIsolationScope().setAttributes(attributes);
+}
+
+/**
+ * Sets an attribute on the isolation scope.
+ *
+ * These attributes are applied to logs, metrics and streamed spans.
+ *
+ * Supported attribute value types are `string`, `number`, `boolean`, `string[]`, `number[]` and `boolean[]`.
+ *
+ * @param key - The attribute key.
+ * @param value - The attribute value.
+ *
+ * @example
+ * ```typescript
+ * Sentry.setAttribute('is_admin', true);
+ * Sentry.setAttribute('render_duration', 150);
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function setAttribute<T extends RawAttribute<T> extends { value: any } | { unit: any } ? AttributeObject : unknown>(
+  key: string,
+  value: RawAttribute<T>,
+): void {
+  getIsolationScope().setAttribute(key, value);
 }
 
 /**

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -142,11 +142,10 @@ export function setAttributes<T extends Record<string, unknown>>(attributes: Raw
  * Sentry.setAttribute('render_duration', 150);
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function setAttribute<T extends RawAttribute<T> extends { value: any } | { unit: any } ? AttributeObject : unknown>(
-  key: string,
-  value: RawAttribute<T>,
-): void {
+export function setAttribute<
+  // oxlint-disable-next-line typescript-eslint/no-explicit-any
+  T extends RawAttribute<T> extends { value: any } | { unit: any } ? AttributeObject : unknown,
+>(key: string, value: RawAttribute<T>): void {
   getIsolationScope().setAttribute(key, value);
 }
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -323,22 +323,18 @@ export class Scope {
   /**
    * Sets attributes onto the scope.
    *
-   * These attributes are currently applied to logs and metrics.
-   * In the future, they will also be applied to spans.
+   * These attributes are applied to logs, metrics and streamed spans.
    *
-   * Important: For now, only strings, numbers and boolean attributes are supported, despite types allowing for
-   * more complex attribute types. We'll add this support in the future but already specify the wider type to
-   * avoid a breaking change in the future.
+   * Supported attribute value types are `string`, `number`, `boolean`, `string[]`, `number[]` and `boolean[]`.
    *
-   * @param newAttributes - The attributes to set on the scope. You can either pass in key-value pairs, or
-   * an object with a `value` and an optional `unit` (if applicable to your attribute).
+   * @param newAttributes - The attributes to set on the scope, as key-value pairs.
    *
    * @example
    * ```typescript
    * scope.setAttributes({
    *   is_admin: true,
    *   payment_selection: 'credit_card',
-   *   render_duration: { value: 'render_duration', unit: 'ms' },
+   *   render_duration: 150,
    * });
    * ```
    */
@@ -355,21 +351,17 @@ export class Scope {
   /**
    * Sets an attribute onto the scope.
    *
-   * These attributes are currently applied to logs and metrics.
-   * In the future, they will also be applied to spans.
+   * These attributes are applied to logs, metrics and streamed spans.
    *
-   * Important: For now, only strings, numbers and boolean attributes are supported, despite types allowing for
-   * more complex attribute types. We'll add this support in the future but already specify the wider type to
-   * avoid a breaking change in the future.
+   * Supported attribute value types are `string`, `number`, `boolean`, `string[]`, `number[]` and `boolean[]`.
    *
    * @param key - The attribute key.
-   * @param value - the attribute value. You can either pass in a raw value, or an attribute
-   * object with a `value` and an optional `unit` (if applicable to your attribute).
+   * @param value - The attribute value.
    *
    * @example
    * ```typescript
    * scope.setAttribute('is_admin', true);
-   * scope.setAttribute('render_duration', { value: 'render_duration', unit: 'ms' });
+   * scope.setAttribute('render_duration', 150);
    * ```
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -25,6 +25,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   setConversationId,
   isInitialized,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -49,6 +49,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -31,6 +31,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -30,6 +30,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/node-core/src/common-exports.ts
+++ b/packages/node-core/src/common-exports.ts
@@ -68,6 +68,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -84,6 +84,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   setConversationId,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -72,6 +72,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -97,6 +97,8 @@ export {
   setMeasurement,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setupConnectErrorHandler,
   setupExpressErrorHandler,
   setupHapiErrorHandler,

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -101,6 +101,8 @@ export {
   setMeasurement,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setupConnectErrorHandler,
   setupExpressErrorHandler,
   setupHapiErrorHandler,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -98,6 +98,8 @@ export {
   setMeasurement,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setupConnectErrorHandler,
   setupExpressErrorHandler,
   setupHapiErrorHandler,

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -66,6 +66,8 @@ export {
   setMeasurement,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   spanToBaggageHeader,
   spanToJSON,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -47,6 +47,8 @@ export {
   setExtras,
   setTag,
   setTags,
+  setAttribute,
+  setAttributes,
   setUser,
   getSpanStatusFromHttpCode,
   setHttpStatus,


### PR DESCRIPTION
Adds top-level `Sentry.setAttribute(s)` APIs, writing attributes to the isolation scope, analogously to `Sentry.setTag(s)`. This was previously missing and should drastically simplify how users can set scope attributes.

```js
Sentry.setAttribute('is_admin', true);
Sentry.setAttributes({
  'user.num_orders': user.numOrders
  'subscription.tier': 'pro'
})
```