### PR TITLE
chore(github): Change range of Write Tool

### DIFF
--- a/.github/workflows/track-framework-updates.yml
+++ b/.github/workflows/track-framework-updates.yml
@@ -60,7 +60,7 @@ jobs:
           claude_args: |
             --model claude-opus-4-8
             --max-turns 80
-            --allowedTools "Read,Write(/.agents/skills/track-framework-updates/output/**),Bash(python3 .agents/skills/track-framework-updates/scripts/collect_updates.py *),Bash(python3 .agents/skills/track-framework-updates/scripts/check_support.py)"
+            --allowedTools "Read,Write,Bash(python3 .agents/skills/track-framework-updates/scripts/collect_updates.py *),Bash(python3 .agents/skills/track-framework-updates/scripts/check_support.py)"
 
       - name: Post job summary
         if: always()


### PR DESCRIPTION
The action still does not have enough permissions for Writing. We probably have to just remove the path.

Related PR: https://github.com/getsentry/sentry-javascript/pull/21726