### PR TITLE
fix(tests): Add dedicated route for Hono query_string tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-route-patterns.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/route-groups/test-route-patterns.ts
@@ -15,6 +15,9 @@ routePatterns.get('/async', async c => {
   return c.text('async response');
 });
 
+// Dedicated route for query_string test to avoid transaction name collisions
+routePatterns.get('/query-test', c => c.text('query test response'));
+
 // .all() registration
 routePatterns.all('/all', c => c.text('all handler response'));
 

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/route-patterns.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/route-patterns.test.ts
@@ -95,18 +95,18 @@ test.describe('request data extraction', () => {
     const transactionPromise = waitForTransaction(APP_NAME, event => {
       return (
         event.contexts?.trace?.op === 'http.server' &&
-        event.transaction === `GET ${PREFIX}` &&
+        event.transaction === `GET ${PREFIX}/query-test` &&
         event.request?.query_string === 'foo=bar&baz=42'
       );
     });
 
-    const response = await fetch(`${baseURL}${PREFIX}?foo=bar&baz=42`);
+    const response = await fetch(`${baseURL}${PREFIX}/query-test?foo=bar&baz=42`);
     expect(response.status).toBe(200);
 
     const transaction = await transactionPromise;
 
     expect(transaction.request?.method).toBe('GET');
-    expect(transaction.request?.url).toContain(PREFIX);
+    expect(transaction.request?.url).toContain(`${PREFIX}/query-test`);
     expect(transaction.request?.query_string).toBe('foo=bar&baz=42');
   });
 


### PR DESCRIPTION
closes #21628

Created it's own route to not have conflicts with other routes.