### PR TITLE
test(node): Add esm/cjs specific test runner utils

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/test.ts
@@ -65,66 +65,60 @@ describe('express with httpIntegration and maxIncomingRequestBodySize: "none"', 
     cleanupChildProcesses();
   });
 
-  createEsmAndCjsTests(
-    __dirname,
-    'scenario.mjs',
-    'instrument-none.mjs',
-    (createRunner, test) => {
-      test('does not capture any request bodies with "none" setting', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: expect.not.objectContaining({
-                data: expect.any(String),
-              }),
-            },
-          })
-          .start();
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-none.mjs', (createRunner, test) => {
+    test('does not capture any request bodies with "none" setting', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: expect.not.objectContaining({
+              data: expect.any(String),
+            }),
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(500)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(500)),
       });
 
-      test('does not capture any request bodies with "none" setting and "ignoreIncomingRequestBody"', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: expect.not.objectContaining({
-                data: expect.any(String),
-              }),
-            },
-          })
-          .expect({
-            transaction: {
-              transaction: 'POST /ignore-request-body',
-              request: expect.not.objectContaining({
-                data: expect.any(String),
-              }),
-            },
-          })
-          .start();
+      await runner.completed();
+    });
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(500)),
-        });
+    test('does not capture any request bodies with "none" setting and "ignoreIncomingRequestBody"', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: expect.not.objectContaining({
+              data: expect.any(String),
+            }),
+          },
+        })
+        .expect({
+          transaction: {
+            transaction: 'POST /ignore-request-body',
+            request: expect.not.objectContaining({
+              data: expect.any(String),
+            }),
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/ignore-request-body', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(500)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(500)),
       });
-    },
-    { failsOnEsm: false },
-  );
+
+      await runner.makeRequest('post', '/ignore-request-body', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(500)),
+      });
+
+      await runner.completed();
+    });
+  });
 });
 
 describe('express with httpIntegration and maxIncomingRequestBodySize: "always"', () => {
@@ -132,53 +126,47 @@ describe('express with httpIntegration and maxIncomingRequestBodySize: "always"'
     cleanupChildProcesses();
   });
 
-  createEsmAndCjsTests(
-    __dirname,
-    'scenario.mjs',
-    'instrument-always.mjs',
-    (createRunner, test) => {
-      test('captures maximum allowed request body length with "always" setting', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: {
-                data: JSON.stringify(generatePayload(MAX_GENERAL)),
-              },
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-always.mjs', (createRunner, test) => {
+    test('captures maximum allowed request body length with "always" setting', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: {
+              data: JSON.stringify(generatePayload(MAX_GENERAL)),
             },
-          })
-          .start();
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(MAX_GENERAL)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(MAX_GENERAL)),
       });
 
-      test('captures large request bodies with "always" setting but respects maximum size limit', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: {
-                data: generatePayloadString(MAX_GENERAL, true),
-              },
+      await runner.completed();
+    });
+
+    test('captures large request bodies with "always" setting but respects maximum size limit', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: {
+              data: generatePayloadString(MAX_GENERAL, true),
             },
-          })
-          .start();
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(MAX_GENERAL + 1)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(MAX_GENERAL + 1)),
       });
-    },
-    { failsOnEsm: false },
-  );
+
+      await runner.completed();
+    });
+  });
 });
 
 describe('express with httpIntegration and maxIncomingRequestBodySize: "small"', () => {
@@ -186,74 +174,68 @@ describe('express with httpIntegration and maxIncomingRequestBodySize: "small"',
     cleanupChildProcesses();
   });
 
-  createEsmAndCjsTests(
-    __dirname,
-    'scenario.mjs',
-    'instrument-small.mjs',
-    (createRunner, test) => {
-      test('keeps small request bodies with "small" setting', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: {
-                data: JSON.stringify(generatePayload(MAX_SMALL)),
-              },
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-small.mjs', (createRunner, test) => {
+    test('keeps small request bodies with "small" setting', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: {
+              data: JSON.stringify(generatePayload(MAX_SMALL)),
             },
-          })
-          .start();
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(MAX_SMALL)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(MAX_SMALL)),
       });
 
