### PR TITLE
fix(core): Improve waiting for tracing channel bindings

### DIFF
--- a/packages/core/src/asyncContext/index.ts
+++ b/packages/core/src/asyncContext/index.ts
@@ -1,9 +1,7 @@
 import type { Carrier } from './../carrier';
 import { getMainCarrier, getSentryCarrier } from './../carrier';
-import type { Scope } from './../scope';
-import { _setSpanForScope } from './../utils/spanOnScope';
 import { getStackAsyncContextStrategy } from './stackStrategy';
-import type { AsyncContextStrategy, TracingChannelBinding } from './types';
+import type { AsyncContextStrategy } from './types';
 
 /**
  * @private Private API with no semver guarantees!
@@ -30,36 +28,4 @@ export function getAsyncContextStrategy(carrier: Carrier): AsyncContextStrategy 
 
   // Otherwise, use the default one (stack)
   return getStackAsyncContextStrategy();
-}
-
-/**
- * Get the runtime binding needed to connect tracing channels to async context.
- */
-export function getTracingChannelBinding(): TracingChannelBinding | undefined {
-  return getAsyncContextStrategy(getMainCarrier()).getTracingChannelBinding?.();
-}
-
-/**
- * Build the default {@link TracingChannelBinding} shared by AsyncLocalStorage-based strategies.
- *
- * The ALS instance is supplied by the caller (kept as `unknown`).
- * The binding clones the current scope, plants the span on it, and reuses the existing isolation scope.
- *
- * The OpenTelemetry strategy does not use this: its store value is an OTel context, not a
- * `{ scope, isolationScope }` pair.
- */
-export function _INTERNAL_createTracingChannelBinding(
-  asyncLocalStorage: unknown,
-  getScopes: () => { scope: Scope; isolationScope: Scope },
-): TracingChannelBinding {
-  return {
-    asyncLocalStorage,
-    getStoreWithActiveSpan: span => {
-      const { scope, isolationScope } = getScopes();
-      const activeScope = scope.clone();
-      _setSpanForScope(activeScope, span);
-
-      return { scope: activeScope, isolationScope };
-    },
-  };
 }

