### PR TITLE
feat(core): Add `extendIntegration` method

### DIFF
--- a/packages/aws-serverless/src/integration/aws/index.ts
+++ b/packages/aws-serverless/src/integration/aws/index.ts
@@ -7,7 +7,7 @@ import { defineIntegration } from '@sentry/core';
  */
 export const awsIntegration = defineIntegration(() => {
   return {
-    name: 'Aws',
+    name: 'Aws' as const,
     setupOnce() {
       registerInstrumentations({
         instrumentations: [new AwsInstrumentation()],

--- a/packages/aws-serverless/src/integration/awslambda.ts
+++ b/packages/aws-serverless/src/integration/awslambda.ts
@@ -29,7 +29,7 @@ const AWS_CLOUDWATCH_CONTEXT_FIELDS = ['log_group', 'log_stream', 'url'] as cons
 
 const _awsLambdaIntegration = ((options: AwsLambdaOptions = {}) => {
   return {
-    name: 'AwsLambda',
+    name: 'AwsLambda' as const,
     setupOnce() {
       instrumentAwsLambda(options);
     },

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -57,7 +57,7 @@ interface BreadcrumbsOptions {
 /** maxStringLength gets capped to prevent 100 breadcrumbs exceeding 1MB event payload size */
 const MAX_ALLOWED_STRING_LENGTH = 1024;
 
-const INTEGRATION_NAME = 'Breadcrumbs';
+const INTEGRATION_NAME = 'Breadcrumbs' as const;
 
 const _breadcrumbsIntegration = ((options: Partial<BreadcrumbsOptions> = {}) => {
   const _options = {

--- a/packages/browser/src/integrations/browserapierrors.ts
+++ b/packages/browser/src/integrations/browserapierrors.ts
@@ -8,7 +8,7 @@ const DEFAULT_EVENT_TARGET =
     ',',
   );
 
-const INTEGRATION_NAME = 'BrowserApiErrors';
+const INTEGRATION_NAME = 'BrowserApiErrors' as const;
 
 type XMLHttpRequestProp = 'onload' | 'onerror' | 'onprogress' | 'onreadystatechange';
 

--- a/packages/browser/src/integrations/browsersession.ts
+++ b/packages/browser/src/integrations/browsersession.ts
@@ -28,7 +28,7 @@ export const browserSessionIntegration = defineIntegration((options: BrowserSess
   const lifecycle = options.lifecycle ?? 'route';
 
   return {
-    name: 'BrowserSession',
+    name: 'BrowserSession' as const,
     setupOnce() {
       if (typeof WINDOW.document === 'undefined') {
         DEBUG_BUILD &&

--- a/packages/browser/src/integrations/contextlines.ts
+++ b/packages/browser/src/integrations/contextlines.ts
@@ -5,7 +5,7 @@ const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
 const DEFAULT_LINES_OF_CONTEXT = 7;
 
-const INTEGRATION_NAME = 'ContextLines';
+const INTEGRATION_NAME = 'ContextLines' as const;
 
 // TODO(v11): Use `dataCollection.frameContextLines` default (5)
 interface ContextLinesOptions {

--- a/packages/browser/src/integrations/culturecontext.ts
+++ b/packages/browser/src/integrations/culturecontext.ts
@@ -2,7 +2,7 @@ import type { CultureContext, IntegrationFn } from '@sentry/core/browser';
 import { defineIntegration, safeSetSpanJSONAttributes } from '@sentry/core/browser';
 import { WINDOW } from '../helpers';
 
-const INTEGRATION_NAME = 'CultureContext';
+const INTEGRATION_NAME = 'CultureContext' as const;
 
 const _cultureContextIntegration = (() => {
   return {

--- a/packages/browser/src/integrations/featureFlags/launchdarkly/integration.ts
+++ b/packages/browser/src/integrations/featureFlags/launchdarkly/integration.ts
@@ -24,7 +24,7 @@ import type { LDContext, LDEvaluationDetail, LDInspectionFlagUsedHandler } from 
  */
 export const launchDarklyIntegration = defineIntegration(() => {
   return {
-    name: 'LaunchDarkly',
+    name: 'LaunchDarkly' as const,
 
     processEvent(event: Event, _hint: EventHint, _client: Client): Event {
       return _INTERNAL_copyFlagsFromScopeToEvent(event);

--- a/packages/browser/src/integrations/featureFlags/openfeature/integration.ts
+++ b/packages/browser/src/integrations/featureFlags/openfeature/integration.ts
@@ -24,7 +24,7 @@ import type { EvaluationDetails, HookContext, HookHints, JsonValue, OpenFeatureH
 
 export const openFeatureIntegration = defineIntegration(() => {
   return {
-    name: 'OpenFeature',
+    name: 'OpenFeature' as const,
 
     processEvent(event: Event, _hint: EventHint, _client: Client): Event {
       return _INTERNAL_copyFlagsFromScopeToEvent(event);

--- a/packages/browser/src/integrations/featureFlags/statsig/integration.ts
+++ b/packages/browser/src/integrations/featureFlags/statsig/integration.ts
@@ -33,7 +33,7 @@ import type { FeatureGate, StatsigClient } from './types';
 export const statsigIntegration = defineIntegration(
   ({ featureFlagClient: statsigClient }: { featureFlagClient: StatsigClient }) => {
     return {
-      name: 'Statsig',
+      name: 'Statsig' as const,
 
       setup(_client: Client) {
         statsigClient.on('gate_evaluation', (event: { gate: FeatureGate }) => {

--- a/packages/browser/src/integrations/featureFlags/unleash/integration.ts
+++ b/packages/browser/src/integrations/featureFlags/unleash/integration.ts
@@ -39,7 +39,7 @@ type UnleashIntegrationOptions = {
 export const unleashIntegration = defineIntegration(
   ({ featureFlagClientClass: unleashClientClass }: UnleashIntegrationOptions) => {
     return {
-      name: 'Unleash',
+      name: 'Unleash' as const,
 
       setupOnce() {
         const unleashClientPrototype = unleashClientClass.prototype as UnleashClient;

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -33,7 +33,7 @@ const STREAMING_CONTENT_TYPES = ['text/event-stream', 'application/x-ndjson', 'a
  */
 export const fetchStreamPerformanceIntegration = defineIntegration(() => {
   return {
-    name: 'FetchStreamPerformance',
+    name: 'FetchStreamPerformance' as const,
 
     setup() {
       // End the stream span when the response body finishes resolving

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -21,7 +21,7 @@ type GlobalHandlersIntegrationsOptionKeys = 'onerror' | 'onunhandledrejection';
 
 type GlobalHandlersIntegrations = Record<GlobalHandlersIntegrationsOptionKeys, boolean>;
 
-const INTEGRATION_NAME = 'GlobalHandlers';
+const INTEGRATION_NAME = 'GlobalHandlers' as const;
 
 const _globalHandlersIntegration = ((options: Partial<GlobalHandlersIntegrations> = {}) => {
   const _options = {

--- a/packages/browser/src/integrations/graphqlClient.ts
+++ b/packages/browser/src/integrations/graphqlClient.ts
@@ -42,7 +42,7 @@ interface GraphQLOperation {
   operationName?: string;
 }
 
-const INTEGRATION_NAME = 'GraphQLClient';
+const INTEGRATION_NAME = 'GraphQLClient' as const;
 
 const _graphqlClientIntegration = ((options: GraphQLClientOptions) => {
   return {

--- a/packages/browser/src/integrations/httpclient.ts
+++ b/packages/browser/src/integrations/httpclient.ts
@@ -18,7 +18,7 @@ import { DEBUG_BUILD } from '../debug-build';
 export type HttpStatusCodeRange = [number, number] | number;
 export type HttpRequestTarget = string | RegExp;
 
-const INTEGRATION_NAME = 'HttpClient';
+const INTEGRATION_NAME = 'HttpClient' as const;
 
 interface HttpClientOptions {
   /**

--- a/packages/browser/src/integrations/httpcontext.ts
+++ b/packages/browser/src/integrations/httpcontext.ts
@@ -7,7 +7,7 @@ import { getHttpRequestData, WINDOW } from '../helpers';
  */
 export const httpContextIntegration = defineIntegration(() => {
   return {
-    name: 'HttpContext',
+    name: 'HttpContext' as const,
     preprocessEvent(event) {
       // if none of the information we want exists, don't bother
       if (!WINDOW.navigator && !WINDOW.location && !WINDOW.document) {

--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -10,7 +10,7 @@ interface LinkedErrorsOptions {
 const DEFAULT_KEY = 'cause';
 const DEFAULT_LIMIT = 5;
 
-const INTEGRATION_NAME = 'LinkedErrors';
+const INTEGRATION_NAME = 'LinkedErrors' as const;
 
 const _linkedErrorsIntegration = ((options: LinkedErrorsOptions = {}) => {
   const limit = options.limit || DEFAULT_LIMIT;

--- a/packages/browser/src/integrations/reportingobserver.ts
+++ b/packages/browser/src/integrations/reportingobserver.ts
@@ -10,7 +10,7 @@ import {
 
 const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
-const INTEGRATION_NAME = 'ReportingObserver';
+const INTEGRATION_NAME = 'ReportingObserver' as const;
 
 interface Report {
   [key: string]: unknown;

--- a/packages/browser/src/integrations/spanstreaming.ts
+++ b/packages/browser/src/integrations/spanstreaming.ts
@@ -12,7 +12,7 @@ import { DEBUG_BUILD } from '../debug-build';
 
 export const spanStreamingIntegration = defineIntegration(() => {
   return {
-    name: 'SpanStreaming',
+    name: 'SpanStreaming' as const,
 
     beforeSetup(client) {
       // If users only set spanStreamingIntegration, without traceLifecycle, we set it to "stream" for them.

--- a/packages/browser/src/integrations/spotlight.ts
+++ b/packages/browser/src/integrations/spotlight.ts
@@ -12,7 +12,7 @@ export type SpotlightConnectionOptions = {
   sidecarUrl?: string;
 };
 
-export const INTEGRATION_NAME = 'SpotlightBrowser';
+export const INTEGRATION_NAME = 'SpotlightBrowser' as const;
 
 export const SPOTLIGHT_IGNORE_SPANS = [{ op: 'ui.interaction.click', name: '#sentry-spotlight' }];
 

--- a/packages/browser/src/integrations/view-hierarchy.ts
+++ b/packages/browser/src/integrations/view-hierarchy.ts
@@ -113,7 +113,7 @@ export const viewHierarchyIntegration = defineIntegration((options: Options = {}
   }
 
   return {
-    name: 'ViewHierarchy',
+    name: 'ViewHierarchy' as const,
     processEvent: (event, hint) => {
       // only capture for error events
       if (event.type !== undefined || options.shouldAttach?.(event, hint) === false) {

--- a/packages/browser/src/integrations/webVitals.ts
+++ b/packages/browser/src/integrations/webVitals.ts
@@ -10,7 +10,7 @@ import {
   trackLcpAsSpan,
 } from '@sentry/browser-utils';
 
-export const WEB_VITALS_INTEGRATION_NAME = 'WebVitals';
+export const WEB_VITALS_INTEGRATION_NAME = 'WebVitals' as const;
 
 export type WebVitalName = 'cls' | 'inp' | 'lcp';
 

--- a/packages/browser/src/integrations/webWorker.ts
+++ b/packages/browser/src/integrations/webWorker.ts
@@ -5,7 +5,7 @@ import { eventFromUnknownInput } from '../eventbuilder';
 import { WINDOW } from '../helpers';
 import { _eventFromRejectionWithPrimitive, _getUnhandledRejectionError } from './globalhandlers';
 
-export const INTEGRATION_NAME = 'WebWorker';
+export const INTEGRATION_NAME = 'WebWorker' as const;
 
 interface WebWorkerMessage {
   _sentryMessage: boolean;

--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -19,7 +19,7 @@ import {
   takeProfileFromGlobalCache,
 } from './utils';
 
-const INTEGRATION_NAME = 'BrowserProfiling';
+const INTEGRATION_NAME = 'BrowserProfiling' as const;
 
 const _browserProfilingIntegration = (() => {
   return {

--- a/packages/bun/src/integrations/bunRuntimeMetrics.ts
+++ b/packages/bun/src/integrations/bunRuntimeMetrics.ts
@@ -2,7 +2,7 @@ import { performance } from 'perf_hooks';
 import { _INTERNAL_safeDateNow, _INTERNAL_safeUnref, defineIntegration, metrics } from '@sentry/core';
 import { _INTERNAL_normalizeCollectionInterval, type NodeRuntimeMetricsOptions } from '@sentry/node';
 
-const INTEGRATION_NAME = 'BunRuntimeMetrics';
+const INTEGRATION_NAME = 'BunRuntimeMetrics' as const;
 const DEFAULT_INTERVAL_MS = 30_000;
 
 /**

--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -16,7 +16,7 @@ import {
 } from '@sentry/core';
 import type { ServeOptions } from 'bun';
 
-const INTEGRATION_NAME = 'BunServer';
+const INTEGRATION_NAME = 'BunServer' as const;
 
 const _bunServerIntegration = (() => {
   return {

--- a/packages/cloudflare/src/integrations/fetch.ts
+++ b/packages/cloudflare/src/integrations/fetch.ts
@@ -18,7 +18,7 @@ import {
   stringMatchesSomePattern,
 } from '@sentry/core';
 
-const INTEGRATION_NAME = 'Fetch';
+const INTEGRATION_NAME = 'Fetch' as const;
 
 const HAS_CLIENT_MAP = new WeakMap<Client, boolean>();
 

--- a/packages/cloudflare/src/integrations/hono.ts
+++ b/packages/cloudflare/src/integrations/hono.ts
@@ -11,7 +11,7 @@ import {
 } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 
-const INTEGRATION_NAME = 'Hono';
+const INTEGRATION_NAME = 'Hono' as const;
 
 interface HonoError extends Error {
   status?: number;

--- a/packages/cloudflare/src/integrations/httpServer.ts
+++ b/packages/cloudflare/src/integrations/httpServer.ts
@@ -1,7 +1,7 @@
 import type { Client, IntegrationFn, MaxRequestBodySize } from '@sentry/core';
 import { captureBodyFromWinterCGRequest, defineIntegration, getIsolationScope } from '@sentry/core';
 
-const INTEGRATION_NAME = 'HttpServer';
+const INTEGRATION_NAME = 'HttpServer' as const;
 
 export interface HttpServerIntegrationOptions {
   /**

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -167,6 +167,64 @@ export function addIntegration(integration: Integration): void {
  * Define an integration function that can be used to create an integration instance.
  * Note that this by design hides the implementation details of the integration, as they are considered internal.
  */
-export function defineIntegration<Fn extends IntegrationFn>(fn: Fn): (...args: Parameters<Fn>) => Integration {
+export function defineIntegration<Fn extends IntegrationFn>(
+  fn: Fn,
+): (...args: Parameters<Fn>) => Integration & { name: ReturnType<Fn>['name'] } {
   return fn;
+}
+
+/**
+ * Wrap a parent integration with an extended integration.
+ * Any passed integration function will call the parent integration function first, if it exists.
+ *
+ * Example usage:
+ *
+ * @example
+ * ```typescript
+ * const parentIntegration = defineIntegration(() => ({
+ *   name: 'ParentIntegration',
+ *   setupOnce: () => {
+ *     console.log('ParentIntegration setupOnce');
+ *   },
+ * }));
+ *
+ * const extendedIntegration = extendIntegration(parentIntegration, {
+ *   setupOnce: () => {
+ *     console.log('ExtendedIntegration setupOnce');
+ *   },
+ * });
+ * ```
+ */
+export function extendIntegration<Base extends Integration, Extended extends Partial<Integration>>(
+  integration: Base,
+  extendedIntegration: Extended,
+): Omit<Base, keyof Extended> & Extended {
+  // The extension overrides the base for any shared key (object spread + the wrapping below), so the
+  // result type drops the overridden base keys rather than intersecting them — `Base & Extended` would
+  // wrongly intersect shared keys (e.g. a re-typed property collapses to `never`).
+  const wrappedIntegration = {
+    ...integration,
+    ...extendedIntegration,
+  } as Omit<Base, keyof Extended> & Extended;
+
+  // Make sure that functions that are extended also call the base functions, if defined
+  // oxlint-disable-next-line guard-for-in
+  for (const key in extendedIntegration) {
+    const baseValue = integration[key as keyof Base];
+    const extendedValue = extendedIntegration[key];
+
+    if (typeof baseValue === 'function' && typeof extendedValue === 'function') {
+      const baseBound = baseValue.bind(wrappedIntegration) as typeof baseValue;
+      const extendedBound = extendedValue.bind(wrappedIntegration) as typeof extendedValue;
+
+      const wrappedFunction = function (this: unknown, ...args: unknown[]): unknown {
+        baseBound(...args);
+        return extendedBound(...args);
+      } as (Omit<Base, keyof Extended> & Extended)[Extract<keyof Extended, string>];
+
+      wrappedIntegration[key] = wrappedFunction;
+    }
+  }
+
+  return wrappedIntegration;
 }

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -195,7 +195,7 @@ export function defineIntegration<Fn extends IntegrationFn>(
  * });
  * ```
  */
-export function extendIntegration<Base extends Integration, Extended extends Partial<Integration>>(
+export function extendIntegration<Base extends Integration, Extended extends Record<string, unknown> & Partial<Integration>>(
   integration: Base,
   extendedIntegration: Extended,
 ): Omit<Base, keyof Extended> & Extended {

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -175,10 +175,11 @@ export function defineIntegration<Fn extends IntegrationFn>(
 
 // When  extending an integration, we allow other properties to be passed-through
 type IntegrationWithOtherProperties = Record<string, unknown> & Integration;
-type ExtendedIntegration<
-  Base extends IntegrationWithOtherProperties,
-  Extended extends Partial<IntegrationWithOtherProperties>,
-> = Omit<Base, keyof Extended> & Extended;
+type ExtendedIntegration<Base extends Integration, Extended extends Partial<IntegrationWithOtherProperties>> = Omit<
+  Base,
+  keyof Extended
+> &
+  Extended;
 
 /**
  * Wrap a parent integration with an extended integration.
@@ -202,10 +203,10 @@ type ExtendedIntegration<
  * });
  * ```
  */
-export function extendIntegration<
-  Base extends IntegrationWithOtherProperties,
-  Extended extends Partial<IntegrationWithOtherProperties>,
->(integration: Base, extendedIntegration: Extended): ExtendedIntegration<Base, Extended> {
+export function extendIntegration<Base extends Integration, Extended extends Partial<IntegrationWithOtherProperties>>(
+  integration: Base,
+  extendedIntegration: Extended,
+): ExtendedIntegration<Base, Extended> {
   // The extension overrides the base for any shared key (object spread + the wrapping below), so the
   // result type drops the overridden base keys rather than intersecting them — `Base & Extended` would
   // wrongly intersect shared keys (e.g. a re-typed property collapses to `never`).

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -173,6 +173,13 @@ export function defineIntegration<Fn extends IntegrationFn>(
   return fn;
 }
 
+// When  extending an integration, we allow other properties to be passed-through
+type IntegrationWithOtherProperties = Record<string, unknown> & Integration;
+type ExtendedIntegration<
+  Base extends IntegrationWithOtherProperties,
+  Extended extends Partial<IntegrationWithOtherProperties>,
+> = Omit<Base, keyof Extended> & Extended;
+
 /**
  * Wrap a parent integration with an extended integration.
  * Any passed integration function will call the parent integration function first, if it exists.
@@ -195,17 +202,17 @@ export function defineIntegration<Fn extends IntegrationFn>(
  * });
  * ```
  */
-export function extendIntegration<Base extends Integration, Extended extends Record<string, unknown> & Partial<Integration>>(
-  integration: Base,
-  extendedIntegration: Extended,
-): Omit<Base, keyof Extended> & Extended {
+export function extendIntegration<
+  Base extends IntegrationWithOtherProperties,
+  Extended extends Partial<IntegrationWithOtherProperties>,
+>(integration: Base, extendedIntegration: Extended): ExtendedIntegration<Base, Extended> {
   // The extension overrides the base for any shared key (object spread + the wrapping below), so the
   // result type drops the overridden base keys rather than intersecting them — `Base & Extended` would
   // wrongly intersect shared keys (e.g. a re-typed property collapses to `never`).
   const wrappedIntegration = {
     ...integration,
     ...extendedIntegration,
-  } as Omit<Base, keyof Extended> & Extended;
+  } as ExtendedIntegration<Base, Extended>;
 
   // Make sure that functions that are extended also call the base functions, if defined
   // oxlint-disable-next-line guard-for-in
@@ -213,16 +220,19 @@ export function extendIntegration<Base extends Integration, Extended extends Rec
     const baseValue = integration[key as keyof Base];
     const extendedValue = extendedIntegration[key];
 
+    type ValueType = typeof extendedValue;
+
     if (typeof baseValue === 'function' && typeof extendedValue === 'function') {
-      const baseBound = baseValue.bind(wrappedIntegration) as typeof baseValue;
-      const extendedBound = extendedValue.bind(wrappedIntegration) as typeof extendedValue;
+      const wrappedFunction = new Proxy(baseValue, {
+        apply: (target, thisArg, args) => {
+          Reflect.apply(target, thisArg, args);
+          return Reflect.apply(extendedValue, thisArg, args);
+        },
+      }) as ValueType;
 
-      const wrappedFunction = function (this: unknown, ...args: unknown[]): unknown {
-        baseBound(...args);
-        return extendedBound(...args);
-      } as (Omit<Base, keyof Extended> & Extended)[Extract<keyof Extended, string>];
-
-      wrappedIntegration[key] = wrappedFunction;
+      // We know this is OK, but typescript does not properly narrow/infer types here
+      // so instead of casting the wrappedFunction to some complicated type, we just make clear that we simply overwrite this
+      (wrappedIntegration as Record<string, unknown>)[key] = wrappedFunction;
     }
   }
 

--- a/packages/core/src/integrations/captureconsole.ts
+++ b/packages/core/src/integrations/captureconsole.ts
@@ -22,7 +22,7 @@ interface CaptureConsoleOptions {
   handled?: boolean;
 }
 
-const INTEGRATION_NAME = 'CaptureConsole';
+const INTEGRATION_NAME = 'CaptureConsole' as const;
 
 const _captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
   const levels = options.levels || CONSOLE_LEVELS;

--- a/packages/core/src/integrations/console.ts
+++ b/packages/core/src/integrations/console.ts
@@ -23,7 +23,7 @@ type GlobalObjectWithUtil = typeof GLOBAL_OBJ & {
   };
 };
 
-const INTEGRATION_NAME = 'Console';
+const INTEGRATION_NAME = 'Console' as const;
 
 /**
  * Captures calls to the `console` API as breadcrumbs in Sentry.

--- a/packages/core/src/integrations/conversationId.ts
+++ b/packages/core/src/integrations/conversationId.ts
@@ -6,7 +6,7 @@ import type { IntegrationFn } from '../types/integration';
 import type { Span } from '../types/span';
 import { spanToJSON } from '../utils/spanUtils';
 
-const INTEGRATION_NAME = 'ConversationId';
+const INTEGRATION_NAME = 'ConversationId' as const;
 
 const _conversationIdIntegration = (() => {
   return {

--- a/packages/core/src/integrations/dedupe.ts
+++ b/packages/core/src/integrations/dedupe.ts
@@ -7,7 +7,7 @@ import type { StackFrame } from '../types/stackframe';
 import { debug } from '../utils/debug-logger';
 import { getFramesFromEvent } from '../utils/stacktrace';
 
-const INTEGRATION_NAME = 'Dedupe';
+const INTEGRATION_NAME = 'Dedupe' as const;
 
 const _dedupeIntegration = (() => {
   let previousEvent: Event | undefined;

--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -34,7 +34,7 @@ export interface EventFiltersOptions {
   disableErrorDefaults: boolean;
 }
 
-const INTEGRATION_NAME = 'EventFilters';
+const INTEGRATION_NAME = 'EventFilters' as const;
 
 /**
  * An integration that filters out events (errors and transactions) based on:
@@ -86,7 +86,7 @@ export const eventFiltersIntegration = defineIntegration((options: Partial<Event
 export const inboundFiltersIntegration = defineIntegration(((options: Partial<EventFiltersOptions> = {}) => {
   return {
     ...eventFiltersIntegration(options),
-    name: 'InboundFilters',
+    name: 'InboundFilters' as const,
   };
 }) satisfies IntegrationFn);
 

--- a/packages/core/src/integrations/extraerrordata.ts
+++ b/packages/core/src/integrations/extraerrordata.ts
@@ -10,7 +10,7 @@ import { normalize } from '../utils/normalize';
 import { setSkipNormalizationHint } from '../utils/normalizationHints';
 import { truncate } from '../utils/string';
 
-const INTEGRATION_NAME = 'ExtraErrorData';
+const INTEGRATION_NAME = 'ExtraErrorData' as const;
 
 interface ExtraErrorDataOptions {
   /**

--- a/packages/core/src/integrations/featureFlags/growthbook.ts
+++ b/packages/core/src/integrations/featureFlags/growthbook.ts
@@ -37,7 +37,7 @@ export type GrowthBookClassLike = new (...args: unknown[]) => GrowthBookLike;
 export const growthbookIntegration: IntegrationFn = defineIntegration(
   ({ growthbookClass }: { growthbookClass: GrowthBookClassLike }) => {
     return {
-      name: 'GrowthBook',
+      name: 'GrowthBook' as const,
 
       setupOnce() {
         const proto = growthbookClass.prototype as GrowthBookLike;

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -7,7 +7,7 @@ import { getOriginalFunction } from '../utils/object';
 
 let originalFunctionToString: () => void;
 
-const INTEGRATION_NAME = 'FunctionToString';
+const INTEGRATION_NAME = 'FunctionToString' as const;
 
 const SETUP_CLIENTS = new WeakMap<Client, boolean>();
 

--- a/packages/core/src/integrations/linkederrors.ts
+++ b/packages/core/src/integrations/linkederrors.ts
@@ -11,7 +11,7 @@ interface LinkedErrorsOptions {
 const DEFAULT_KEY = 'cause';
 const DEFAULT_LIMIT = 5;
 
-const INTEGRATION_NAME = 'LinkedErrors';
+const INTEGRATION_NAME = 'LinkedErrors' as const;
 
 const _linkedErrorsIntegration = ((options: LinkedErrorsOptions = {}) => {
   const limit = options.limit || DEFAULT_LIMIT;

--- a/packages/core/src/integrations/moduleMetadata.ts
+++ b/packages/core/src/integrations/moduleMetadata.ts
@@ -14,7 +14,7 @@ import { forEachEnvelopeItem } from '../utils/envelope';
  */
 export const moduleMetadataIntegration = defineIntegration(() => {
   return {
-    name: 'ModuleMetadata',
+    name: 'ModuleMetadata' as const,
     setup(client) {
       // We need to strip metadata from stack frames before sending them to Sentry since these are client side only.
       client.on('beforeEnvelope', envelope => {

--- a/packages/core/src/integrations/requestdata.ts
+++ b/packages/core/src/integrations/requestdata.ts
@@ -28,7 +28,7 @@ type RequestDataIntegrationOptions = {
   include?: RequestDataIncludeOptions;
 };
 
-const INTEGRATION_NAME = 'RequestData';
+const INTEGRATION_NAME = 'RequestData' as const;
 
 const _requestDataIntegration = ((options: RequestDataIntegrationOptions = {}) => {
   // Per spec, integration-level options override global dataCollection.

--- a/packages/core/src/integrations/rewriteframes.ts
+++ b/packages/core/src/integrations/rewriteframes.ts
@@ -7,7 +7,7 @@ import { GLOBAL_OBJ } from '../utils/worldwide';
 
 type StackFrameIteratee = (frame: StackFrame) => StackFrame;
 
-const INTEGRATION_NAME = 'RewriteFrames';
+const INTEGRATION_NAME = 'RewriteFrames' as const;
 
 interface RewriteFramesOptions {
   /**

--- a/packages/core/src/integrations/spanStreaming.ts
+++ b/packages/core/src/integrations/spanStreaming.ts
@@ -10,7 +10,7 @@ import { spanIsSampled } from '../utils/spanUtils';
 
 export const spanStreamingIntegration = defineIntegration(() => {
   return {
-    name: 'SpanStreaming',
+    name: 'SpanStreaming' as const,
 
     setup(client) {
       const initialMessage = 'SpanStreaming integration requires';

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -569,7 +569,7 @@ interface SupabaseIntegrationOptions {
   sendOperationData?: boolean;
 }
 
-const INTEGRATION_NAME = 'Supabase';
+const INTEGRATION_NAME = 'Supabase' as const;
 
 const _supabaseIntegration = ((supabaseClient: unknown, options: { sendOperationData?: boolean }) => {
   return {

--- a/packages/core/src/integrations/third-party-errors-filter.ts
+++ b/packages/core/src/integrations/third-party-errors-filter.ts
@@ -48,7 +48,7 @@ interface Options {
  */
 export const thirdPartyErrorFilterIntegration = defineIntegration((options: Options) => {
   return {
-    name: 'ThirdPartyErrorsFilter',
+    name: 'ThirdPartyErrorsFilter' as const,
     setup(client) {
       // We need to strip metadata from stack frames before sending them to Sentry since these are client side only.
       client.on('beforeEnvelope', envelope => {

--- a/packages/core/src/integrations/zoderrors.ts
+++ b/packages/core/src/integrations/zoderrors.ts
@@ -21,7 +21,7 @@ interface ZodErrorsOptions {
 }
 
 const DEFAULT_LIMIT = 10;
-const INTEGRATION_NAME = 'ZodErrors';
+const INTEGRATION_NAME = 'ZodErrors' as const;
 
 /**
  * Simplified ZodIssue type definition

--- a/packages/core/src/logs/console-integration.ts
+++ b/packages/core/src/logs/console-integration.ts
@@ -15,7 +15,7 @@ interface CaptureConsoleOptions {
   levels: ConsoleLevel[];
 }
 
-const INTEGRATION_NAME = 'ConsoleLogs';
+const INTEGRATION_NAME = 'ConsoleLogs' as const;
 
 const DEFAULT_ATTRIBUTES = {
   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.log.console',

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -65,7 +65,13 @@ export { initAndBind, setCurrentClient } from './sdk';
 export { createTransport } from './transports/base';
 export { makeOfflineTransport } from './transports/offline';
 export { makeMultiplexedTransport, MULTIPLEXED_TRANSPORT_EXTRA_KEY } from './transports/multiplexed';
-export { getIntegrationsToSetup, addIntegration, defineIntegration, installedIntegrations } from './integration';
+export {
+  getIntegrationsToSetup,
+  addIntegration,
+  defineIntegration,
+  extendIntegration,
+  installedIntegrations,
+} from './integration';
 export {
   _INTERNAL_skipAiProviderWrapping,
   _INTERNAL_shouldSkipAiProviderWrapping,

--- a/packages/core/src/tracing/anthropic-ai/constants.ts
+++ b/packages/core/src/tracing/anthropic-ai/constants.ts
@@ -1,6 +1,6 @@
 import type { InstrumentedMethodRegistry } from '../ai/utils';
 
-export const ANTHROPIC_AI_INTEGRATION_NAME = 'Anthropic_AI';
+export const ANTHROPIC_AI_INTEGRATION_NAME = 'Anthropic_AI' as const;
 
 // https://docs.anthropic.com/en/api/messages
 // https://docs.anthropic.com/en/api/models-list

--- a/packages/core/src/tracing/google-genai/constants.ts
+++ b/packages/core/src/tracing/google-genai/constants.ts
@@ -1,6 +1,6 @@
 import type { InstrumentedMethodRegistry } from '../ai/utils';
 
-export const GOOGLE_GENAI_INTEGRATION_NAME = 'Google_GenAI';
+export const GOOGLE_GENAI_INTEGRATION_NAME = 'Google_GenAI' as const;
 
 // https://ai.google.dev/api/rest/v1/models/generateContent
 // https://ai.google.dev/api/rest/v1/chats/sendMessage

--- a/packages/core/src/tracing/langchain/constants.ts
+++ b/packages/core/src/tracing/langchain/constants.ts
@@ -1,4 +1,4 @@
-export const LANGCHAIN_INTEGRATION_NAME = 'LangChain';
+export const LANGCHAIN_INTEGRATION_NAME = 'LangChain' as const;
 export const LANGCHAIN_ORIGIN = 'auto.ai.langchain';
 
 export const ROLE_MAP: Record<string, string> = {

--- a/packages/core/src/tracing/langgraph/constants.ts
+++ b/packages/core/src/tracing/langgraph/constants.ts
@@ -1,2 +1,2 @@
-export const LANGGRAPH_INTEGRATION_NAME = 'LangGraph';
+export const LANGGRAPH_INTEGRATION_NAME = 'LangGraph' as const;
 export const LANGGRAPH_ORIGIN = 'auto.ai.langgraph';

--- a/packages/core/src/tracing/openai/constants.ts
+++ b/packages/core/src/tracing/openai/constants.ts
@@ -1,6 +1,6 @@
 import type { InstrumentedMethodRegistry } from '../ai/utils';
 
-export const OPENAI_INTEGRATION_NAME = 'OpenAI';
+export const OPENAI_INTEGRATION_NAME = 'OpenAI' as const;
 
 // https://platform.openai.com/docs/quickstart?api-mode=responses
 // https://platform.openai.com/docs/quickstart?api-mode=chat

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { getCurrentScope } from '../../src/currentScopes';
-import { addIntegration, getIntegrationsToSetup, installedIntegrations, setupIntegration } from '../../src/integration';
+import {
+  addIntegration,
+  extendIntegration,
+  getIntegrationsToSetup,
+  installedIntegrations,
+  setupIntegration,
+} from '../../src/integration';
 import { setCurrentClient } from '../../src/sdk';
 import type { Integration } from '../../src/types/integration';
 import type { CoreOptions } from '../../src/types/options';
@@ -681,5 +687,172 @@ describe('addIntegration', () => {
     expect(integration2.afterAllSetup).toHaveBeenCalledTimes(0);
 
     expect(logs).toHaveBeenCalledWith('Integration skipped because it was already installed: test');
+  });
+});
+
+describe('extendIntegration', () => {
+  it('merges static (non-function) properties, with the extension taking precedence', () => {
+    const base = { name: 'Base', version: 1, baseOnly: 'a' };
+    const result = extendIntegration(base, { name: 'Extended', version: 2, extendedOnly: 'b' });
+
+    expect(result.name).toBe('Extended');
+    expect(result.version).toBe(2);
+    expect(result.baseOnly).toBe('a');
+    expect(result.extendedOnly).toBe('b');
+  });
+
+  it('returns a new object without mutating either input', () => {
+    const baseSetupOnce = vi.fn();
+    const extension = { setupOnce: vi.fn() };
+    const base = { name: 'Base', setupOnce: baseSetupOnce };
+
+    const result = extendIntegration(base, extension);
+
+    expect(result).not.toBe(base);
+    expect(base.setupOnce).toBe(baseSetupOnce);
+    expect(result.setupOnce).not.toBe(baseSetupOnce);
+    expect(result.setupOnce).not.toBe(extension.setupOnce);
+  });
+
+  it('wraps a method present on both so the base runs before the extension', () => {
+    const calls: string[] = [];
+    const base = {
+      name: 'Base',
+      setupOnce: () => {
+        calls.push('base');
+      },
+    };
+
+    const result = extendIntegration(base, {
+      setupOnce: () => {
+        calls.push('extended');
+      },
+    });
+
+    result.setupOnce();
+
+    expect(calls).toEqual(['base', 'extended']);
+  });
+
+  it('forwards arguments to both methods and returns the extension method’s value', () => {
+    const baseRun = vi.fn();
+    const extendedRun = vi.fn().mockReturnValue('extended-result');
+    const base = { name: 'Base', run: baseRun };
+
+    const result = extendIntegration(base, { run: extendedRun });
+
+    const returnValue = result.run('arg', 42);
+
+    expect(baseRun).toHaveBeenCalledWith('arg', 42);
+    expect(extendedRun).toHaveBeenCalledWith('arg', 42);
+    expect(returnValue).toBe('extended-result');
+  });
+
+  it('binds both methods to the merged integration so they see the merged properties', () => {
+    const seenThis: unknown[] = [];
+    const base = {
+      name: 'Base',
+      setupOnce(this: unknown) {
+        seenThis.push(this);
+      },
+    };
+
+    const result = extendIntegration(base, {
+      extra: 'value',
+      setupOnce(this: unknown) {
+        seenThis.push(this);
+      },
+    });
+
+    result.setupOnce();
+
+    const [baseThis, extendedThis] = seenThis;
+    expect(baseThis).toBe(result);
+    expect(extendedThis).toBe(result);
+    // The base method can reach extension-provided properties through `this`.
+    expect((baseThis as { extra?: string }).extra).toBe('value');
+  });
+
+  it('always runs the base before the extension even when the wrapped method is called detached', () => {
+    const calls: string[] = [];
+    const base = {
+      name: 'Base',
+      setupOnce: () => {
+        calls.push('base');
+      },
+    };
+
+    const result = extendIntegration(base, {
+      setupOnce: () => {
+        calls.push('extended');
+      },
+    });
+
+    const detached = result.setupOnce;
+    detached();
+
+    expect(calls).toEqual(['base', 'extended']);
+  });
+
+  it('uses the extension method as-is (not wrapped) when the base has no method of that name', () => {
+    const extendedSetupOnce = vi.fn();
+    const base = { name: 'Base' };
+
+    const result = extendIntegration(base, { setupOnce: extendedSetupOnce });
+
+    expect(result.setupOnce).toBe(extendedSetupOnce);
+
+    result.setupOnce();
+    expect(extendedSetupOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves base-only methods untouched and callable', () => {
+    const baseRun = vi.fn();
+    const base = { name: 'Base', run: baseRun };
+
+    const result = extendIntegration(base, { setupOnce: vi.fn() });
+
+    // Not present on the extension, so it is the original reference, not a wrapper.
+    expect(result.run).toBe(baseRun);
+    result.run();
+    expect(baseRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the extension overwrite a base method with a non-function value (no wrapping, base not called)', () => {
+    const baseHook = vi.fn();
+    const result = extendIntegration(
+      { name: 'Base', hook: baseHook } as unknown as Integration,
+      { hook: 'replaced' } as unknown as Partial<Integration>,
+    );
+
+    expect((result as unknown as { hook: unknown }).hook).toBe('replaced');
+    expect(baseHook).not.toHaveBeenCalled();
+  });
+
+  it('wraps every shared method independently', () => {
+    const order: string[] = [];
+    const base = {
+      name: 'Base',
+      setupOnce: () => {
+        order.push('base:setupOnce');
+      },
+      teardown: () => {
+        order.push('base:teardown');
+      },
+    };
+
+    const result = extendIntegration(base, {
+      setupOnce: () => {
+        order.push('ext:setupOnce');
+      },
+      teardown: () => {
+        order.push('ext:teardown');
+      },
+    });
+
+    result.setupOnce();
+    result.teardown();
+
+    expect(order).toEqual(['base:setupOnce', 'ext:setupOnce', 'base:teardown', 'ext:teardown']);
   });
 });

--- a/packages/deno/src/integrations/breadcrumbs.ts
+++ b/packages/deno/src/integrations/breadcrumbs.ts
@@ -25,7 +25,7 @@ interface BreadcrumbsOptions {
   sentry: boolean;
 }
 
-const INTEGRATION_NAME = 'Breadcrumbs';
+const INTEGRATION_NAME = 'Breadcrumbs' as const;
 
 /**
  * Note: This `breadcrumbsIntegration` is almost the same as the one from @sentry/browser.

--- a/packages/deno/src/integrations/context.ts
+++ b/packages/deno/src/integrations/context.ts
@@ -1,7 +1,7 @@
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration, safeSetSpanJSONAttributes } from '@sentry/core';
 
-const INTEGRATION_NAME = 'DenoContext';
+const INTEGRATION_NAME = 'DenoContext' as const;
 
 function getOSName(): string {
   switch (Deno.build.os) {

--- a/packages/deno/src/integrations/contextlines.ts
+++ b/packages/deno/src/integrations/contextlines.ts
@@ -1,7 +1,7 @@
 import type { Event, IntegrationFn, StackFrame } from '@sentry/core';
 import { addContextToFrame, defineIntegration, LRUMap } from '@sentry/core';
 
-const INTEGRATION_NAME = 'ContextLines';
+const INTEGRATION_NAME = 'ContextLines' as const;
 const FILE_CONTENT_CACHE = new LRUMap<string, string | null>(100);
 const DEFAULT_LINES_OF_CONTEXT = 7;
 

--- a/packages/deno/src/integrations/deno-cron.ts
+++ b/packages/deno/src/integrations/deno-cron.ts
@@ -7,7 +7,7 @@ type CronFn = () => void | Promise<void>;
 // Parameters<typeof Deno.cron> doesn't work well with the overloads 🤔
 type CronParams = [string, string | Deno.CronSchedule, CronFn | CronOptions, CronFn | CronOptions | undefined];
 
-const INTEGRATION_NAME = 'DenoCron';
+const INTEGRATION_NAME = 'DenoCron' as const;
 
 const SETUP_CLIENTS = new WeakMap<Client, boolean>();
 

--- a/packages/deno/src/integrations/deno-serve.ts
+++ b/packages/deno/src/integrations/deno-serve.ts
@@ -4,7 +4,7 @@ import { setAsyncLocalStorageAsyncContextStrategy } from '../async';
 import type { RequestHandlerWrapperOptions } from '../wrap-deno-request-handler';
 import { wrapDenoRequestHandler } from '../wrap-deno-request-handler';
 
-const INTEGRATION_NAME = 'DenoServe';
+const INTEGRATION_NAME = 'DenoServe' as const;
 
 export type ServeParams =
   // [(Request) => Response]

--- a/packages/deno/src/integrations/denoRuntimeMetrics.ts
+++ b/packages/deno/src/integrations/denoRuntimeMetrics.ts
@@ -1,6 +1,6 @@
 import { _INTERNAL_safeDateNow, defineIntegration, metrics } from '@sentry/core';
 
-const INTEGRATION_NAME = 'DenoRuntimeMetrics';
+const INTEGRATION_NAME = 'DenoRuntimeMetrics' as const;
 const DEFAULT_INTERVAL_MS = 30_000;
 const MIN_INTERVAL_MS = 1_000;
 

--- a/packages/deno/src/integrations/globalhandlers.ts
+++ b/packages/deno/src/integrations/globalhandlers.ts
@@ -5,7 +5,7 @@ type GlobalHandlersIntegrationsOptionKeys = 'error' | 'unhandledrejection';
 
 type GlobalHandlersIntegrations = Record<GlobalHandlersIntegrationsOptionKeys, boolean>;
 
-const INTEGRATION_NAME = 'GlobalHandlers';
+const INTEGRATION_NAME = 'GlobalHandlers' as const;
 let isExiting = false;
 
 const _globalHandlersIntegration = ((options?: GlobalHandlersIntegrations) => {

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -18,7 +18,7 @@ import {
   HTTP_SERVER_DIAGNOSTICS_CHANNEL_SUPPORTED,
 } from '../denoVersion';
 
-const INTEGRATION_NAME = 'DenoHttp';
+const INTEGRATION_NAME = 'DenoHttp' as const;
 
 export interface DenoHttpIntegrationOptions {
   /**

--- a/packages/deno/src/integrations/mysql.ts
+++ b/packages/deno/src/integrations/mysql.ts
@@ -1,9 +1,9 @@
 import { mysqlChannelIntegration } from '@sentry/server-utils/orchestrion';
 import type { Integration, IntegrationFn } from '@sentry/core';
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, extendIntegration } from '@sentry/core';
 import { setAsyncLocalStorageAsyncContextStrategy } from '../async';
 
-const INTEGRATION_NAME = 'DenoMysql';
+const INTEGRATION_NAME = 'DenoMysql' as const;
 
 /**
  * Create spans for `mysql` queries under Deno.
@@ -19,13 +19,13 @@ const INTEGRATION_NAME = 'DenoMysql';
  */
 const _denoMysqlIntegration = (() => {
   const inner = mysqlChannelIntegration();
-  return {
+
+  return extendIntegration(inner, {
     name: INTEGRATION_NAME,
     setupOnce() {
       setAsyncLocalStorageAsyncContextStrategy();
-      inner.setupOnce?.();
     },
-  };
+  });
 }) satisfies IntegrationFn;
 
 export const denoMysqlIntegration = defineIntegration(_denoMysqlIntegration) as () => Integration & {

--- a/packages/deno/src/integrations/normalizepaths.ts
+++ b/packages/deno/src/integrations/normalizepaths.ts
@@ -1,7 +1,7 @@
 import type { IntegrationFn } from '@sentry/core';
 import { createStackParser, defineIntegration, dirname, nodeStackLineParser } from '@sentry/core';
 
-const INTEGRATION_NAME = 'NormalizePaths';
+const INTEGRATION_NAME = 'NormalizePaths' as const;
 
 function appRootFromErrorStack(error: Error): string | undefined {
   // We know at the other end of the stack from here is the entry point that called 'init'

--- a/packages/deno/src/integrations/redis.ts
+++ b/packages/deno/src/integrations/redis.ts
@@ -8,7 +8,7 @@ import type { Integration, IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { setAsyncLocalStorageAsyncContextStrategy } from '../async';
 
-const INTEGRATION_NAME = 'DenoRedis';
+const INTEGRATION_NAME = 'DenoRedis' as const;
 
 export interface DenoRedisIntegrationOptions {
   /**

--- a/packages/deno/src/integrations/tracing/vercelai.ts
+++ b/packages/deno/src/integrations/tracing/vercelai.ts
@@ -6,7 +6,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
 import { vercelAiIntegration as serverUtilsVercelAiIntegration } from '@sentry/server-utils';
 
-const INTEGRATION_NAME = 'VercelAI';
+const INTEGRATION_NAME = 'VercelAI' as const;
 
 interface VercelAiOptions {
   /**

--- a/packages/deno/src/integrations/tracing/vercelai.ts
+++ b/packages/deno/src/integrations/tracing/vercelai.ts
@@ -3,10 +3,8 @@
  */
 
 import type { IntegrationFn } from '@sentry/core';
-import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
+import { addVercelAiProcessors, defineIntegration, extendIntegration } from '@sentry/core';
 import { vercelAiIntegration as serverUtilsVercelAiIntegration } from '@sentry/server-utils';
-
-const INTEGRATION_NAME = 'VercelAI' as const;
 
 interface VercelAiOptions {
   /**
@@ -19,14 +17,12 @@ interface VercelAiOptions {
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   const inner = serverUtilsVercelAiIntegration(options);
 
-  return {
-    ...inner,
-    name: INTEGRATION_NAME,
+  return extendIntegration(inner, {
     options,
     setup(client) {
       addVercelAiProcessors(client);
     },
-  };
+  });
 }) satisfies IntegrationFn;
 
 /**

--- a/packages/feedback/src/core/integration.ts
+++ b/packages/feedback/src/core/integration.ts
@@ -339,7 +339,7 @@ export const buildFeedbackIntegration = ({
     };
 
     return {
-      name: 'Feedback',
+      name: 'Feedback' as const,
       setupOnce() {
         if (!isBrowser() || !_options.autoInject) {
           return;

--- a/packages/feedback/src/modal/integration.tsx
+++ b/packages/feedback/src/modal/integration.tsx
@@ -21,7 +21,7 @@ function getUser(): User | undefined {
 
 export const feedbackModalIntegration = ((): FeedbackModalIntegration => {
   return {
-    name: 'FeedbackModal',
+    name: 'FeedbackModal' as const,
     setupOnce() {},
     createDialog: ({ options, screenshotIntegration, sendFeedback, shadow }) => {
       const shadowRoot = shadow as ShadowRoot;

--- a/packages/feedback/src/screenshot/integration.ts
+++ b/packages/feedback/src/screenshot/integration.ts
@@ -6,7 +6,7 @@ import { ScreenshotEditorFactory } from './components/ScreenshotEditor';
 
 export const feedbackScreenshotIntegration = ((): FeedbackScreenshotIntegration => {
   return {
-    name: 'FeedbackScreenshot',
+    name: 'FeedbackScreenshot' as const,
     setupOnce() {},
     createInput: ({ h, hooks, dialog, options }) => {
       const outputBuffer = DOCUMENT.createElement('canvas');

--- a/packages/google-cloud-serverless/src/integrations/gcp-context.ts
+++ b/packages/google-cloud-serverless/src/integrations/gcp-context.ts
@@ -15,7 +15,7 @@ const GCP_CONTEXT_ATTRIBUTE_MAP: Record<string, string> = {
 
 const _gcpContextIntegration = (() => {
   return {
-    name: 'GcpContext',
+    name: 'GcpContext' as const,
     processSegmentSpan(span) {
       const gcpContext = getCurrentScope().getScopeData().contexts['gcp.function.context'];
       if (!gcpContext) {

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
@@ -27,7 +27,7 @@ export interface Stub {
 
 const SERVICE_PATH_REGEX = /^(\w+)\.googleapis.com$/;
 
-const INTEGRATION_NAME = 'GoogleCloudGrpc';
+const INTEGRATION_NAME = 'GoogleCloudGrpc' as const;
 
 const SETUP_CLIENTS = new WeakMap<Client, boolean>();
 

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
@@ -16,7 +16,7 @@ interface RequestFunction extends CallableFunction {
   (reqOpts: RequestOptions, callback: ResponseCallback): void;
 }
 
-const INTEGRATION_NAME = 'GoogleCloudHttp';
+const INTEGRATION_NAME = 'GoogleCloudHttp' as const;
 
 const SETUP_CLIENTS = new WeakMap<Client, boolean>();
 

--- a/packages/nestjs/src/integrations/nest.ts
+++ b/packages/nestjs/src/integrations/nest.ts
@@ -6,7 +6,7 @@ import { SentryNestEventInstrumentation } from './sentry-nest-event-instrumentat
 import { SentryNestInstrumentation } from './sentry-nest-instrumentation';
 import { SentryNestScheduleInstrumentation } from './sentry-nest-schedule-instrumentation';
 
-const INTEGRATION_NAME = 'Nest';
+const INTEGRATION_NAME = 'Nest' as const;
 
 const instrumentNestCore = generateInstrumentOnce(`${INTEGRATION_NAME}.Core`, () => {
   return new NestInstrumentationCore();

--- a/packages/node-core/src/integrations/anr/index.ts
+++ b/packages/node-core/src/integrations/anr/index.ts
@@ -59,7 +59,7 @@ async function getContexts(client: NodeClient): Promise<Contexts> {
   return event?.contexts || {};
 }
 
-const INTEGRATION_NAME = 'Anr';
+const INTEGRATION_NAME = 'Anr' as const;
 
 type AnrInternal = { startWorker: () => void; stopWorker: () => void };
 

--- a/packages/node-core/src/integrations/childProcess.ts
+++ b/packages/node-core/src/integrations/childProcess.ts
@@ -19,7 +19,7 @@ interface Options {
   captureWorkerErrors?: boolean;
 }
 
-const INTEGRATION_NAME = 'ChildProcess';
+const INTEGRATION_NAME = 'ChildProcess' as const;
 
 /**
  * Capture breadcrumbs and events for child processes and worker threads.

--- a/packages/node-core/src/integrations/console.ts
+++ b/packages/node-core/src/integrations/console.ts
@@ -32,7 +32,7 @@ interface ConsoleIntegrationOptions {
  */
 export const consoleIntegration = defineIntegration((options: Partial<ConsoleIntegrationOptions> = {}) => {
   return {
-    name: 'Console',
+    name: 'Console' as const,
     setup(client) {
       if (process.env.LAMBDA_TASK_ROOT) {
         maybeInstrument('console', instrumentConsoleLambda);

--- a/packages/node-core/src/integrations/context.ts
+++ b/packages/node-core/src/integrations/context.ts
@@ -26,7 +26,7 @@ interface ProcessWithCurrentValues extends NodeJS.Process {
   availableMemory?(): number;
 }
 
-const INTEGRATION_NAME = 'Context';
+const INTEGRATION_NAME = 'Context' as const;
 
 interface DeviceContextOptions {
   cpu?: boolean;

--- a/packages/node-core/src/integrations/contextlines.ts
+++ b/packages/node-core/src/integrations/contextlines.ts
@@ -7,7 +7,7 @@ import { DEBUG_BUILD } from '../debug-build';
 const LRU_FILE_CONTENTS_CACHE = new LRUMap<string, Record<number, string>>(10);
 const LRU_FILE_CONTENTS_FS_READ_FAILED = new LRUMap<string, 1>(20);
 const DEFAULT_LINES_OF_CONTEXT = 7;
-const INTEGRATION_NAME = 'ContextLines';
+const INTEGRATION_NAME = 'ContextLines' as const;
 // Determines the upper bound of lineno/colno that we will attempt to read. Large colno values are likely to be
 // minified code while large lineno values are likely to be bundled code.
 // Exported for testing purposes.

--- a/packages/node-core/src/integrations/http/httpServerIntegration.ts
+++ b/packages/node-core/src/integrations/http/httpServerIntegration.ts
@@ -17,7 +17,7 @@ import { DEBUG_BUILD } from '../../debug-build';
 export { recordRequestSession };
 
 const HTTP_SERVER_INSTRUMENTED_KEY = createContextKey('sentry_http_server_instrumented');
-const INTEGRATION_NAME = 'Http.Server';
+const INTEGRATION_NAME = 'Http.Server' as const;
 
 // Inlining this type to not depend on newer TS types
 interface WeakRefImpl<T> {
@@ -171,6 +171,6 @@ const _httpServerIntegration = ((options: HttpServerIntegrationOptions = {}) => 
 export const httpServerIntegration = _httpServerIntegration as (
   options?: HttpServerIntegrationOptions,
 ) => Integration & {
-  name: 'HttpServer';
+  name: 'Http.Server';
   setupOnce: () => void;
 };

--- a/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
@@ -37,7 +37,7 @@ import { DEBUG_BUILD } from '../../debug-build';
 import type { NodeClient } from '../../sdk/client';
 import { addStartSpanCallback } from './httpServerIntegration';
 
-const INTEGRATION_NAME = 'Http.ServerSpans';
+const INTEGRATION_NAME = 'Http.ServerSpans' as const;
 
 // Tree-shakable guard to remove all code related to tracing
 declare const __SENTRY_TRACING__: boolean;
@@ -266,7 +266,7 @@ const _httpServerSpansIntegration = ((options: HttpServerSpansIntegrationOptions
 export const httpServerSpansIntegration = _httpServerSpansIntegration as (
   options?: HttpServerSpansIntegrationOptions,
 ) => Integration & {
-  name: 'HttpServerSpans';
+  name: 'Http.ServerSpans';
   setup: (client: NodeClient) => void;
   processEvent: (event: Event) => Event | null;
 };

--- a/packages/node-core/src/integrations/http/index.ts
+++ b/packages/node-core/src/integrations/http/index.ts
@@ -10,7 +10,7 @@ import { httpServerSpansIntegration } from './httpServerSpansIntegration';
 import type { SentryHttpInstrumentationOptions } from './SentryHttpInstrumentation';
 import { SentryHttpInstrumentation } from './SentryHttpInstrumentation';
 
-const INTEGRATION_NAME = 'Http';
+const INTEGRATION_NAME = 'Http' as const;
 
 interface HttpOptions {
   /**

--- a/packages/node-core/src/integrations/local-variables/local-variables-async.ts
+++ b/packages/node-core/src/integrations/local-variables/local-variables-async.ts
@@ -102,7 +102,7 @@ export const localVariablesAsyncIntegration = defineIntegration(((
   }
 
   return {
-    name: 'LocalVariablesAsync',
+    name: 'LocalVariablesAsync' as const,
     async setup(client: NodeClient) {
       const clientOptions = client.getOptions();
 

--- a/packages/node-core/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node-core/src/integrations/local-variables/local-variables-sync.ts
@@ -221,7 +221,7 @@ class AsyncSession implements DebugSession {
   }
 }
 
-const INTEGRATION_NAME = 'LocalVariables';
+const INTEGRATION_NAME = 'LocalVariables' as const;
 
 /**
  * Adds local variables to exception frames

--- a/packages/node-core/src/integrations/modules.ts
+++ b/packages/node-core/src/integrations/modules.ts
@@ -7,7 +7,7 @@ type ModuleInfo = Record<string, string>;
 
 let moduleCache: ModuleInfo | undefined;
 
-const INTEGRATION_NAME = 'Modules';
+const INTEGRATION_NAME = 'Modules' as const;
 
 declare const __SENTRY_SERVER_MODULES__: Record<string, string>;
 

--- a/packages/node-core/src/integrations/node-fetch/index.ts
+++ b/packages/node-core/src/integrations/node-fetch/index.ts
@@ -36,7 +36,7 @@ const instrumentSentryNodeFetch = generateInstrumentOnce(
 
 const _nativeNodeFetchIntegration = ((options: NodeFetchOptions = {}) => {
   return {
-    name: 'NodeFetch',
+    name: 'NodeFetch' as const,
     setupOnce() {
       instrumentSentryNodeFetch(options);
     },

--- a/packages/node-core/src/integrations/nodeRuntimeMetrics.ts
+++ b/packages/node-core/src/integrations/nodeRuntimeMetrics.ts
@@ -1,7 +1,7 @@
 import { monitorEventLoopDelay, performance } from 'perf_hooks';
 import { _INTERNAL_safeDateNow, _INTERNAL_safeUnref, defineIntegration, metrics } from '@sentry/core';
 
-const INTEGRATION_NAME = 'NodeRuntimeMetrics';
+const INTEGRATION_NAME = 'NodeRuntimeMetrics' as const;
 const DEFAULT_INTERVAL_MS = 30_000;
 const MIN_COLLECTION_INTERVAL_MS = 1_000;
 const EVENT_LOOP_DELAY_RESOLUTION_MS = 10;

--- a/packages/node-core/src/integrations/onuncaughtexception.ts
+++ b/packages/node-core/src/integrations/onuncaughtexception.ts
@@ -27,7 +27,7 @@ interface OnUncaughtExceptionOptions {
   onFatalError?(this: void, firstError: Error, secondError?: Error): void;
 }
 
-const INTEGRATION_NAME = 'OnUncaughtException';
+const INTEGRATION_NAME = 'OnUncaughtException' as const;
 
 /**
  * Add a global exception handler.

--- a/packages/node-core/src/integrations/processSession.ts
+++ b/packages/node-core/src/integrations/processSession.ts
@@ -1,6 +1,6 @@
 import { defineIntegration, endSession, getIsolationScope, startSession } from '@sentry/core';
 
-const INTEGRATION_NAME = 'ProcessSession';
+const INTEGRATION_NAME = 'ProcessSession' as const;
 
 /**
  * Records a Session for the current process to track release health.

--- a/packages/node-core/src/integrations/spotlight.ts
+++ b/packages/node-core/src/integrations/spotlight.ts
@@ -10,7 +10,7 @@ type SpotlightConnectionOptions = {
   sidecarUrl?: string;
 };
 
-export const INTEGRATION_NAME = 'Spotlight';
+export const INTEGRATION_NAME = 'Spotlight' as const;
 
 const _spotlightIntegration = ((options: Partial<SpotlightConnectionOptions> = {}) => {
   const _options = {

--- a/packages/node-core/src/integrations/systemError.ts
+++ b/packages/node-core/src/integrations/systemError.ts
@@ -1,7 +1,7 @@
 import * as util from 'node:util';
 import { defineIntegration } from '@sentry/core';
 
-const INTEGRATION_NAME = 'NodeSystemError';
+const INTEGRATION_NAME = 'NodeSystemError' as const;
 
 type SystemErrorContext = {
   dest?: string; // If present, the file path destination when reporting a file system error

--- a/packages/node-core/src/light/integrations/httpIntegration.ts
+++ b/packages/node-core/src/light/integrations/httpIntegration.ts
@@ -16,7 +16,7 @@ import type { ClientRequest } from 'node:http';
 import { errorMonitor } from 'node:events';
 import { NODE_VERSION } from '../../nodeVersion';
 
-const INTEGRATION_NAME = 'Http';
+const INTEGRATION_NAME = 'Http' as const;
 
 const FULLY_SUPPORTS_HTTP_DIAGNOSTICS_CHANNEL =
   (NODE_VERSION.major === 22 && NODE_VERSION.minor >= 12) ||

--- a/packages/node-core/src/light/integrations/nativeNodeFetchIntegration.ts
+++ b/packages/node-core/src/light/integrations/nativeNodeFetchIntegration.ts
@@ -9,7 +9,7 @@ import {
   getAbsoluteUrl,
 } from '../../utils/outgoingFetchRequest';
 
-const INTEGRATION_NAME = 'NodeFetch';
+const INTEGRATION_NAME = 'NodeFetch' as const;
 
 export interface NativeNodeFetchIntegrationOptions {
   /**

--- a/packages/node-core/src/light/integrations/otlpIntegration.ts
+++ b/packages/node-core/src/light/integrations/otlpIntegration.ts
@@ -20,7 +20,7 @@ interface OtlpIntegrationOptions {
   collectorUrl?: string;
 }
 
-const INTEGRATION_NAME = 'OtlpIntegration';
+const INTEGRATION_NAME = 'OtlpIntegration' as const;
 
 const _otlpIntegration = ((userOptions: OtlpIntegrationOptions = {}) => {
   const options = {

--- a/packages/node-native/src/event-loop-block-integration.ts
+++ b/packages/node-native/src/event-loop-block-integration.ts
@@ -25,7 +25,7 @@ import { registerThread, threadPoll } from '@sentry/node-native-stacktrace';
 import type { ThreadBlockedIntegrationOptions, WorkerStartData } from './common';
 import { POLL_RATIO } from './common';
 
-const INTEGRATION_NAME = 'ThreadBlocked';
+const INTEGRATION_NAME = 'ThreadBlocked' as const;
 const DEFAULT_THRESHOLD_MS = 1_000;
 
 function log(message: string, ...args: unknown[]): void {

--- a/packages/node/src/integrations/featureFlagShims/launchDarkly.ts
+++ b/packages/node/src/integrations/featureFlagShims/launchDarkly.ts
@@ -13,7 +13,7 @@ export const launchDarklyIntegrationShim = defineIntegration((_options?: unknown
   }
 
   return {
-    name: 'LaunchDarkly',
+    name: 'LaunchDarkly' as const,
   };
 });
 

--- a/packages/node/src/integrations/featureFlagShims/openFeature.ts
+++ b/packages/node/src/integrations/featureFlagShims/openFeature.ts
@@ -13,7 +13,7 @@ export const openFeatureIntegrationShim = defineIntegration((_options?: unknown)
   }
 
   return {
-    name: 'OpenFeature',
+    name: 'OpenFeature' as const,
   };
 });
 

--- a/packages/node/src/integrations/featureFlagShims/statsig.ts
+++ b/packages/node/src/integrations/featureFlagShims/statsig.ts
@@ -13,6 +13,6 @@ export const statsigIntegrationShim = defineIntegration((_options?: unknown) => 
   }
 
   return {
-    name: 'Statsig',
+    name: 'Statsig' as const,
   };
 });

--- a/packages/node/src/integrations/featureFlagShims/unleash.ts
+++ b/packages/node/src/integrations/featureFlagShims/unleash.ts
@@ -13,6 +13,6 @@ export const unleashIntegrationShim = defineIntegration((_options?: unknown) => 
   }
 
   return {
-    name: 'Unleash',
+    name: 'Unleash' as const,
   };
 });

--- a/packages/node/src/integrations/fs/index.ts
+++ b/packages/node/src/integrations/fs/index.ts
@@ -2,7 +2,7 @@ import { defineIntegration } from '@sentry/core';
 import { enableFsInstrumentation } from './vendored/instrumentation';
 import type { FsInstrumentationConfig } from './vendored/types';
 
-const INTEGRATION_NAME = 'FileSystem';
+const INTEGRATION_NAME = 'FileSystem' as const;
 
 /**
  * This integration will create spans for `fs` API operations, like reading and writing files.

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -20,7 +20,7 @@ import {
   SentryHttpInstrumentation,
 } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Http';
+const INTEGRATION_NAME = 'Http' as const;
 
 // TODO(v11): Consolidate all the various HTTP integration options into one,
 // and deprecate the duplicated and aliased options.

--- a/packages/node/src/integrations/node-fetch/index.ts
+++ b/packages/node/src/integrations/node-fetch/index.ts
@@ -74,7 +74,7 @@ const instrumentSentryNodeFetch = generateInstrumentOnce(
 
 const _nativeNodeFetchIntegration = ((options: NodeFetchOptions = {}) => {
   return {
-    name: 'NodeFetch',
+    name: 'NodeFetch' as const,
     setupOnce() {
       const instrumentSpans = _shouldInstrumentSpans(options, getClient<NodeClient>()?.getOptions());
 

--- a/packages/node/src/integrations/tracing/amqplib/index.ts
+++ b/packages/node/src/integrations/tracing/amqplib/index.ts
@@ -3,7 +3,7 @@ import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 import { AmqplibInstrumentation } from './vendored/instrumentation';
 
-const INTEGRATION_NAME = 'Amqplib';
+const INTEGRATION_NAME = 'Amqplib' as const;
 
 export const instrumentAmqplib = generateInstrumentOnce(INTEGRATION_NAME, () => new AmqplibInstrumentation());
 

--- a/packages/node/src/integrations/tracing/connect/index.ts
+++ b/packages/node/src/integrations/tracing/connect/index.ts
@@ -8,7 +8,7 @@ type ConnectApp = {
   use: (middleware: any) => void;
 };
 
-const INTEGRATION_NAME = 'Connect';
+const INTEGRATION_NAME = 'Connect' as const;
 
 export const instrumentConnect = generateInstrumentOnce(INTEGRATION_NAME, () => new ConnectInstrumentation());
 

--- a/packages/node/src/integrations/tracing/dataloader/index.ts
+++ b/packages/node/src/integrations/tracing/dataloader/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Dataloader';
+const INTEGRATION_NAME = 'Dataloader' as const;
 
 export const instrumentDataloader = generateInstrumentOnce(INTEGRATION_NAME, () => new DataloaderInstrumentation());
 

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -17,7 +17,7 @@ export { expressErrorHandler } from '@sentry/core';
 import { DEBUG_BUILD } from '../../debug-build';
 import { setHttpServerSpanRouteAttribute } from '../../utils/setHttpServerSpanRouteAttribute';
 
-const INTEGRATION_NAME = 'Express';
+const INTEGRATION_NAME = 'Express' as const;
 const SUPPORTED_VERSIONS = ['>=4.0.0 <6'];
 
 export function setupExpressErrorHandler(

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -89,7 +89,7 @@ interface FastifyHandlerOptions {
   shouldHandleError: (error: Error, request: FastifyRequest, reply: FastifyReply) => boolean;
 }
 
-const INTEGRATION_NAME = 'Fastify';
+const INTEGRATION_NAME = 'Fastify' as const;
 
 export const instrumentFastifyV3 = generateInstrumentOnce(
   `${INTEGRATION_NAME}.v3`,

--- a/packages/node/src/integrations/tracing/firebase/firebase.ts
+++ b/packages/node/src/integrations/tracing/firebase/firebase.ts
@@ -3,7 +3,7 @@ import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 import { FirebaseInstrumentation } from './otel';
 
-const INTEGRATION_NAME = 'Firebase';
+const INTEGRATION_NAME = 'Firebase' as const;
 
 export const instrumentFirebase = generateInstrumentOnce(INTEGRATION_NAME, () => new FirebaseInstrumentation());
 

--- a/packages/node/src/integrations/tracing/genericPool/index.ts
+++ b/packages/node/src/integrations/tracing/genericPool/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'GenericPool';
+const INTEGRATION_NAME = 'GenericPool' as const;
 
 export const instrumentGenericPool = generateInstrumentOnce(INTEGRATION_NAME, () => new GenericPoolInstrumentation({}));
 

--- a/packages/node/src/integrations/tracing/graphql/index.ts
+++ b/packages/node/src/integrations/tracing/graphql/index.ts
@@ -32,7 +32,7 @@ interface GraphqlOptions {
   useOperationNameForRootSpan?: boolean;
 }
 
-const INTEGRATION_NAME = 'Graphql';
+const INTEGRATION_NAME = 'Graphql' as const;
 
 export const instrumentGraphql = generateInstrumentOnce(
   INTEGRATION_NAME,

--- a/packages/node/src/integrations/tracing/hapi/index.ts
+++ b/packages/node/src/integrations/tracing/hapi/index.ts
@@ -12,7 +12,7 @@ import { ensureIsWrapped, generateInstrumentOnce } from '@sentry/node-core';
 import { DEBUG_BUILD } from '../../../debug-build';
 import type { Request, RequestEvent, Server } from './types';
 
-const INTEGRATION_NAME = 'Hapi';
+const INTEGRATION_NAME = 'Hapi' as const;
 
 export const instrumentHapi = generateInstrumentOnce(INTEGRATION_NAME, () => new HapiInstrumentation());
 

--- a/packages/node/src/integrations/tracing/hono/index.ts
+++ b/packages/node/src/integrations/tracing/hono/index.ts
@@ -17,7 +17,7 @@ import { AttributeNames } from './constants';
 import { HonoInstrumentation } from './instrumentation';
 import type { Context, MiddlewareHandler, MiddlewareHandlerInterface, Next } from './types';
 
-const INTEGRATION_NAME = 'Hono';
+const INTEGRATION_NAME = 'Hono' as const;
 
 function addHonoSpanAttributes(span: Span): void {
   const attributes = spanToJSON(span).data;

--- a/packages/node/src/integrations/tracing/kafka/index.ts
+++ b/packages/node/src/integrations/tracing/kafka/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Kafka';
+const INTEGRATION_NAME = 'Kafka' as const;
 
 export const instrumentKafka = generateInstrumentOnce(INTEGRATION_NAME, () => new KafkaJsInstrumentation());
 

--- a/packages/node/src/integrations/tracing/knex/index.ts
+++ b/packages/node/src/integrations/tracing/knex/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Knex';
+const INTEGRATION_NAME = 'Knex' as const;
 
 export const instrumentKnex = generateInstrumentOnce(INTEGRATION_NAME, () => new KnexInstrumentation());
 

--- a/packages/node/src/integrations/tracing/koa/index.ts
+++ b/packages/node/src/integrations/tracing/koa/index.ts
@@ -11,7 +11,7 @@ interface KoaOptions {
   ignoreLayersType?: Array<'middleware' | 'router'>;
 }
 
-const INTEGRATION_NAME = 'Koa';
+const INTEGRATION_NAME = 'Koa' as const;
 
 export const instrumentKoa = generateInstrumentOnce(
   INTEGRATION_NAME,

--- a/packages/node/src/integrations/tracing/lrumemoizer/index.ts
+++ b/packages/node/src/integrations/tracing/lrumemoizer/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'LruMemoizer';
+const INTEGRATION_NAME = 'LruMemoizer' as const;
 
 export const instrumentLruMemoizer = generateInstrumentOnce(INTEGRATION_NAME, () => new LruMemoizerInstrumentation());
 

--- a/packages/node/src/integrations/tracing/mongo/index.ts
+++ b/packages/node/src/integrations/tracing/mongo/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Mongo';
+const INTEGRATION_NAME = 'Mongo' as const;
 
 export const instrumentMongo = generateInstrumentOnce(INTEGRATION_NAME, () => new MongoDBInstrumentation());
 

--- a/packages/node/src/integrations/tracing/mongoose/index.ts
+++ b/packages/node/src/integrations/tracing/mongoose/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Mongoose';
+const INTEGRATION_NAME = 'Mongoose' as const;
 
 export const instrumentMongoose = generateInstrumentOnce(INTEGRATION_NAME, () => new MongooseInstrumentation());
 

--- a/packages/node/src/integrations/tracing/mysql/index.ts
+++ b/packages/node/src/integrations/tracing/mysql/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Mysql';
+const INTEGRATION_NAME = 'Mysql' as const;
 
 export const instrumentMysql = generateInstrumentOnce(INTEGRATION_NAME, () => new MySQLInstrumentation({}));
 

--- a/packages/node/src/integrations/tracing/mysql2/index.ts
+++ b/packages/node/src/integrations/tracing/mysql2/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Mysql2';
+const INTEGRATION_NAME = 'Mysql2' as const;
 
 export const instrumentMysql2 = generateInstrumentOnce(INTEGRATION_NAME, () => new MySQL2Instrumentation());
 

--- a/packages/node/src/integrations/tracing/postgres/index.ts
+++ b/packages/node/src/integrations/tracing/postgres/index.ts
@@ -7,7 +7,7 @@ interface PostgresIntegrationOptions {
   ignoreConnectSpans?: boolean;
 }
 
-const INTEGRATION_NAME = 'Postgres';
+const INTEGRATION_NAME = 'Postgres' as const;
 
 export const instrumentPostgres = generateInstrumentOnce(
   INTEGRATION_NAME,

--- a/packages/node/src/integrations/tracing/postgresjs.ts
+++ b/packages/node/src/integrations/tracing/postgresjs.ts
@@ -28,7 +28,7 @@ import {
 import { addOriginToSpan, generateInstrumentOnce } from '@sentry/node-core';
 import { DEBUG_BUILD } from '../../debug-build';
 
-const INTEGRATION_NAME = 'PostgresJs';
+const INTEGRATION_NAME = 'PostgresJs' as const;
 const SUPPORTED_VERSIONS = ['>=3.0.0 <4'];
 const SQL_OPERATION_REGEX = /^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)/i;
 

--- a/packages/node/src/integrations/tracing/prisma/index.ts
+++ b/packages/node/src/integrations/tracing/prisma/index.ts
@@ -8,7 +8,7 @@ import { PrismaInstrumentation } from './vendored/instrumentation';
 import type { PrismaV5TracingHelper } from './vendored/v5-tracing-helper';
 import type { PrismaV6TracingHelper } from './vendored/v6-tracing-helper';
 
-const INTEGRATION_NAME = 'Prisma';
+const INTEGRATION_NAME = 'Prisma' as const;
 
 type CompatibilityLayerTraceHelper = PrismaV5TracingHelper & PrismaV6TracingHelper;
 

--- a/packages/node/src/integrations/tracing/redis/index.ts
+++ b/packages/node/src/integrations/tracing/redis/index.ts
@@ -41,7 +41,7 @@ interface RedisOptions {
   maxCacheKeyLength?: number;
 }
 
-const INTEGRATION_NAME = 'Redis';
+const INTEGRATION_NAME = 'Redis' as const;
 
 /* Only exported for testing purposes */
 export let _redisOptions: RedisOptions = {};

--- a/packages/node/src/integrations/tracing/tedious/index.ts
+++ b/packages/node/src/integrations/tracing/tedious/index.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
 
-const INTEGRATION_NAME = 'Tedious';
+const INTEGRATION_NAME = 'Tedious' as const;
 
 export const instrumentTedious = generateInstrumentOnce(INTEGRATION_NAME, () => new TediousInstrumentation({}));
 

--- a/packages/node/src/integrations/tracing/vercelai/constants.ts
+++ b/packages/node/src/integrations/tracing/vercelai/constants.ts
@@ -1,1 +1,1 @@
-export const INTEGRATION_NAME = 'VercelAI';
+export const INTEGRATION_NAME = 'VercelAI' as const;

--- a/packages/node/src/integrations/tracing/vercelai/index.ts
+++ b/packages/node/src/integrations/tracing/vercelai/index.ts
@@ -1,5 +1,5 @@
 import type { Client, IntegrationFn } from '@sentry/core';
-import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
+import { addVercelAiProcessors, defineIntegration, extendIntegration } from '@sentry/core';
 import { generateInstrumentOnce, type modulesIntegration } from '@sentry/node-core';
 import { vercelAiIntegration as serverUtilsVercelAiIntegration } from '@sentry/server-utils';
 import { INTEGRATION_NAME } from './constants';
@@ -22,12 +22,10 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
 
   const parentIntegration = serverUtilsVercelAiIntegration(options);
 
-  return {
-    name: INTEGRATION_NAME,
+  return extendIntegration(parentIntegration, {
     options,
     setupOnce() {
       instrumentation = instrumentVercelAi();
-      parentIntegration.setupOnce?.();
     },
     afterAllSetup(client) {
       // Auto-detect if we should force the integration when running with 'ai' package available
@@ -40,7 +38,7 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
         instrumentation?.callWhenPatched(() => addVercelAiProcessors(client));
       }
     },
-  };
+  });
 }) satisfies IntegrationFn;
 
 /**

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -652,7 +652,7 @@ export const _nodeProfilingIntegration = ((): ProfilingIntegration<NodeClient> =
   }
 
   return {
-    name: 'ProfilingIntegration',
+    name: 'ProfilingIntegration' as const,
     _profiler: new ContinuousProfiler(),
     setup(client: NodeClient) {
       DEBUG_BUILD && debug.log('[Profiling] Profiling integration setup.');

--- a/packages/react-router/src/server/integration/lowQualityTransactionsFilterIntegration.ts
+++ b/packages/react-router/src/server/integration/lowQualityTransactionsFilterIntegration.ts
@@ -13,7 +13,7 @@ const LOW_QUALITY_TRANSACTIONS_FILTERS = [
 
 // TODO(v11): Remove the `_options` parameter (unused and only kept for back-compat with the previous signature)
 const _lowQualityTransactionsFilterIntegration = ((_options?: NodeOptions) => ({
-  name: 'LowQualityTransactionsFilter',
+  name: 'LowQualityTransactionsFilter' as const,
   beforeSetup(client) {
     const opts = client.getOptions();
     opts.ignoreSpans = [...(opts.ignoreSpans || []), ...LOW_QUALITY_TRANSACTIONS_FILTERS];

--- a/packages/react-router/src/server/integration/reactRouterServer.ts
+++ b/packages/react-router/src/server/integration/reactRouterServer.ts
@@ -5,7 +5,7 @@ import { ReactRouterInstrumentation } from '../instrumentation/reactRouter';
 import { registerServerBuildGlobal } from '../serverBuild';
 import { enableOtelDataLoaderSpanCreation } from '../serverGlobals';
 
-const INTEGRATION_NAME = 'ReactRouterServer';
+const INTEGRATION_NAME = 'ReactRouterServer' as const;
 
 const instrumentReactRouter = generateInstrumentOnce(INTEGRATION_NAME, () => {
   return new ReactRouterInstrumentation();

--- a/packages/remix/src/server/integrations/opentelemetry.ts
+++ b/packages/remix/src/server/integrations/opentelemetry.ts
@@ -16,7 +16,7 @@ const instrumentRemix = generateInstrumentOnce(INTEGRATION_NAME, (options?: Remi
 
 const _remixIntegration = (() => {
   return {
-    name: 'Remix',
+    name: 'Remix' as const,
     setupOnce() {
       const client = getClient();
       const options = client?.getOptions() as RemixOptions | undefined;

--- a/packages/server-utils/src/integrations/tracing-channel/mysql.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/mysql.ts
@@ -15,7 +15,7 @@ import { CHANNELS } from '../../orchestrion/channels';
 
 // NOTE: this uses the same name as the OTel integration by design.
 // When enabled, OTel 'Mysql' integration is omitted from the default set.
-const INTEGRATION_NAME = 'Mysql';
+const INTEGRATION_NAME = 'Mysql' as const;
 
 // OpenTelemetry "OLD" db/net semantic-conventions. We inline them rather than
 // importing `@opentelemetry/semantic-conventions` to keep this integration's

--- a/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
+++ b/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
@@ -12,7 +12,7 @@ import {
  */
 export function svelteKitSpansIntegration(): Integration {
   return {
-    name: 'SvelteKitSpansEnhancement',
+    name: 'SvelteKitSpansEnhancement' as const,
     // Using preprocessEvent to ensure the processing happens before user-configured
     // event processors are executed
     preprocessEvent(event) {

--- a/packages/vercel-edge/src/integrations/tracing/vercelai.ts
+++ b/packages/vercel-edge/src/integrations/tracing/vercelai.ts
@@ -11,7 +11,7 @@
 import type { IntegrationFn } from '@sentry/core';
 import { addVercelAiProcessors, defineIntegration } from '@sentry/core';
 
-const INTEGRATION_NAME = 'VercelAI';
+const INTEGRATION_NAME = 'VercelAI' as const;
 
 interface VercelAiOptions {
   /**

--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -18,7 +18,7 @@ import {
   stringMatchesSomePattern,
 } from '@sentry/core';
 
-const INTEGRATION_NAME = 'WinterCGFetch';
+const INTEGRATION_NAME = 'WinterCGFetch' as const;
 
 const HAS_CLIENT_MAP = new WeakMap<Client, boolean>();
 

--- a/packages/vue/src/integration.ts
+++ b/packages/vue/src/integration.ts
@@ -18,7 +18,7 @@ const DEFAULT_CONFIG: VueOptions = {
   },
 };
 
-const INTEGRATION_NAME = 'Vue';
+const INTEGRATION_NAME = 'Vue' as const;
 
 export type VueIntegrationOptions = Partial<VueOptions>;
 


### PR DESCRIPTION
This adds a new method, `extendIntegration`, that can be used to safely extend an integration.

Today, we have the problem that if we extend an integration (e.g. node extending something from server-utils), we have to manually call the parent integration functions. This is a bit brittle because a) it requires you to know exactly what methods the parent integration has, which we usually want to abstract away from users on purpose. also, if a parent integration changes, this could be forgotten/lost.

Usage:

```js
const _denoMysqlIntegration = (() => {
  const inner = mysqlChannelIntegration();

  return extendIntegration(inner, {
    name: INTEGRATION_NAME,
    setupOnce() {
      setAsyncLocalStorageAsyncContextStrategy();
    },
  });
}) satisfies IntegrationFn;
```

vs. before:

```js
onst _denoMysqlIntegration = (() => {
  const inner = mysqlChannelIntegration();
  return {
    name: INTEGRATION_NAME,
    setupOnce() {
      setAsyncLocalStorageAsyncContextStrategy();
      inner.setupOnce?.();
    },
  };
}) satisfies IntegrationFn;
```

In addition, I also improved `defineIntegration` to maintain a static name, and made all integration names static for easier access. 

Note: We have a bunch of places where we started to type integrations manually, e.g. 

```ts
export const denoMysqlIntegration = defineIntegration(_denoMysqlIntegration) as () => Integration & {
  name: 'DenoMysql';
  setupOnce: () => void;
};
```

We should revert this in v11. We purposefully did not do this because we want to keep the underlying implementation flexible. I think this was done sometimes to make it easier to extend/call things, but usually this should not be necessary and the extend helper should help with making things type safe a bit easier.