### PR TITLE
feat(core): Add `isTracingSuppressed` to the async context strategy

### DIFF
--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -3,6 +3,7 @@ import type { Span } from '../types/span';
 import type { getTraceData } from '../utils/traceData';
 import type {
   continueTrace,
+  isTracingSuppressed,
   startInactiveSpan,
   startNewTrace,
   startSpan,
@@ -85,6 +86,9 @@ export interface AsyncContextStrategy {
 
   /** Suppress tracing in the given callback, ensuring no spans are generated inside of it.  */
   suppressTracing?: typeof suppressTracing;
+
+  /** If tracing is suppressed in the given scope.  */
+  isTracingSuppressed?: typeof isTracingSuppressed;
 
   /** Get trace data as serialized string values for propagation via `sentry-trace` and `baggage`. */
   getTraceData?: typeof getTraceData;

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -17,6 +17,7 @@ export {
   continueTrace,
   withActiveSpan,
   suppressTracing,
+  isTracingSuppressed,
   startNewTrace,
   SUPPRESS_TRACING_KEY,
 } from './trace';

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -291,6 +291,17 @@ export function suppressTracing<T>(callback: () => T): T {
   });
 }
 
+/** Check if tracing is suppressed. */
+export function isTracingSuppressed(scope = getCurrentScope()): boolean {
+  const acs = getAcs();
+
+  if (acs.isTracingSuppressed) {
+    return acs.isTracingSuppressed(scope);
+  }
+
+  return scope.getScopeData().sdkProcessingMetadata[SUPPRESS_TRACING_KEY] === true;
+}
+
 /**
  * Starts a new trace for the duration of the provided callback. Spans started within the
  * callback will be part of the new trace instead of a potentially previously started trace.
@@ -372,7 +383,7 @@ function createChildOrRootSpan({
 
   const client = getClient();
   if (_shouldIgnoreStreamedSpan(client, spanArguments)) {
-    if (!_isTracingSuppressed(scope)) {
+    if (!isTracingSuppressed(scope)) {
       // if tracing is actively suppressed (Sentry.suppressTracing(...)),
       // we don't want to record a client outcome for the ignored span
       client?.recordDroppedEvent('ignored', 'span');
@@ -489,9 +500,9 @@ function _startRootSpan(
   const finalAttributes = mutableSpanSamplingData.spanAttributes;
 
   const currentPropagationContext = scope.getPropagationContext();
-  const isTracingSuppressed = _isTracingSuppressed(scope);
+  const _isTracingSuppressed = isTracingSuppressed(scope);
 
-  const [sampled, sampleRate, localSampleRateWasApplied] = isTracingSuppressed
+  const [sampled, sampleRate, localSampleRateWasApplied] = _isTracingSuppressed
     ? [false]
     : sampleSpan(
         options,
@@ -515,7 +526,7 @@ function _startRootSpan(
     sampled,
   });
 
-  if (!sampled && client && !isTracingSuppressed) {
+  if (!sampled && client && !_isTracingSuppressed) {
     DEBUG_BUILD && debug.log('[Tracing] Discarding root span because its trace was not chosen to be sampled.');
     client.recordDroppedEvent('sample_rate', hasSpanStreamingEnabled(client) ? 'span' : 'transaction');
   }
@@ -540,8 +551,8 @@ function _startChildSpan(
   isolationScope: Scope,
 ): Span {
   const { spanId, traceId } = parentSpan.spanContext();
-  const isTracingSuppressed = _isTracingSuppressed(scope);
-  const sampled = isTracingSuppressed ? false : spanIsSampled(parentSpan);
+  const _isTracingSuppressed = isTracingSuppressed(scope);
+  const sampled = _isTracingSuppressed ? false : spanIsSampled(parentSpan);
 
   const childSpan = sampled
     ? new SentrySpan({
@@ -569,7 +580,7 @@ function _startChildSpan(
       // record a client outcome for the child.
       childSpan.dropReason = parentSpan.dropReason;
       client.recordDroppedEvent(parentSpan.dropReason, 'span');
-    } else if (!isTracingSuppressed) {
+    } else if (!_isTracingSuppressed) {
       // Otherwise, the child is not sampled due to sampling of the parent span,
       // hence we record a sample_rate client outcome for the child.
       childSpan.dropReason = 'sample_rate';
@@ -641,8 +652,4 @@ function _shouldIgnoreStreamedSpan(client: Client | undefined, spanArguments: Se
 
 function _isIgnoredSpan(span: Span): span is SentryNonRecordingSpan {
   return spanIsNonRecordingSpan(span) && span.dropReason === 'ignored';
-}
-
-function _isTracingSuppressed(scope: Scope): boolean {
-  return scope.getScopeData().sdkProcessingMetadata[SUPPRESS_TRACING_KEY] === true;
 }

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -19,11 +19,13 @@ import { getAsyncContextStrategy } from '../../../src/asyncContext';
 import {
   continueTrace,
   getDynamicSamplingContextFromSpan,
+  isTracingSuppressed,
   registerSpanErrorInstrumentation,
   SentrySpan,
   startInactiveSpan,
   startSpan,
   startSpanManual,
+  SUPPRESS_TRACING_KEY,
   suppressTracing,
   withActiveSpan,
 } from '../../../src/tracing';
@@ -2558,6 +2560,60 @@ describe('suppressTracing', () => {
     expect(spanIsSampled(span3)).toBe(false);
     expect(spanIsSampled(span4)).toBe(false);
     expect(spanIsSampled(span5)).toBe(true);
+  });
+});
+
+describe('isTracingSuppressed', () => {
+  beforeEach(() => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    setAsyncContextStrategy(undefined);
+
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 1 });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when tracing is not suppressed', () => {
+    expect(isTracingSuppressed()).toBe(false);
+  });
+
+  it('returns true while inside suppressTracing', () => {
+    const suppressed = suppressTracing(() => isTracingSuppressed());
+    expect(suppressed).toBe(true);
+  });
+
+  it('returns false again after suppressTracing has finished', () => {
+    suppressTracing(() => {
+      expect(isTracingSuppressed()).toBe(true);
+    });
+
+    expect(isTracingSuppressed()).toBe(false);
+  });
+
+  it('only suppresses tracing within the active scope', () => {
+    withScope(() => {
+      const suppressed = suppressTracing(() => isTracingSuppressed());
+      expect(suppressed).toBe(true);
+    });
+
+    // Outside of the suppressed scope, tracing is no longer suppressed
+    expect(isTracingSuppressed()).toBe(false);
+  });
+
+  it('respects a scope passed in explicitly', () => {
+    const scope = getCurrentScope().clone();
+    scope.setSDKProcessingMetadata({ [SUPPRESS_TRACING_KEY]: true });
+
+    expect(isTracingSuppressed(scope)).toBe(true);
+    expect(isTracingSuppressed()).toBe(false);
   });
 });
 

--- a/packages/node-core/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node-core/src/integrations/http/SentryHttpInstrumentation.ts
@@ -1,6 +1,5 @@
 import { subscribe } from 'node:diagnostics_channel';
 import { context, trace } from '@opentelemetry/api';
-import { isTracingSuppressed } from '@opentelemetry/core';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
 import type { ClientRequest, IncomingMessage, ServerResponse } from 'node:http';
@@ -11,7 +10,13 @@ import type {
   HttpModuleExport,
   Span,
 } from '@sentry/core';
-import { getHttpClientSubscriptions, patchHttpModuleClient, SDK_VERSION, getRequestOptions } from '@sentry/core';
+import {
+  getHttpClientSubscriptions,
+  patchHttpModuleClient,
+  SDK_VERSION,
+  getRequestOptions,
+  isTracingSuppressed,
+} from '@sentry/core';
 import { INSTRUMENTATION_NAME } from './constants';
 import { HTTP_ON_CLIENT_REQUEST } from '@sentry/core';
 import { NODE_VERSION } from '../../nodeVersion';
@@ -172,8 +177,7 @@ export class SentryHttpInstrumentation extends InstrumentationBase<SentryHttpIns
       spans: options.createSpansForOutgoingRequests && (options.spans ?? true),
       ignoreOutgoingRequests(url, request) {
         return (
-          isTracingSuppressed(context.active()) ||
-          !!options.ignoreOutgoingRequests?.(url, getRequestOptions(request as ClientRequest))
+          isTracingSuppressed() || !!options.ignoreOutgoingRequests?.(url, getRequestOptions(request as ClientRequest))
         );
       },
       outgoingRequestHook(span, request) {

--- a/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
@@ -2,7 +2,7 @@ import { errorMonitor } from 'node:events';
 import type { IncomingHttpHeaders } from 'node:http';
 import { context, SpanKind, trace } from '@opentelemetry/api';
 import type { RPCMetadata } from '@opentelemetry/core';
-import { getRPCMetadata, isTracingSuppressed, RPCType, setRPCMetadata } from '@opentelemetry/core';
+import { getRPCMetadata, RPCType, setRPCMetadata } from '@opentelemetry/core';
 import {
   HTTP_RESPONSE_STATUS_CODE,
   HTTP_ROUTE,
@@ -32,6 +32,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   stripUrlQueryAndFragment,
+  isTracingSuppressed,
 } from '@sentry/core';
 import { DEBUG_BUILD } from '../../debug-build';
 import type { NodeClient } from '../../sdk/client';
@@ -306,7 +307,7 @@ function shouldIgnoreSpansForIncomingRequest(
     ignoreIncomingRequests?: (urlPath: string, request: HttpIncomingMessage) => boolean;
   },
 ): boolean {
-  if (isTracingSuppressed(context.active())) {
+  if (isTracingSuppressed()) {
     return true;
   }
 

--- a/packages/node-core/src/integrations/node-fetch/SentryNodeFetchInstrumentation.ts
+++ b/packages/node-core/src/integrations/node-fetch/SentryNodeFetchInstrumentation.ts
@@ -1,8 +1,6 @@
-import { context } from '@opentelemetry/api';
-import { isTracingSuppressed } from '@opentelemetry/core';
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
 import { InstrumentationBase } from '@opentelemetry/instrumentation';
-import { LRUMap, SDK_VERSION } from '@sentry/core';
+import { LRUMap, SDK_VERSION, isTracingSuppressed } from '@sentry/core';
 import * as diagch from 'diagnostics_channel';
 import { NODE_MAJOR, NODE_MINOR } from '../../nodeVersion';
 import {
@@ -184,7 +182,7 @@ export class SentryNodeFetchInstrumentation extends InstrumentationBase<SentryNo
    * Check if the given outgoing request should be ignored.
    */
   private _shouldIgnoreOutgoingRequest(request: UndiciRequest): boolean {
-    if (isTracingSuppressed(context.active())) {
+    if (isTracingSuppressed()) {
       return true;
     }
 

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -11,7 +11,7 @@ import type { CurrentScopes } from './types';
 import { getContextFromScope, getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
 import { getTraceData } from './utils/getTraceData';
-import { suppressTracing } from './utils/suppressTracing';
+import { suppressTracing, isTracingSuppressed } from './utils/suppressTracing';
 
 interface ContextApi {
   _getContextManager(): {
@@ -110,6 +110,7 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     startInactiveSpan,
     getActiveSpan,
     suppressTracing,
+    isTracingSuppressed,
     getTraceData,
     continueTrace,
     startNewTrace,

--- a/packages/opentelemetry/src/utils/suppressTracing.ts
+++ b/packages/opentelemetry/src/utils/suppressTracing.ts
@@ -1,8 +1,18 @@
 import { context } from '@opentelemetry/api';
-import { suppressTracing as suppressTracingImpl } from '@opentelemetry/core';
+import {
+  suppressTracing as suppressTracingImpl,
+  isTracingSuppressed as isTracingSuppressedImpl,
+} from '@opentelemetry/core';
+import type { Scope } from '@sentry/core';
+import { getContextFromScope } from './contextData';
 
 /** Suppress tracing in the given callback, ensuring no spans are generated inside of it. */
 export function suppressTracing<T>(callback: () => T): T {
   const ctx = suppressTracingImpl(context.active());
   return context.with(ctx, callback);
+}
+
+export function isTracingSuppressed(scope?: Scope): boolean {
+  const ctx = scope ? getContextFromScope(scope) : context.active();
+  return ctx ? isTracingSuppressedImpl(ctx) : false;
 }

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -10,6 +10,7 @@ import {
   getDynamicSamplingContextFromClient,
   getDynamicSamplingContextFromSpan,
   getRootSpan,
+  isTracingSuppressed,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
@@ -2104,6 +2105,42 @@ describe('suppressTracing', () => {
     expect(spanIsSampled(span3)).toBe(false);
     expect(spanIsSampled(span4)).toBe(false);
     expect(spanIsSampled(span5)).toBe(true);
+  });
+});
+
+describe('isTracingSuppressed', () => {
+  beforeEach(() => {
+    mockSdkInit({ tracesSampleRate: 1 });
+  });
+
+  afterEach(async () => {
+    await cleanupOtel();
+  });
+
+  it('returns false when tracing is not suppressed', () => {
+    expect(isTracingSuppressed()).toBe(false);
+  });
+
+  it('returns true while inside suppressTracing', () => {
+    const suppressed = suppressTracing(() => isTracingSuppressed());
+    expect(suppressed).toBe(true);
+  });
+
+  it('returns false again after suppressTracing has finished', () => {
+    suppressTracing(() => {
+      expect(isTracingSuppressed()).toBe(true);
+    });
+
+    expect(isTracingSuppressed()).toBe(false);
+  });
+
+  it('stays suppressed across async boundaries within suppressTracing', async () => {
+    const suppressed = await suppressTracing(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+      return isTracingSuppressed();
+    });
+
+    expect(suppressed).toBe(true);
   });
 });
 


### PR DESCRIPTION
Exposes a public `isTracingSuppressed` helper from `@sentry/core` and routes it through the async context strategy, mirroring `suppressTracing`.

Previously `isTracingSuppressed` only existed as a private helper that checked the scope's SDK processing metadata. That's correct for the core (stack) strategy, but on OTel-based SDKs (e.g. Node) tracing suppression lives on the active OpenTelemetry context — so a metadata-only check could disagree with `suppressTracing`. Routing through the async context strategy keeps the two consistent across runtimes.

### Changes
- **`@sentry/core`**: export `isTracingSuppressed`, which delegates to `acs.isTracingSuppressed` and falls back to the scope-metadata check. Added `isTracingSuppressed` to the `AsyncContextStrategy` type and replaced the private `_isTracingSuppressed` usages.
- **`@sentry/opentelemetry`**: implement `isTracingSuppressed` (reads the active OTel context) and register it on the async context strategy.
- **`@sentry/node-core`**: `SentryHttpInstrumentation` and `SentryNodeFetchInstrumentation` now call core's `isTracingSuppressed()` instead of importing it from `@opentelemetry/core`.
- Added unit tests in `@sentry/core` and `@sentry/opentelemetry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)