### PR TITLE
ref(core): Move `spanStreamingIntegration` setup into `ServerRuntimeClient`

### DIFF
--- a/packages/cloudflare/src/sdk.ts
+++ b/packages/cloudflare/src/sdk.ts
@@ -9,7 +9,6 @@ import {
   initAndBind,
   linkedErrorsIntegration,
   requestDataIntegration,
-  spanStreamingIntegration,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
 import type { CloudflareClientOptions, CloudflareOptions } from './client';
@@ -59,15 +58,10 @@ export function init(options: CloudflareOptions): CloudflareClient | undefined {
   const flushLock = options.ctx ? makeFlushLock(options.ctx) : undefined;
   delete options.ctx;
 
-  const resolvedIntegrations = getIntegrationsToSetup(options);
-  if (options.traceLifecycle === 'stream' && !resolvedIntegrations.some(i => i.name === 'SpanStreaming')) {
-    resolvedIntegrations.push(spanStreamingIntegration());
-  }
-
   const clientOptions: CloudflareClientOptions = {
     ...options,
     stackParser: stackParserFromStackParserOptions(options.stackParser || defaultStackParser),
-    integrations: resolvedIntegrations,
+    integrations: getIntegrationsToSetup(options),
     transport: options.transport || makeCloudflareTransport,
     flushLock,
   };

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -2,6 +2,7 @@ import { createCheckInEnvelope } from './checkin';
 import { Client } from './client';
 import { getIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
+import { spanStreamingIntegration } from './integrations/spanStreaming';
 import type { Scope } from './scope';
 import { DEFAULT_TRANSPORT_BUFFER_SIZE } from './transports/base';
 import { addUserAgentToTransportHeaders } from './transports/userAgent';
@@ -38,6 +39,13 @@ export class ServerRuntimeClient<
    */
   public constructor(options: O) {
     addUserAgentToTransportHeaders(options);
+
+    // When span streaming is enabled (`traceLifecycle: 'stream'`), the `spanStreamingIntegration`
+    // is required to flush spans. We add it here so the individual server SDKs don't have to.
+    // A user-provided `spanStreamingIntegration` always takes precedence over the one we add.
+    if (options.traceLifecycle === 'stream' && !options.integrations.some(i => i.name === 'SpanStreaming')) {
+      options.integrations.push(spanStreamingIntegration());
+    }
 
     super(options);
 

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -9,7 +9,6 @@ import {
   linkedErrorsIntegration,
   nodeStackLineParser,
   requestDataIntegration,
-  spanStreamingIntegration,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
 import { DenoClient } from './client';
@@ -118,15 +117,10 @@ export function init(options: DenoOptions = {}): Client {
     options.defaultIntegrations = getDefaultIntegrations(options);
   }
 
-  const resolvedIntegrations = getIntegrationsToSetup(options);
-  if (options.traceLifecycle === 'stream' && !resolvedIntegrations.some(i => i.name === 'SpanStreaming')) {
-    resolvedIntegrations.push(spanStreamingIntegration());
-  }
-
   const clientOptions: ServerRuntimeClientOptions = {
     ...options,
     stackParser: stackParserFromStackParserOptions(options.stackParser || defaultStackParser),
-    integrations: resolvedIntegrations,
+    integrations: getIntegrationsToSetup(options),
     transport: options.transport || makeFetchTransport,
   };
 

--- a/packages/node-core/src/light/sdk.ts
+++ b/packages/node-core/src/light/sdk.ts
@@ -11,7 +11,6 @@ import {
   linkedErrorsIntegration,
   propagationContextFromHeaders,
   requestDataIntegration,
-  spanStreamingIntegration,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
@@ -167,10 +166,6 @@ function getClientOptions(
     defaultIntegrations,
     integrations,
   });
-
-  if (mergedOptions.traceLifecycle === 'stream' && !resolvedIntegrations.some(i => i.name === 'SpanStreaming')) {
-    resolvedIntegrations.push(spanStreamingIntegration());
-  }
 
   return {
     ...mergedOptions,

--- a/packages/node-core/src/sdk/index.ts
+++ b/packages/node-core/src/sdk/index.ts
@@ -13,7 +13,6 @@ import {
   linkedErrorsIntegration,
   propagationContextFromHeaders,
   requestDataIntegration,
-  spanStreamingIntegration,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
 import {
@@ -217,10 +216,6 @@ function getClientOptions(
     defaultIntegrations,
     integrations,
   });
-
-  if (mergedOptions.traceLifecycle === 'stream' && !resolvedIntegrations.some(i => i.name === 'SpanStreaming')) {
-    resolvedIntegrations.push(spanStreamingIntegration());
-  }
 
   return {
     ...mergedOptions,

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -16,7 +16,6 @@ import {
   linkedErrorsIntegration,
   nodeStackLineParser,
   requestDataIntegration,
-  spanStreamingIntegration,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
 import {
@@ -93,15 +92,10 @@ export function init(options: VercelEdgeOptions = {}): Client | undefined {
   options.environment =
     options.environment || process.env.SENTRY_ENVIRONMENT || getVercelEnv(false) || process.env.NODE_ENV;
 
-  const resolvedIntegrations = getIntegrationsToSetup(options);
-  if (options.traceLifecycle === 'stream' && !resolvedIntegrations.some(i => i.name === 'SpanStreaming')) {
-    resolvedIntegrations.push(spanStreamingIntegration());
-  }
-
   const client = new VercelEdgeClient({
     ...options,
     stackParser: stackParserFromStackParserOptions(options.stackParser || nodeStackParser),
-    integrations: resolvedIntegrations,
+    integrations: getIntegrationsToSetup(options),
     transport: options.transport || makeEdgeTransport,
   });
   // The client is on the current scope, from where it generally is inherited


### PR DESCRIPTION
Now that all our server runtime SDKs support span streaming (they didn't initially), we can move the per-SDK-init-based logic to add `spanStreamingIntegration` if `traceLifecycle: 'stream'` was set, to the `ServerRuntimeClient`.

This makes span streaming enabling more consistent for setups that only use a client. Also for SDKs like electron that init themselves with e.g. a `NodeClient` and therefore had to manually add the integration. h/t @timfish for raising this