### PR TITLE
fix(sveltekit): Avoid capturing preloaded 400 errors on client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+Work in this release was contributed by @hyunbinseo. Thank you for your contribution!
+
 ## 10.61.0
 
 ### Important Changes

--- a/packages/sveltekit/src/client/handleError.ts
+++ b/packages/sveltekit/src/client/handleError.ts
@@ -51,12 +51,17 @@ export function handleErrorWithSentry(handleError?: HandleClientError): HandleCl
 function is4xxError(input: SafeHandleServerErrorInput): boolean {
   const { status } = input;
 
-  // Pre-SvelteKit 2.x, the status is not available,
-  // so we don't know if this is a 4xx error
-  if (!status) {
-    return false;
+  if (status && status >= 400 && status < 500) {
+    return true;
   }
 
-  // SvelteKit 2.0 offers a reliable way to check for a Not Found error:
-  return status >= 400 && status < 500;
+  // SvelteKit __data.json requests return HTTP 200 with errors embedded in JSON,
+  // so get_status() may resolve to 500 for a deserialized plain error object.
+  // Fall back to checking input.error.status directly.
+  const errorStatus =
+    typeof input.error === 'object' && input.error !== null
+      ? (input.error as Record<string, unknown>)['status']
+      : undefined;
+
+  return typeof errorStatus === 'number' && errorStatus >= 400 && errorStatus < 500;
 }

--- a/packages/sveltekit/test/client/handleError.test.ts
+++ b/packages/sveltekit/test/client/handleError.test.ts
@@ -76,4 +76,20 @@ describe('handleError (client)', () => {
     // Check that the default handler wasn't invoked
     expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
   });
+
+  it.each([400, 401, 403, 404, 429, 499])(
+    "doesn't capture %s errors embedded in __data.json (HTTP 200 wrapper)",
+    async statusCode => {
+      const wrappedHandleError = handleErrorWithSentry(handleError);
+      await wrappedHandleError({
+        // SvelteKit resolves get_status() to 500 for plain deserialized error objects
+        status: 500,
+        error: { type: 'error', error: { message: `Error: ${statusCode}` }, status: statusCode },
+        event: navigationEvent,
+        message: `Error: ${statusCode}`,
+      });
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    },
+  );
 });


### PR DESCRIPTION
As reported in https://github.com/getsentry/sentry-javascript/issues/21775 we'd catch client-side 400 errors for server responses coming from pre-loaded (e.g. on hover loading) server responses.

The 4xx error detection logic adjustment, as well as the test are courtesy of @hyunbinseo who suggested these changes in the issue. Thanks for figuring this out! I'm merely the messenger and initial reviewer here :) 

closes  https://github.com/getsentry/sentry-javascript/issues/21775