### PR TITLE
test(e2e): Add `no-browser-session` lighthouse e2e test mode

### DIFF
--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/package.json
@@ -14,6 +14,7 @@
     "build:no-integrations": "vite build --mode no-integrations",
     "build:no-browser-api-errors": "vite build --mode no-browser-api-errors",
     "build:no-breadcrumbs": "vite build --mode no-breadcrumbs",
+    "build:no-browser-session": "vite build --mode no-browser-session",
     "build:tracing": "vite build --mode tracing",
     "build:tracing-lazy-import": "vite build --mode tracing-lazy-import",
     "build:tracing-replay": "vite build --mode tracing-replay",

--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
@@ -100,6 +100,16 @@ if (import.meta.env.MODE === 'tracing-replay') {
     environment: 'qa',
     integrations: defaultIntegrations => defaultIntegrations.filter(integration => integration.name !== 'Breadcrumbs'),
   });
+} else if (import.meta.env.MODE === 'no-browser-session') {
+  // Default integrations minus Breadcrumbs, which adds a lot of monkey patching to
+  // DOM and Network APIs as well as event targets and listeners
+  Sentry.init({
+    dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
+    release: 'lighthouse-fixture',
+    environment: 'qa',
+    integrations: defaultIntegrations =>
+      defaultIntegrations.filter(integration => integration.name !== 'BrowserSession'),
+  });
 } else if (import.meta.env.MODE === 'init-only') {
   // enabled: false makes the SDK a guaranteed no-op (no transport allocation,
   // no DSN warning). We're measuring pure SDK-loading + tree-shaking cost.

--- a/scripts/lighthouse-bundle-and-upload.mjs
+++ b/scripts/lighthouse-bundle-and-upload.mjs
@@ -1,7 +1,7 @@
 /**
  * Bundle the `lighthouse-react` test app for each mode (no-sentry, init-only,
  * errors-only, minimal-integrations, no-integrations, no-browser-api-errors,
- * no-breadcrumbs, tracing, tracing-lazy-import, tracing-replay) and POST the
+ * no-breadcrumbs, no-browser-session, tracing, tracing-lazy-import, tracing-replay) and POST the
  * tarballs to the Sentry Lighthouse lab (https://lighthouse.sentry.gg). The lab
  * runs Lighthouse asynchronously and ships results to Sentry on its own
  * schedule — this script exits as soon as the upload succeeds.
@@ -42,6 +42,7 @@ const MODES = [
   'no-integrations',
   'no-browser-api-errors',
   'no-breadcrumbs',
+  'no-browser-session',
   'tracing',
   'tracing-lazy-import',
   'tracing-replay',


### PR DESCRIPTION
New theory: `browserSessionIntegration` captures and sends a session right within `setupOnce`. I could see this causing overhead, given we send out an envelope. Let's see if this is it. Deferring the session capturing (`requestIdleTimeout` or similar) should be fairly easy and safe