### PR TITLE
ref(server-utils): Set error attributes on span and simplify error info extraction

### DIFF
--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -3,6 +3,7 @@ import type { AsyncLocalStorage } from 'node:async_hooks';
 import type { ExclusiveEventHintOrCaptureContext, Span } from '@sentry/core';
 import { debug, captureException, SPAN_STATUS_ERROR, getAsyncContextStrategy, getMainCarrier } from '@sentry/core';
 import { DEBUG_BUILD } from './debug-build';
+import { ERROR_TYPE, SENTRY_STATUS_MESSAGE } from '@sentry/conventions/attributes';
 
 export type TracingChannelPayloadWithSpan<TData extends object> = TData & {
   _sentrySpan?: Span;
@@ -103,7 +104,9 @@ export function bindTracingChannelToSpan<TData extends object>(
         captureException(data.error, getErrorHint(data.error));
       }
 
-      span.setStatus({ code: SPAN_STATUS_ERROR, message: getErrorMessage(data.error) });
+      const { message, attributes } = getErrorInfo(data.error);
+      span.setStatus({ code: SPAN_STATUS_ERROR, message });
+      span.setAttributes(attributes);
     },
     asyncEnd(data) {
       endBoundSpan(data, beforeSpanEnd);
@@ -186,10 +189,26 @@ function endBoundSpan<TData extends object>(
   span.end();
 }
 
-/** Best-effort short message for a span status: an error-like's `message`, otherwise its string form. */
-function getErrorMessage(error: unknown): string {
-  if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') {
-    return error.message;
-  }
-  return String(error);
+type ErrorInfo = {
+  message: string;
+  attributes: Record<string, string>;
+};
+
+/**
+ * Best-effort message and attribute extraction for thrown/rejected values.
+ */
+function getErrorInfo(error: unknown): ErrorInfo {
+  const isObject = !!error && typeof error === 'object';
+  const raw = isObject ? ('message' in error ? error.message : undefined) : error;
+
+  const message = raw ? String(raw) : 'unknown_error';
+  const type = isObject && 'name' in error ? String(error.name) : 'unknown';
+
+  return {
+    message,
+    attributes: {
+      [ERROR_TYPE]: type,
+      [SENTRY_STATUS_MESSAGE]: message,
+    },
+  };
 }

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -3,7 +3,7 @@ import type { AsyncLocalStorage } from 'node:async_hooks';
 import type { ExclusiveEventHintOrCaptureContext, Span } from '@sentry/core';
 import { debug, captureException, SPAN_STATUS_ERROR, getAsyncContextStrategy, getMainCarrier } from '@sentry/core';
 import { DEBUG_BUILD } from './debug-build';
-import { ERROR_TYPE, SENTRY_STATUS_MESSAGE } from '@sentry/conventions/attributes';
+import { ERROR_TYPE } from '@sentry/conventions/attributes';
 
 export type TracingChannelPayloadWithSpan<TData extends object> = TData & {
   _sentrySpan?: Span;
@@ -208,7 +208,6 @@ function getErrorInfo(error: unknown): ErrorInfo {
     message,
     attributes: {
       [ERROR_TYPE]: type,
-      [SENTRY_STATUS_MESSAGE]: message,
     },
   };
 }

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -370,6 +370,84 @@ describe('bindTracingChannelToSpan', () => {
       expect(spanToJSON(span).status).toBe('callback-sync-throw');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
+
+    describe('error status and attributes', () => {
+      it('derives the type from `name` and the status message from `message` for an Error instance', () => {
+        const { channel, span } = setup('test:lifecycle:error-attrs-error');
+
+        expect(() =>
+          channel.traceSync(
+            () => {
+              throw new TypeError('bad input');
+            },
+            { operation: 'read' },
+          ),
+        ).toThrow('bad input');
+
+        const { status, data } = spanToJSON(span);
+        expect(status).toBe('bad input');
+        expect(data['error.type']).toBe('TypeError');
+        expect(data['sentry.status.message']).toBe('bad input');
+      });
+
+      it('stringifies a thrown primitive and marks the type unknown', () => {
+        const { channel, span } = setup('test:lifecycle:error-attrs-string');
+
+        expect(() =>
+          channel.traceSync(
+            () => {
+              throw 'plain failure';
+            },
+            { operation: 'read' },
+          ),
+        ).toThrow('plain failure');
+
+        const { status, data } = spanToJSON(span);
+        expect(status).toBe('plain failure');
+        expect(data['error.type']).toBe('unknown');
+        expect(data['sentry.status.message']).toBe('plain failure');
+      });
+
+      it('falls back to unknown_error for an error-like object without `name` or `message`', () => {
+        const { channel, span } = setup('test:lifecycle:error-attrs-bare');
+
+        expect(() =>
+          channel.traceSync(
+            () => {
+              throw { code: 500 };
+            },
+            { operation: 'read' },
+          ),
+        ).toThrow();
+
+        const { status, data } = spanToJSON(span);
+        expect(status).toBe('unknown_error');
+        expect(data['error.type']).toBe('unknown');
+        expect(data['sentry.status.message']).toBe('unknown_error');
+      });
+
+      it('falls back to unknown_error when a falsy value is thrown', () => {
+        const { channel, span } = setup('test:lifecycle:error-attrs-falsy');
+
+        let threw = false;
+        try {
+          channel.traceSync(
+            () => {
+              throw 0;
+            },
+            { operation: 'read' },
+          );
+        } catch {
+          threw = true;
+        }
+
+        expect(threw).toBe(true);
+        const { status, data } = spanToJSON(span);
+        expect(status).toBe('unknown_error');
+        expect(data['error.type']).toBe('unknown');
+        expect(data['sentry.status.message']).toBe('unknown_error');
+      });
+    });
   });
 
   describe('captureError', () => {

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -387,7 +387,6 @@ describe('bindTracingChannelToSpan', () => {
         const { status, data } = spanToJSON(span);
         expect(status).toBe('bad input');
         expect(data['error.type']).toBe('TypeError');
-        expect(data['sentry.status.message']).toBe('bad input');
       });
 
       it('stringifies a thrown primitive and marks the type unknown', () => {
@@ -405,7 +404,6 @@ describe('bindTracingChannelToSpan', () => {
         const { status, data } = spanToJSON(span);
         expect(status).toBe('plain failure');
         expect(data['error.type']).toBe('unknown');
-        expect(data['sentry.status.message']).toBe('plain failure');
       });
 
       it('falls back to unknown_error for an error-like object without `name` or `message`', () => {
@@ -423,7 +421,6 @@ describe('bindTracingChannelToSpan', () => {
         const { status, data } = spanToJSON(span);
         expect(status).toBe('unknown_error');
         expect(data['error.type']).toBe('unknown');
-        expect(data['sentry.status.message']).toBe('unknown_error');
       });
 
       it('falls back to unknown_error when a falsy value is thrown', () => {
@@ -445,7 +442,6 @@ describe('bindTracingChannelToSpan', () => {
         const { status, data } = spanToJSON(span);
         expect(status).toBe('unknown_error');
         expect(data['error.type']).toBe('unknown');
-        expect(data['sentry.status.message']).toBe('unknown_error');
       });
     });
   });


### PR DESCRIPTION
When a traced operation throws or rejects, we now set `error.type` and `sentry.status.message` attributes on the span alongside the existing error status, so the error type lines up with the rest of our span conventions.

We talked about this yday, generally tracing channels allow us to observe more errors than before in some cases but these errors are not necessarily "unhandled", but we can still set the error attributes so our users can understand more about the op failure even if handled.