-      test('truncates too large request bodies with "small" setting', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: {
-                data: generatePayloadString(MAX_SMALL, true),
-              },
+      await runner.completed();
+    });
+
+    test('truncates too large request bodies with "small" setting', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: {
+              data: generatePayloadString(MAX_SMALL, true),
             },
-          })
-          .start();
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(MAX_SMALL + 1)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(MAX_SMALL + 1)),
       });
 
-      test('truncates too large non-ASCII request bodies with "small" setting', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: {
-                // 250 emojis, each 4 bytes in UTF-8 (resulting in 1000 bytes --> MAX_SMALL)
-                data: generateEmojiPayloadString(250, true),
-              },
+      await runner.completed();
+    });
+
+    test('truncates too large non-ASCII request bodies with "small" setting', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: {
+              // 250 emojis, each 4 bytes in UTF-8 (resulting in 1000 bytes --> MAX_SMALL)
+              data: generateEmojiPayloadString(250, true),
             },
-          })
-          .start();
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generateEmojiPayload(MAX_SMALL + 1)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generateEmojiPayload(MAX_SMALL + 1)),
       });
-    },
-    { failsOnEsm: false },
-  );
+
+      await runner.completed();
+    });
+  });
 });
 
 describe('express with httpIntegration and maxIncomingRequestBodySize: "medium"', () => {
@@ -261,51 +243,45 @@ describe('express with httpIntegration and maxIncomingRequestBodySize: "medium"'
     cleanupChildProcesses();
   });
 
-  createEsmAndCjsTests(
-    __dirname,
-    'scenario.mjs',
-    'instrument-medium.mjs',
-    (createRunner, test) => {
-      test('keeps medium request bodies with "medium" setting', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: {
-                data: JSON.stringify(generatePayload(MAX_MEDIUM)),
-              },
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-medium.mjs', (createRunner, test) => {
+    test('keeps medium request bodies with "medium" setting', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: {
+              data: JSON.stringify(generatePayload(MAX_MEDIUM)),
             },
-          })
-          .start();
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(MAX_MEDIUM)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(MAX_MEDIUM)),
       });
 
