### PR TITLE
ref(node): Infer orchestrion integration names

### DIFF
--- a/packages/node/src/sdk/diagnosticsChannelInjection.ts
+++ b/packages/node/src/sdk/diagnosticsChannelInjection.ts
@@ -14,7 +14,7 @@ import type { Integration } from '@sentry/core';
  */
 export interface DiagnosticsChannelInjection {
   /** Channel-based integrations to register, replacing their OTel equivalents. */
-  integrations: Integration[];
+  integrations: Integration[] | readonly Integration[];
   /** OTel integration names these replace; filtered out of the default set. */
   replacedOtelIntegrationNames: string[];
   /** Installs the module hooks that inject the diagnostics channels. */

--- a/packages/node/src/sdk/experimentalUseDiagnosticsChannelInjection.ts
+++ b/packages/node/src/sdk/experimentalUseDiagnosticsChannelInjection.ts
@@ -40,12 +40,15 @@ import { setDiagnosticsChannelInjectionLoader } from './diagnosticsChannelInject
  * @experimental May change or be removed in any release.
  */
 export function experimentalUseDiagnosticsChannelInjection(): void {
-  setDiagnosticsChannelInjectionLoader(
-    (): DiagnosticsChannelInjection => ({
-      integrations: [mysqlChannelIntegration(), lruMemoizerChannelIntegration()],
-      replacedOtelIntegrationNames: ['Mysql', 'LruMemoizer'],
+  setDiagnosticsChannelInjectionLoader((): DiagnosticsChannelInjection => {
+    const integrations = [mysqlChannelIntegration(), lruMemoizerChannelIntegration()] as const;
+    const replacedOtelIntegrationNames = integrations.map(i => i.name);
+
+    return {
+      integrations,
+      replacedOtelIntegrationNames,
       register: registerDiagnosticsChannelInjection,
       detect: detectOrchestrionSetup,
-    }),
-  );
+    };
+  });
 }

--- a/packages/server-utils/src/integrations/tracing-channel/lru-memoizer.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/lru-memoizer.ts
@@ -6,7 +6,7 @@ import { CHANNELS } from '../../orchestrion/channels';
 
 // Same name as the OTel integration by design — when enabled, the OTel
 // 'LruMemoizer' integration is omitted from the default set.
-const INTEGRATION_NAME = 'LruMemoizer';
+const INTEGRATION_NAME = 'LruMemoizer' as const;
 
 interface LruMemoizerChannelContext {
   arguments: unknown[];


### PR DESCRIPTION
Instead of requiring us to keep this as a string list, we can infer this from the integrations that are defined.
Also small cleanup of integration names to make infernal possible (not really used right now but may be helpful to debug things in the future...)