### PR TITLE
test: Pin webpack to 5.107.0

### DIFF
--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -49,7 +49,7 @@
     "ember-source": "~5.8.0",
     "loader.js": "^4.7.0",
     "tracked-built-ins": "^3.3.0",
-    "webpack": "^5.91.0",
+    "webpack": "~5.107.0",
     "@playwright/test": "~1.56.0",
     "@sentry/ember": "file:../../packed/sentry-ember-packed.tgz",
     "@sentry-internal/test-utils": "link:../../../test-utils",


### PR DESCRIPTION
Somehow this fails with webpack 5.108.0, for whatever reason...