--- a/packages/core/src/asyncContext/tracing-channel-binding.ts
+++ b/packages/core/src/asyncContext/tracing-channel-binding.ts
@@ -43,7 +43,7 @@ export function waitForTracingChannelBinding(callback: () => void, retries = 1):
  * `{ scope, isolationScope }` pair.
  */
 export function _INTERNAL_createTracingChannelBinding(
-  asyncLocalStorage: unknown,
+  asyncLocalStorage: NonNullable<unknown>,
   getScopes: () => { scope: Scope; isolationScope: Scope },
 ): TracingChannelBinding {
   return {

--- a/packages/core/src/asyncContext/tracing-channel-binding.ts
+++ b/packages/core/src/asyncContext/tracing-channel-binding.ts
@@ -1,0 +1,55 @@
+import { getMainCarrier } from '../carrier';
+import type { Scope } from '../scope';
+import { _setSpanForScope } from '../utils/spanOnScope';
+import { getAsyncContextStrategy } from './index';
+import type { TracingChannelBinding } from './types';
+
+/**
+ * Execute a callback whenever the tracing channel binding is available.
+ * If it is not available after retry, the callback is not executed.
+ */
+export function waitForTracingChannelBinding(callback: () => void, retries = 1): void {
+  const binding = getAsyncContextStrategy(getMainCarrier()).getTracingChannelBinding?.();
+
+  if (binding) {
+    callback();
+    return;
+  }
+
+  if (!retries) {
+    return;
+  }
+
+  // It is possible that the binding is not available yet when this is initially called
+  // This happens when users use a custom OTEL setup
+  // In this case, we wait for a tick and try again afterwards
+  // If it still fails, we bail and do nothing
+  setTimeout(() => {
+    waitForTracingChannelBinding(callback, retries - 1);
+  }, 1);
+}
+
+/**
+ * Build the default {@link TracingChannelBinding} shared by AsyncLocalStorage-based strategies.
+ *
+ * The ALS instance is supplied by the caller (kept as `unknown`).
+ * The binding clones the current scope, plants the span on it, and reuses the existing isolation scope.
+ *
+ * The OpenTelemetry strategy does not use this: its store value is an OTel context, not a
+ * `{ scope, isolationScope }` pair.
+ */
+export function _INTERNAL_createTracingChannelBinding(
+  asyncLocalStorage: unknown,
+  getScopes: () => { scope: Scope; isolationScope: Scope },
+): TracingChannelBinding {
+  return {
+    asyncLocalStorage,
+    getStoreWithActiveSpan: span => {
+      const { scope, isolationScope } = getScopes();
+      const activeScope = scope.clone();
+      _setSpanForScope(activeScope, span);
+
+      return { scope: activeScope, isolationScope };
+    },
+  };
+}

--- a/packages/core/src/asyncContext/tracing-channel-binding.ts
+++ b/packages/core/src/asyncContext/tracing-channel-binding.ts
@@ -1,6 +1,7 @@
 import { getMainCarrier } from '../carrier';
 import type { Scope } from '../scope';
 import { _setSpanForScope } from '../utils/spanOnScope';
+import { safeUnref } from '../utils/timer';
 import { getAsyncContextStrategy } from './index';
 import type { TracingChannelBinding } from './types';
 
@@ -24,9 +25,12 @@ export function waitForTracingChannelBinding(callback: () => void, retries = 1):
   // This happens when users use a custom OTEL setup
   // In this case, we wait for a tick and try again afterwards
   // If it still fails, we bail and do nothing
-  setTimeout(() => {
-    waitForTracingChannelBinding(callback, retries - 1);
-  }, 1);
+  // `safeUnref` so this retry timer never keeps the process alive on its own (Node server runtimes).
+  safeUnref(
+    setTimeout(() => {
+      waitForTracingChannelBinding(callback, retries - 1);
+    }, 1),
+  );
 }
 
 /**

--- a/packages/core/src/asyncContext/types.ts
+++ b/packages/core/src/asyncContext/types.ts
@@ -21,7 +21,7 @@ export interface TracingChannelBinding {
   /**
    * The ALS instance that will be bound to the channel.
    */
-  asyncLocalStorage: unknown;
+  asyncLocalStorage: NonNullable<unknown>;
 
   /**
    * Activates a span for the tracing channels nested invocations, the return value must be the same type as the `asyncLocalStorage` inner value.

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -49,11 +49,11 @@ export {
   hasExternalPropagationContext,
 } from './currentScopes';
 export { getDefaultCurrentScope, getDefaultIsolationScope } from './defaultScopes';
+export { setAsyncContextStrategy, getAsyncContextStrategy } from './asyncContext';
 export {
-  setAsyncContextStrategy,
-  getTracingChannelBinding as _INTERNAL_getTracingChannelBinding,
+  waitForTracingChannelBinding,
   _INTERNAL_createTracingChannelBinding,
-} from './asyncContext';
+} from './asyncContext/tracing-channel-binding';
 export { getGlobalSingleton, getMainCarrier } from './carrier';
 export { makeSession, closeSession, updateSession } from './session';
 export { Scope } from './scope';

--- a/packages/core/test/lib/asyncContext/tracing-channel-binding.test.ts
+++ b/packages/core/test/lib/asyncContext/tracing-channel-binding.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAsyncContextStrategy, setAsyncContextStrategy } from '../../../src/asyncContext';
+import { waitForTracingChannelBinding } from '../../../src/asyncContext/tracing-channel-binding';
+import type { TracingChannelBinding } from '../../../src/asyncContext/types';
+import { getMainCarrier } from '../../../src/carrier';
+
+const FAKE_BINDING: TracingChannelBinding = {
+  asyncLocalStorage: {},
+  getStoreWithActiveSpan: () => ({}),
+};
+
+/** Install an async context strategy whose `getTracingChannelBinding` is driven by `provider`. */
+function setBindingProvider(provider: (() => TracingChannelBinding | undefined) | undefined): void {
+  setAsyncContextStrategy({
+    ...getAsyncContextStrategy(getMainCarrier()),
+    getTracingChannelBinding: provider,
+  });
+}
+
+describe('waitForTracingChannelBinding', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setAsyncContextStrategy(undefined);
+  });
+
+  afterEach(() => {
+    setAsyncContextStrategy(undefined);
+    vi.useRealTimers();
+  });
+
+  it('runs the callback synchronously when the binding is already available', () => {
+    const getBinding = vi.fn(() => FAKE_BINDING);
+    setBindingProvider(getBinding);
+
+    const callback = vi.fn();
+    waitForTracingChannelBinding(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    // Resolved on the first attempt, so no retry should be scheduled.
+    expect(getBinding).toHaveBeenCalledTimes(1);
+    vi.runAllTimers();
+    expect(getBinding).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on the next tick and runs the callback once the binding becomes available', () => {
+    const getBinding = vi.fn<[], TracingChannelBinding | undefined>(() => FAKE_BINDING);
+    getBinding.mockReturnValueOnce(undefined);
+    setBindingProvider(getBinding);
+
+    const callback = vi.fn();
+    waitForTracingChannelBinding(callback);
+
+    // Not available on the first (synchronous) attempt.
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not run the callback if the binding never becomes available (default single retry)', () => {
+    const getBinding = vi.fn(() => undefined);
+    setBindingProvider(getBinding);
+
+    const callback = vi.fn();
+    waitForTracingChannelBinding(callback);
+
+    expect(callback).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(callback).not.toHaveBeenCalled();
+
+    // The single retry is exhausted — no further attempts are scheduled.
+    expect(getBinding).toHaveBeenCalledTimes(2);
+    vi.runAllTimers();
+    expect(getBinding).toHaveBeenCalledTimes(2);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not retry when retries is 0', () => {
+    const getBinding = vi.fn(() => undefined);
+    setBindingProvider(getBinding);
+
+    const callback = vi.fn();
+    waitForTracingChannelBinding(callback, 0);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(getBinding).toHaveBeenCalledTimes(1);
+
+    // No retry is scheduled when no retries remain.
+    vi.runAllTimers();
+    expect(getBinding).toHaveBeenCalledTimes(1);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('honors a custom retry count', () => {
+    const getBinding = vi.fn<[], TracingChannelBinding | undefined>(() => FAKE_BINDING);
+    getBinding.mockReturnValueOnce(undefined).mockReturnValueOnce(undefined).mockReturnValue(FAKE_BINDING);
+    setBindingProvider(getBinding);
+
+    const callback = vi.fn();
+    waitForTracingChannelBinding(callback, 2);
+
+    expect(callback).not.toHaveBeenCalled(); // attempt 1 (sync): undefined
+
+    vi.advanceTimersByTime(1);
+    expect(callback).not.toHaveBeenCalled(); // attempt 2: undefined
+
+    vi.advanceTimersByTime(1);
+    expect(callback).toHaveBeenCalledTimes(1); // attempt 3: available
+  });
+
+  it('does nothing when the strategy exposes no `getTracingChannelBinding`', () => {
+    // The default (stack) strategy has no tracing-channel binding support.
+    setAsyncContextStrategy(undefined);
+
+    const callback = vi.fn();
+    waitForTracingChannelBinding(callback, 0);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node-core/src/sdk/index.ts
+++ b/packages/node-core/src/sdk/index.ts
@@ -114,7 +114,7 @@ function _init(
     initializeEsmLoader();
   }
 
-  setOpenTelemetryContextAsyncContextStrategy();
+  setOpenTelemetryContextAsyncContextStrategy(options);
 
   const scope = getCurrentScope();
   scope.update(options.initialScope);

--- a/packages/node/src/integrations/tracing/redis/index.ts
+++ b/packages/node/src/integrations/tracing/redis/index.ts
@@ -7,6 +7,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   spanToJSON,
   truncate,
+  waitForTracingChannelBinding,
 } from '@sentry/core';
 import * as dc from 'node:diagnostics_channel';
 import { subscribeRedisDiagnosticChannels, type RedisTracingChannelFactory } from '@sentry/server-utils';
@@ -128,9 +129,9 @@ export const instrumentRedis = Object.assign(
     // so defer to the next tick.
     // Check this here to ensure this does not fail at runtime for Node <= 18.18.0
     if (dc.tracingChannel) {
-      void Promise.resolve().then(() =>
-        subscribeRedisDiagnosticChannels(dc.tracingChannel as RedisTracingChannelFactory, cacheResponseHook),
-      );
+      waitForTracingChannelBinding(() => {
+        subscribeRedisDiagnosticChannels(dc.tracingChannel as RedisTracingChannelFactory, cacheResponseHook);
+      });
     }
 
     // todo: implement them gradually

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,5 +1,5 @@
 import * as api from '@opentelemetry/api';
-import type { Scope, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
+import type { Scope, TracingChannelBinding, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
 import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
 import {
   SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY,
@@ -12,23 +12,14 @@ import { getContextFromScope, getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
 import { getTraceData } from './utils/getTraceData';
 import { suppressTracing } from './utils/suppressTracing';
-import { getAsyncLocalStorage } from './asyncLocalStorageContextManager';
-
-interface ContextApi {
-  _getContextManager():
-    | undefined
-    | {
-        getAsyncLocalStorageLookup(): {
-          asyncLocalStorage: unknown;
-        };
-      };
-}
 
 /**
  * Sets the async context strategy to use follow the OTEL context under the hood.
  * We handle forking a hub inside of our custom OTEL Context Manager (./otelContextManager.ts)
  */
-export function setOpenTelemetryContextAsyncContextStrategy(options?: { skipOpenTelemetrySetup?: boolean }): void {
+export function setOpenTelemetryContextAsyncContextStrategy(options?: {
+  getTracingChannelBinding?: () => TracingChannelBinding | undefined;
+}): void {
   function getScopes(): CurrentScopes {
     const ctx = api.context.active();
     const scopes = getScopesFromContext(ctx);
@@ -119,32 +110,6 @@ export function setOpenTelemetryContextAsyncContextStrategy(options?: { skipOpen
     // The types here don't fully align, because our own `Span` type is narrower
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,
-    getTracingChannelBinding: () => {
-      // Default case: by default we can just access the async local storage instance here
-      // this will work no matter if this called before or after the Otel ContextManager was setup
-      if (!options?.skipOpenTelemetrySetup) {
-        const asyncLocalStorage = getAsyncLocalStorage();
-
-        return {
-          asyncLocalStorage,
-          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span),
-        };
-      }
-
-      // Else, if we have a custom context manager, we need to access it via the context manager
-      // this may not be available yet, if this is called before the Otel ContextManager was setup
-      // in this case, we need to return undefined and retry later, hoping that the setup works by then
-      try {
-        const contextManager = (api.context as unknown as ContextApi)._getContextManager();
-        const asyncLocalStorage = contextManager?.getAsyncLocalStorageLookup().asyncLocalStorage;
-
-        return {
-          asyncLocalStorage,
-          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span as api.Span),
-        };
-      } catch {
-        return undefined;
-      }
-    },
+    getTracingChannelBinding: options?.getTracingChannelBinding,
   });
 }

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,5 +1,5 @@
 import * as api from '@opentelemetry/api';
-import type { Scope, Span, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
+import type { Scope, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
 import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
 import {
   SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY,
@@ -12,20 +12,23 @@ import { getContextFromScope, getScopesFromContext } from './utils/contextData';
 import { getActiveSpan } from './utils/getActiveSpan';
 import { getTraceData } from './utils/getTraceData';
 import { suppressTracing } from './utils/suppressTracing';
+import { getAsyncLocalStorage } from './asyncLocalStorageContextManager';
 
 interface ContextApi {
-  _getContextManager(): {
-    getAsyncLocalStorageLookup(): {
-      asyncLocalStorage: unknown;
-    };
-  };
+  _getContextManager():
+    | undefined
+    | {
+        getAsyncLocalStorageLookup(): {
+          asyncLocalStorage: unknown;
+        };
+      };
 }
 
 /**
  * Sets the async context strategy to use follow the OTEL context under the hood.
  * We handle forking a hub inside of our custom OTEL Context Manager (./otelContextManager.ts)
  */
-export function setOpenTelemetryContextAsyncContextStrategy(): void {
+export function setOpenTelemetryContextAsyncContextStrategy(options?: { skipOpenTelemetrySetup?: boolean }): void {
   function getScopes(): CurrentScopes {
     const ctx = api.context.active();
     const scopes = getScopesFromContext(ctx);
@@ -117,13 +120,27 @@ export function setOpenTelemetryContextAsyncContextStrategy(): void {
     // than the OTEL one - but this is OK for here, as we now we'll only have OTEL spans passed around
     withActiveSpan: withActiveSpan as typeof defaultWithActiveSpan,
     getTracingChannelBinding: () => {
-      try {
-        const contextManager = (api.context as unknown as ContextApi)._getContextManager();
-        const lookup = contextManager.getAsyncLocalStorageLookup();
+      // Default case: by default we can just access the async local storage instance here
+      // this will work no matter if this called before or after the Otel ContextManager was setup
+      if (!options?.skipOpenTelemetrySetup) {
+        const asyncLocalStorage = getAsyncLocalStorage();
 
         return {
-          asyncLocalStorage: lookup.asyncLocalStorage,
-          getStoreWithActiveSpan: (span: Span) => api.trace.setSpan(api.context.active(), span as api.Span),
+          asyncLocalStorage,
+          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span),
+        };
+      }
+
+      // Else, if we have a custom context manager, we need to access it via the context manager
+      // this may not be available yet, if this is called before the Otel ContextManager was setup
+      // in this case, we need to return undefined and retry later, hoping that the setup works by then
+      try {
+        const contextManager = (api.context as unknown as ContextApi)._getContextManager();
+        const asyncLocalStorage = contextManager?.getAsyncLocalStorageLookup().asyncLocalStorage;
+
+        return {
+          asyncLocalStorage,
+          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span as api.Span),
         };
       } catch {
         return undefined;

--- a/packages/opentelemetry/src/asyncLocalStorageContextManager.ts
+++ b/packages/opentelemetry/src/asyncLocalStorageContextManager.ts
@@ -25,10 +25,11 @@ import type { Context, ContextManager } from '@opentelemetry/api';
 import { ROOT_CONTEXT } from '@opentelemetry/api';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { EventEmitter } from 'node:events';
-import { SENTRY_SCOPES_CONTEXT_KEY } from './constants';
-import type { AsyncLocalStorageLookup } from './contextManager';
 import { buildContextWithSentryScopes } from './utils/buildContextWithSentryScopes';
 import { setIsSetup } from './utils/setupCheck';
+import { getAsyncContextStrategy, getMainCarrier } from '@sentry/core';
+import type { AsyncLocalStorageLookup } from './contextManager';
+import { SENTRY_SCOPES_CONTEXT_KEY } from './constants';
 
 type ListenerFn = (...args: unknown[]) => unknown;
 
@@ -39,29 +40,23 @@ type PatchMap = Record<string, WeakMap<ListenerFn, ListenerFn>>;
 
 const ADD_LISTENER_METHODS = ['addListener', 'on', 'once', 'prependListener', 'prependOnceListener'] as const;
 
-let _asyncLocalStorage: AsyncLocalStorage<Context> | undefined;
-
-/** Get hold of the async local storage instance. */
-export function getAsyncLocalStorage(): AsyncLocalStorage<Context> {
-  if (!_asyncLocalStorage) {
-    _asyncLocalStorage = new AsyncLocalStorage<Context>();
-  }
-  return _asyncLocalStorage;
-}
-
 /**
  * OpenTelemetry-compatible context manager using Node.js `AsyncLocalStorage`.
  * Semantics match `@opentelemetry/context-async-hooks` (function `bind` + `EventEmitter` patching).
  */
 export class SentryAsyncLocalStorageContextManager implements ContextManager {
-  protected readonly _asyncLocalStorage;
+  protected readonly _asyncLocalStorage: AsyncLocalStorage<Context>;
 
   private readonly _kOtListeners = Symbol('OtListeners');
   private _wrapped = false;
 
   public constructor() {
     setIsSetup('SentryContextManager');
-    this._asyncLocalStorage = getAsyncLocalStorage();
+    // Pick the instance from the async context strategy
+    // this should normally always be there, but if it is not for whatever reason, we fall back to a new instance
+    this._asyncLocalStorage =
+      (getAsyncContextStrategy(getMainCarrier()).getTracingChannelBinding?.()
+        ?.asyncLocalStorage as AsyncLocalStorage<Context>) ?? new AsyncLocalStorage<Context>();
   }
 
   public active(): Context {

--- a/packages/opentelemetry/src/asyncLocalStorageContextManager.ts
+++ b/packages/opentelemetry/src/asyncLocalStorageContextManager.ts
@@ -25,11 +25,11 @@ import type { Context, ContextManager } from '@opentelemetry/api';
 import { ROOT_CONTEXT } from '@opentelemetry/api';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { EventEmitter } from 'node:events';
+import type { AsyncLocalStorageLookup } from './contextManager';
+import { SENTRY_SCOPES_CONTEXT_KEY } from './constants';
 import { buildContextWithSentryScopes } from './utils/buildContextWithSentryScopes';
 import { setIsSetup } from './utils/setupCheck';
 import { getAsyncContextStrategy, getMainCarrier } from '@sentry/core';
-import type { AsyncLocalStorageLookup } from './contextManager';
-import { SENTRY_SCOPES_CONTEXT_KEY } from './constants';
 
 type ListenerFn = (...args: unknown[]) => unknown;
 

--- a/packages/opentelemetry/src/asyncLocalStorageContextManager.ts
+++ b/packages/opentelemetry/src/asyncLocalStorageContextManager.ts
@@ -39,18 +39,29 @@ type PatchMap = Record<string, WeakMap<ListenerFn, ListenerFn>>;
 
 const ADD_LISTENER_METHODS = ['addListener', 'on', 'once', 'prependListener', 'prependOnceListener'] as const;
 
+let _asyncLocalStorage: AsyncLocalStorage<Context> | undefined;
+
+/** Get hold of the async local storage instance. */
+export function getAsyncLocalStorage(): AsyncLocalStorage<Context> {
+  if (!_asyncLocalStorage) {
+    _asyncLocalStorage = new AsyncLocalStorage<Context>();
+  }
+  return _asyncLocalStorage;
+}
+
 /**
  * OpenTelemetry-compatible context manager using Node.js `AsyncLocalStorage`.
  * Semantics match `@opentelemetry/context-async-hooks` (function `bind` + `EventEmitter` patching).
  */
 export class SentryAsyncLocalStorageContextManager implements ContextManager {
-  protected readonly _asyncLocalStorage = new AsyncLocalStorage<Context>();
+  protected readonly _asyncLocalStorage;
 
   private readonly _kOtListeners = Symbol('OtListeners');
   private _wrapped = false;
 
   public constructor() {
     setIsSetup('SentryContextManager');
+    this._asyncLocalStorage = getAsyncLocalStorage();
   }
 
   public active(): Context {

--- a/packages/opentelemetry/src/exports.ts
+++ b/packages/opentelemetry/src/exports.ts
@@ -39,7 +39,6 @@ export { suppressTracing } from './utils/suppressTracing';
 
 export { setupEventContextTrace } from './setupEventContextTrace';
 
-export { setOpenTelemetryContextAsyncContextStrategy } from './asyncContextStrategy';
 // eslint-disable-next-line typescript/no-deprecated
 export { wrapContextManagerClass } from './contextManager';
 

--- a/packages/opentelemetry/src/index.browser.ts
+++ b/packages/opentelemetry/src/index.browser.ts
@@ -12,6 +12,9 @@ export class SentryAsyncLocalStorageContextManager {
   }
 }
 
+// This is the generic, non-node specific async context strategy
+export { setOpenTelemetryContextAsyncContextStrategy } from './asyncContextStrategy';
+
 export type AsyncLocalStorageLookup = {
   asyncLocalStorage: unknown;
   contextSymbol: symbol;

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -3,3 +3,6 @@ export * from './exports';
 // Node-specific exports
 export { SentryAsyncLocalStorageContextManager } from './asyncLocalStorageContextManager';
 export type { AsyncLocalStorageLookup } from './contextManager';
+
+// We export the node-specific variant here that uses async local storage
+export { setNodeOpenTelemetryContextAsyncContextStrategy as setOpenTelemetryContextAsyncContextStrategy } from './nodeAsyncContextStrategy';

--- a/packages/opentelemetry/src/nodeAsyncContextStrategy.ts
+++ b/packages/opentelemetry/src/nodeAsyncContextStrategy.ts
@@ -25,7 +25,7 @@ export function setNodeOpenTelemetryContextAsyncContextStrategy(options?: { skip
  * In the default case, we build the local storage instance ourselves here.
  * The default asyncLocalStorageContextManager will then use this internally.
  */
-function getDefaultAsyncLocalStorageFactory() {
+function getDefaultAsyncLocalStorageFactory(): () => TracingChannelBinding {
   const defaultAsyncLocalStorage = new AsyncLocalStorage<api.Context>();
 
   return () => {
@@ -41,16 +41,18 @@ function getDefaultAsyncLocalStorageFactory() {
  * this may not be available yet, if this is called before the Otel ContextManager was setup
  * in this case, we need to return undefined and retry later, hoping that the setup works by then
  */
-function getCustomAsyncLocalStorageFactory() {
+function getCustomAsyncLocalStorageFactory(): () => TracingChannelBinding | undefined {
   return () => {
     try {
       const contextManager = (api.context as unknown as ContextApi)._getContextManager();
       const asyncLocalStorage = contextManager?.getAsyncLocalStorageLookup().asyncLocalStorage;
 
-      return {
-        asyncLocalStorage,
-        getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span as api.Span),
-      } satisfies TracingChannelBinding;
+      return asyncLocalStorage
+        ? ({
+            asyncLocalStorage,
+            getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span as api.Span),
+          } satisfies TracingChannelBinding)
+        : undefined;
     } catch {
       return undefined;
     }

--- a/packages/opentelemetry/src/nodeAsyncContextStrategy.ts
+++ b/packages/opentelemetry/src/nodeAsyncContextStrategy.ts
@@ -1,0 +1,45 @@
+import * as api from '@opentelemetry/api';
+import { setOpenTelemetryContextAsyncContextStrategy } from './asyncContextStrategy';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface ContextApi {
+  _getContextManager():
+    | undefined
+    | {
+        getAsyncLocalStorageLookup(): {
+          asyncLocalStorage: unknown;
+        };
+      };
+}
+
+export function setNodeOpenTelemetryContextAsyncContextStrategy(options?: { skipOpenTelemetrySetup?: boolean }): void {
+  const defaultAsyncLocalStorage = new AsyncLocalStorage<api.Context>();
+
+  setOpenTelemetryContextAsyncContextStrategy({
+    getTracingChannelBinding: () => {
+      // Default case: by default we can just access the async local storage instance here
+      // this will work no matter if this called before or after the Otel ContextManager was setup
+      if (!options?.skipOpenTelemetrySetup) {
+        return {
+          asyncLocalStorage: defaultAsyncLocalStorage,
+          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span),
+        };
+      }
+
+      // Else, if we have a custom context manager, we need to access it via the context manager
+      // this may not be available yet, if this is called before the Otel ContextManager was setup
+      // in this case, we need to return undefined and retry later, hoping that the setup works by then
+      try {
+        const contextManager = (api.context as unknown as ContextApi)._getContextManager();
+        const asyncLocalStorage = contextManager?.getAsyncLocalStorageLookup().asyncLocalStorage;
+
+        return {
+          asyncLocalStorage,
+          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span as api.Span),
+        };
+      } catch {
+        return undefined;
+      }
+    },
+  });
+}

--- a/packages/opentelemetry/src/nodeAsyncContextStrategy.ts
+++ b/packages/opentelemetry/src/nodeAsyncContextStrategy.ts
@@ -1,6 +1,7 @@
 import * as api from '@opentelemetry/api';
 import { setOpenTelemetryContextAsyncContextStrategy } from './asyncContextStrategy';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { TracingChannelBinding } from '@sentry/core';
 
 interface ContextApi {
   _getContextManager():
@@ -13,33 +14,45 @@ interface ContextApi {
 }
 
 export function setNodeOpenTelemetryContextAsyncContextStrategy(options?: { skipOpenTelemetrySetup?: boolean }): void {
+  setOpenTelemetryContextAsyncContextStrategy({
+    getTracingChannelBinding: !options?.skipOpenTelemetrySetup
+      ? getDefaultAsyncLocalStorageFactory()
+      : getCustomAsyncLocalStorageFactory(),
+  });
+}
+
+/**
+ * In the default case, we build the local storage instance ourselves here.
+ * The default asyncLocalStorageContextManager will then use this internally.
+ */
+function getDefaultAsyncLocalStorageFactory() {
   const defaultAsyncLocalStorage = new AsyncLocalStorage<api.Context>();
 
-  setOpenTelemetryContextAsyncContextStrategy({
-    getTracingChannelBinding: () => {
-      // Default case: by default we can just access the async local storage instance here
-      // this will work no matter if this called before or after the Otel ContextManager was setup
-      if (!options?.skipOpenTelemetrySetup) {
-        return {
-          asyncLocalStorage: defaultAsyncLocalStorage,
-          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span),
-        };
-      }
+  return () => {
+    return {
+      asyncLocalStorage: defaultAsyncLocalStorage,
+      getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span),
+    } satisfies TracingChannelBinding;
+  };
+}
 
-      // Else, if we have a custom context manager, we need to access it via the context manager
-      // this may not be available yet, if this is called before the Otel ContextManager was setup
-      // in this case, we need to return undefined and retry later, hoping that the setup works by then
-      try {
-        const contextManager = (api.context as unknown as ContextApi)._getContextManager();
-        const asyncLocalStorage = contextManager?.getAsyncLocalStorageLookup().asyncLocalStorage;
+/**
+ * If we have a custom context manager, we need to access it via the context manager
+ * this may not be available yet, if this is called before the Otel ContextManager was setup
+ * in this case, we need to return undefined and retry later, hoping that the setup works by then
+ */
+function getCustomAsyncLocalStorageFactory() {
+  return () => {
+    try {
+      const contextManager = (api.context as unknown as ContextApi)._getContextManager();
+      const asyncLocalStorage = contextManager?.getAsyncLocalStorageLookup().asyncLocalStorage;
 
-        return {
-          asyncLocalStorage,
-          getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span as api.Span),
-        };
-      } catch {
-        return undefined;
-      }
-    },
-  });
+      return {
+        asyncLocalStorage,
+        getStoreWithActiveSpan: span => api.trace.setSpan(api.context.active(), span as api.Span),
+      } satisfies TracingChannelBinding;
+    } catch {
+      return undefined;
+    }
+  };
 }

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -1,7 +1,7 @@
 import type { TracingChannel, TracingChannelSubscribers } from 'node:diagnostics_channel';
 import type { AsyncLocalStorage } from 'node:async_hooks';
 import type { ExclusiveEventHintOrCaptureContext, Span } from '@sentry/core';
-import { _INTERNAL_getTracingChannelBinding, debug, captureException, SPAN_STATUS_ERROR } from '@sentry/core';
+import { debug, captureException, SPAN_STATUS_ERROR, getAsyncContextStrategy, getMainCarrier } from '@sentry/core';
 import { DEBUG_BUILD } from './debug-build';
 
 export type TracingChannelPayloadWithSpan<TData extends object> = TData & {
@@ -133,7 +133,7 @@ function bindSpanToChannelStore<TData extends object>(
   getSpan: (data: TracingChannelPayloadWithSpan<TData>) => Span | undefined,
 ): TracingChannelBindingHandle<TData> {
   // Grabs the tracing channel binding defined by the AsyncContext strategy implementation
-  const binding = _INTERNAL_getTracingChannelBinding();
+  const binding = getAsyncContextStrategy(getMainCarrier()).getTracingChannelBinding?.();
 
   // If no binding, then either the implementer doesn't support tracing channels or there is no active strategy
   // Failure mode here means we would still access the channel and potentially subscribe to it, but parenting will be off.

--- a/packages/server-utils/src/vercel-ai/index.ts
+++ b/packages/server-utils/src/vercel-ai/index.ts
@@ -1,4 +1,4 @@
-import { defineIntegration, type IntegrationFn } from '@sentry/core';
+import { defineIntegration, waitForTracingChannelBinding, type IntegrationFn } from '@sentry/core';
 import { subscribeVercelAiTracingChannel } from './vercel-ai-dc-subscriber';
 import * as dc from 'node:diagnostics_channel';
 
@@ -35,9 +35,9 @@ const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {
 
       // Subscribe to the `ai` SDK's native telemetry tracing channel (ai >= 7).
       // This is a no-op on versions that don't publish to the channel, so it is always safe to call.
-      // The factory needs the Sentry OTel context manager, which `initOpenTelemetry()` registers after `setupOnce`, so defer a tick.
-      // Options are passed in here rather than read back off the integration per event.
-      void Promise.resolve().then(() => subscribeVercelAiTracingChannel(dc.tracingChannel, options));
+      waitForTracingChannelBinding(() => {
+        subscribeVercelAiTracingChannel(dc.tracingChannel, options);
+      });
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -63,7 +63,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
 
 /** Inits the Sentry NextJS SDK on the Edge Runtime. */
 export function init(options: VercelEdgeOptions = {}): Client | undefined {
-  setOpenTelemetryContextAsyncContextStrategy();
+  setOpenTelemetryContextAsyncContextStrategy(options);
 
   const scope = getCurrentScope();
   scope.update(options.initialScope);

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -63,7 +63,9 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
 
 /** Inits the Sentry NextJS SDK on the Edge Runtime. */
 export function init(options: VercelEdgeOptions = {}): Client | undefined {
-  setOpenTelemetryContextAsyncContextStrategy(options);
+  // We force skipOpenTelemetrySetup: true here, because this triggers the custom lookup for the AsyncLocalStorage instance
+  // Since we use a custom Context Manager here (because AsyncLocalStorage is looked up differently than in Node), we need to do this
+  setOpenTelemetryContextAsyncContextStrategy({ skipOpenTelemetrySetup: true });
 
   const scope = getCurrentScope();
   scope.update(options.initialScope);


### PR DESCRIPTION
We rely on the async local storage instance for the tracing channel bindings.

Previously, this was picked up from the otel context manager (in otel-mode). However, this is only setup after the integrations run, leading to a race condition where this was not available yet.

The "fix" for this we used so far was to setup the channel-based listeners in the next tick via `Promise.resolve()`. Apart from being a bit hacky, this also has a concrete problem: If code runs synchrounsly after Sentry.init(), this could be unhandled by our integration (this was surfaced when moving vercel ai v6 to use orchestrion, where this failed in CJS).

So this PR changes this a bit, so that in the happy path where we use our own context manager, we can use a consistent instance of async local storage even before the manager is setup. In this case, we can setup the integrations in a sync way and everything just works.

If users use a custom context manager, this will/may not work though. So in this case we continue to use the lookup from the context manager (this can be removed in v11). Since this means we have the same problems as before, I added a small utility `waitForTracingChannelBinding` to abstract this away - this will try to see if this is setup and if so, exectute the provided callback synchronously. Else, it will wait a tick and try again (mirroring what we had before). 

While at this, I also cleaned up internal exports from core a bit - one of them can be reproduced with more public APIs already, we just never exported `getAsyncContextStrategy` from core but this is fine to export IMHO.

I also adjusted the type a bit so that `asyncLocalStorage` in the binding is unknown but non nullable, as this could accidentally become undefined which would not be caught by types but is not really intended - in this case the whole binding should be undefined.