### PR TITLE
fix(react-router): Bump peerDependencies for react-router 8

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -64,9 +64,9 @@
     "vite": "^6.4.3"
   },
   "peerDependencies": {
-    "@react-router/node": "7.x",
+    "@react-router/node": "7.x || ^8.x",
     "react": ">=18",
-    "react-router": "7.x"
+    "react-router": "7.x || ^8.x"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",


### PR DESCRIPTION
ref: #21622 

Updating peerDependencies for React Router 8 support. That was forgotten in https://github.com/getsentry/sentry-javascript/pull/21633