### PR TITLE
feat(core): Pass normalizedRequest to the sampling context for root spans

### DIFF
--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -499,6 +499,7 @@ function _startRootSpan(
           name,
           parentSampled: finalParentSampled,
           attributes: finalAttributes,
+          normalizedRequest: isolationScope.getScopeData().sdkProcessingMetadata.normalizedRequest,
           parentSampleRate: parseSampleRate(currentPropagationContext.dsc?.sample_rate),
         },
         currentPropagationContext.sampleRand,

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -801,6 +801,20 @@ describe('startSpan', () => {
         inheritOrSampleWith: expect.any(Function),
       });
     });
+
+    it('passes normalizedRequest from the isolation scope to the sampling context', () => {
+      const options = getDefaultTestClientOptions({ tracesSampler });
+      client = new TestClient(options);
+      setCurrentClient(client);
+      client.init();
+
+      const normalizedRequest = { url: '/test?query=123', method: 'GET', query_string: 'query=123' };
+      getIsolationScope().setSDKProcessingMetadata({ normalizedRequest });
+
+      startSpan({ name: 'outer' }, () => {});
+
+      expect(tracesSampler).toHaveBeenLastCalledWith(expect.objectContaining({ normalizedRequest }));
+    });
   });
 
   it('includes the scope at the time the span was started when finished', async () => {


### PR DESCRIPTION
# What

Forward the isolation scope's `normalizedRequest` into the `tracesSampler` sampling context for root spans. `_startRootSpan` now includes it in the object passed to the sampler.

# Why

`SamplingContext` already advertises a `normalizedRequest` field, and server SDKs already record the incoming request on the isolation scope, but core never wired the two together for root spans, so `tracesSampler` always received `normalizedRequest: undefined` on the standard root-span path. This closes that gap so custom samplers can decide based on the incoming request (drop health-check routes, raise the rate for `/api/*`, key off the HTTP method) instead of reverse-engineering it from the span name or attributes, which for an incoming HTTP root span may not yet carry the route at sampling time.

Extracted standalone from #21666 (the `SentryTracerProvider` stack): it has no dependency on that work, ships on its own merits, and shrinks #21666's review surface.