### PR TITLE
fix(node): Avoid failing at runtime if tracingChannel is not available

### DIFF
--- a/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from 'node:diagnostics_channel';
+import * as dc from 'node:diagnostics_channel';
 import {
   flushIfServerless,
   GLOBAL_OBJ,
@@ -55,8 +55,13 @@ function setupStorageTracingChannel(operation: TracedOperation): void {
   const keys = (data: TraceContext): string[] => data.keys ?? [];
   const mountBase = (data: TraceContext): string => (data.base ?? '').replace(/:$/, '');
 
+  // Bail if this is not available
+  if (!dc.tracingChannel) {
+    return;
+  }
+
   bindTracingChannelToSpan(
-    tracingChannel<TraceContext>(`unstorage.${operation}`),
+    dc.tracingChannel<TraceContext>(`unstorage.${operation}`),
     data => {
       const cacheKeys = keys(data);
 

--- a/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
@@ -150,6 +150,10 @@ function setupH3TracingChannels(): void {
 }
 
 function setupSrvxTracingChannels(): void {
+  if (!dc.tracingChannel) {
+    return;
+  }
+
   // Store the parent span per-request so middleware and fetch share the same parent.
   // WeakMap ensures per-request isolation in concurrent environments and automatic cleanup.
   const requestParentSpans = new WeakMap<Request, Span>();

--- a/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
@@ -1,4 +1,4 @@
-import { tracingChannel } from 'node:diagnostics_channel';
+import * as dc from 'node:diagnostics_channel';
 import {
   getActiveSpan,
   getClient,
@@ -80,8 +80,13 @@ function getParameterizedRoute(event: H3TracingRequestEvent['event']): string | 
 }
 
 function setupH3TracingChannels(): void {
+  // Bail if this is not available
+  if (!dc.tracingChannel) {
+    return;
+  }
+
   const { channel: h3Channel } = bindTracingChannelToSpan(
-    tracingChannel<H3TracingRequestEvent>('h3.request'),
+    dc.tracingChannel<H3TracingRequestEvent>('h3.request'),
     data => {
       const parsedUrl = parseStringToURLObject(data.event.url.href);
       const routePattern = getParameterizedRoute(data.event);
@@ -150,7 +155,7 @@ function setupSrvxTracingChannels(): void {
   const requestParentSpans = new WeakMap<Request, Span>();
 
   bindTracingChannelToSpan(
-    tracingChannel<SrvxRequestEvent>('srvx.request'),
+    dc.tracingChannel<SrvxRequestEvent>('srvx.request'),
     data => {
       const parsedUrl = data.request._url ? parseStringToURLObject(data.request._url.href) : undefined;
       const [spanName, urlAttributes] = getHttpSpanDetailsFromUrlObject(parsedUrl, 'server', 'auto.http.nitro.srvx', {
@@ -186,7 +191,7 @@ function setupSrvxTracingChannels(): void {
   );
 
   bindTracingChannelToSpan(
-    tracingChannel<SrvxRequestEvent>('srvx.middleware'),
+    dc.tracingChannel<SrvxRequestEvent>('srvx.middleware'),
     data => {
       // For the first middleware, capture the current parent span per-request
       if (data.middleware?.index === 0) {

--- a/packages/node/src/integrations/tracing/redis/index.ts
+++ b/packages/node/src/integrations/tracing/redis/index.ts
@@ -8,7 +8,7 @@ import {
   spanToJSON,
   truncate,
 } from '@sentry/core';
-import { tracingChannel } from 'node:diagnostics_channel';
+import * as dc from 'node:diagnostics_channel';
 import { subscribeRedisDiagnosticChannels, type RedisTracingChannelFactory } from '@sentry/server-utils';
 import { generateInstrumentOnce } from '@sentry/node-core';
 import type { IORedisCommandArgs } from '../../../utils/redisCache';
@@ -126,9 +126,12 @@ export const instrumentRedis = Object.assign(
     // OTel context via `bindStore`, which needs the Sentry OTel context manager to
     // be registered — `initOpenTelemetry()` does that after integration `setupOnce`,
     // so defer to the next tick.
-    void Promise.resolve().then(() =>
-      subscribeRedisDiagnosticChannels(tracingChannel as RedisTracingChannelFactory, cacheResponseHook),
-    );
+    // Check this here to ensure this does not fail at runtime for Node <= 18.18.0
+    if (dc.tracingChannel) {
+      void Promise.resolve().then(() =>
+        subscribeRedisDiagnosticChannels(dc.tracingChannel as RedisTracingChannelFactory, cacheResponseHook),
+      );
+    }
 
     // todo: implement them gradually
     // new LegacyRedisInstrumentation({}),


### PR DESCRIPTION
Since tracingChannel is not available before node 18.19., this would fail at runtime.
Instead, this can check at runtime if it exists and simply avoid using it on older versions.