### PR TITLE
feat(mongoose): Instrument mongoose >= 9.7 via native tracing channels

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/instrument.mjs
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/scenario.mjs
@@ -1,0 +1,48 @@
+import * as Sentry from '@sentry/node';
+import mongoose from 'mongoose';
+
+async function run() {
+  await mongoose.connect(process.env.MONGO_URL || '');
+
+  const BlogPostSchema = new mongoose.Schema({
+    title: String,
+    body: String,
+    date: Date,
+  });
+
+  const BlogPost = mongoose.model('BlogPost', BlogPostSchema);
+
+  await Sentry.startSpan(
+    {
+      name: 'Test Transaction',
+      op: 'transaction',
+    },
+    async () => {
+      const post = new BlogPost({ title: 'Test', body: 'Test body', date: new Date() });
+      await post.save();
+
+      // Filter with a real value, to assert it is redacted out of `db.query.text`.
+      await BlogPost.findOne({ title: 'Test' });
+
+      await BlogPost.aggregate([{ $match: { title: 'Test' } }]);
+
+      await BlogPost.insertMany([
+        { title: 'Insert1', body: 'b', date: new Date() },
+        { title: 'Insert2', body: 'b', date: new Date() },
+      ]);
+
+      await BlogPost.bulkWrite([
+        { insertOne: { document: { title: 'Bulk1', body: 'b', date: new Date() } } },
+        { insertOne: { document: { title: 'Bulk2', body: 'b', date: new Date() } } },
+      ]);
+
+      // Drive a cursor to exercise the `mongoose:cursor:next` channel.
+      const cursor = BlogPost.find().cursor();
+      for (let doc = await cursor.next(); doc != null; doc = await cursor.next()) {
+        // iterate
+      }
+    },
+  );
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/test.ts
@@ -1,0 +1,118 @@
+import { MongoMemoryServer } from 'mongodb-memory-server-global';
+import { afterAll, beforeAll, expect } from 'vitest';
+import { conditionalTest } from '../../../utils';
+import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
+
+// mongoose >= 9.7.0 publishes its operations via `node:diagnostics_channel`, so the SDK subscribes
+// to those channels (`subscribeMongooseDiagnosticChannels`) instead of monkey-patching. This suite
+// pins `^9.7` and asserts the diagnostics-channel path: stable OTel DB semconv attributes, redacted
+// query text, span relationships, and that the legacy IITM patcher does NOT also fire (no double
+// instrumentation). mongoose 9 requires Node >=20.19, so this suite is skipped on older Node.
+conditionalTest({ min: 20 })('Mongoose tracing channel Test', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    process.env.MONGO_URL = mongoServer.getUri();
+  }, 30000);
+
+  afterAll(async () => {
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+    cleanupChildProcesses();
+  });
+
+  const expectedSpan = (operation: string, extraData: Record<string, unknown> = {}) =>
+    expect.objectContaining({
+      data: expect.objectContaining({
+        'db.system.name': 'mongodb',
+        'db.namespace': 'test',
+        'db.collection.name': 'blogposts',
+        'db.operation.name': operation,
+        'server.address': expect.any(String),
+        'server.port': expect.any(Number),
+        ...extraData,
+      }),
+      description: `mongoose.blogposts.${operation}`,
+      op: 'db',
+      origin: 'auto.db.mongoose.diagnostic_channel',
+    });
+
+  const EXPECTED_TRANSACTION = {
+    transaction: 'Test Transaction',
+    spans: expect.arrayContaining([
+      expectedSpan('save'),
+      // filter values are redacted out of `db.query.text`
+      expectedSpan('findOne', { 'db.query.text': '{"title":"?"}' }),
+      expectedSpan('aggregate', { 'db.query.text': '[{"$match":{"title":"?"}}]' }),
+      expectedSpan('insertMany', { 'db.operation.batch.size': 2 }),
+      expectedSpan('bulkWrite', { 'db.operation.batch.size': 2 }),
+      // a cursor iteration emits a span per `.next()` via the `mongoose:cursor:next` channel
+      expectedSpan('find'),
+    ]),
+  };
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario.mjs',
+    'instrument.mjs',
+    (createTestRunner, test) => {
+      test('subscribes to mongoose >= 9.7 diagnostics channels with stable semconv attributes', async () => {
+        await createTestRunner().expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
+      });
+
+      test('does not double-instrument: the legacy IITM mongoose patcher does not fire on 9.7', async () => {
+        await createTestRunner()
+          .expect({
+            transaction: event => {
+              const spans = event.spans || [];
+              // The monkey-patch path (origin `auto.db.otel.mongoose`) must be inactive on 9.7+.
+              expect(spans.find(span => span.origin === 'auto.db.otel.mongoose')).toBeUndefined();
+              // ...while the diagnostics-channel path is active.
+              expect(spans.find(span => span.origin === 'auto.db.mongoose.diagnostic_channel')).toBeDefined();
+            },
+          })
+          .start()
+          .completed();
+      });
+
+      test('never leaks raw filter values into db.query.text', async () => {
+        await createTestRunner()
+          .expect({
+            transaction: event => {
+              const spans = event.spans || [];
+              for (const span of spans) {
+                const queryText = span.data?.['db.query.text'];
+                if (typeof queryText === 'string') {
+                  expect(queryText).not.toContain('Test');
+                }
+              }
+            },
+          })
+          .start()
+          .completed();
+      });
+
+      test('nests the mongodb driver span under the mongoose channel span', async () => {
+        await createTestRunner()
+          .expect({
+            transaction: event => {
+              const spans = event.spans || [];
+              const mongooseSave = spans.find(span => span.description === 'mongoose.blogposts.save');
+              expect(mongooseSave).toBeDefined();
+              // the underlying mongodb driver span must parent to the mongoose channel span,
+              // proving the channel span is the active async context for the traced operation
+              const driverChild = spans.find(
+                span => span.parent_span_id === mongooseSave?.span_id && span.origin === 'auto.db.otel.mongo',
+              );
+              expect(driverChild).toBeDefined();
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    { additionalDependencies: { mongoose: '^9.7' } },
+  );
+});

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v9/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v9/test.ts
@@ -3,8 +3,10 @@ import { afterAll, beforeAll, expect } from 'vitest';
 import { conditionalTest } from '../../../utils';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
-// Pins mongoose 9 (top of our supported `>=5.9.7 <10` range) so the latest major is exercised
-// against a real mongoose. mongoose 9 requires Node >=20.19, so this suite is skipped on older Node.
+// Pins the highest mongoose 9 below 9.7, the top of the IITM patcher's `>=5.9.7 <9.7.0` range, so the
+// monkey-patch path is exercised against a real mongoose 9. mongoose >= 9.7 publishes via
+// diagnostics_channel and is covered by the `mongoose-tracing-channel` suite instead.
+// mongoose 9 requires Node >=20.19, so this suite is skipped on older Node.
 conditionalTest({ min: 20 })('Mongoose v9 Test', () => {
   let mongoServer: MongoMemoryServer;
 
@@ -55,6 +57,6 @@ conditionalTest({ min: 20 })('Mongoose v9 Test', () => {
         await createTestRunner().expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
       });
     },
-    { additionalDependencies: { mongoose: '^9' } },
+    { additionalDependencies: { mongoose: '>=9 <9.7' } },
   );
 });

--- a/packages/node/src/integrations/tracing/mongoose/index.ts
+++ b/packages/node/src/integrations/tracing/mongoose/index.ts
@@ -1,19 +1,22 @@
 import { MongooseInstrumentation } from './vendored/mongoose';
 import type { IntegrationFn } from '@sentry/core';
-import { defineIntegration } from '@sentry/core';
+import { defineIntegration, extendIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
+import { mongooseChannelIntegration } from '@sentry/server-utils';
 
 const INTEGRATION_NAME = 'Mongoose' as const;
 
 export const instrumentMongoose = generateInstrumentOnce(INTEGRATION_NAME, () => new MongooseInstrumentation());
 
 const _mongooseIntegration = (() => {
-  return {
+  // The diagnostics_channel subscription (mongoose >= 9.7) lives in server-utils so it is shared
+  // across server runtimes; we extend it here to also run the IITM-based patcher for mongoose < 9.7.
+  return extendIntegration(mongooseChannelIntegration(), {
     name: INTEGRATION_NAME,
     setupOnce() {
       instrumentMongoose();
     },
-  };
+  });
 }) satisfies IntegrationFn;
 
 /**

--- a/packages/node/src/integrations/tracing/mongoose/index.ts
+++ b/packages/node/src/integrations/tracing/mongoose/index.ts
@@ -2,7 +2,7 @@ import { MongooseInstrumentation } from './vendored/mongoose';
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration, extendIntegration } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
-import { mongooseChannelIntegration } from '@sentry/server-utils';
+import { mongooseIntegration as mongooseChannelIntegration } from '@sentry/server-utils';
 
 const INTEGRATION_NAME = 'Mongoose' as const;
 

--- a/packages/node/src/integrations/tracing/mongoose/vendored/mongoose.ts
+++ b/packages/node/src/integrations/tracing/mongoose/vendored/mongoose.ts
@@ -107,7 +107,10 @@ export class MongooseInstrumentation extends InstrumentationBase<Instrumentation
   protected init(): InstrumentationModuleDefinition {
     const module = new InstrumentationNodeModuleDefinition(
       'mongoose',
-      ['>=5.9.7 <10'],
+      // mongoose >= 9.7.0 publishes via diagnostics_channel and is instrumented by
+      // `subscribeMongooseDiagnosticChannels` instead, so this IITM patcher must not
+      // overlap it — otherwise every operation would emit two mongoose spans.
+      ['>=5.9.7 <9.7.0'],
       this.patch.bind(this),
       this.unpatch.bind(this),
     );

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-export { mongooseChannelIntegration } from './mongoose';
+export { mongooseIntegration } from './mongoose';
 export {
   IOREDIS_DC_CHANNEL_COMMAND,
   IOREDIS_DC_CHANNEL_CONNECT,

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -4,6 +4,7 @@
  * @module
  */
 
+export { mongooseChannelIntegration } from './mongoose';
 export {
   IOREDIS_DC_CHANNEL_COMMAND,
   IOREDIS_DC_CHANNEL_CONNECT,

--- a/packages/server-utils/src/mongoose/index.ts
+++ b/packages/server-utils/src/mongoose/index.ts
@@ -1,4 +1,4 @@
-import { defineIntegration, type IntegrationFn } from '@sentry/core';
+import { defineIntegration, type IntegrationFn, waitForTracingChannelBinding } from '@sentry/core';
 import * as dc from 'node:diagnostics_channel';
 import { subscribeMongooseDiagnosticChannels } from './mongoose-dc-subscriber';
 
@@ -13,10 +13,9 @@ const _mongooseIntegration = (() => {
 
       // Subscribe to mongoose's native tracing channels (mongoose >= 9.7).
       // This is a no-op on versions that don't publish to the channels, so it is always safe to call.
-      // `bindTracingChannelToSpan` (inside the subscriber) makes the span the active context via
-      // `bindStore`, which needs the Sentry OTel context manager — `initOpenTelemetry()` registers
-      // that after `setupOnce`, so defer a tick.
-      void Promise.resolve().then(() => subscribeMongooseDiagnosticChannels(dc.tracingChannel));
+      waitForTracingChannelBinding(() => {
+        subscribeMongooseDiagnosticChannels(dc.tracingChannel);
+      });
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/server-utils/src/mongoose/index.ts
+++ b/packages/server-utils/src/mongoose/index.ts
@@ -2,7 +2,7 @@ import { defineIntegration, type IntegrationFn } from '@sentry/core';
 import * as dc from 'node:diagnostics_channel';
 import { subscribeMongooseDiagnosticChannels } from './mongoose-dc-subscriber';
 
-const _mongooseChannelIntegration = (() => {
+const _mongooseIntegration = (() => {
   return {
     name: 'Mongoose',
     setupOnce() {
@@ -28,4 +28,4 @@ const _mongooseChannelIntegration = (() => {
  * On older mongoose versions the channels are never published to, so this integration is inert and
  * the IITM-based patcher (gated to `< 9.7.0`) handles instrumentation instead.
  */
-export const mongooseChannelIntegration = defineIntegration(_mongooseChannelIntegration);
+export const mongooseIntegration = defineIntegration(_mongooseIntegration);

--- a/packages/server-utils/src/mongoose/index.ts
+++ b/packages/server-utils/src/mongoose/index.ts
@@ -1,0 +1,31 @@
+import { defineIntegration, type IntegrationFn } from '@sentry/core';
+import * as dc from 'node:diagnostics_channel';
+import { subscribeMongooseDiagnosticChannels } from './mongoose-dc-subscriber';
+
+const _mongooseChannelIntegration = (() => {
+  return {
+    name: 'Mongoose',
+    setupOnce() {
+      // Bail on Node <= 18.18.0, where `tracingChannel` does not exist.
+      if (!dc.tracingChannel) {
+        return;
+      }
+
+      // Subscribe to mongoose's native tracing channels (mongoose >= 9.7).
+      // This is a no-op on versions that don't publish to the channels, so it is always safe to call.
+      // `bindTracingChannelToSpan` (inside the subscriber) makes the span the active context via
+      // `bindStore`, which needs the Sentry OTel context manager — `initOpenTelemetry()` registers
+      // that after `setupOnce`, so defer a tick.
+      void Promise.resolve().then(() => subscribeMongooseDiagnosticChannels(dc.tracingChannel));
+    },
+  };
+}) satisfies IntegrationFn;
+
+/**
+ * Auto-instrument the [mongoose](https://www.npmjs.com/package/mongoose) library via its native
+ * `node:diagnostics_channel` tracing channels (mongoose >= 9.7).
+ *
+ * On older mongoose versions the channels are never published to, so this integration is inert and
+ * the IITM-based patcher (gated to `< 9.7.0`) handles instrumentation instead.
+ */
+export const mongooseChannelIntegration = defineIntegration(_mongooseChannelIntegration);

--- a/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
@@ -1,0 +1,193 @@
+import type { TracingChannel } from 'node:diagnostics_channel';
+import {
+  DB_COLLECTION_NAME,
+  DB_NAMESPACE,
+  DB_OPERATION_BATCH_SIZE,
+  DB_OPERATION_NAME,
+  DB_QUERY_TEXT,
+  DB_SYSTEM_NAME,
+  SERVER_ADDRESS,
+  SERVER_PORT,
+} from '@sentry/conventions/attributes';
+import { debug, SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
+import { DEBUG_BUILD } from '../debug-build';
+import { bindTracingChannelToSpan } from '../tracing-channel';
+
+// Channel names published by mongoose >= 9.7.0 (see mongoose `lib/tracing.js`,
+// `lib/query.js`, `lib/aggregate.js`, `lib/model.js` and `lib/cursor/*`).
+// Hardcoded so the subscriber does not have to import mongoose — the channels
+// just have to be subscribed to before the user's mongoose code publishes.
+export const MONGOOSE_DC_CHANNEL_QUERY = 'mongoose:query';
+export const MONGOOSE_DC_CHANNEL_AGGREGATE = 'mongoose:aggregate';
+export const MONGOOSE_DC_CHANNEL_MODEL_SAVE = 'mongoose:model:save';
+export const MONGOOSE_DC_CHANNEL_MODEL_INSERT_MANY = 'mongoose:model:insertMany';
+export const MONGOOSE_DC_CHANNEL_MODEL_BULK_WRITE = 'mongoose:model:bulkWrite';
+export const MONGOOSE_DC_CHANNEL_CURSOR_NEXT = 'mongoose:cursor:next';
+
+const ORIGIN = 'auto.db.mongoose.diagnostic_channel';
+const DB_SYSTEM_NAME_VALUE_MONGODB = 'mongodb';
+
+// Cap recursion so a self-referential or pathologically deep query can never
+// stall (or blow the stack in) instrumentation.
+const MAX_REDACTION_DEPTH = 10;
+
+/**
+ * Shape of the context object mongoose >= 9.7.0 publishes on its tracing
+ * channels (mongoose's `TracingContext`, see `types/tracing.d.ts`).
+ *
+ * Node's `tracePromise` mutates this same object with `result`/`error` once the
+ * operation settles, which `bindTracingChannelToSpan` reads in its lifecycle
+ * handlers — hence both are declared optional here.
+ *
+ * Unlike redis/ioredis, mongoose does NOT pre-sanitize the payload, so `args`
+ * carries the raw user query. We redact it before emitting `db.query.text`.
+ */
+export interface MongooseTracingData {
+  operation: string;
+  /** Absent for connection-level `aggregate()` calls, which have no model/collection. */
+  collection?: string;
+  database?: string;
+  serverAddress?: string;
+  serverPort?: number;
+  /** Cursor channels only: the cursor's fetch batch size and tailable flag. */
+  batchSize?: number;
+  tailable?: boolean;
+  /**
+   * Operation-specific arguments. `filter` (queries/cursors) and `pipeline`
+   * (aggregations) carry the query shape; `docs`/`ops` carry batch payloads.
+   */
+  args?: {
+    filter?: unknown;
+    pipeline?: unknown;
+    docs?: unknown;
+    ops?: unknown;
+    [key: string]: unknown;
+  };
+  result?: unknown;
+  error?: Error;
+}
+
+/**
+ * Platform-provided factory that creates a native tracing channel for the given name. The
+ * subscriber binds the span and its lifecycle onto the channel via `bindTracingChannelToSpan`,
+ * which propagates the active span through the runtime's async context.
+ *
+ * Node passes `node:diagnostics_channel`'s `tracingChannel` directly.
+ */
+export type MongooseTracingChannelFactory = <T extends object>(name: string) => TracingChannel<T, T>;
+
+let subscribed = false;
+let activeUnbinds: Array<() => void> = [];
+
+/**
+ * Subscribe Sentry span handlers to mongoose's diagnostics-channel events
+ * (`mongoose:query`, `:aggregate`, `:model:save`, `:model:insertMany`,
+ * `:model:bulkWrite`, `:cursor:next`), published by mongoose >= 9.7.0.
+ *
+ * On older mongoose versions the channels are never published to, so the
+ * subscribers are inert — there is no double-instrumentation against the
+ * IITM-based vendored patcher, which is gated to `< 9.7.0`.
+ *
+ * Idempotent: subsequent calls are a no-op.
+ */
+export function subscribeMongooseDiagnosticChannels(tracingChannel: MongooseTracingChannelFactory): void {
+  if (subscribed) return;
+  subscribed = true;
+
+  try {
+    activeUnbinds.push(
+      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_QUERY),
+      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_AGGREGATE),
+      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_SAVE),
+      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_INSERT_MANY),
+      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_BULK_WRITE),
+      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_CURSOR_NEXT),
+    );
+  } catch {
+    // The factory relies on `node:diagnostics_channel`, which isn't always
+    // available. Fail closed; the SDK simply won't emit mongoose spans here.
+    DEBUG_BUILD && debug.log('Mongoose node:diagnostics_channel subscription failed.');
+  }
+}
+
+function setupChannel(tracingChannel: MongooseTracingChannelFactory, channelName: string): () => void {
+  return bindTracingChannelToSpan(
+    tracingChannel<MongooseTracingData>(channelName),
+    data => {
+      const collection = data.collection;
+      const queryText = redactMongoQuery(data.args?.pipeline ?? data.args?.filter);
+      const batchSize = getBatchSize(data);
+
+      return startInactiveSpan({
+        name: collection ? `mongoose.${collection}.${data.operation}` : `mongoose.${data.operation}`,
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+          [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MONGODB,
+          [DB_OPERATION_NAME]: data.operation,
+          ...(collection != null ? { [DB_COLLECTION_NAME]: collection } : {}),
+          ...(data.database != null ? { [DB_NAMESPACE]: data.database } : {}),
+          ...(queryText != null ? { [DB_QUERY_TEXT]: queryText } : {}),
+          ...(batchSize != null ? { [DB_OPERATION_BATCH_SIZE]: batchSize } : {}),
+          ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
+          ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
+        },
+      });
+    },
+    // Query failures are surfaced to (and usually handled by) the caller; only annotate the
+    // span so we don't emit a duplicate error event for every failed query.
+    { captureError: false },
+  ).unbind;
+}
+
+/**
+ * `db.operation.batch.size` is only meaningful for genuine batch operations.
+ * Mongoose's cursor `batchSize` is a fetch-tuning option, not a batch operation
+ * size, so it is intentionally excluded here.
+ */
+function getBatchSize(data: MongooseTracingData): number | undefined {
+  const args = data.args;
+  const batch = data.operation === 'insertMany' ? args?.docs : data.operation === 'bulkWrite' ? args?.ops : undefined;
+  return Array.isArray(batch) && batch.length > 1 ? batch.length : undefined;
+}
+
+/**
+ * Serialize a mongoose filter/pipeline into `db.query.text` while stripping every
+ * value: keys and Mongo operators (`$gt`, `$in`, …) are preserved, leaf values
+ * become `'?'`. Mongoose does not sanitize its channel payload, so this prevents
+ * raw user data (potential PII) from leaving the process. Returns `undefined`
+ * (rather than throwing) on anything it cannot serialize.
+ */
+function redactMongoQuery(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  try {
+    const redacted = redactValue(value, 0);
+    const text = JSON.stringify(redacted);
+    // Skip empty/uninformative shapes (e.g. a `findOne()` with no filter).
+    return text == null || text === '{}' || text === '[]' ? undefined : text;
+  } catch {
+    return undefined;
+  }
+}
+
+function redactValue(value: unknown, depth: number): unknown {
+  if (depth > MAX_REDACTION_DEPTH) return '?';
+  if (Array.isArray(value)) {
+    return value.map(item => redactValue(item, depth + 1));
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      out[key] = redactValue((value as Record<string, unknown>)[key], depth + 1);
+    }
+    return out;
+  }
+  return '?';
+}
+
+/** Test-only: detach all channel bindings and reset module-local subscribe state. */
+export function _resetMongooseDiagnosticChannelsForTesting(): void {
+  activeUnbinds.forEach(unbind => unbind());
+  activeUnbinds = [];
+  subscribed = false;
+}

--- a/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
@@ -122,12 +122,12 @@ function setupChannel(tracingChannel: MongooseTracingChannelFactory, channelName
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
         [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MONGODB,
         [DB_OPERATION_NAME]: data.operation,
-        ...(collection != null ? { [DB_COLLECTION_NAME]: collection } : {}),
-        ...(data.database != null ? { [DB_NAMESPACE]: data.database } : {}),
-        ...(queryText != null ? { [DB_QUERY_TEXT]: queryText } : {}),
-        ...(batchSize != null ? { [DB_OPERATION_BATCH_SIZE]: batchSize } : {}),
-        ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
-        ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
+        [DB_COLLECTION_NAME]: collection ?? undefined,
+        [DB_NAMESPACE]: data.database ?? undefined,
+        [DB_QUERY_TEXT]: queryText ?? undefined,
+        [DB_OPERATION_BATCH_SIZE]: batchSize ?? undefined,
+        [SERVER_ADDRESS]: data.serverAddress ?? undefined,
+        [SERVER_PORT]: data.serverPort ?? undefined,
       },
     });
   });

--- a/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
@@ -141,6 +141,7 @@ function setupChannel(tracingChannel: MongooseTracingChannelFactory, channelName
 function getBatchSize(data: MongooseTracingData): number | undefined {
   const args = data.args;
   const batch = data.operation === 'insertMany' ? args?.docs : data.operation === 'bulkWrite' ? args?.ops : undefined;
+
   return Array.isArray(batch) && batch.length > 1 ? batch.length : undefined;
 }
 
@@ -159,6 +160,7 @@ function redactMongoQuery(value: unknown): string | undefined {
   try {
     const redacted = redactValue(value, 0);
     const text = JSON.stringify(redacted);
+
     // Skip empty/uninformative shapes (e.g. a `findOne()` with no filter).
     return text == null || text === '{}' || text === '[]' ? undefined : text;
   } catch {
@@ -180,7 +182,9 @@ function redactValue(value: unknown, depth: number): unknown {
     for (const key of Object.keys(value as Record<string, unknown>)) {
       out[key] = redactValue((value as Record<string, unknown>)[key], depth + 1);
     }
+
     return out;
   }
+
   return '?';
 }

--- a/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
@@ -77,7 +77,6 @@ export interface MongooseTracingData {
 export type MongooseTracingChannelFactory = <T extends object>(name: string) => TracingChannel<T, T>;
 
 let subscribed = false;
-let activeUnbinds: Array<() => void> = [];
 
 /**
  * Subscribe Sentry span handlers to mongoose's diagnostics-channel events
@@ -95,14 +94,12 @@ export function subscribeMongooseDiagnosticChannels(tracingChannel: MongooseTrac
   subscribed = true;
 
   try {
-    activeUnbinds.push(
-      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_QUERY),
-      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_AGGREGATE),
-      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_SAVE),
-      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_INSERT_MANY),
-      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_BULK_WRITE),
-      setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_CURSOR_NEXT),
-    );
+    setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_QUERY);
+    setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_AGGREGATE);
+    setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_SAVE);
+    setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_INSERT_MANY);
+    setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_MODEL_BULK_WRITE);
+    setupChannel(tracingChannel, MONGOOSE_DC_CHANNEL_CURSOR_NEXT);
   } catch {
     // The factory relies on `node:diagnostics_channel`, which isn't always
     // available. Fail closed; the SDK simply won't emit mongoose spans here.
@@ -110,34 +107,28 @@ export function subscribeMongooseDiagnosticChannels(tracingChannel: MongooseTrac
   }
 }
 
-function setupChannel(tracingChannel: MongooseTracingChannelFactory, channelName: string): () => void {
-  return bindTracingChannelToSpan(
-    tracingChannel<MongooseTracingData>(channelName),
-    data => {
-      const collection = data.collection;
-      const queryText = redactMongoQuery(data.args?.pipeline ?? data.args?.filter);
-      const batchSize = getBatchSize(data);
+function setupChannel(tracingChannel: MongooseTracingChannelFactory, channelName: string): void {
+  bindTracingChannelToSpan(tracingChannel<MongooseTracingData>(channelName), data => {
+    const collection = data.collection;
+    const queryText = redactMongoQuery(data.args?.pipeline ?? data.args?.filter);
+    const batchSize = getBatchSize(data);
 
-      return startInactiveSpan({
-        name: collection ? `mongoose.${collection}.${data.operation}` : `mongoose.${data.operation}`,
-        attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
-          [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MONGODB,
-          [DB_OPERATION_NAME]: data.operation,
-          ...(collection != null ? { [DB_COLLECTION_NAME]: collection } : {}),
-          ...(data.database != null ? { [DB_NAMESPACE]: data.database } : {}),
-          ...(queryText != null ? { [DB_QUERY_TEXT]: queryText } : {}),
-          ...(batchSize != null ? { [DB_OPERATION_BATCH_SIZE]: batchSize } : {}),
-          ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
-          ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
-        },
-      });
-    },
-    // Query failures are surfaced to (and usually handled by) the caller; only annotate the
-    // span so we don't emit a duplicate error event for every failed query.
-    { captureError: false },
-  ).unbind;
+    return startInactiveSpan({
+      name: collection ? `mongoose.${collection}.${data.operation}` : `mongoose.${data.operation}`,
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+        [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MONGODB,
+        [DB_OPERATION_NAME]: data.operation,
+        ...(collection != null ? { [DB_COLLECTION_NAME]: collection } : {}),
+        ...(data.database != null ? { [DB_NAMESPACE]: data.database } : {}),
+        ...(queryText != null ? { [DB_QUERY_TEXT]: queryText } : {}),
+        ...(batchSize != null ? { [DB_OPERATION_BATCH_SIZE]: batchSize } : {}),
+        ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
+        ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
+      },
+    });
+  });
 }
 
 /**
@@ -183,11 +174,4 @@ function redactValue(value: unknown, depth: number): unknown {
     return out;
   }
   return '?';
-}
-
-/** Test-only: detach all channel bindings and reset module-local subscribe state. */
-export function _resetMongooseDiagnosticChannelsForTesting(): void {
-  activeUnbinds.forEach(unbind => unbind());
-  activeUnbinds = [];
-  subscribed = false;
 }

--- a/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
@@ -90,7 +90,9 @@ let subscribed = false;
  * Idempotent: subsequent calls are a no-op.
  */
 export function subscribeMongooseDiagnosticChannels(tracingChannel: MongooseTracingChannelFactory): void {
-  if (subscribed) return;
+  if (subscribed) {
+    return;
+  }
   subscribed = true;
 
   try {
@@ -150,7 +152,10 @@ function getBatchSize(data: MongooseTracingData): number | undefined {
  * (rather than throwing) on anything it cannot serialize.
  */
 function redactMongoQuery(value: unknown): string | undefined {
-  if (value == null) return undefined;
+  if (value == null) {
+    return undefined;
+  }
+
   try {
     const redacted = redactValue(value, 0);
     const text = JSON.stringify(redacted);
@@ -162,10 +167,14 @@ function redactMongoQuery(value: unknown): string | undefined {
 }
 
 function redactValue(value: unknown, depth: number): unknown {
-  if (depth > MAX_REDACTION_DEPTH) return '?';
+  if (depth > MAX_REDACTION_DEPTH) {
+    return '?';
+  }
+
   if (Array.isArray(value)) {
     return value.map(item => redactValue(item, depth + 1));
   }
+
   if (value && typeof value === 'object') {
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>)) {

--- a/packages/server-utils/test/mongoose/mongoose-dc-subscriber.test.ts
+++ b/packages/server-utils/test/mongoose/mongoose-dc-subscriber.test.ts
@@ -17,9 +17,8 @@ import {
   spanToJSON,
   startSpan,
 } from '@sentry/core';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  _resetMongooseDiagnosticChannelsForTesting,
   MONGOOSE_DC_CHANNEL_AGGREGATE,
   MONGOOSE_DC_CHANNEL_CURSOR_NEXT,
   MONGOOSE_DC_CHANNEL_MODEL_BULK_WRITE,
@@ -131,18 +130,25 @@ const factory = tracingChannel as MongooseTracingChannelFactory;
 describe('subscribeMongooseDiagnosticChannels', () => {
   let captureExceptionSpy: ReturnType<typeof vi.spyOn>;
 
-  // `node:diagnostics_channel` channels are process-global. `_reset…` calls each binding's `unbind`,
-  // so we can subscribe and fully detach per test without handlers leaking across tests.
-  beforeEach(() => {
+  // The subscriber captures the async-context strategy's ALS when it binds, so the strategy must be
+  // installed before we subscribe — and both must stay fixed for the file. We do that once here,
+  // mirroring production where `setupOnce` subscribes a single time. Per-test we only reset the client
+  // and scopes (cleared in `afterEach`), so nothing leaks between tests.
+  beforeAll(() => {
     installTestAsyncContextStrategy();
-    initTestClient();
-    captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
     subscribeMongooseDiagnosticChannels(factory);
   });
 
-  afterEach(() => {
-    _resetMongooseDiagnosticChannelsForTesting();
+  afterAll(() => {
     setAsyncContextStrategy(undefined);
+  });
+
+  beforeEach(() => {
+    initTestClient();
+    captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+  });
+
+  afterEach(() => {
     getCurrentScope().clear();
     getCurrentScope().setClient(undefined);
     getGlobalScope().clear();

--- a/packages/server-utils/test/mongoose/mongoose-dc-subscriber.test.ts
+++ b/packages/server-utils/test/mongoose/mongoose-dc-subscriber.test.ts
@@ -1,0 +1,325 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { tracingChannel } from 'node:diagnostics_channel';
+import type { Scope, Span } from '@sentry/core';
+import * as SentryCore from '@sentry/core';
+import {
+  _INTERNAL_setSpanForScope,
+  Client,
+  createTransport,
+  getActiveSpan,
+  getCurrentScope,
+  getDefaultCurrentScope,
+  getDefaultIsolationScope,
+  getGlobalScope,
+  initAndBind,
+  resolvedSyncPromise,
+  setAsyncContextStrategy,
+  spanToJSON,
+  startSpan,
+} from '@sentry/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  _resetMongooseDiagnosticChannelsForTesting,
+  MONGOOSE_DC_CHANNEL_AGGREGATE,
+  MONGOOSE_DC_CHANNEL_CURSOR_NEXT,
+  MONGOOSE_DC_CHANNEL_MODEL_BULK_WRITE,
+  MONGOOSE_DC_CHANNEL_MODEL_INSERT_MANY,
+  MONGOOSE_DC_CHANNEL_MODEL_SAVE,
+  MONGOOSE_DC_CHANNEL_QUERY,
+  type MongooseTracingChannelFactory,
+  subscribeMongooseDiagnosticChannels,
+} from '../../src/mongoose/mongoose-dc-subscriber';
+
+interface TestStore {
+  scope: Scope;
+  isolationScope: Scope;
+}
+
+class TestClient extends Client<any> {
+  public eventFromException(): PromiseLike<any> {
+    return resolvedSyncPromise({});
+  }
+  public eventFromMessage(): PromiseLike<any> {
+    return resolvedSyncPromise({});
+  }
+}
+
+function initTestClient(): void {
+  initAndBind(TestClient, {
+    dsn: 'https://username@domain/123',
+    integrations: [],
+    sendClientReports: false,
+    stackParser: () => [],
+    tracesSampleRate: 1,
+    transport: () => createTransport({ recordDroppedEvent: () => undefined }, () => resolvedSyncPromise({})),
+  });
+}
+
+function installTestAsyncContextStrategy(): void {
+  const asyncStorage = new AsyncLocalStorage<TestStore>();
+
+  function getScopes(): TestStore {
+    return (
+      asyncStorage.getStore() || {
+        scope: getDefaultCurrentScope(),
+        isolationScope: getDefaultIsolationScope(),
+      }
+    );
+  }
+
+  setAsyncContextStrategy({
+    withScope: callback => {
+      const scope = getScopes().scope.clone();
+      const isolationScope = getScopes().isolationScope;
+      return asyncStorage.run({ scope, isolationScope }, () => callback(scope));
+    },
+    withSetScope: (scope, callback) => {
+      const isolationScope = getScopes().isolationScope;
+      return asyncStorage.run({ scope, isolationScope }, () => callback(scope));
+    },
+    withIsolationScope: callback => {
+      const scope = getScopes().scope;
+      const isolationScope = getScopes().isolationScope.clone();
+      return asyncStorage.run({ scope, isolationScope }, () => callback(isolationScope));
+    },
+    withSetIsolationScope: (isolationScope, callback) => {
+      const scope = getScopes().scope;
+      return asyncStorage.run({ scope, isolationScope }, () => callback(isolationScope));
+    },
+    getCurrentScope: () => getScopes().scope,
+    getIsolationScope: () => getScopes().isolationScope,
+    getTracingChannelBinding: () => ({
+      asyncLocalStorage: asyncStorage,
+      getStoreWithActiveSpan: span => {
+        const scope = getScopes().scope.clone();
+        const isolationScope = getScopes().isolationScope;
+        _INTERNAL_setSpanForScope(scope, span);
+        return { scope, isolationScope };
+      },
+    }),
+  });
+}
+
+/** Drives a channel's `tracePromise` and captures the span bound by the subscriber. */
+async function traceOperation(
+  channelName: string,
+  data: Record<string, unknown>,
+  outcome: { result?: unknown; error?: Error },
+): Promise<{ span: Span | undefined; childParentSpanId: string | undefined }> {
+  const channel = tracingChannel(channelName);
+  let span: Span | undefined;
+  let childParentSpanId: string | undefined;
+
+  const run = channel.tracePromise(async () => {
+    span = getActiveSpan();
+    startSpan({ name: 'child' }, child => {
+      childParentSpanId = spanToJSON(child).parent_span_id;
+    });
+    if (outcome.error) {
+      throw outcome.error;
+    }
+    return outcome.result;
+  }, data);
+
+  await run.catch(() => undefined);
+
+  return { span, childParentSpanId };
+}
+
+const factory = tracingChannel as MongooseTracingChannelFactory;
+
+describe('subscribeMongooseDiagnosticChannels', () => {
+  let captureExceptionSpy: ReturnType<typeof vi.spyOn>;
+
+  // `node:diagnostics_channel` channels are process-global. `_reset…` calls each binding's `unbind`,
+  // so we can subscribe and fully detach per test without handlers leaking across tests.
+  beforeEach(() => {
+    installTestAsyncContextStrategy();
+    initTestClient();
+    captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('event-id');
+    subscribeMongooseDiagnosticChannels(factory);
+  });
+
+  afterEach(() => {
+    _resetMongooseDiagnosticChannelsForTesting();
+    setAsyncContextStrategy(undefined);
+    getCurrentScope().clear();
+    getCurrentScope().setClient(undefined);
+    getGlobalScope().clear();
+    vi.clearAllMocks();
+  });
+
+  describe('query channel', () => {
+    it('creates a db span with stable semconv attributes', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_QUERY,
+        {
+          operation: 'findOne',
+          collection: 'blogposts',
+          database: 'test',
+          serverAddress: '127.0.0.1',
+          serverPort: 27017,
+          args: { filter: { title: 'secret', views: { $gt: 100 } } },
+        },
+        { result: { title: 'secret' } },
+      );
+
+      expect(span).toBeDefined();
+      const json = spanToJSON(span!);
+      expect(json.description).toBe('mongoose.blogposts.findOne');
+      expect(json.op).toBe('db');
+      expect(json.origin).toBe('auto.db.mongoose.diagnostic_channel');
+      expect(json.data['db.system.name']).toBe('mongodb');
+      expect(json.data['db.operation.name']).toBe('findOne');
+      expect(json.data['db.collection.name']).toBe('blogposts');
+      expect(json.data['db.namespace']).toBe('test');
+      expect(json.data['server.address']).toBe('127.0.0.1');
+      expect(json.data['server.port']).toBe(27017);
+      expect(json.timestamp).toBeDefined();
+    });
+
+    it('redacts filter values in db.query.text but keeps keys and operators', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_QUERY,
+        { operation: 'find', collection: 'users', args: { filter: { email: 'a@b.com', age: { $gte: 21 } } } },
+        { result: [] },
+      );
+
+      const queryText = spanToJSON(span!).data['db.query.text'] as string;
+      expect(queryText).toBe('{"email":"?","age":{"$gte":"?"}}');
+      // raw values never leak
+      expect(queryText).not.toContain('a@b.com');
+      expect(queryText).not.toContain('21');
+    });
+
+    it('omits db.query.text for an empty filter', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_QUERY,
+        { operation: 'find', collection: 'users', args: { filter: {} } },
+        { result: [] },
+      );
+
+      expect(spanToJSON(span!).data['db.query.text']).toBeUndefined();
+    });
+
+    it('sets error status and does NOT capture an exception on failure', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_QUERY,
+        { operation: 'findOne', collection: 'users', args: { filter: { _id: 1 } } },
+        { error: new Error('connection lost') },
+      );
+
+      expect(spanToJSON(span!).status).toBe('connection lost');
+      expect(spanToJSON(span!).timestamp).toBeDefined();
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+    });
+
+    it('parents the mongoose span to the surrounding span and parents children to it', async () => {
+      let outerSpanId: string | undefined;
+      let result: Awaited<ReturnType<typeof traceOperation>> | undefined;
+
+      await startSpan({ name: 'outer' }, async outer => {
+        outerSpanId = outer.spanContext().spanId;
+        result = await traceOperation(
+          MONGOOSE_DC_CHANNEL_QUERY,
+          { operation: 'find', collection: 'users', args: { filter: {} } },
+          { result: [] },
+        );
+      });
+
+      expect(spanToJSON(result!.span!).parent_span_id).toBe(outerSpanId);
+      expect(result!.childParentSpanId).toBe(result!.span!.spanContext().spanId);
+    });
+  });
+
+  describe('aggregate channel', () => {
+    it('redacts pipeline values and handles a missing collection', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_AGGREGATE,
+        { operation: 'aggregate', args: { pipeline: [{ $match: { status: 'active' } }] } },
+        { result: [] },
+      );
+
+      const json = spanToJSON(span!);
+      // connection-level aggregate has no collection -> name degrades gracefully
+      expect(json.description).toBe('mongoose.aggregate');
+      expect(json.data['db.collection.name']).toBeUndefined();
+      expect(json.data['db.query.text']).toBe('[{"$match":{"status":"?"}}]');
+    });
+  });
+
+  describe('model channels', () => {
+    it('creates a save span', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_MODEL_SAVE,
+        { operation: 'save', collection: 'blogposts', args: { options: {} } },
+        { result: {} },
+      );
+
+      expect(spanToJSON(span!).description).toBe('mongoose.blogposts.save');
+      expect(spanToJSON(span!).data['db.operation.name']).toBe('save');
+    });
+
+    it('sets db.operation.batch.size from insertMany docs (> 1 only)', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_MODEL_INSERT_MANY,
+        { operation: 'insertMany', collection: 'blogposts', args: { docs: [{}, {}, {}] } },
+        { result: [{}, {}, {}] },
+      );
+
+      expect(spanToJSON(span!).data['db.operation.batch.size']).toBe(3);
+    });
+
+    it('does not set batch size for a single insertMany doc', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_MODEL_INSERT_MANY,
+        { operation: 'insertMany', collection: 'blogposts', args: { docs: [{}] } },
+        { result: [{}] },
+      );
+
+      expect(spanToJSON(span!).data['db.operation.batch.size']).toBeUndefined();
+    });
+
+    it('sets db.operation.batch.size from bulkWrite ops', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_MODEL_BULK_WRITE,
+        { operation: 'bulkWrite', collection: 'blogposts', args: { ops: [{}, {}] } },
+        { result: {} },
+      );
+
+      expect(spanToJSON(span!).data['db.operation.batch.size']).toBe(2);
+    });
+  });
+
+  describe('cursor channel', () => {
+    it('creates a span per cursor iteration without treating cursor batchSize as an operation batch', async () => {
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_CURSOR_NEXT,
+        { operation: 'find', collection: 'blogposts', batchSize: 50, tailable: false, args: { filter: { a: 1 } } },
+        { result: {} },
+      );
+
+      const json = spanToJSON(span!);
+      expect(json.description).toBe('mongoose.blogposts.find');
+      // cursor fetch batchSize is NOT db.operation.batch.size
+      expect(json.data['db.operation.batch.size']).toBeUndefined();
+      expect(json.data['db.query.text']).toBe('{"a":"?"}');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('does not throw or double-subscribe on a second call', async () => {
+      subscribeMongooseDiagnosticChannels(factory);
+
+      const { span } = await traceOperation(
+        MONGOOSE_DC_CHANNEL_QUERY,
+        { operation: 'find', collection: 'users', args: { filter: {} } },
+        { result: [] },
+      );
+
+      // a single subscription means a single span, ended exactly once
+      expect(span).toBeDefined();
+      expect(spanToJSON(span!).timestamp).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
Instruments mongoose >= 9.7 through its native `diagnostics_channel` tracing channels instead of monkey-patching, the same way we did for redis/ioredis. The subscription lives in `server-utils` as `mongooseChannelIntegration`, and the node `mongooseIntegration` extends it (via `extendIntegration`) to keep running the IITM patcher for mongoose < 9.7.


The channel path emits the latest stable DB semconv, so there is an attribute drift. We did that for redis so I thought to do the same here, but we could match the legacy attributes and drop them later for v11 if that's what we want.