-      test('truncates large request bodies with "medium" setting', async () => {
-        const runner = createRunner()
-          .expect({
-            transaction: {
-              transaction: 'POST /test-body-size',
-              request: {
-                data: generatePayloadString(MAX_MEDIUM, true),
-              },
+      await runner.completed();
+    });
+
+    test('truncates large request bodies with "medium" setting', async () => {
+      const runner = createRunner()
+        .expect({
+          transaction: {
+            transaction: 'POST /test-body-size',
+            request: {
+              data: generatePayloadString(MAX_MEDIUM, true),
             },
-          })
-          .start();
+          },
+        })
+        .start();
 
-        await runner.makeRequest('post', '/test-body-size', {
-          headers: { 'Content-Type': 'application/json' },
-          data: JSON.stringify(generatePayload(MAX_MEDIUM + 1)),
-        });
-
-        await runner.completed();
+      await runner.makeRequest('post', '/test-body-size', {
+        headers: { 'Content-Type': 'application/json' },
+        data: JSON.stringify(generatePayload(MAX_MEDIUM + 1)),
       });
-    },
-    { failsOnEsm: false },
-  );
+
+      await runner.completed();
+    });
+  });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
@@ -22,6 +22,7 @@ import {
   GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
 } from '../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+import { createEsmTests } from '../../../utils/runner/createEsmAndCjsTests';
 
 describe('LangChain integration', () => {
   afterAll(() => {
@@ -245,43 +246,36 @@ describe('LangChain integration', () => {
     },
   );
 
-  createEsmAndCjsTests(
-    __dirname,
-    'scenario-openai-before-langchain.mjs',
-    'instrument.mjs',
-    (createRunner, test) => {
-      test('demonstrates timing issue with duplicate spans (ESM only)', async () => {
-        await createRunner()
-          .ignore('event')
-          .expect({ transaction: { transaction: 'main' } })
-          .expect({
-            span: container => {
-              expect(container.items).toHaveLength(2);
-              const anthropicSpan = container.items.find(
-                span => span.attributes['sentry.origin'].value === 'auto.ai.anthropic',
-              );
-              expect(anthropicSpan).toBeDefined();
-              expect(anthropicSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+  createEsmTests(__dirname, 'scenario-openai-before-langchain.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('demonstrates timing issue with duplicate spans', async () => {
+      await createRunner()
+        .ignore('event')
+        .expect({ transaction: { transaction: 'main' } })
+        .expect({
+          span: container => {
+            expect(container.items).toHaveLength(2);
+            const anthropicSpan = container.items.find(
+              span => span.attributes['sentry.origin'].value === 'auto.ai.anthropic',
+            );
+            expect(anthropicSpan).toBeDefined();
+            expect(anthropicSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
 
-              // LangChain call is instrumented by LangChain.
-              const langchainSpan = container.items.find(
-                span => span.attributes['sentry.origin'].value === 'auto.ai.langchain',
-              );
-              expect(langchainSpan).toBeDefined();
-              expect(langchainSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
+            // LangChain call is instrumented by LangChain.
+            const langchainSpan = container.items.find(
+              span => span.attributes['sentry.origin'].value === 'auto.ai.langchain',
+            );
+            expect(langchainSpan).toBeDefined();
+            expect(langchainSpan!.name).toBe('chat claude-3-5-sonnet-20241022');
 
-              // Third call (not present): Direct Anthropic call made AFTER LangChain import
-              // is NOT instrumented, which demonstrates the skip mechanism works for NEW
-              // clients. We should only have ONE Anthropic span (the first one), not two.
-            },
-          })
-          .start()
-          .completed();
-      });
-    },
-    // This test fails on CJS because we use dynamic imports to simulate importing LangChain after the Anthropic client is created
-    { failsOnCjs: true },
-  );
+            // Third call (not present): Direct Anthropic call made AFTER LangChain import
+            // is NOT instrumented, which demonstrates the skip mechanism works for NEW
+            // clients. We should only have ONE Anthropic span (the first one), not two.
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
 
   createEsmAndCjsTests(
     __dirname,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
 import { conditionalTest } from '../../../../utils';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../../utils/runner';
+import { createEsmTests } from '../../../../utils/runner/createEsmAndCjsTests';
 
 // LangChain v1 requires Node.js 20+ (dropped Node 18 support)
 // See: https://docs.langchain.com/oss/javascript/migrate/langgraph-v1#dropped-node-18-support
@@ -273,12 +274,12 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
     },
   );
 
-  createEsmAndCjsTests(
+  createEsmTests(
     __dirname,
     'scenario-openai-before-langchain.mjs',
     'instrument.mjs',
     (createRunner, test) => {
-      test('demonstrates timing issue with duplicate spans (ESM only)', async () => {
+      test('demonstrates timing issue with duplicate spans', async () => {
         await createRunner()
           .ignore('event')
           .expect({ transaction: { transaction: 'main' } })
@@ -306,7 +307,6 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
       });
     },
     {
-      failsOnCjs: true,
       additionalDependencies: {
         langchain: '^1.0.0',
         '@langchain/core': '^1.0.0',

--- a/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect } from 'vitest';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+import { createCjsTests } from '../../../utils/runner/createEsmAndCjsTests';
 
 describe('lru-memoizer', () => {
   afterAll(() => {
@@ -35,28 +36,22 @@ describe('lru-memoizer', () => {
     { failsOnEsm: true },
   );
 
-  createEsmAndCjsTests(
-    __dirname,
-    'scenario-parallel.mjs',
-    'instrument.mjs',
-    (createTestRunner, test) => {
-      test('keeps each span context across parallel memoized requests', async () => {
-        // Each parallel request emits a transaction whose callback must have run in its own context.
-        // Two identical expectations keep this order-independent.
-        const expectation = {
-          transaction: {
-            contexts: {
-              trace: expect.objectContaining({
-                op: expect.stringMatching(/^(first|second)$/),
-                data: expect.objectContaining({ 'memoized.context_preserved': true }),
-              }),
-            },
+  createCjsTests(__dirname, 'scenario-parallel.mjs', 'instrument.mjs', (createTestRunner, test) => {
+    test('keeps each span context across parallel memoized requests', async () => {
+      // Each parallel request emits a transaction whose callback must have run in its own context.
+      // Two identical expectations keep this order-independent.
+      const expectation = {
+        transaction: {
+          contexts: {
+            trace: expect.objectContaining({
+              op: expect.stringMatching(/^(first|second)$/),
+              data: expect.objectContaining({ 'memoized.context_preserved': true }),
+            }),
           },
-        };
+        },
+      };
 
-        await createTestRunner().expect(expectation).expect(expectation).start().completed();
-      });
-    },
-    { failsOnEsm: true },
-  );
+      await createTestRunner().expect(expectation).expect(expectation).start().completed();
+    });
+  });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/mysql-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql-streamed/test.ts
@@ -1,7 +1,8 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP } from '@sentry/core';
 import type { SerializedStreamedSpanContainer } from '@sentry/core';
 import { afterAll, describe, expect } from 'vitest';
-import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+import { cleanupChildProcesses } from '../../../utils/runner';
+import { createCjsTests } from '../../../utils/runner/createEsmAndCjsTests';
 
 describe('mysql auto instrumentation (streamed)', () => {
   afterAll(() => {
@@ -119,44 +120,26 @@ describe('mysql auto instrumentation (streamed)', () => {
   };
 
   describe('with connection.connect()', () => {
-    createEsmAndCjsTests(
-      __dirname,
-      'scenario-withConnect.mjs',
-      'instrument.mjs',
-      (createTestRunner, test) => {
-        test('should auto-instrument `mysql` package when using connection.connect()', async () => {
-          await createTestRunner().expect({ span: assertMysqlSpans }).start().completed();
-        });
-      },
-      { failsOnEsm: true },
-    );
+    createCjsTests(__dirname, 'scenario-withConnect.mjs', 'instrument.mjs', (createTestRunner, test) => {
+      test('should auto-instrument `mysql` package when using connection.connect()', async () => {
+        await createTestRunner().expect({ span: assertMysqlSpans }).start().completed();
+      });
+    });
   });
 
   describe('query without callback', () => {
-    createEsmAndCjsTests(
-      __dirname,
-      'scenario-withoutCallback.mjs',
-      'instrument.mjs',
-      (createTestRunner, test) => {
-        test('should auto-instrument `mysql` package when using query without callback', async () => {
-          await createTestRunner().expect({ span: assertMysqlSpans }).start().completed();
-        });
-      },
-      { failsOnEsm: true },
-    );
+    createCjsTests(__dirname, 'scenario-withoutCallback.mjs', 'instrument.mjs', (createTestRunner, test) => {
+      test('should auto-instrument `mysql` package when using query without callback', async () => {
+        await createTestRunner().expect({ span: assertMysqlSpans }).start().completed();
+      });
+    });
   });
 
   describe('without connection.connect()', () => {
-    createEsmAndCjsTests(
-      __dirname,
-      'scenario-withoutConnect.mjs',
-      'instrument.mjs',
-      (createTestRunner, test) => {
-        test('should auto-instrument `mysql` package without connection.connect()', async () => {
-          await createTestRunner().expect({ span: assertMysqlSpans }).start().completed();
-        });
-      },
-      { failsOnEsm: true },
-    );
+    createCjsTests(__dirname, 'scenario-withoutConnect.mjs', 'instrument.mjs', (createTestRunner, test) => {
+      test('should auto-instrument `mysql` package without connection.connect()', async () => {
+        await createTestRunner().expect({ span: assertMysqlSpans }).start().completed();
+      });
+    });
   });
 });

--- a/dev-packages/node-integration-tests/utils/runner/createEsmAndCjsTests.ts
+++ b/dev-packages/node-integration-tests/utils/runner/createEsmAndCjsTests.ts
@@ -4,10 +4,24 @@ import { cp, mkdir, readFile, rm, writeFile } from 'fs/promises';
 import { basename, join } from 'path';
 import { promisify } from 'util';
 import { afterAll, beforeAll, test, type TestAPI } from 'vitest';
-import { createRunner } from './createRunner';
+import { CLEANUP_STEPS, createRunner } from './createRunner';
 
 const execPromise = promisify(exec);
 
+interface ScenarioPaths {
+  cjs: {
+    scenario: string;
+    instrument: string;
+  };
+  esm: {
+    scenario: string;
+    instrument: string;
+  };
+}
+
+/**
+ * Run one or multiple tests in ESM and CJS for a given scenario and instrument file.
+ */
 export function createEsmAndCjsTests(
   cwd: string,
   scenarioPath: string,
@@ -22,15 +36,155 @@ export function createEsmAndCjsTests(
     failsOnCjs?: boolean;
     failsOnEsm?: boolean;
     /**
-     * `additionalDependencies` to install in a tmp dir for the esm and cjs tests
-     * This could be used to override packages that live in the parent package.json for the specific run of the test
-     * e.g. `{ ai: '^5.0.0' }` to test Vercel AI v5
+     * `additionalDependencies` to install in the tmp dir.
      */
     additionalDependencies?: Record<string, string>;
     /** Copy these files/dirs into the tmp dir. */
     copyPaths?: string[];
   },
 ): void {
+  const [tmpDirPath, createTmpDir, paths] = prepareTmpDir(cwd, scenarioPath, instrumentPath, options);
+
+  const esmTestFn = options?.failsOnEsm ? wrapTestApi(test.fails, 'esm - fails') : wrapTestApi(test, 'esm');
+  const cjsTestFn = options?.failsOnCjs ? wrapTestApi(test.fails, 'cjs - fails') : wrapTestApi(test, 'cjs');
+  const createdRunners = new Set<ReturnType<typeof createRunner>>();
+
+  callback(
+    () => trackRunner(createdRunners, createRunner(paths.esm.scenario).withFlags('--import', paths.esm.instrument)),
+    esmTestFn,
+    'esm',
+    tmpDirPath,
+  );
+
+  callback(
+    () => trackRunner(createdRunners, createRunner(paths.cjs.scenario).withFlags('--require', paths.cjs.instrument)),
+    cjsTestFn,
+    'cjs',
+    tmpDirPath,
+  );
+
+  setupAndCleanup(createTmpDir, createdRunners, tmpDirPath);
+}
+
+/**
+ * Run one or multiple tests in ESM only for a given scenario and instrument file.
+ */
+export function createEsmTests(
+  cwd: string,
+  scenarioPath: string,
+  instrumentPath: string,
+  callback: (createTestRunner: () => ReturnType<typeof createRunner>, testFn: typeof test, cwd: string) => void,
+  options?: {
+    /**
+     * `additionalDependencies` to install in the tmp dir.
+     */
+    additionalDependencies?: Record<string, string>;
+    /** Copy these files/dirs into the tmp dir. */
+    copyPaths?: string[];
+  },
+) {
+  const [tmpDirPath, createTmpDir, paths] = prepareTmpDir(cwd, scenarioPath, instrumentPath, options);
+
+  // Track the runners created by this invocation so we can tear down only their resources in
+  // `afterAll` — rather than clearing the global `CLEANUP_STEPS`, which would also kill child
+  // processes, docker containers and mock servers owned by sibling suites in the same worker.
+  const createdRunners = new Set<ReturnType<typeof createRunner>>();
+  function trackRunner(runner: ReturnType<typeof createRunner>): ReturnType<typeof createRunner> {
+    createdRunners.add(runner);
+    return runner;
+  }
+
+  callback(
+    () => trackRunner(createRunner(paths.esm.scenario).withFlags('--import', paths.esm.instrument)),
+    test,
+    tmpDirPath,
+  );
+
+  setupAndCleanup(createTmpDir, createdRunners, tmpDirPath);
+}
+
+/**
+ * Run one or multiple tests in CJS only for a given scenario and instrument file.
+ */
+export function createCjsTests(
+  cwd: string,
+  scenarioPath: string,
+  instrumentPath: string,
+  callback: (createTestRunner: () => ReturnType<typeof createRunner>, testFn: typeof test, cwd: string) => void,
+  options?: {
+    /**
+     * `additionalDependencies` to install in the tmp dir.
+     */
+    additionalDependencies?: Record<string, string>;
+    /** Copy these files/dirs into the tmp dir. */
+    copyPaths?: string[];
+  },
+) {
+  const [tmpDirPath, createTmpDir, paths] = prepareTmpDir(cwd, scenarioPath, instrumentPath, options);
+  const createdRunners = new Set<ReturnType<typeof createRunner>>();
+
+  callback(
+    () => trackRunner(createdRunners, createRunner(paths.cjs.scenario).withFlags('--import', paths.cjs.instrument)),
+    test,
+    tmpDirPath,
+  );
+
+  setupAndCleanup(createTmpDir, createdRunners, tmpDirPath);
+}
+
+function trackRunner(
+  createdRunners: Set<ReturnType<typeof createRunner>>,
+  runner: ReturnType<typeof createRunner>,
+): ReturnType<typeof createRunner> {
+  createdRunners.add(runner);
+  // Also add this to global cleanup steps in case something goes wrong here
+  // oxlint-disable-next-line typescript/unbound-method
+  CLEANUP_STEPS.add(runner.cleanup);
+  return runner;
+}
+
+/**
+ * Register beforeAll and afterAll hooks to create the tmp directory and cleanup after the tests have run.
+ */
+function setupAndCleanup(
+  createTmpDir: () => Promise<void>,
+  createdRunners: Set<ReturnType<typeof createRunner>>,
+  tmpDirPath: string,
+) {
+  // Create tmp directory and install additionalDependencies (with retries)
+  beforeAll(async () => {
+    await createTmpDir();
+  }, 120_000);
+
+  // Clean up the tmp directory after both esm and cjs suites have run
+  afterAll(async () => {
+    // First do cleanup — but only of the runners this invocation created!
+    for (const runner of createdRunners) {
+      runner.cleanup();
+      // Remove this from global cleanup steps
+      // oxlint-disable-next-line typescript/unbound-method
+      CLEANUP_STEPS.delete(runner.cleanup);
+    }
+    createdRunners.clear();
+
+    try {
+      await rm(tmpDirPath, { recursive: true, force: true });
+    } catch {
+      if (process.env.DEBUG) {
+        // eslint-disable-next-line no-console
+        console.error(`Failed to remove tmp dir: ${tmpDirPath}`);
+      }
+    }
+  }, 30_000);
+}
+
+/** Returns: tmpDir, createTmpDir(), scenarioPaths */
+function prepareTmpDir(
+  cwd: string,
+  scenarioPath: string,
+  instrumentPath: string,
+  options?: { additionalDependencies?: Record<string, string>; copyPaths?: string[] },
+): [string, () => Promise<void>, ScenarioPaths] {
   const mjsScenarioPath = join(cwd, scenarioPath);
   const mjsInstrumentPath = join(cwd, instrumentPath);
 
@@ -97,54 +251,18 @@ export function createEsmAndCjsTests(
     }
   }
 
-  const esmTestFn = options?.failsOnEsm ? wrapTestApi(test.fails, 'esm - fails') : wrapTestApi(test, 'esm');
-  const cjsTestFn = options?.failsOnCjs ? wrapTestApi(test.fails, 'cjs - fails') : wrapTestApi(test, 'cjs');
+  const paths: ScenarioPaths = {
+    cjs: {
+      scenario: cjsScenarioPath,
+      instrument: cjsInstrumentPath,
+    },
+    esm: {
+      scenario: esmScenarioPathForRun,
+      instrument: esmInstrumentPathForRun,
+    },
+  };
 
-  // Track the runners created by this invocation so we can tear down only their resources in
-  // `afterAll` — rather than clearing the global `CLEANUP_STEPS`, which would also kill child
-  // processes, docker containers and mock servers owned by sibling suites in the same worker.
-  const createdRunners = new Set<ReturnType<typeof createRunner>>();
-  function trackRunner(runner: ReturnType<typeof createRunner>): ReturnType<typeof createRunner> {
-    createdRunners.add(runner);
-    return runner;
-  }
-
-  callback(
-    () => trackRunner(createRunner(esmScenarioPathForRun).withFlags('--import', esmInstrumentPathForRun)),
-    esmTestFn,
-    'esm',
-    tmpDirPath,
-  );
-
-  callback(
-    () => trackRunner(createRunner(cjsScenarioPath).withFlags('--require', cjsInstrumentPath)),
-    cjsTestFn,
-    'cjs',
-    tmpDirPath,
-  );
-
-  // Create tmp directory and install additionalDependencies (with retries)
-  beforeAll(async () => {
-    await createTmpDir();
-  }, 120_000);
-
-  // Clean up the tmp directory after both esm and cjs suites have run
-  afterAll(async () => {
-    // First do cleanup — but only of the runners this invocation created!
-    for (const runner of createdRunners) {
-      runner.cleanup();
-    }
-    createdRunners.clear();
-
-    try {
-      await rm(tmpDirPath, { recursive: true, force: true });
-    } catch {
-      if (process.env.DEBUG) {
-        // eslint-disable-next-line no-console
-        console.error(`Failed to remove tmp dir: ${tmpDirPath}`);
-      }
-    }
-  }, 30_000);
+  return [tmpDirPath, createTmpDir, paths];
 }
 
 async function convertEsmFileToCjs(inputPath: string, outputPath: string): Promise<void> {
@@ -225,7 +343,10 @@ async function npmInstallWithRetry(cwd: string, deps: string[]): Promise<void> {
 
 // Wrap the test API so it prepends the test name with the mode
 // Also wraps the nested fields `only`, `skip`, `each`, and `for`
-function wrapTestApi(api: TestAPI | typeof test.fails | typeof test.only | typeof test.skip, suffix: string) {
+function wrapTestApi(
+  api: TestAPI | typeof test.fails | typeof test.only | typeof test.skip,
+  suffix: string,
+): typeof api {
   return new Proxy(api, {
     apply: (target, thisArg, args: Parameters<typeof api>) => {
       if (typeof args[0] === 'string') {

--- a/dev-packages/node-integration-tests/utils/runner/createEsmAndCjsTests.ts
+++ b/dev-packages/node-integration-tests/utils/runner/createEsmAndCjsTests.ts
@@ -84,18 +84,10 @@ export function createEsmTests(
   },
 ) {
   const [tmpDirPath, createTmpDir, paths] = prepareTmpDir(cwd, scenarioPath, instrumentPath, options);
-
-  // Track the runners created by this invocation so we can tear down only their resources in
-  // `afterAll` — rather than clearing the global `CLEANUP_STEPS`, which would also kill child
-  // processes, docker containers and mock servers owned by sibling suites in the same worker.
   const createdRunners = new Set<ReturnType<typeof createRunner>>();
-  function trackRunner(runner: ReturnType<typeof createRunner>): ReturnType<typeof createRunner> {
-    createdRunners.add(runner);
-    return runner;
-  }
 
   callback(
-    () => trackRunner(createRunner(paths.esm.scenario).withFlags('--import', paths.esm.instrument)),
+    () => trackRunner(createdRunners, createRunner(paths.esm.scenario).withFlags('--import', paths.esm.instrument)),
     test,
     tmpDirPath,
   );
@@ -124,7 +116,7 @@ export function createCjsTests(
   const createdRunners = new Set<ReturnType<typeof createRunner>>();
 
   callback(
-    () => trackRunner(createdRunners, createRunner(paths.cjs.scenario).withFlags('--import', paths.cjs.instrument)),
+    () => trackRunner(createdRunners, createRunner(paths.cjs.scenario).withFlags('--require', paths.cjs.instrument)),
     test,
     tmpDirPath,
   );

--- a/dev-packages/node-integration-tests/utils/runner/createRunner.ts
+++ b/dev-packages/node-integration-tests/utils/runner/createRunner.ts
@@ -108,7 +108,7 @@ type StartResult = {
   ): Promise<T | undefined>;
 };
 
-const CLEANUP_STEPS = new Set<VoidFunction>();
+export const CLEANUP_STEPS = new Set<VoidFunction>();
 
 export function cleanupChildProcesses(): void {
   for (const step of CLEANUP_STEPS) {


### PR DESCRIPTION
This make some small adjustments to the node test runner, as well as exposing two new methods for faster tests:

* Make sure that cleanup steps are also kept in the global space, so if something fails with cleanup of one specific runner, it will still be cleaned up by the global cleanup.
* Removed some unneeded `failsOnEsm: false` definitions

Two new methods now exist for faster tests:

* `createEsmTests`
* `createCjsTests`

This works the same as `createEsmAndCjsTests`, but does... only run a single set. For now, I did not change the code to actually generate both variants in the tmp dir (as the file i/o is actually super fast so not really the bottleneck, but may be cleaned up later). However, we can use this in places where we do not need to run things in both environments.

In this PR, I have rewritten to the new methods in the following places only:

* Where we deliberately only test one way because we use syntax that does not work in the other (e.g. langchain)
* For libraries that do not work in ESM, where we now only have a single test with `failsOnEsm: true` to ensure we find out if that stops failing, but we do not need to run every single scenario in failure mode, only one.

In follow ups, we can think about only running one or two tests per integration in esm&cjs mode to verify it generally works in both, and run other scenarios only in esm or cjs, for faster test execution times.