### PR TITLE
chore: Fix version bump for bundler plugin fixtures

### DIFF
--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -26,10 +26,7 @@ function updateWorkspaceDeps(pkgPath, workspaceNames, newVersion, { bumpVersion 
     for (const [dep, value] of Object.entries(pkg.pnpm.overrides)) {
       if (!workspaceNames.has(dep)) continue;
 
-      pkg.pnpm.overrides[dep] = value.replace(
-        /(?<=sentry-[\w-]+-)\d+\.\d+\.\d+(-[\w.]+)?(?=\.tgz$)/,
-        newVersion,
-      );
+      pkg.pnpm.overrides[dep] = value.replace(/(?<=sentry-[\w-]+-)\d+\.\d+\.\d+(-[\w.]+)?(?=\.tgz$)/, newVersion);
     }
   }
 

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -5,6 +5,38 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
 }
 
+function updateWorkspaceDeps(pkgPath, workspaceNames, newVersion, { bumpVersion } = {}) {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+
+  if (bumpVersion) {
+    pkg.version = newVersion;
+  }
+
+  for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
+    if (!pkg[depType]) continue;
+
+    for (const [dep, ver] of Object.entries(pkg[depType])) {
+      if (workspaceNames.has(dep) && !ver.startsWith('workspace:')) {
+        pkg[depType][dep] = newVersion;
+      }
+    }
+  }
+
+  if (pkg.pnpm?.overrides) {
+    for (const [dep, value] of Object.entries(pkg.pnpm.overrides)) {
+      if (!workspaceNames.has(dep)) continue;
+
+      pkg.pnpm.overrides[dep] = value.replace(
+        /(?<=sentry-[\w-]+-)\d+\.\d+\.\d+(-[\w.]+)?(?=\.tgz$)/,
+        newVersion,
+      );
+    }
+  }
+
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  return pkg;
+}
+
 /**
  * Bumps the version of all workspace packages and their internal dependencies.
  * This replicates the behavior of:
@@ -29,39 +61,38 @@ function bumpVersions(rootDir, newVersion) {
   // Read all workspace package.json files upfront.
   // This ensures we fail early if any workspace is unreadable,
   // before writing any changes (no partial updates).
-  const workspacePackages = [];
   const workspaceNames = new Set();
+  const workspacePkgPaths = [];
   for (const workspace of workspaces) {
     const pkgPath = path.join(rootDir, workspace, 'package.json');
     const pkg = readJson(pkgPath);
     workspaceNames.add(pkg.name);
-    workspacePackages.push({ pkgPath, pkg });
+    workspacePkgPaths.push(pkgPath);
   }
 
   // Apply version bumps
-  for (const { pkgPath, pkg } of workspacePackages) {
-    pkg.version = newVersion;
-
-    // Update internal workspace dependency versions (exact, no ^)
-    // This covers dependencies, devDependencies, and peerDependencies
-    for (const depType of ['dependencies', 'devDependencies', 'peerDependencies']) {
-      if (!pkg[depType]) {
-        continue;
-      }
-
-      for (const [dep, ver] of Object.entries(pkg[depType])) {
-        // Update all workspace dependencies to the new exact version,
-        // matching lerna's --force-publish --exact behavior
-        if (workspaceNames.has(dep) && !ver.startsWith('workspace:')) {
-          pkg[depType][dep] = newVersion;
-        }
-      }
-    }
-
-    fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  for (const pkgPath of workspacePkgPaths) {
+    updateWorkspaceDeps(pkgPath, workspaceNames, newVersion, { bumpVersion: true });
   }
 
-  return workspacePackages.length;
+  // Update bundler-plugin integration test fixtures.
+  // These are standalone pnpm projects (not workspaces) that reference local tarballs
+  // with version-stamped filenames, so they need explicit patching.
+  const fixturesDir = path.join(rootDir, 'dev-packages', 'bundler-plugin-integration-tests', 'fixtures');
+
+  if (fs.existsSync(fixturesDir)) {
+    for (const entry of fs.readdirSync(fixturesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+
+      const fixturePkgPath = path.join(fixturesDir, entry.name, 'package.json');
+
+      if (!fs.existsSync(fixturePkgPath)) continue;
+
+      updateWorkspaceDeps(fixturePkgPath, workspaceNames, newVersion);
+    }
+  }
+
+  return workspacePkgPaths.length;
 }
 
 // CLI entry point

--- a/scripts/bump-version.test.ts
+++ b/scripts/bump-version.test.ts
@@ -260,6 +260,47 @@ describe('bump-version', () => {
     expect(() => bumpVersions(rootDir, '2.0.0')).toThrow('workspaces');
   });
 
+  it('updates bundler-plugin integration test fixture versions and tarball paths', () => {
+    const rootDir = tracked(
+      setupFixture({
+        packages: {
+          'packages/core': { name: '@sentry/core', version: '10.0.0' },
+          'packages/bundler-plugins': { name: '@sentry/bundler-plugins', version: '10.0.0' },
+        },
+      }),
+    );
+
+    const fixturesDir = path.join(rootDir, 'dev-packages', 'bundler-plugin-integration-tests', 'fixtures');
+    writePackageJson(path.join(fixturesDir, 'esbuild'), {
+      name: 'esbuild-integration-tests',
+      version: '1.0.0',
+      private: true,
+      dependencies: {
+        esbuild: '0.28.0',
+        '@sentry/bundler-plugins': '10.0.0',
+      },
+      pnpm: {
+        overrides: {
+          '@sentry/bundler-plugins':
+            'file:../../../../packages/bundler-plugins/sentry-bundler-plugins-10.0.0.tgz',
+          '@sentry/core': 'file:../../../../packages/core/sentry-core-10.0.0.tgz',
+        },
+      },
+    });
+
+    bumpVersions(rootDir, '10.1.0');
+
+    const fixture = readPackageJson(path.join(fixturesDir, 'esbuild'));
+    expect(fixture.dependencies['@sentry/bundler-plugins']).toBe('10.1.0');
+    expect(fixture.dependencies['esbuild']).toBe('0.28.0');
+    expect(fixture.pnpm.overrides['@sentry/bundler-plugins']).toBe(
+      'file:../../../../packages/bundler-plugins/sentry-bundler-plugins-10.1.0.tgz',
+    );
+    expect(fixture.pnpm.overrides['@sentry/core']).toBe(
+      'file:../../../../packages/core/sentry-core-10.1.0.tgz',
+    );
+  });
+
   it('throws when a workspace package.json is unreadable and does not partially update', () => {
     const rootDir = tracked(createTempDir());
     writePackageJson(rootDir, {

--- a/scripts/bump-version.test.ts
+++ b/scripts/bump-version.test.ts
@@ -281,8 +281,7 @@ describe('bump-version', () => {
       },
       pnpm: {
         overrides: {
-          '@sentry/bundler-plugins':
-            'file:../../../../packages/bundler-plugins/sentry-bundler-plugins-10.0.0.tgz',
+          '@sentry/bundler-plugins': 'file:../../../../packages/bundler-plugins/sentry-bundler-plugins-10.0.0.tgz',
           '@sentry/core': 'file:../../../../packages/core/sentry-core-10.0.0.tgz',
         },
       },
@@ -296,9 +295,7 @@ describe('bump-version', () => {
     expect(fixture.pnpm.overrides['@sentry/bundler-plugins']).toBe(
       'file:../../../../packages/bundler-plugins/sentry-bundler-plugins-10.1.0.tgz',
     );
-    expect(fixture.pnpm.overrides['@sentry/core']).toBe(
-      'file:../../../../packages/core/sentry-core-10.1.0.tgz',
-    );
+    expect(fixture.pnpm.overrides['@sentry/core']).toBe('file:../../../../packages/core/sentry-core-10.1.0.tgz');
   });
 
   it('throws when a workspace package.json is unreadable and does not partially update', () => {


### PR DESCRIPTION
The bundler plugin fixtures are not part of our yarn workspace, therefore the updates were not part of it.

I, with the help of Claude, refactored the script to use `updateWorkspaceDeps`, which could be used for any `package.json` that updates to the latest release.

So we now also manually loop over the `bundler-plugin-integration-tests/fixtures` folder and update the dependencies there too. Before it was only used for our workspace folders.