### PR TITLE
ci: Relax check for PR reminder workflow

### DIFF
--- a/scripts/pr-review-reminder.mjs
+++ b/scripts/pr-review-reminder.mjs
@@ -254,7 +254,7 @@ export default async function run({ github, context, core }) {
 
     for (const reviewer of pendingReviewers) {
       const requestEvents = timeline
-        .filter(e => e.event === 'review_requested' && e.requested_reviewer?.login === reviewer.login)
+        .filter(e => e.event === 'review_requested')
         .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
 
       if (requestEvents.length === 0) {


### PR DESCRIPTION
Noticed this was not always triggering. After looking at this, the cause (at least sometimes) is that a review was requested by somebody else than the PR creator, possibly also by the system when it auto-assigns folks. I don't think we need to check on this, so we can relax this a bit.