### PR TITLE
test(e2e): Add more lighthouse react e2e test SDK init modes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,8 @@
   "[typescript]": {
     "editor.defaultFormatter": "oxc.oxc-vscode"
   },
-  "oxc.suppressProgramErrors": true
+  "oxc.suppressProgramErrors": true,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  }
 }

--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/package.json
@@ -10,6 +10,8 @@
     "build:no-sentry": "vite build --mode no-sentry",
     "build:init-only": "vite build --mode init-only",
     "build:errors-only": "vite build --mode errors-only",
+    "build:no-integrations": "vite build --mode no-integrations",
+    "build:no-browser-api-errors": "vite build --mode no-browser-api-errors",
     "build:tracing": "vite build --mode tracing",
     "build:tracing-replay": "vite build --mode tracing-replay",
     "preview": "vite preview",

--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
@@ -33,6 +33,27 @@ if (import.meta.env.MODE === 'tracing-replay') {
     release: 'lighthouse-fixture',
     environment: 'qa',
   });
+} else if (import.meta.env.MODE === 'no-integrations') {
+  // DSN set but every integration disabled. Isolates the cost of the enabled
+  // client itself from the default instrumentation that wraps DOM/timer/network APIs.
+  Sentry.init({
+    dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
+    release: 'lighthouse-fixture',
+    environment: 'qa',
+    defaultIntegrations: false,
+    integrations: [],
+  });
+} else if (import.meta.env.MODE === 'no-browser-api-errors') {
+  // Default integrations minus BrowserApiErrors, which wraps addEventListener/
+  // removeEventListener on ~32 prototypes plus setTimeout/setInterval/rAF/XHR.
+  // Isolates that global monkey-patching cost from the rest of the defaults.
+  Sentry.init({
+    dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
+    release: 'lighthouse-fixture',
+    environment: 'qa',
+    integrations: defaultIntegrations =>
+      defaultIntegrations.filter(integration => integration.name !== 'BrowserApiErrors'),
+  });
 } else if (import.meta.env.MODE === 'init-only') {
   // enabled: false makes the SDK a guaranteed no-op (no transport allocation,
   // no DSN warning). We're measuring pure SDK-loading + tree-shaking cost.

--- a/scripts/lighthouse-bundle-and-upload.mjs
+++ b/scripts/lighthouse-bundle-and-upload.mjs
@@ -1,11 +1,12 @@
 /**
  * Bundle the `lighthouse-react` test app for each mode (no-sentry, init-only,
- * errors-only, tracing, tracing-replay) and POST the tarballs to the Sentry
- * Lighthouse lab (https://lighthouse.sentry.gg). The lab runs Lighthouse
- * asynchronously and ships results to Sentry on its own schedule — this script
- * exits as soon as the upload succeeds.
+ * errors-only, no-integrations, no-browser-api-errors, tracing, tracing-replay)
+ * and POST the tarballs to the Sentry Lighthouse lab
+ * (https://lighthouse.sentry.gg). The lab runs Lighthouse asynchronously and
+ * ships results to Sentry on its own schedule — this script exits as soon as
+ * the upload succeeds.
  *
- * Single-app static matrix: 1 app × 5 modes = 5 cells.
+ * Single-app static matrix: 1 app × 7 modes = 7 cells.
  *
  * Zero runtime dependencies — uses Node 22 builtins (fetch, FormData, Blob) and
  * the system `tar`. Every external command is invoked via `execFileSync` with
@@ -33,7 +34,15 @@ const E2E_DIR = path.join(WORKSPACE, 'dev-packages/e2e-tests');
 
 const APP = 'lighthouse-react';
 const APP_DIR = 'lighthouse-react';
-const MODES = ['no-sentry', 'init-only', 'errors-only', 'tracing', 'tracing-replay'];
+const MODES = [
+  'no-sentry',
+  'init-only',
+  'errors-only',
+  'no-integrations',
+  'no-browser-api-errors',
+  'tracing',
+  'tracing-replay',
+];
 const STATIC_DIR = 'dist';
 
 async function run() {


### PR DESCRIPTION
- `no-browser-api-errors`: errors-only but without this integration. Suspicion: patching all these event listeners creates overhead for react-based apps
- `no-integrations`: init without default integration to check if just the client setup alone already causes significant overhead