### PR TITLE
fix(replays): Record replay `trace_ids` with span streaming

### DIFF
--- a/packages/replay-internal/src/coreHandlers/handleAfterSegmentSpanEnd.ts
+++ b/packages/replay-internal/src/coreHandlers/handleAfterSegmentSpanEnd.ts
@@ -1,4 +1,5 @@
 import type { Span } from '@sentry/core';
+import { spanIsSampled } from '@sentry/core';
 import type { ReplayContainer } from '../types';
 import { addTraceIdToContext } from './util/addTraceIdToContext';
 
@@ -6,7 +7,7 @@ type AfterSegmentSpanEndCallback = (segmentSpan: Span) => void;
 
 export function handleAfterSegmentSpanEnd(replay: ReplayContainer): AfterSegmentSpanEndCallback {
   return (segmentSpan: Span) => {
-    if (!replay.isEnabled()) {
+    if (!replay.isEnabled() || !spanIsSampled(segmentSpan)) {
       return;
     }
 

--- a/packages/replay-internal/src/coreHandlers/handleAfterSegmentSpanEnd.ts
+++ b/packages/replay-internal/src/coreHandlers/handleAfterSegmentSpanEnd.ts
@@ -1,0 +1,18 @@
+import type { Span } from '@sentry/core';
+import type { ReplayContainer } from '../types';
+import { addTraceIdToContext } from './util/addTraceIdToContext';
+
+type AfterSegmentSpanEndCallback = (segmentSpan: Span) => void;
+
+export function handleAfterSegmentSpanEnd(replay: ReplayContainer): AfterSegmentSpanEndCallback {
+  return (segmentSpan: Span) => {
+    if (!replay.isEnabled()) {
+      return;
+    }
+
+    const traceId = segmentSpan.spanContext().traceId;
+    if (traceId) {
+      addTraceIdToContext(replay, traceId);
+    }
+  };
+}

--- a/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts
@@ -2,6 +2,7 @@ import type { ErrorEvent, Event, TransactionEvent, TransportMakeRequestResponse 
 import { setTimeout } from '@sentry/browser-utils';
 import type { ReplayContainer } from '../types';
 import { isErrorEvent, isTransactionEvent } from '../util/eventUtils';
+import { addTraceIdToContext } from './util/addTraceIdToContext';
 
 type AfterSendEventCallback = (event: Event, sendResponse: TransportMakeRequestResponse) => void;
 
@@ -32,13 +33,9 @@ export function handleAfterSendEvent(replay: ReplayContainer): AfterSendEventCal
 }
 
 function handleTransactionEvent(replay: ReplayContainer, event: TransactionEvent): void {
-  const replayContext = replay.getContext();
-
-  // Collect traceIds in _context regardless of `recordingMode`
-  // In error mode, _context gets cleared on every checkout
-  // We limit to max. 100 transactions linked
-  if (event.contexts?.trace?.trace_id && replayContext.traceIds.size < 100) {
-    replayContext.traceIds.add(event.contexts.trace.trace_id);
+  const traceId = event.contexts?.trace?.trace_id;
+  if (traceId) {
+    addTraceIdToContext(replay, traceId);
   }
 }
 

--- a/packages/replay-internal/src/coreHandlers/util/addTraceIdToContext.ts
+++ b/packages/replay-internal/src/coreHandlers/util/addTraceIdToContext.ts
@@ -1,0 +1,10 @@
+import type { ReplayContainer } from '../../types';
+
+const MAX_TRACE_IDS = 100;
+
+export function addTraceIdToContext(replay: ReplayContainer, traceId: string): void {
+  const replayContext = replay.getContext();
+  if (replayContext.traceIds.size < MAX_TRACE_IDS) {
+    replayContext.traceIds.add(traceId);
+  }
+}

--- a/packages/replay-internal/src/util/addGlobalListeners.ts
+++ b/packages/replay-internal/src/util/addGlobalListeners.ts
@@ -1,6 +1,7 @@
 import type { DynamicSamplingContext } from '@sentry/core';
 import { addEventProcessor, getClient } from '@sentry/core';
 import { addClickKeypressInstrumentationHandler, addHistoryInstrumentationHandler } from '@sentry/browser-utils';
+import { handleAfterSegmentSpanEnd } from '../coreHandlers/handleAfterSegmentSpanEnd';
 import { handleAfterSendEvent } from '../coreHandlers/handleAfterSendEvent';
 import { handleBeforeSendEvent } from '../coreHandlers/handleBeforeSendEvent';
 import { handleBreadcrumbs } from '../coreHandlers/handleBreadcrumbs';
@@ -42,6 +43,8 @@ export function addGlobalListeners(replay: ReplayContainer): void {
         }
       }
     });
+
+    client.on('afterSegmentSpanEnd', handleAfterSegmentSpanEnd(replay));
 
     client.on('spanStart', span => {
       replay.lastActiveSpan = span;

--- a/packages/replay-internal/test/integration/coreHandlers/handleAfterSegmentSpanEnd.test.ts
+++ b/packages/replay-internal/test/integration/coreHandlers/handleAfterSegmentSpanEnd.test.ts
@@ -91,4 +91,24 @@ describe('Integration | coreHandlers | handleAfterSegmentSpanEnd', () => {
 
     expect(Array.from(replay.getContext().traceIds)).toEqual([]);
   });
+
+  it('does not record traceIds for unsampled spans', async () => {
+    ({ replay } = await resetSdkMock({
+      replayOptions: {
+        stickySession: false,
+      },
+      sentryOptions: {
+        replaysSessionSampleRate: 1.0,
+        replaysOnErrorSampleRate: 0.0,
+      },
+    }));
+
+    const client = getClient()!;
+
+    client.emit('afterSegmentSpanEnd', {
+      spanContext: () => ({ traceId: 'trace-unsampled', spanId: 'span1', traceFlags: 0 }),
+    } as unknown as Span);
+
+    expect(Array.from(replay.getContext().traceIds)).toEqual([]);
+  });
 });

--- a/packages/replay-internal/test/integration/coreHandlers/handleAfterSegmentSpanEnd.test.ts
+++ b/packages/replay-internal/test/integration/coreHandlers/handleAfterSegmentSpanEnd.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import type { Span } from '@sentry/core';
+import { getClient } from '@sentry/core';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { ReplayContainer } from '../../../src/replay';
+import { resetSdkMock } from '../../mocks/resetSdkMock';
+
+let replay: ReplayContainer;
+
+describe('Integration | coreHandlers | handleAfterSegmentSpanEnd', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    replay.stop();
+  });
+
+  it('records traceIds from afterSegmentSpanEnd', async () => {
+    ({ replay } = await resetSdkMock({
+      replayOptions: {
+        stickySession: false,
+      },
+      sentryOptions: {
+        replaysSessionSampleRate: 1.0,
+        replaysOnErrorSampleRate: 0.0,
+      },
+    }));
+
+    const client = getClient()!;
+
+    client.emit('afterSegmentSpanEnd', {
+      spanContext: () => ({ traceId: 'trace-stream-1', spanId: 'span1', traceFlags: 1 }),
+    } as unknown as Span);
+
+    client.emit('afterSegmentSpanEnd', {
+      spanContext: () => ({ traceId: 'trace-stream-2', spanId: 'span2', traceFlags: 1 }),
+    } as unknown as Span);
+
+    expect(Array.from(replay.getContext().traceIds)).toEqual(['trace-stream-1', 'trace-stream-2']);
+  });
+
+  it('limits traceIds from afterSegmentSpanEnd to max. 100', async () => {
+    ({ replay } = await resetSdkMock({
+      replayOptions: {
+        stickySession: false,
+      },
+      sentryOptions: {
+        replaysSessionSampleRate: 1.0,
+        replaysOnErrorSampleRate: 0.0,
+      },
+    }));
+
+    const client = getClient()!;
+
+    for (let i = 0; i < 150; i++) {
+      client.emit('afterSegmentSpanEnd', {
+        spanContext: () => ({ traceId: `tr-${i}`, spanId: `sp-${i}`, traceFlags: 1 }),
+      } as unknown as Span);
+    }
+
+    expect(replay.getContext().traceIds.size).toBe(100);
+    expect(Array.from(replay.getContext().traceIds)).toEqual(
+      Array(100)
+        .fill(undefined)
+        .map((_, i) => `tr-${i}`),
+    );
+  });
+
+  it('does not record traceIds from afterSegmentSpanEnd when replay is disabled', async () => {
+    ({ replay } = await resetSdkMock({
+      replayOptions: {
+        stickySession: false,
+      },
+      sentryOptions: {
+        replaysSessionSampleRate: 1.0,
+        replaysOnErrorSampleRate: 0.0,
+      },
+    }));
+
+    const client = getClient()!;
+
+    replay['_isEnabled'] = false;
+
+    client.emit('afterSegmentSpanEnd', {
+      spanContext: () => ({ traceId: 'trace-stream-1', spanId: 'span1', traceFlags: 1 }),
+    } as unknown as Span);
+
+    expect(Array.from(replay.getContext().traceIds)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Replay events' `trace_ids` property is currently only set in `handleTransactionEvent`:

https://github.com/getsentry/sentry-javascript/blob/1dfd68253bbbb423d6a0fb28c51d714e80b24ca3/packages/replay-internal/src/coreHandlers/handleAfterSendEvent.ts#L34-L43

This never fires when span streaming is enabled, as we no longer emit transaction events. As a consequence,  replays' `trace_ids` list is always empty under span streaming.

Add another equivalent hook on `afterSegmentSpanEnd` to record `trace_ids` when span streaming is enabled.

Only sampled spans are considered, which matches the previous behaviour for transactions.

---

🤖: Claude/Opus 4.6 did a first pass and then I refactored it into shape. Claude wrote the tests though (looked fine to me).