### PR TITLE
ref(node): Streamline Prisma instrumentation (v6 and v7)

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -92,6 +92,10 @@ describe('Prisma ORM v6 Tests', () => {
                 },
                 description: 'DELETE FROM "public"."User" WHERE "public"."User"."email"::text LIKE $1',
               });
+
+              // The db query span name must always be rewritten to the SQL text; the raw engine span
+              // name should never leak through.
+              expect(spans.find(span => span.description === 'prisma:engine:db_query')).toBeUndefined();
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -25,6 +25,22 @@ describe('Prisma ORM v6 Tests', () => {
               const spans = transaction.spans || [];
               expect(spans.length).toBeGreaterThanOrEqual(5);
 
+              // Each operation span is a direct child of the transaction; the db query span is a child of the engine query span.
+              const rootSpanId = transaction.contexts?.trace?.span_id;
+
+              const operationSpans = spans.filter(s => s.description === 'prisma:client:operation');
+              expect(operationSpans.length).toBeGreaterThanOrEqual(1);
+              operationSpans.forEach(operation => {
+                expect(operation.parent_span_id).toBe(rootSpanId);
+              });
+
+              const dbQuerySpan = spans.find(
+                s => s.data?.['sentry.origin'] === 'auto.db.otel.prisma' && s.data?.['db.query.text'],
+              );
+              expect(dbQuerySpan).toBeDefined();
+              const dbQueryParent = spans.find(s => s.span_id === dbQuerySpan?.parent_span_id);
+              expect(dbQueryParent?.description).toBe('prisma:engine:query');
+
               function expectPrismaSpanToIncludeSpanWith(span: Partial<SpanJSON>) {
                 expect(spans).toContainEqual(
                   expect.objectContaining({

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -26,6 +26,22 @@ conditionalTest({ min: 20 })('Prisma ORM v7 Tests', () => {
               const spans = transaction.spans || [];
               expect(spans.length).toBeGreaterThanOrEqual(5);
 
+              // Each operation span is a direct child of the transaction; the db query span is a child of its operation span.
+              const rootSpanId = transaction.contexts?.trace?.span_id;
+
+              const operationSpans = spans.filter(s => s.description === 'prisma:client:operation');
+              expect(operationSpans.length).toBeGreaterThanOrEqual(1);
+              operationSpans.forEach(operation => {
+                expect(operation.parent_span_id).toBe(rootSpanId);
+              });
+
+              const prismaDbQuerySpan = spans.find(
+                s => s.data?.['sentry.origin'] === 'auto.db.otel.prisma' && s.data?.['db.query.text'],
+              );
+              expect(prismaDbQuerySpan).toBeDefined();
+              const dbQueryParent = spans.find(s => s.span_id === prismaDbQuerySpan?.parent_span_id);
+              expect(dbQueryParent?.description).toBe('prisma:client:operation');
+
               // Verify Prisma spans have the correct origin
               const prismaSpans = spans.filter(
                 span => span.data && span.data['sentry.origin'] === 'auto.db.otel.prisma',

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -58,6 +58,10 @@ conditionalTest({ min: 20 })('Prisma ORM v7 Tests', () => {
               expect(dbQuerySpan?.op).toBe('db');
               expect(dbQuerySpan?.description).toBe(dbQuerySpan?.data?.['db.query.text']);
               expect(dbQuerySpan?.description).not.toBe('prisma:client:db_query');
+
+              // The db query span name must always be rewritten to the SQL text; the raw client span
+              // name should never leak through.
+              expect(spans.find(span => span.description === 'prisma:client:db_query')).toBeUndefined();
             },
           })
           .start()

--- a/packages/node/src/integrations/tracing/prisma/index.ts
+++ b/packages/node/src/integrations/tracing/prisma/index.ts
@@ -1,5 +1,6 @@
 import type { Link, Tracer } from '@opentelemetry/api';
 import { context, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
+import type { Instrumentation } from '@opentelemetry/instrumentation';
 import type { IdGenerator } from '@opentelemetry/sdk-trace-base';
 import { consoleSandbox, defineIntegration, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';

--- a/packages/node/src/integrations/tracing/prisma/index.ts
+++ b/packages/node/src/integrations/tracing/prisma/index.ts
@@ -54,6 +54,10 @@ type TracerWithIdGenerator = Tracer & {
 
 interface PrismaOptions {
   /**
+   * @deprecated This is no longer used, v5 works out of the box.
+   */
+  prismaInstrumentation?: Instrumentation;
+  /**
    * Configuration passed through to the {@link PrismaInstrumentation} constructor.
    */
   instrumentationConfig?: ConstructorParameters<typeof PrismaInstrumentation>[0];
@@ -172,7 +176,7 @@ export const instrumentPrisma = generateInstrumentOnce<PrismaOptions>(INTEGRATIO
  * Adds Sentry tracing instrumentation for the [prisma](https://www.npmjs.com/package/prisma) library.
  * For more information, see the [`prismaIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/prisma/).
  *
- * NOTE: This integration works out of the box with Prisma v5, v6, and v7.
+ * NOTE: This integration works out of the box with Prisma v6, and v7.
  * On Prisma versions prior to v6, add `previewFeatures = ["tracing"]` to the client generator block of your Prisma schema:
  *
  *    ```

--- a/packages/node/src/integrations/tracing/prisma/index.ts
+++ b/packages/node/src/integrations/tracing/prisma/index.ts
@@ -190,10 +190,9 @@ export const prismaIntegration = defineIntegration((options?: PrismaOptions) => 
         return;
       }
 
-      // The v6/v7 tracing helper folds origin, the db_query span rename, and the db.system backfill
-      // directly into span creation (see vendored/active-tracing-helper.ts). This hook backstops the
-      // Prisma v5 engine spans created via the `createEngineSpan` compatibility path above, which
-      // bypass the helper. The guards below are idempotent, so it's a no-op for helper-created spans.
+      // Prisma v5 engine spans are created via the `createEngineSpan` path above, which bypasses the
+      // tracing helper, so this hook applies origin, the db_query rename, and the db.system backfill to
+      // them. v6/v7 spans already get these from the helper; the guards are idempotent, so it's a no-op there.
       client.on('spanStart', span => {
         const spanJSON = spanToJSON(span);
         if (spanJSON.description?.startsWith('prisma:')) {

--- a/packages/node/src/integrations/tracing/prisma/index.ts
+++ b/packages/node/src/integrations/tracing/prisma/index.ts
@@ -1,6 +1,5 @@
 import type { Link, Tracer } from '@opentelemetry/api';
 import { context, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
-import type { Instrumentation } from '@opentelemetry/instrumentation';
 import type { IdGenerator } from '@opentelemetry/sdk-trace-base';
 import { consoleSandbox, defineIntegration, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON } from '@sentry/core';
 import { generateInstrumentOnce } from '@sentry/node-core';
@@ -54,10 +53,6 @@ type TracerWithIdGenerator = Tracer & {
 };
 
 interface PrismaOptions {
-  /**
-   * @deprecated This is no longer used, v5 works out of the box.
-   */
-  prismaInstrumentation?: Instrumentation;
   /**
    * Configuration passed through to the {@link PrismaInstrumentation} constructor.
    */
@@ -177,26 +172,8 @@ export const instrumentPrisma = generateInstrumentOnce<PrismaOptions>(INTEGRATIO
  * Adds Sentry tracing instrumentation for the [prisma](https://www.npmjs.com/package/prisma) library.
  * For more information, see the [`prismaIntegration` documentation](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/prisma/).
  *
- * NOTE: By default, this integration works with Prisma version 6.
- * To get performance instrumentation for other Prisma versions,
- * 1. Install the `@prisma/instrumentation` package with the desired version.
- * 1. Pass a `new PrismaInstrumentation()` instance as exported from `@prisma/instrumentation` to the `prismaInstrumentation` option of this integration:
- *
- *    ```js
- *    import { PrismaInstrumentation } from '@prisma/instrumentation'
- *
- *    Sentry.init({
- *      integrations: [
- *        prismaIntegration({
- *          // Override the default instrumentation that Sentry uses
- *          prismaInstrumentation: new PrismaInstrumentation()
- *        })
- *      ]
- *    })
- *    ```
- *
- *    The passed instrumentation instance will override the default instrumentation instance the integration would use, while the `prismaIntegration` will still ensure data compatibility for the various Prisma versions.
- * 1. Depending on your Prisma version (prior to version 6), add `previewFeatures = ["tracing"]` to the client generator block of your Prisma schema:
+ * NOTE: This integration works out of the box with Prisma v5, v6, and v7.
+ * On Prisma versions prior to v6, add `previewFeatures = ["tracing"]` to the client generator block of your Prisma schema:
  *
  *    ```
  *    generator client {
@@ -218,6 +195,10 @@ export const prismaIntegration = defineIntegration((options?: PrismaOptions) => 
         return;
       }
 
+      // The v6/v7 tracing helper folds origin, the db_query span rename, and the db.system backfill
+      // directly into span creation (see vendored/active-tracing-helper.ts). This hook backstops the
+      // Prisma v5 engine spans created via the `createEngineSpan` compatibility path above, which
+      // bypass the helper. The guards below are idempotent, so it's a no-op for helper-created spans.
       client.on('spanStart', span => {
         const spanJSON = spanToJSON(span);
         if (spanJSON.description?.startsWith('prisma:')) {

--- a/packages/node/src/integrations/tracing/prisma/index.ts
+++ b/packages/node/src/integrations/tracing/prisma/index.ts
@@ -104,7 +104,7 @@ class SentryPrismaInteropInstrumentation extends PrismaInstrumentation {
 
         try {
           engineSpanEvent.spans.forEach(engineSpan => {
-            const kind = engineSpanKindToOTELSpanKind(engineSpan.kind);
+            const kind = engineSpan.kind === 'client' ? SpanKind.CLIENT : SpanKind.INTERNAL;
 
             const parentSpanId = engineSpan.parent_span_id;
             const spanId = engineSpan.span_id;
@@ -156,16 +156,6 @@ class SentryPrismaInteropInstrumentation extends PrismaInstrumentation {
         }
       };
     }
-  }
-}
-
-function engineSpanKindToOTELSpanKind(engineSpanKind: V5EngineSpanKind): SpanKind {
-  switch (engineSpanKind) {
-    case 'client':
-      return SpanKind.CLIENT;
-    case 'internal':
-    default: // Other span kinds aren't currently supported
-      return SpanKind.INTERNAL;
   }
 }
 

--- a/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
@@ -11,8 +11,6 @@
  *   `db.system` for older Prisma versions
  */
 
-import type { Context } from '@opentelemetry/api';
-import { context as _context, trace } from '@opentelemetry/api';
 import type { Span, SpanAttributes, SpanKindValue, SpanLink } from '@sentry/core';
 import {
   getActiveSpan,
@@ -72,8 +70,8 @@ export class ActiveTracingHelper implements TracingHelper {
     return true;
   }
 
-  public getTraceParent(context?: Context): string {
-    const spanContext = context ? trace.getSpanContext(context) : getActiveSpan()?.spanContext();
+  public getTraceParent(span?: Span): string {
+    const spanContext = (span ?? getActiveSpan())?.spanContext();
     if (spanContext) {
       return `00-${spanContext.traceId}-${spanContext.spanId}-0${spanContext.traceFlags}`;
     }
@@ -89,8 +87,8 @@ export class ActiveTracingHelper implements TracingHelper {
     }
   }
 
-  public getActiveContext(): Context | undefined {
-    return _context.active();
+  public getActiveContext(): Span | undefined {
+    return getActiveSpan();
   }
 
   public runInChildSpan<R>(nameOrOptions: string | ExtendedSpanOptions, callback: SpanCallback<R>): R {
@@ -106,7 +104,7 @@ export class ActiveTracingHelper implements TracingHelper {
       return callback();
     }
 
-    const context = options.context ?? _context.active();
+    const parentSpan = options.context ?? getActiveSpan();
 
     const attributes = buildSpanAttributes(name, options.attributes as Record<string, unknown> | undefined);
     const spanOptions = {
@@ -115,16 +113,15 @@ export class ActiveTracingHelper implements TracingHelper {
       kind: options.kind as SpanKindValue | undefined,
       links: options.links as SpanLink[] | undefined,
       startTime: options.startTime,
+      parentSpan,
     };
 
     if (options.active === false) {
-      const span = _context.with(context, () => startInactiveSpan(spanOptions));
-      return endSpan(span, () => callback(span, context));
+      const span = startInactiveSpan(spanOptions);
+      return endSpan(span, () => callback(span, parentSpan));
     }
 
-    return _context.with(context, () =>
-      startSpanManual(spanOptions, span => endSpan(span, () => callback(span, context))),
-    );
+    return startSpanManual(spanOptions, span => endSpan(span, () => callback(span, parentSpan)));
   }
 }
 

--- a/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
@@ -23,7 +23,7 @@ import {
   startInactiveSpan,
   startSpanManual,
 } from '@sentry/core';
-import type { EngineSpan, EngineSpanKind, ExtendedSpanOptions, SpanCallback, TracingHelper } from './types';
+import type { EngineSpan, ExtendedSpanOptions, SpanCallback, TracingHelper } from './types';
 
 const showAllTraces = process.env.PRISMA_SHOW_ALL_TRACES === 'true';
 
@@ -34,16 +34,6 @@ const PRISMA_ORIGIN = 'auto.db.otel.prisma';
 type Options = {
   ignoreSpanTypes: (string | RegExp)[];
 };
-
-function engineSpanKindToSentrySpanKind(engineSpanKind: EngineSpanKind): SpanKindValue {
-  switch (engineSpanKind) {
-    case 'client':
-      return SPAN_KIND.CLIENT;
-    case 'internal':
-    default:
-      return SPAN_KIND.INTERNAL;
-  }
-}
 
 /**
  * Folds the former `index.ts` `spanStart` hook into span creation: tags the Sentry origin and
@@ -156,7 +146,7 @@ function dispatchEngineSpan(
     {
       name: buildSpanName(engineSpan.name, attributes),
       attributes,
-      kind: engineSpanKindToSentrySpanKind(engineSpan.kind),
+      kind: engineSpan.kind === 'client' ? SPAN_KIND.CLIENT : SPAN_KIND.INTERNAL,
       startTime: engineSpan.startTime,
     },
     span => {

--- a/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
@@ -122,7 +122,9 @@ export class ActiveTracingHelper implements TracingHelper {
       return endSpan(span, () => callback(span, context));
     }
 
-    return _context.with(context, () => startSpanManual(spanOptions, span => endSpan(span, () => callback(span, context))));
+    return _context.with(context, () =>
+      startSpanManual(spanOptions, span => endSpan(span, () => callback(span, context))),
+    );
   }
 }
 

--- a/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
@@ -6,146 +6,188 @@
  * - Vendored from: https://github.com/prisma/prisma/tree/b6feea5565ec577545a79547d24273ccdd11b4c7/packages/instrumentation
  * - Upstream version: @prisma/instrumentation@7.8.0
  * - Replaced `@prisma/instrumentation-contract` imports with local vendored types
- * - Minor TypeScript strictness adjustments for this repository's compiler settings
+ * - Span creation was migrated from the OTel tracer to Sentry's span APIs (`startSpanManual` /
+ *   `startInactiveSpan`)
+ * - The former `index.ts` `spanStart` hook is folded into span creation: the Sentry origin, the
+ *   `db_query` -> query-text span rename, and the `db.system` backfill for older Prisma versions are
+ *   applied where the spans are started instead of via a client hook
  */
-/* eslint-disable */
 
+import type { Context } from '@opentelemetry/api';
+import { context as _context, trace } from '@opentelemetry/api';
+import type { Span, SpanAttributes, SpanKindValue, SpanLink } from '@sentry/core';
 import {
-  Attributes,
-  Context,
-  context as _context,
-  Span,
-  SpanKind,
-  SpanOptions,
-  trace,
-  Tracer,
-  TracerProvider,
-} from '@opentelemetry/api';
+  getActiveSpan,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SPAN_KIND,
+  startInactiveSpan,
+  startSpanManual,
+} from '@sentry/core';
 import type { EngineSpan, EngineSpanKind, ExtendedSpanOptions, SpanCallback, TracingHelper } from './types';
 
 const showAllTraces = process.env.PRISMA_SHOW_ALL_TRACES === 'true';
 
 const nonSampledTraceParent = `00-10-10-00`;
 
+const PRISMA_ORIGIN = 'auto.db.otel.prisma';
+
 type Options = {
-  tracerProvider: TracerProvider;
   ignoreSpanTypes: (string | RegExp)[];
 };
 
-function engineSpanKindToOtelSpanKind(engineSpanKind: EngineSpanKind): SpanKind {
+function engineSpanKindToSentrySpanKind(engineSpanKind: EngineSpanKind): SpanKindValue {
   switch (engineSpanKind) {
     case 'client':
-      return SpanKind.CLIENT;
+      return SPAN_KIND.CLIENT;
     case 'internal':
     default:
-      return SpanKind.INTERNAL;
+      return SPAN_KIND.INTERNAL;
   }
 }
 
+/**
+ * Folds the former `index.ts` `spanStart` hook into span creation: tags the Sentry origin and
+ * backfills `db.system` for older Prisma versions that emit `prisma:engine:db_query` without it.
+ */
+function buildSpanAttributes(name: string, attributes: Record<string, unknown> | undefined): SpanAttributes {
+  const merged: SpanAttributes = {
+    ...(attributes as SpanAttributes | undefined),
+    [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: PRISMA_ORIGIN,
+  };
+
+  if (name === 'prisma:engine:db_query' && merged['db.system'] == null) {
+    merged['db.system'] = 'prisma';
+  }
+
+  return merged;
+}
+
+/**
+ * Uses the query text as the span name for db query spans (e.g. `SELECT * FROM "User"`), matching the
+ * behavior the SDK previously applied via the `spanStart` hook. v5/v6 emit `prisma:engine:db_query`;
+ * v7 inlined the engine and emits `prisma:client:db_query`.
+ */
+function buildSpanName(name: string, attributes: SpanAttributes): string {
+  const queryText = attributes['db.query.text'];
+  if ((name === 'prisma:engine:db_query' || name === 'prisma:client:db_query') && typeof queryText === 'string') {
+    return queryText;
+  }
+  return name;
+}
+
 export class ActiveTracingHelper implements TracingHelper {
-  private tracerProvider: TracerProvider;
   private ignoreSpanTypes: (string | RegExp)[];
 
-  constructor({ tracerProvider, ignoreSpanTypes }: Options) {
-    this.tracerProvider = tracerProvider;
+  public constructor({ ignoreSpanTypes }: Options) {
     this.ignoreSpanTypes = ignoreSpanTypes;
   }
 
-  isEnabled(): boolean {
+  public isEnabled(): boolean {
     return true;
   }
 
-  getTraceParent(context?: Context | undefined): string {
-    const span = trace.getSpanContext(context ?? _context.active());
-    if (span) {
-      return `00-${span.traceId}-${span.spanId}-0${span.traceFlags}`;
+  public getTraceParent(context?: Context): string {
+    const spanContext = context ? trace.getSpanContext(context) : getActiveSpan()?.spanContext();
+    if (spanContext) {
+      return `00-${spanContext.traceId}-${spanContext.spanId}-0${spanContext.traceFlags}`;
     }
     return nonSampledTraceParent;
   }
 
-  dispatchEngineSpans(spans: EngineSpan[]): void {
-    const tracer = this.tracerProvider.getTracer('prisma');
+  public dispatchEngineSpans(spans: EngineSpan[]): void {
     const linkIds = new Map<string, string>();
     const roots = spans.filter(span => span.parentId === null);
 
     for (const root of roots) {
-      dispatchEngineSpan(tracer, root, spans, linkIds, this.ignoreSpanTypes);
+      dispatchEngineSpan(root, spans, linkIds, this.ignoreSpanTypes);
     }
   }
 
-  getActiveContext(): Context | undefined {
+  public getActiveContext(): Context | undefined {
     return _context.active();
   }
 
-  runInChildSpan<R>(options: string | ExtendedSpanOptions, callback: SpanCallback<R>): R {
-    if (typeof options === 'string') {
-      options = { name: options };
-    }
+  public runInChildSpan<R>(nameOrOptions: string | ExtendedSpanOptions, callback: SpanCallback<R>): R {
+    const options: ExtendedSpanOptions = typeof nameOrOptions === 'string' ? { name: nameOrOptions } : nameOrOptions;
 
     if (options.internal && !showAllTraces) {
       return callback();
     }
 
-    const tracer = this.tracerProvider.getTracer('prisma');
-    const context = options.context ?? this.getActiveContext();
     const name = `prisma:client:${options.name}`;
 
     if (shouldIgnoreSpan(name, this.ignoreSpanTypes)) {
       return callback();
     }
 
+    const context = options.context ?? _context.active();
+
+    const attributes = buildSpanAttributes(name, options.attributes as Record<string, unknown> | undefined);
+    const spanOptions = {
+      name: buildSpanName(name, attributes),
+      attributes,
+      kind: options.kind as SpanKindValue | undefined,
+      links: options.links as SpanLink[] | undefined,
+      startTime: options.startTime,
+    };
+
     if (options.active === false) {
-      const span = tracer.startSpan(name, options, context);
+      const span = _context.with(context, () => startInactiveSpan(spanOptions));
       return endSpan(span, callback(span, context));
     }
 
-    return tracer.startActiveSpan(name, options, span => endSpan(span, callback(span, context)));
+    return _context.with(context, () => startSpanManual(spanOptions, span => endSpan(span, callback(span, context))));
   }
 }
 
 function dispatchEngineSpan(
-  tracer: Tracer,
   engineSpan: EngineSpan,
   allSpans: EngineSpan[],
   linkIds: Map<string, string>,
   ignoreSpanTypes: (string | RegExp)[],
-) {
-  if (shouldIgnoreSpan(engineSpan.name, ignoreSpanTypes)) return;
+): void {
+  if (shouldIgnoreSpan(engineSpan.name, ignoreSpanTypes)) {
+    return;
+  }
 
-  const spanOptions = {
-    attributes: engineSpan.attributes as Attributes,
-    kind: engineSpanKindToOtelSpanKind(engineSpan.kind),
-    startTime: engineSpan.startTime,
-  } satisfies SpanOptions;
+  const attributes = buildSpanAttributes(engineSpan.name, engineSpan.attributes);
 
-  tracer.startActiveSpan(engineSpan.name, spanOptions, span => {
-    linkIds.set(engineSpan.id, span.spanContext().spanId);
+  startSpanManual(
+    {
+      name: buildSpanName(engineSpan.name, attributes),
+      attributes,
+      kind: engineSpanKindToSentrySpanKind(engineSpan.kind),
+      startTime: engineSpan.startTime,
+    },
+    span => {
+      linkIds.set(engineSpan.id, span.spanContext().spanId);
 
-    if (engineSpan.links) {
-      span.addLinks(
-        engineSpan.links.flatMap(link => {
-          const linkedId = linkIds.get(link);
-          if (!linkedId) {
-            return [];
-          }
-          return {
-            context: {
-              spanId: linkedId,
-              traceId: span.spanContext().traceId,
-              traceFlags: span.spanContext().traceFlags,
-            },
-          };
-        }),
-      );
-    }
+      if (engineSpan.links) {
+        span.addLinks(
+          engineSpan.links.flatMap(link => {
+            const linkedId = linkIds.get(link);
+            if (!linkedId) {
+              return [];
+            }
+            return {
+              context: {
+                spanId: linkedId,
+                traceId: span.spanContext().traceId,
+                traceFlags: span.spanContext().traceFlags,
+              },
+            };
+          }),
+        );
+      }
 
-    const children = allSpans.filter(s => s.parentId === engineSpan.id);
-    for (const child of children) {
-      dispatchEngineSpan(tracer, child, allSpans, linkIds, ignoreSpanTypes);
-    }
+      const children = allSpans.filter(s => s.parentId === engineSpan.id);
+      for (const child of children) {
+        dispatchEngineSpan(child, allSpans, linkIds, ignoreSpanTypes);
+      }
 
-    span.end(engineSpan.endTime);
-  });
+      span.end(engineSpan.endTime);
+    },
+  );
 }
 
 function endSpan<T>(span: Span, result: T): T {

--- a/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
@@ -104,7 +104,7 @@ export class ActiveTracingHelper implements TracingHelper {
       return callback();
     }
 
-    const parentSpan = options.context ?? getActiveSpan();
+    const parentSpan = getActiveSpan();
 
     const attributes = buildSpanAttributes(name, options.attributes as Record<string, unknown> | undefined);
     const spanOptions = {

--- a/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
@@ -6,11 +6,9 @@
  * - Vendored from: https://github.com/prisma/prisma/tree/b6feea5565ec577545a79547d24273ccdd11b4c7/packages/instrumentation
  * - Upstream version: @prisma/instrumentation@7.8.0
  * - Replaced `@prisma/instrumentation-contract` imports with local vendored types
- * - Span creation was migrated from the OTel tracer to Sentry's span APIs (`startSpanManual` /
- *   `startInactiveSpan`)
- * - The former `index.ts` `spanStart` hook is folded into span creation: the Sentry origin, the
- *   `db_query` -> query-text span rename, and the `db.system` backfill for older Prisma versions are
- *   applied where the spans are started instead of via a client hook
+ * - Span creation uses Sentry's span APIs (`startSpanManual` / `startInactiveSpan`) instead of the OTel tracer
+ * - Span creation sets the Sentry origin, renames `db_query` spans to their SQL text, and backfills
+ *   `db.system` for older Prisma versions
  */
 
 import type { Context } from '@opentelemetry/api';
@@ -36,8 +34,7 @@ type Options = {
 };
 
 /**
- * Folds the former `index.ts` `spanStart` hook into span creation: tags the Sentry origin and
- * backfills `db.system` for older Prisma versions that emit `prisma:engine:db_query` without it.
+ * Older Prisma versions emit `prisma:engine:db_query` spans without a `db.system`, so it's backfilled here.
  */
 function buildSpanAttributes(name: string, attributes: Record<string, unknown> | undefined): SpanAttributes {
   const merged: SpanAttributes = {
@@ -53,9 +50,8 @@ function buildSpanAttributes(name: string, attributes: Record<string, unknown> |
 }
 
 /**
- * Uses the query text as the span name for db query spans (e.g. `SELECT * FROM "User"`), matching the
- * behavior the SDK previously applied via the `spanStart` hook. v5/v6 emit `prisma:engine:db_query`;
- * v7 inlined the engine and emits `prisma:client:db_query`.
+ * Db query spans are named after their SQL text (e.g. `SELECT * FROM "User"`) rather than the generic
+ * engine name. v5/v6 emit `prisma:engine:db_query`; v7 inlined the engine and emits `prisma:client:db_query`.
  */
 function buildSpanName(name: string, attributes: SpanAttributes): string {
   const queryText = attributes['db.query.text'];

--- a/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/active-tracing-helper.ts
@@ -119,10 +119,10 @@ export class ActiveTracingHelper implements TracingHelper {
 
     if (options.active === false) {
       const span = _context.with(context, () => startInactiveSpan(spanOptions));
-      return endSpan(span, callback(span, context));
+      return endSpan(span, () => callback(span, context));
     }
 
-    return _context.with(context, () => startSpanManual(spanOptions, span => endSpan(span, callback(span, context))));
+    return _context.with(context, () => startSpanManual(spanOptions, span => endSpan(span, () => callback(span, context))));
   }
 }
 
@@ -176,7 +176,15 @@ function dispatchEngineSpan(
   );
 }
 
-function endSpan<T>(span: Span, result: T): T {
+function endSpan<T>(span: Span, run: () => T): T {
+  let result: T;
+  try {
+    result = run();
+  } catch (reason) {
+    span.end();
+    throw reason;
+  }
+
   if (isPromiseLike(result)) {
     return result.then(
       value => {

--- a/packages/node/src/integrations/tracing/prisma/vendored/constants.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/constants.ts
@@ -7,7 +7,6 @@
  * - Upstream version: @prisma/instrumentation@7.8.0
  * - Replaced `import packageJson from '../package.json'` with hardcoded values
  */
-/* eslint-disable */
 
 import { SDK_VERSION } from '@sentry/core';
 

--- a/packages/node/src/integrations/tracing/prisma/vendored/global.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/global.ts
@@ -7,7 +7,6 @@
  * - Upstream version: @prisma/instrumentation-contract@7.8.0
  * - Replaced `import packageJson from '../package.json'` with hardcoded major version
  */
-/* eslint-disable */
 
 import type { PrismaInstrumentationGlobalValue, TracingHelper } from './types';
 
@@ -44,6 +43,6 @@ export function setGlobalTracingHelper(helper: TracingHelper): void {
 }
 
 export function clearGlobalTracingHelper(): void {
-  delete globalThisWithPrismaInstrumentation[GLOBAL_VERSIONED_INSTRUMENTATION_KEY];
-  delete globalThisWithPrismaInstrumentation[GLOBAL_INSTRUMENTATION_KEY];
+  globalThisWithPrismaInstrumentation[GLOBAL_VERSIONED_INSTRUMENTATION_KEY] = undefined;
+  globalThisWithPrismaInstrumentation[GLOBAL_INSTRUMENTATION_KEY] = undefined;
 }

--- a/packages/node/src/integrations/tracing/prisma/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/instrumentation.ts
@@ -7,19 +7,15 @@
  * - Upstream version: @prisma/instrumentation@7.8.0
  * - Replaced `@prisma/instrumentation-contract` imports with local vendored equivalents
  * - Replaced `import { VERSION, NAME, MODULE_NAME } from './constants'` with local vendored constants
+ * - Dropped the unused `setTracerProvider`/`tracerProvider` plumbing; the tracing helper creates spans
+ *   through Sentry's span APIs, which resolve the active client themselves
  */
-/* eslint-disable */
 
-import { trace, TracerProvider } from '@opentelemetry/api';
-import {
-  InstrumentationBase,
-  InstrumentationConfig,
-  InstrumentationNodeModuleDefinition,
-} from '@opentelemetry/instrumentation';
-import { clearGlobalTracingHelper, getGlobalTracingHelper, setGlobalTracingHelper } from './global';
-
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
 import { ActiveTracingHelper } from './active-tracing-helper';
 import { MODULE_NAME, NAME, SUPPORTED_MODULE_VERSIONS, VERSION } from './constants';
+import { clearGlobalTracingHelper, getGlobalTracingHelper, setGlobalTracingHelper } from './global';
 
 export interface PrismaInstrumentationConfig {
   ignoreSpanTypes?: (string | RegExp)[];
@@ -28,38 +24,31 @@ export interface PrismaInstrumentationConfig {
 type Config = PrismaInstrumentationConfig & InstrumentationConfig;
 
 export class PrismaInstrumentation extends InstrumentationBase {
-  private tracerProvider: TracerProvider | undefined;
-
-  constructor(config: Config = {}) {
+  public constructor(config: Config = {}) {
     super(NAME, VERSION, config);
   }
 
-  setTracerProvider(tracerProvider: TracerProvider): void {
-    this.tracerProvider = tracerProvider;
-  }
-
-  init() {
+  public init(): InstrumentationNodeModuleDefinition[] {
     const module = new InstrumentationNodeModuleDefinition(MODULE_NAME, SUPPORTED_MODULE_VERSIONS);
 
     return [module];
   }
 
-  enable() {
+  public enable(): void {
     const config = this._config as Config;
 
     setGlobalTracingHelper(
       new ActiveTracingHelper({
-        tracerProvider: this.tracerProvider ?? trace.getTracerProvider(),
         ignoreSpanTypes: config.ignoreSpanTypes ?? [],
       }),
     );
   }
 
-  disable() {
+  public disable(): void {
     clearGlobalTracingHelper();
   }
 
-  isEnabled() {
+  public isEnabled(): boolean {
     return getGlobalTracingHelper() !== undefined;
   }
 }

--- a/packages/node/src/integrations/tracing/prisma/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/instrumentation.ts
@@ -7,8 +7,8 @@
  * - Upstream version: @prisma/instrumentation@7.8.0
  * - Replaced `@prisma/instrumentation-contract` imports with local vendored equivalents
  * - Replaced `import { VERSION, NAME, MODULE_NAME } from './constants'` with local vendored constants
- * - Dropped the unused `setTracerProvider`/`tracerProvider` plumbing; the tracing helper creates spans
- *   through Sentry's span APIs, which resolve the active client themselves
+ * - Removed the unused `setTracerProvider`/`tracerProvider` members; spans are created through Sentry's
+ *   span APIs, which resolve the active client themselves
  */
 
 import type { InstrumentationConfig } from '@opentelemetry/instrumentation';

--- a/packages/node/src/integrations/tracing/prisma/vendored/types.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/types.ts
@@ -21,8 +21,6 @@ export interface ExtendedSpanOptions extends SpanOptions {
   internal?: boolean;
   /** Whether it propagates context (?=true) */
   active?: boolean;
-  /** The parent span to attach the new span to */
-  context?: Span;
 }
 
 export type EngineSpanId = string;

--- a/packages/node/src/integrations/tracing/prisma/vendored/types.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/types.ts
@@ -5,8 +5,9 @@
  * NOTICE from the Sentry authors:
  * - Vendored from: https://github.com/prisma/prisma/tree/b6feea5565ec577545a79547d24273ccdd11b4c7/packages/instrumentation-contract
  * - Upstream version: @prisma/instrumentation-contract@7.8.0
+ * - Trimmed to the members the SDK's tracing helper relies on (dropped the unused `EngineTrace`,
+ *   `EngineTraceEvent`, and `LogLevel` types)
  */
-/* eslint-disable */
 
 import type { Context, Span, SpanOptions } from '@opentelemetry/api';
 
@@ -40,33 +41,11 @@ export type EngineSpan = {
   links?: EngineSpanId[];
 };
 
-export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'query';
-
-export interface EngineTraceEvent {
-  spanId: EngineSpanId;
-  target?: string;
-  level: LogLevel;
-  timestamp: HrTime;
-  attributes: Record<string, unknown> & {
-    message?: string;
-    query?: string;
-    duration_ms?: number;
-    params?: string;
-  };
-}
-
-export interface EngineTrace {
-  spans: EngineSpan[];
-  events: EngineTraceEvent[];
-}
-
 export interface TracingHelper {
   isEnabled(): boolean;
   getTraceParent(context?: Context): string;
   dispatchEngineSpans(spans: EngineSpan[]): void;
-
   getActiveContext(): Context | undefined;
-
   runInChildSpan<R>(nameOrOptions: string | ExtendedSpanOptions, callback: SpanCallback<R>): R;
 }
 

--- a/packages/node/src/integrations/tracing/prisma/vendored/types.ts
+++ b/packages/node/src/integrations/tracing/prisma/vendored/types.ts
@@ -9,9 +9,10 @@
  *   `EngineTraceEvent`, and `LogLevel` types)
  */
 
-import type { Context, Span, SpanOptions } from '@opentelemetry/api';
+import type { SpanOptions } from '@opentelemetry/api';
+import type { Span } from '@sentry/core';
 
-export type SpanCallback<R> = (span?: Span, context?: Context) => R;
+export type SpanCallback<R> = (span?: Span, parentSpan?: Span) => R;
 
 export interface ExtendedSpanOptions extends SpanOptions {
   /** The name of the span */
@@ -20,8 +21,8 @@ export interface ExtendedSpanOptions extends SpanOptions {
   internal?: boolean;
   /** Whether it propagates context (?=true) */
   active?: boolean;
-  /** The context to append the span to */
-  context?: Context;
+  /** The parent span to attach the new span to */
+  context?: Span;
 }
 
 export type EngineSpanId = string;
@@ -43,9 +44,9 @@ export type EngineSpan = {
 
 export interface TracingHelper {
   isEnabled(): boolean;
-  getTraceParent(context?: Context): string;
+  getTraceParent(span?: Span): string;
   dispatchEngineSpans(spans: EngineSpan[]): void;
-  getActiveContext(): Context | undefined;
+  getActiveContext(): Span | undefined;
   runInChildSpan<R>(nameOrOptions: string | ExtendedSpanOptions, callback: SpanCallback<R>): R;
 }
 


### PR DESCRIPTION
Streamlines the vendored Prisma instrumentation onto Sentry's span APIs (v6/v7):

- Folds attributes previously set via the `spanStart` hook into span creation in the instrumentation.
- Uses `startSpanManual`/`startInactiveSpan` from `@sentry/core` instead of the OTel tracer in the vendored tracing helper.
- Removes unused code: `setTracerProvider`/`tracerProvider` and unused contract types (`EngineTrace`, `EngineTraceEvent`, `LogLevel`).

v5 cleanup will be done in a followup.

Part of https://github.com/getsentry/sentry-javascript/issues/20744

Closes https://github.com/getsentry/sentry-javascript/issues/21820
