### PR TITLE
feat(core): Add deferred segment-span transaction capture

### DIFF
--- a/packages/core/src/carrier.ts
+++ b/packages/core/src/carrier.ts
@@ -2,6 +2,7 @@ import type { AsyncContextStack } from './asyncContext/stackStrategy';
 import type { AsyncContextStrategy } from './asyncContext/types';
 import type { Client } from './client';
 import type { Scope } from './scope';
+import type { SegmentSpanCaptureStrategy } from './tracing/segmentSpanCaptureStrategy';
 import type { SerializedLog } from './types/log';
 import type { SerializedMetric } from './types/metric';
 import { SDK_VERSION } from './utils/version';
@@ -38,6 +39,9 @@ export interface SentryCarrier {
    * This is used to store metrics that are sent to Sentry.
    */
   clientToMetricBufferMap?: WeakMap<Client, Array<SerializedMetric>>;
+
+  /** Strategy for assembling segment spans into transactions; set by SDKs that defer capture. */
+  segmentSpanCaptureStrategy?: SegmentSpanCaptureStrategy;
 
   /** Overwrites TextEncoder used in `@sentry/core`, need for `react-native@0.73` and older */
   encodePolyfill?: (input: string) => Uint8Array;

--- a/packages/core/src/tracing/deferSegmentSpanCapture.ts
+++ b/packages/core/src/tracing/deferSegmentSpanCapture.ts
@@ -1,0 +1,125 @@
+import type { Client } from '../client';
+import { getCurrentScope } from '../currentScopes';
+import type { Scope } from '../scope';
+import type { Span } from '../types/span';
+import { debounce } from '../utils/debounce';
+import {
+  getSegmentSpanCaptureStrategy,
+  type SegmentSpanConverter,
+  setSegmentSpanCaptureStrategy,
+} from './segmentSpanCaptureStrategy';
+import { getCapturedScopesOnSpan } from './utils';
+
+// Spans already sent in a transaction, so a child ending after its segment can be emitted as its own
+// orphan transaction instead of being dropped or sent twice.
+const CAPTURED_SPANS = new WeakSet<Span>();
+
+const isSpanAlreadyCaptured = (span: Span): boolean => CAPTURED_SPANS.has(span);
+const markSpanCaptured = (span: Span): void => {
+  CAPTURED_SPANS.add(span);
+};
+
+// Per-client so each client's flush/close drains only its own captures: one client's flush must not
+// snapshot another's transaction early. Mirrors the per-client log/metric buffers.
+const CLIENT_QUEUES = new WeakMap<Client, DeferredCaptureQueue>();
+
+interface DeferredCaptureQueue {
+  enqueue: (capture: () => void) => void;
+  flush: () => void;
+}
+
+/**
+ * @private Private API with no semver guarantees!
+ *
+ * Enable deferred segment-span transaction capture for a client (idempotent per client). Deferring the
+ * snapshot lets children that close just after their segment still land in the transaction; pending
+ * captures drain on `flush`, so `Sentry.flush()` / `client.close()` cannot resolve before they run.
+ */
+export function _INTERNAL_setDeferSegmentSpanCapture(client: Client): void {
+  if (!getSegmentSpanCaptureStrategy()) {
+    setSegmentSpanCaptureStrategy(deferredSegmentSpanCaptureStrategy);
+  }
+  // A client that never opts in has no queue and falls back to synchronous capture below.
+  getClientQueue(client);
+}
+
+const deferredSegmentSpanCaptureStrategy = {
+  onSegmentSpanEnded(scope: Scope, client: Client, convert: SegmentSpanConverter): void {
+    const queue = CLIENT_QUEUES.get(client);
+    if (!queue) {
+      // Client never opted into deferral: capture synchronously, exactly as if no strategy existed.
+      const transactionEvent = convert();
+      if (transactionEvent) {
+        scope.captureEvent(transactionEvent);
+      }
+      return;
+    }
+
+    queue.enqueue(() => {
+      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      if (transactionEvent) {
+        // Capture via the client active at span end (passing its scope for context), so a later-tick
+        // capture reaches that client even if the current client changed since (e.g. after re-init).
+        client.captureEvent(transactionEvent, undefined, scope);
+      }
+    });
+  },
+
+  onChildSpanEnded(span: Span, rootSpan: Span, client: Client, convert: SegmentSpanConverter): void {
+    const queue = CLIENT_QUEUES.get(client);
+    // Only a late child of an already-captured segment is an orphan. Inert under span streaming, where
+    // `CAPTURED_SPANS` is never populated.
+    if (!queue || CAPTURED_SPANS.has(span) || !CAPTURED_SPANS.has(rootSpan)) {
+      return;
+    }
+
+    const scope = getCapturedScopesOnSpan(span).scope || getCurrentScope();
+    queue.enqueue(() => {
+      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      if (transactionEvent?.contexts?.trace?.data) {
+        // Tag orphans so they're distinguishable downstream (mirrors the OTel span exporter).
+        transactionEvent.contexts.trace.data['sentry.parent_span_already_sent'] = true;
+      }
+      if (transactionEvent) {
+        client.captureEvent(transactionEvent, undefined, scope);
+      }
+    });
+  },
+};
+
+function getClientQueue(client: Client): DeferredCaptureQueue {
+  const existing = CLIENT_QUEUES.get(client);
+  if (existing) {
+    return existing;
+  }
+
+  const pendingCaptures = new Set<() => void>();
+  const debouncedDrain = debounce(
+    () => {
+      const captures = [...pendingCaptures];
+      pendingCaptures.clear();
+      for (const capture of captures) {
+        capture();
+      }
+    },
+    1,
+    { maxWait: 100 },
+  );
+
+  const queue: DeferredCaptureQueue = {
+    enqueue: capture => {
+      pendingCaptures.add(capture);
+      debouncedDrain();
+    },
+    flush: () => {
+      debouncedDrain.flush();
+    },
+  };
+
+  client.on('flush', () => {
+    queue.flush();
+  });
+
+  CLIENT_QUEUES.set(client, queue);
+  return queue;
+}

--- a/packages/core/src/tracing/deferSegmentSpanCapture.ts
+++ b/packages/core/src/tracing/deferSegmentSpanCapture.ts
@@ -1,5 +1,5 @@
 import type { Client } from '../client';
-import { getClient } from '../currentScopes';
+import type { Scope } from '../scope';
 import type { Span } from '../types/span';
 import { debounce } from '../utils/debounce';
 import { getSegmentSpanCaptureStrategy, setSegmentSpanCaptureStrategy } from './segmentSpanCaptureStrategy';
@@ -15,8 +15,9 @@ const markSpanCaptured = (span: Span): void => {
 
 // One debounced queue per client, drained on the client's `flush`/`close`. Mirrors the OpenTelemetry
 // span exporter, which holds one such buffer per instance, and the debounce window matches it. The
-// capturing client is bound when the span ends (not re-resolved at drain time), so a deferred capture
-// lands on the client that created the span even if a different client became current in the meantime.
+// capturing client is resolved from the span's captured scope and bound when the span ends, not
+// re-resolved at drain time, so a deferred transaction lands on the client that created the span even if
+// the current client (or the captured scope's own client) is reassigned before the debounce fires.
 const CLIENT_QUEUES = new WeakMap<Client, (capture: () => void) => void>();
 
 /**
@@ -64,11 +65,11 @@ export function _INTERNAL_setDeferSegmentSpanCapture(client: Client): void {
 }
 
 const deferredSegmentSpanCaptureStrategy = {
-  onSegmentSpanEnded(convert: SegmentSpanConverter): void {
-    const client = getClient();
+  onSegmentSpanEnded(convert: SegmentSpanConverter, scope: Scope): void {
+    const client = scope.getClient();
     const enqueue = client && CLIENT_QUEUES.get(client);
     if (!enqueue) {
-      // The current client didn't enable deferral: capture synchronously.
+      // The capturing client didn't enable deferral: capture synchronously.
       const transactionEvent = convert();
       if (transactionEvent) {
         client?.captureEvent(transactionEvent);
@@ -84,28 +85,32 @@ const deferredSegmentSpanCaptureStrategy = {
     });
   },
 
-  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter): void {
+  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter, scope: Scope): void {
     // Only a late child of an already-captured segment is an orphan. Inert under span streaming, where
     // `CAPTURED_SPANS` is never populated.
     if (CAPTURED_SPANS.has(span) || !CAPTURED_SPANS.has(rootSpan)) {
       return;
     }
 
-    const client = getClient();
+    const client = scope.getClient();
     const enqueue = client && CLIENT_QUEUES.get(client);
-    if (!enqueue) {
-      return;
-    }
 
-    enqueue(() => {
+    const captureOrphan = (): void => {
       const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
       if (transactionEvent?.contexts?.trace?.data) {
         // Tag orphans so they're distinguishable downstream (mirrors the OTel span exporter).
         transactionEvent.contexts.trace.data['sentry.parent_span_already_sent'] = true;
       }
       if (transactionEvent) {
-        client.captureEvent(transactionEvent);
+        client?.captureEvent(transactionEvent);
       }
-    });
+    };
+
+    // Defer when the capturing client batches; otherwise emit now so the orphan isn't dropped.
+    if (enqueue) {
+      enqueue(captureOrphan);
+    } else {
+      captureOrphan();
+    }
   },
 };

--- a/packages/core/src/tracing/deferSegmentSpanCapture.ts
+++ b/packages/core/src/tracing/deferSegmentSpanCapture.ts
@@ -10,14 +10,12 @@ import {
 } from './segmentSpanCaptureStrategy';
 import { getCapturedScopesOnSpan } from './utils';
 
-// Spans already sent in a transaction, so a child ending after its segment can be emitted as its own
-// orphan transaction instead of being dropped or sent twice.
-const CAPTURED_SPANS = new WeakSet<Span>();
+// Spans already sent in a transaction, mapped to the client that sent them. A child ending after its
+// segment can then be emitted as its own orphan transaction (instead of dropped or sent twice), routed
+// to the same client that sent the segment rather than whatever client is current when the child ends.
+const CAPTURED_SPAN_CLIENTS = new WeakMap<Span, Client>();
 
-const isSpanAlreadyCaptured = (span: Span): boolean => CAPTURED_SPANS.has(span);
-const markSpanCaptured = (span: Span): void => {
-  CAPTURED_SPANS.add(span);
-};
+const isSpanAlreadyCaptured = (span: Span): boolean => CAPTURED_SPAN_CLIENTS.has(span);
 
 // Per-client so each client's flush/close drains only its own captures: one client's flush must not
 // snapshot another's transaction early. Mirrors the per-client log/metric buffers.
@@ -56,7 +54,10 @@ const deferredSegmentSpanCaptureStrategy = {
     }
 
     queue.enqueue(() => {
-      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      const transactionEvent = convert({
+        isSpanAlreadyCaptured,
+        onSpanCaptured: span => CAPTURED_SPAN_CLIENTS.set(span, client),
+      });
       if (transactionEvent) {
         // Capture via the client active at span end (passing its scope for context), so a later-tick
         // capture reaches that client even if the current client changed since (e.g. after re-init).
@@ -65,17 +66,23 @@ const deferredSegmentSpanCaptureStrategy = {
     });
   },
 
-  onChildSpanEnded(span: Span, rootSpan: Span, client: Client, convert: SegmentSpanConverter): void {
-    const queue = CLIENT_QUEUES.get(client);
+  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter): void {
+    // Route the orphan to the client that sent its segment, not the current one — which may have
+    // changed since (e.g. after re-init) — so it lands with its segment and survives a client swap.
+    const client = CAPTURED_SPAN_CLIENTS.get(rootSpan);
+    const queue = client && CLIENT_QUEUES.get(client);
     // Only a late child of an already-captured segment is an orphan. Inert under span streaming, where
-    // `CAPTURED_SPANS` is never populated.
-    if (!queue || CAPTURED_SPANS.has(span) || !CAPTURED_SPANS.has(rootSpan)) {
+    // no client is recorded.
+    if (!client || !queue || CAPTURED_SPAN_CLIENTS.has(span)) {
       return;
     }
 
     const scope = getCapturedScopesOnSpan(span).scope || getCurrentScope();
     queue.enqueue(() => {
-      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      const transactionEvent = convert({
+        isSpanAlreadyCaptured,
+        onSpanCaptured: capturedSpan => CAPTURED_SPAN_CLIENTS.set(capturedSpan, client),
+      });
       if (transactionEvent?.contexts?.trace?.data) {
         // Tag orphans so they're distinguishable downstream (mirrors the OTel span exporter).
         transactionEvent.contexts.trace.data['sentry.parent_span_already_sent'] = true;

--- a/packages/core/src/tracing/deferSegmentSpanCapture.ts
+++ b/packages/core/src/tracing/deferSegmentSpanCapture.ts
@@ -1,103 +1,43 @@
 import type { Client } from '../client';
-import { getCurrentScope } from '../currentScopes';
-import type { Scope } from '../scope';
+import { getClient } from '../currentScopes';
 import type { Span } from '../types/span';
 import { debounce } from '../utils/debounce';
-import {
-  getSegmentSpanCaptureStrategy,
-  type SegmentSpanConverter,
-  setSegmentSpanCaptureStrategy,
-} from './segmentSpanCaptureStrategy';
-import { getCapturedScopesOnSpan } from './utils';
+import { getSegmentSpanCaptureStrategy, setSegmentSpanCaptureStrategy } from './segmentSpanCaptureStrategy';
+import type { SegmentSpanConverter } from './segmentSpanCaptureStrategy';
 
-// Spans already sent in a transaction, mapped to the client that sent them. A child ending after its
-// segment can then be emitted as its own orphan transaction (instead of dropped or sent twice), routed
-// to the same client that sent the segment rather than whatever client is current when the child ends.
-const CAPTURED_SPAN_CLIENTS = new WeakMap<Span, Client>();
+// Spans already sent in a transaction, so a child ending after its segment can be emitted as its own
+// orphan transaction instead of being dropped or sent twice.
+const CAPTURED_SPANS = new WeakSet<Span>();
+const isSpanAlreadyCaptured = (span: Span): boolean => CAPTURED_SPANS.has(span);
+const markSpanCaptured = (span: Span): void => {
+  CAPTURED_SPANS.add(span);
+};
 
-const isSpanAlreadyCaptured = (span: Span): boolean => CAPTURED_SPAN_CLIENTS.has(span);
-
-// Per-client so each client's flush/close drains only its own captures: one client's flush must not
-// snapshot another's transaction early. Mirrors the per-client log/metric buffers.
-const CLIENT_QUEUES = new WeakMap<Client, DeferredCaptureQueue>();
-
-interface DeferredCaptureQueue {
-  enqueue: (capture: () => void) => void;
-  flush: () => void;
-}
+// One debounced queue per client, drained on the client's `flush`/`close`. Mirrors the OpenTelemetry
+// span exporter, which holds one such buffer per instance, and the debounce window matches it. The
+// capturing client is bound when the span ends (not re-resolved at drain time), so a deferred capture
+// lands on the client that created the span even if a different client became current in the meantime.
+const CLIENT_QUEUES = new WeakMap<Client, (capture: () => void) => void>();
 
 /**
  * @private Private API with no semver guarantees!
  *
- * Enable deferred segment-span transaction capture for a client (idempotent per client). Deferring the
- * snapshot lets children that close just after their segment still land in the transaction; pending
- * captures drain on `flush`, so `Sentry.flush()` / `client.close()` cannot resolve before they run.
+ * Enable deferred segment-span transaction capture for a client: create its debounced queue and
+ * register the strategy (idempotent).
+ *
+ * `SentrySpan` otherwise assembles the transaction synchronously the instant a segment span ends, which
+ * drops children whose async instrumentation closes them later (a diagnostics-channel `asyncEnd`
+ * callback in the same tick, or engine spans replayed on a later tick). The debounced snapshot delays
+ * capture just enough for those later span ends to land first; a child that still ends after it is
+ * emitted as its own orphan transaction. Pending captures drain on the client's `flush` hook, so
+ * `Sentry.flush()` / `client.close()` cannot resolve before they run.
  */
 export function _INTERNAL_setDeferSegmentSpanCapture(client: Client): void {
   if (!getSegmentSpanCaptureStrategy()) {
     setSegmentSpanCaptureStrategy(deferredSegmentSpanCaptureStrategy);
   }
-  // A client that never opts in has no queue and falls back to synchronous capture below.
-  getClientQueue(client);
-}
-
-const deferredSegmentSpanCaptureStrategy = {
-  onSegmentSpanEnded(scope: Scope, client: Client, convert: SegmentSpanConverter): void {
-    const queue = CLIENT_QUEUES.get(client);
-    if (!queue) {
-      // Client never opted into deferral: capture synchronously, exactly as if no strategy existed.
-      const transactionEvent = convert();
-      if (transactionEvent) {
-        scope.captureEvent(transactionEvent);
-      }
-      return;
-    }
-
-    queue.enqueue(() => {
-      const transactionEvent = convert({
-        isSpanAlreadyCaptured,
-        onSpanCaptured: span => CAPTURED_SPAN_CLIENTS.set(span, client),
-      });
-      if (transactionEvent) {
-        // Capture via the client active at span end (passing its scope for context), so a later-tick
-        // capture reaches that client even if the current client changed since (e.g. after re-init).
-        client.captureEvent(transactionEvent, undefined, scope);
-      }
-    });
-  },
-
-  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter): void {
-    // Route the orphan to the client that sent its segment, not the current one — which may have
-    // changed since (e.g. after re-init) — so it lands with its segment and survives a client swap.
-    const client = CAPTURED_SPAN_CLIENTS.get(rootSpan);
-    const queue = client && CLIENT_QUEUES.get(client);
-    // Only a late child of an already-captured segment is an orphan. Inert under span streaming, where
-    // no client is recorded.
-    if (!client || !queue || CAPTURED_SPAN_CLIENTS.has(span)) {
-      return;
-    }
-
-    const scope = getCapturedScopesOnSpan(span).scope || getCurrentScope();
-    queue.enqueue(() => {
-      const transactionEvent = convert({
-        isSpanAlreadyCaptured,
-        onSpanCaptured: capturedSpan => CAPTURED_SPAN_CLIENTS.set(capturedSpan, client),
-      });
-      if (transactionEvent?.contexts?.trace?.data) {
-        // Tag orphans so they're distinguishable downstream (mirrors the OTel span exporter).
-        transactionEvent.contexts.trace.data['sentry.parent_span_already_sent'] = true;
-      }
-      if (transactionEvent) {
-        client.captureEvent(transactionEvent, undefined, scope);
-      }
-    });
-  },
-};
-
-function getClientQueue(client: Client): DeferredCaptureQueue {
-  const existing = CLIENT_QUEUES.get(client);
-  if (existing) {
-    return existing;
+  if (CLIENT_QUEUES.has(client)) {
+    return;
   }
 
   const pendingCaptures = new Set<() => void>();
@@ -113,20 +53,59 @@ function getClientQueue(client: Client): DeferredCaptureQueue {
     { maxWait: 100 },
   );
 
-  const queue: DeferredCaptureQueue = {
-    enqueue: capture => {
-      pendingCaptures.add(capture);
-      debouncedDrain();
-    },
-    flush: () => {
-      debouncedDrain.flush();
-    },
-  };
-
   client.on('flush', () => {
-    queue.flush();
+    debouncedDrain.flush();
   });
 
-  CLIENT_QUEUES.set(client, queue);
-  return queue;
+  CLIENT_QUEUES.set(client, capture => {
+    pendingCaptures.add(capture);
+    debouncedDrain();
+  });
 }
+
+const deferredSegmentSpanCaptureStrategy = {
+  onSegmentSpanEnded(convert: SegmentSpanConverter): void {
+    const client = getClient();
+    const enqueue = client && CLIENT_QUEUES.get(client);
+    if (!enqueue) {
+      // The current client didn't enable deferral: capture synchronously.
+      const transactionEvent = convert();
+      if (transactionEvent) {
+        client?.captureEvent(transactionEvent);
+      }
+      return;
+    }
+
+    enqueue(() => {
+      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      if (transactionEvent) {
+        client.captureEvent(transactionEvent);
+      }
+    });
+  },
+
+  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter): void {
+    // Only a late child of an already-captured segment is an orphan. Inert under span streaming, where
+    // `CAPTURED_SPANS` is never populated.
+    if (CAPTURED_SPANS.has(span) || !CAPTURED_SPANS.has(rootSpan)) {
+      return;
+    }
+
+    const client = getClient();
+    const enqueue = client && CLIENT_QUEUES.get(client);
+    if (!enqueue) {
+      return;
+    }
+
+    enqueue(() => {
+      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      if (transactionEvent?.contexts?.trace?.data) {
+        // Tag orphans so they're distinguishable downstream (mirrors the OTel span exporter).
+        transactionEvent.contexts.trace.data['sentry.parent_span_already_sent'] = true;
+      }
+      if (transactionEvent) {
+        client.captureEvent(transactionEvent);
+      }
+    });
+  },
+};

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -10,7 +10,8 @@ export {
   spanIsTracerProviderSpan,
 } from './utils';
 export { startIdleSpan, TRACING_DEFAULTS } from './idleSpan';
-export { SentrySpan, _INTERNAL_setDeferSegmentSpanCapture } from './sentrySpan';
+export { SentrySpan } from './sentrySpan';
+export { _INTERNAL_setDeferSegmentSpanCapture } from './deferSegmentSpanCapture';
 export { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
 export { setHttpStatus, getSpanStatusFromHttpCode } from './spanstatus';
 export { SPAN_STATUS_ERROR, SPAN_STATUS_OK, SPAN_STATUS_UNSET } from './spanstatus';

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -10,7 +10,7 @@ export {
   spanIsTracerProviderSpan,
 } from './utils';
 export { startIdleSpan, TRACING_DEFAULTS } from './idleSpan';
-export { SentrySpan } from './sentrySpan';
+export { SentrySpan, _INTERNAL_setDeferSegmentSpanCapture } from './sentrySpan';
 export { SentryNonRecordingSpan } from './sentryNonRecordingSpan';
 export { setHttpStatus, getSpanStatusFromHttpCode } from './spanstatus';
 export { SPAN_STATUS_ERROR, SPAN_STATUS_OK, SPAN_STATUS_UNSET } from './spanstatus';

--- a/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
+++ b/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
@@ -5,11 +5,13 @@ import type { TransactionEvent } from '../types/event';
 import type { Span } from '../types/span';
 
 /**
- * Optional hooks a deferring strategy passes when converting: skip spans already sent, record the ones
- * it sends (for orphan tracking). The synchronous default passes neither.
+ * Callbacks the deferred-capture strategy hands to `_convertSpanToTransaction` when assembling a
+ * transaction. The synchronous (browser) path calls the converter with no options, so neither runs.
  */
 export interface SegmentSpanCaptureConvertOptions {
+  /** Skip a descendant already sent in an earlier transaction, so it isn't sent twice. */
   isSpanAlreadyCaptured?: (span: Span) => boolean;
+  /** Record each span included here, so a child that ends after the snapshot can be emitted as an orphan. */
   onSpanCaptured?: (span: Span) => void;
 }
 

--- a/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
+++ b/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
@@ -26,7 +26,7 @@ export interface SegmentSpanCaptureStrategy {
   /** Assemble and capture a segment (root or standalone-root) span's transaction. */
   onSegmentSpanEnded(scope: Scope, client: Client, convert: SegmentSpanConverter): void;
   /** Consider a child that ended after its segment for emission as its own orphan transaction. */
-  onChildSpanEnded(span: Span, rootSpan: Span, client: Client, convert: SegmentSpanConverter): void;
+  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter): void;
 }
 
 /**

--- a/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
+++ b/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
@@ -1,6 +1,4 @@
 import { getMainCarrier, getSentryCarrier } from '../carrier';
-import type { Client } from '../client';
-import type { Scope } from '../scope';
 import type { TransactionEvent } from '../types/event';
 import type { Span } from '../types/span';
 
@@ -24,7 +22,7 @@ export type SegmentSpanConverter = (options?: SegmentSpanCaptureConvertOptions) 
  */
 export interface SegmentSpanCaptureStrategy {
   /** Assemble and capture a segment (root or standalone-root) span's transaction. */
-  onSegmentSpanEnded(scope: Scope, client: Client, convert: SegmentSpanConverter): void;
+  onSegmentSpanEnded(convert: SegmentSpanConverter): void;
   /** Consider a child that ended after its segment for emission as its own orphan transaction. */
   onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter): void;
 }

--- a/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
+++ b/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
@@ -1,4 +1,5 @@
 import { getMainCarrier, getSentryCarrier } from '../carrier';
+import type { Scope } from '../scope';
 import type { TransactionEvent } from '../types/event';
 import type { Span } from '../types/span';
 
@@ -21,10 +22,10 @@ export type SegmentSpanConverter = (options?: SegmentSpanCaptureConvertOptions) 
  * behind this seam tree-shakes the deferral machinery out of SDKs that never register one (e.g. browser).
  */
 export interface SegmentSpanCaptureStrategy {
-  /** Assemble and capture a segment (root or standalone-root) span's transaction. */
-  onSegmentSpanEnded(convert: SegmentSpanConverter): void;
+  /** Assemble and capture a segment (root or standalone-root) span's transaction through its captured scope. */
+  onSegmentSpanEnded(convert: SegmentSpanConverter, scope: Scope): void;
   /** Consider a child that ended after its segment for emission as its own orphan transaction. */
-  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter): void;
+  onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter, scope: Scope): void;
 }
 
 /**

--- a/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
+++ b/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
@@ -1,0 +1,42 @@
+import { getMainCarrier, getSentryCarrier } from '../carrier';
+import type { Client } from '../client';
+import type { Scope } from '../scope';
+import type { TransactionEvent } from '../types/event';
+import type { Span } from '../types/span';
+
+/**
+ * Optional hooks a deferring strategy passes when converting: skip spans already sent, record the ones
+ * it sends (for orphan tracking). The synchronous default passes neither.
+ */
+export interface SegmentSpanCaptureConvertOptions {
+  isSpanAlreadyCaptured?: (span: Span) => boolean;
+  onSpanCaptured?: (span: Span) => void;
+}
+
+export type SegmentSpanConverter = (options?: SegmentSpanCaptureConvertOptions) => TransactionEvent | undefined;
+
+/**
+ * Assembles segment spans into transactions. Registered by SDKs that defer capture (see
+ * `_INTERNAL_setDeferSegmentSpanCapture`); when unset, `SentrySpan` captures synchronously. Living
+ * behind this seam tree-shakes the deferral machinery out of SDKs that never register one (e.g. browser).
+ */
+export interface SegmentSpanCaptureStrategy {
+  /** Assemble and capture a segment (root or standalone-root) span's transaction. */
+  onSegmentSpanEnded(scope: Scope, client: Client, convert: SegmentSpanConverter): void;
+  /** Consider a child that ended after its segment for emission as its own orphan transaction. */
+  onChildSpanEnded(span: Span, rootSpan: Span, client: Client, convert: SegmentSpanConverter): void;
+}
+
+/**
+ * @private Private API with no semver guarantees!
+ *
+ * Set the global segment-span capture strategy (or clear it with `undefined`).
+ */
+export function setSegmentSpanCaptureStrategy(strategy: SegmentSpanCaptureStrategy | undefined): void {
+  getSentryCarrier(getMainCarrier()).segmentSpanCaptureStrategy = strategy;
+}
+
+/** Get the global segment-span capture strategy, or `undefined` when none is registered. */
+export function getSegmentSpanCaptureStrategy(): SegmentSpanCaptureStrategy | undefined {
+  return getSentryCarrier(getMainCarrier()).segmentSpanCaptureStrategy;
+}

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -68,22 +68,18 @@ const DEFERRED_SEGMENT_SPAN_CAPTURES = new WeakMap<Client, (capture: () => void)
 const CAPTURED_SPANS = new WeakSet<Span>();
 
 /**
- * Opt a client into (or out of) deferring its segment-span transaction capture.
- * Set by the SDK client during setup (e.g. the Node SDK); see {@link DEFERRED_SEGMENT_SPAN_CAPTURES}.
+ * Defer a client's segment-span transaction capture. Set once by the SDK during setup (e.g. the Node
+ * SDK); see {@link DEFERRED_SEGMENT_SPAN_CAPTURES}. Idempotent, and deferral stays on for the client's
+ * lifetime (there is no opt-out: deferral is a set-once-at-setup property, never toggled mid-session).
  *
  * The transaction is otherwise assembled from the live span tree the instant a root span ends, which
  * drops children whose async instrumentation closes them later (a diagnostics-channel `asyncEnd`
- * callback in the same tick, or engine spans replayed on a later tick). A debounced timer — the same
- * one the OpenTelemetry span exporter uses — delays the snapshot just enough for those later span ends
- * to land first. Pending captures are drained synchronously on the client's `flush` hook so
+ * callback in the same tick, or engine spans replayed on a later tick). A debounced timer (the same one
+ * the OpenTelemetry span exporter uses) delays the snapshot just enough for those later span ends to
+ * land first. Pending captures are drained synchronously on the client's `flush` hook so
  * `Sentry.flush()` / `client.close()` cannot resolve before they run.
  */
-export function _INTERNAL_setDeferSegmentSpanCapture(client: Client, defer: boolean): void {
-  if (!defer) {
-    DEFERRED_SEGMENT_SPAN_CAPTURES.delete(client);
-    return;
-  }
-
+export function _INTERNAL_setDeferSegmentSpanCapture(client: Client): void {
   if (DEFERRED_SEGMENT_SPAN_CAPTURES.has(client)) {
     return;
   }

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import type { Client } from '../client';
 import { getClient, getCurrentScope } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { createSpanEnvelope } from '../envelope';
@@ -26,7 +27,9 @@ import type {
 } from '../types/span';
 import type { SpanStatus } from '../types/spanStatus';
 import type { TimedEvent } from '../types/timedEvent';
+import { debounce } from '../utils/debounce';
 import { debug } from '../utils/debug-logger';
+import { isBrowser } from '../utils/isBrowser';
 import { generateSpanId, generateTraceId } from '../utils/propagationContext';
 import {
   addStatusMessageAttribute,
@@ -50,6 +53,58 @@ import { hasSpanStreamingEnabled } from './spans/hasSpanStreamingEnabled';
 import { getCapturedScopesOnSpan, markSpanSourceAsExplicit, spanShouldInferOtelSource } from './utils';
 
 const MAX_SPAN_COUNT = 1000;
+
+// Clients whose segment-span transaction capture should be deferred (rather than run synchronously on
+// span end), mapped to the function that queues a deferred capture. Tracked per client rather than as
+// a process-wide flag so pending captures and their timer cannot leak across `Sentry.init()` calls —
+// a client that never opts in is simply absent. Enabled per client by SDKs that assemble transactions
+// from the live span tree on root-span end (e.g. the Node SDK), which would otherwise drop children
+// that close after it. Every other setup keeps its synchronous capture.
+const DEFERRED_SEGMENT_SPAN_CAPTURES = new WeakMap<Client, (capture: () => void) => void>();
+
+/**
+ * Opt a client into (or out of) deferring its segment-span transaction capture.
+ * Set by the SDK client during setup (e.g. the Node SDK); see {@link DEFERRED_SEGMENT_SPAN_CAPTURES}.
+ *
+ * The transaction is otherwise assembled from the live span tree the instant a root span ends, which
+ * drops children whose async instrumentation closes them later (a diagnostics-channel `asyncEnd`
+ * callback in the same tick, or engine spans replayed on a later tick). A debounced timer — the same
+ * one the OpenTelemetry span exporter uses — delays the snapshot just enough for those later span ends
+ * to land first. Pending captures are drained synchronously on the client's `flush` hook so
+ * `Sentry.flush()` / `client.close()` cannot resolve before they run.
+ */
+export function _INTERNAL_setDeferSegmentSpanCapture(client: Client, defer: boolean): void {
+  if (!defer) {
+    DEFERRED_SEGMENT_SPAN_CAPTURES.delete(client);
+    return;
+  }
+
+  if (DEFERRED_SEGMENT_SPAN_CAPTURES.has(client)) {
+    return;
+  }
+
+  const pendingCaptures = new Set<() => void>();
+  const debouncedDrain = debounce(
+    () => {
+      const captures = [...pendingCaptures];
+      pendingCaptures.clear();
+      for (const capture of captures) {
+        capture();
+      }
+    },
+    1,
+    { maxWait: 100 },
+  );
+
+  client.on('flush', () => {
+    debouncedDrain.flush();
+  });
+
+  DEFERRED_SEGMENT_SPAN_CAPTURES.set(client, capture => {
+    pendingCaptures.add(capture);
+    debouncedDrain();
+  });
+}
 
 /**
  * Span contains all data about a span
@@ -367,10 +422,31 @@ export class SentrySpan implements Span {
       return;
     }
 
-    const transactionEvent = this._convertSpanToTransaction();
-    if (transactionEvent) {
-      const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
-      scope.captureEvent(transactionEvent);
+    const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
+
+    // The transaction is assembled synchronously from the live span tree the instant the root span
+    // ends, dropping children whose async instrumentation closes them after it (a diagnostics-channel
+    // `asyncEnd` callback in the same tick, or engine spans replayed on a later tick). Clients that
+    // opted in defer the snapshot via a debounced timer so those later span ends land first; every
+    // other setup keeps its synchronous capture. Never deferred in the browser, where there is no such
+    // pattern and a deferred capture could be lost on page unload.
+    const deferCapture = client && DEFERRED_SEGMENT_SPAN_CAPTURES.get(client);
+    if (client && deferCapture && !isBrowser()) {
+      deferCapture(() => {
+        const transactionEvent = this._convertSpanToTransaction();
+        if (transactionEvent) {
+          // Capture through the client resolved when the span ended, not the scope: a capture that
+          // fires on a later tick must reach the client active at span end and never whatever client
+          // is current when the timer fires (e.g. a different client after re-init), and the scope's
+          // client reference can be reassigned. Only the snapshot is deferred, so late children land.
+          client.captureEvent(transactionEvent, undefined, scope);
+        }
+      });
+    } else {
+      const transactionEvent = this._convertSpanToTransaction();
+      if (transactionEvent) {
+        scope.captureEvent(transactionEvent);
+      }
     }
   }
 

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -376,16 +376,15 @@ export class SentrySpan implements Span {
       return;
     }
 
-    const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
-
     // A registered strategy defers the snapshot so children closing just after the segment still land
     // (and late ones can orphan); without one, assemble synchronously from the live tree.
-    const strategy = client && getSegmentSpanCaptureStrategy();
+    const strategy = getSegmentSpanCaptureStrategy();
     if (strategy) {
-      strategy.onSegmentSpanEnded(scope, client, options => this._convertSpanToTransaction(options));
+      strategy.onSegmentSpanEnded(options => this._convertSpanToTransaction(options));
     } else {
       const transactionEvent = this._convertSpanToTransaction();
       if (transactionEvent) {
+        const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
         scope.captureEvent(transactionEvent);
       }
     }

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -364,9 +364,11 @@ export class SentrySpan implements Span {
     // Non-segment children aren't captured on their own. A registered strategy may re-emit a late child
     // as its own orphan transaction; without one, it's dropped.
     if (!isSegmentSpan) {
-      getSegmentSpanCaptureStrategy()?.onChildSpanEnded(this, rootSpan, options =>
-        this._convertSpanToTransaction(options),
-      );
+      const strategy = getSegmentSpanCaptureStrategy();
+      if (strategy) {
+        const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
+        strategy.onChildSpanEnded(this, rootSpan, options => this._convertSpanToTransaction(options), scope);
+      }
       return;
     }
 
@@ -378,13 +380,13 @@ export class SentrySpan implements Span {
 
     // A registered strategy defers the snapshot so children closing just after the segment still land
     // (and late ones can orphan); without one, assemble synchronously from the live tree.
+    const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
     const strategy = getSegmentSpanCaptureStrategy();
     if (strategy) {
-      strategy.onSegmentSpanEnded(options => this._convertSpanToTransaction(options));
+      strategy.onSegmentSpanEnded(options => this._convertSpanToTransaction(options), scope);
     } else {
       const transactionEvent = this._convertSpanToTransaction();
       if (transactionEvent) {
-        const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
         scope.captureEvent(transactionEvent);
       }
     }

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -62,6 +62,11 @@ const MAX_SPAN_COUNT = 1000;
 // that close after it. Every other setup keeps its synchronous capture.
 const DEFERRED_SEGMENT_SPAN_CAPTURES = new WeakMap<Client, (capture: () => void) => void>();
 
+// Spans already included in a captured transaction. Used so a child that ends after its root segment
+// was captured can be emitted as its own orphan transaction (see `_onSpanEnded`) without any span ever
+// being sent in more than one transaction.
+const CAPTURED_SPANS = new WeakSet<Span>();
+
 /**
  * Opt a client into (or out of) deferring its segment-span transaction capture.
  * Set by the SDK client during setup (e.g. the Node SDK); see {@link DEFERRED_SEGMENT_SPAN_CAPTURES}.
@@ -398,9 +403,24 @@ export class SentrySpan implements Span {
     // A segment span is basically the root span of a local span tree.
     // So for now, this is either what we previously refer to as the root span,
     // or a standalone span.
-    const isSegmentSpan = this._isStandaloneSpan || this === getRootSpan(this);
+    const rootSpan = getRootSpan(this);
+    const isSegmentSpan = this._isStandaloneSpan || this === rootSpan;
 
-    if (!isSegmentSpan) {
+    // A child span that ends after its root segment's transaction was already captured can no longer be
+    // part of it. Mirror the OpenTelemetry span exporter, which emits such a late child as its own
+    // (orphan) transaction in the same trace instead of dropping it. Only for clients that defer the
+    // segment capture (the SentryTracerProvider, the no-exporter native-assembly path); other setups
+    // keep the synchronous drop. `CAPTURED_SPANS` is only populated during a non-streaming capture, so
+    // this stays inert under span streaming (where late children stream individually).
+    const isOrphanSegment =
+      !isSegmentSpan &&
+      !!client &&
+      !!DEFERRED_SEGMENT_SPAN_CAPTURES.get(client) &&
+      !isBrowser() &&
+      !CAPTURED_SPANS.has(this) &&
+      CAPTURED_SPANS.has(rootSpan);
+
+    if (!isSegmentSpan && !isOrphanSegment) {
       return;
     }
 
@@ -433,7 +453,7 @@ export class SentrySpan implements Span {
     const deferCapture = client && DEFERRED_SEGMENT_SPAN_CAPTURES.get(client);
     if (client && deferCapture && !isBrowser()) {
       deferCapture(() => {
-        const transactionEvent = this._convertSpanToTransaction();
+        const transactionEvent = this._convertSpanToTransaction({ orphanedFromSentParent: isOrphanSegment });
         if (transactionEvent) {
           // Capture through the client resolved when the span ended, not the scope: a capture that
           // fires on a later tick must reach the client active at span end and never whatever client
@@ -453,7 +473,7 @@ export class SentrySpan implements Span {
   /**
    * Finish the transaction & prepare the event to send to Sentry.
    */
-  private _convertSpanToTransaction(): TransactionEvent | undefined {
+  private _convertSpanToTransaction(options: { orphanedFromSentParent?: boolean } = {}): TransactionEvent | undefined {
     // We can only convert finished spans
     if (!isFullFinishedSpan(spanToJSON(this))) {
       return undefined;
@@ -472,10 +492,22 @@ export class SentrySpan implements Span {
       return undefined;
     }
 
-    // The transaction span itself as well as any potential standalone spans should be filtered out
-    const finishedSpans = getSpanDescendants(this).filter(span => span !== this && !isStandaloneSpan(span));
-
-    const spans = finishedSpans.map(span => spanToJSON(span)).filter(isFullFinishedSpan);
+    // Skip the transaction span itself, standalone spans, and spans already sent in another transaction.
+    // Marking everything we send as captured lets a child that ends later be emitted as its own orphan
+    // transaction (see `_onSpanEnded`) instead of being dropped or sent twice.
+    CAPTURED_SPANS.add(this);
+    const spans: SpanJSON[] = [];
+    for (const descendant of getSpanDescendants(this)) {
+      if (descendant === this || isStandaloneSpan(descendant) || CAPTURED_SPANS.has(descendant)) {
+        continue;
+      }
+      const spanJSON = spanToJSON(descendant);
+      if (!isFullFinishedSpan(spanJSON)) {
+        continue;
+      }
+      CAPTURED_SPANS.add(descendant);
+      spans.push(spanJSON);
+    }
 
     const source = this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
 
@@ -518,6 +550,12 @@ export class SentrySpan implements Span {
         },
       }),
     };
+
+    // Mirror the OpenTelemetry span exporter: tag a transaction whose parent span was already sent (an
+    // orphan emitted from `_onSpanEnded`) so it can be distinguished downstream.
+    if (options.orphanedFromSentParent && transaction.contexts?.trace?.data) {
+      transaction.contexts.trace.data['sentry.parent_span_already_sent'] = true;
+    }
 
     const measurements = timedEventsToMeasurements(this._events);
     const hasMeasurements = measurements && Object.keys(measurements).length;

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -364,11 +364,9 @@ export class SentrySpan implements Span {
     // Non-segment children aren't captured on their own. A registered strategy may re-emit a late child
     // as its own orphan transaction; without one, it's dropped.
     if (!isSegmentSpan) {
-      if (client) {
-        getSegmentSpanCaptureStrategy()?.onChildSpanEnded(this, rootSpan, client, options =>
-          this._convertSpanToTransaction(options),
-        );
-      }
+      getSegmentSpanCaptureStrategy()?.onChildSpanEnded(this, rootSpan, options =>
+        this._convertSpanToTransaction(options),
+      );
       return;
     }
 

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-import type { Client } from '../client';
 import { getClient, getCurrentScope } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { createSpanEnvelope } from '../envelope';
@@ -27,9 +26,7 @@ import type {
 } from '../types/span';
 import type { SpanStatus } from '../types/spanStatus';
 import type { TimedEvent } from '../types/timedEvent';
-import { debounce } from '../utils/debounce';
 import { debug } from '../utils/debug-logger';
-import { isBrowser } from '../utils/isBrowser';
 import { generateSpanId, generateTraceId } from '../utils/propagationContext';
 import {
   addStatusMessageAttribute,
@@ -49,63 +46,11 @@ import { timestampInSeconds } from '../utils/time';
 import { getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { logSpanEnd } from './logSpans';
 import { timedEventsToMeasurements } from './measurement';
+import { getSegmentSpanCaptureStrategy, type SegmentSpanCaptureConvertOptions } from './segmentSpanCaptureStrategy';
 import { hasSpanStreamingEnabled } from './spans/hasSpanStreamingEnabled';
 import { getCapturedScopesOnSpan, markSpanSourceAsExplicit, spanShouldInferOtelSource } from './utils';
 
 const MAX_SPAN_COUNT = 1000;
-
-// Clients whose segment-span transaction capture should be deferred (rather than run synchronously on
-// span end), mapped to the function that queues a deferred capture. Tracked per client rather than as
-// a process-wide flag so pending captures and their timer cannot leak across `Sentry.init()` calls —
-// a client that never opts in is simply absent. Enabled per client by SDKs that assemble transactions
-// from the live span tree on root-span end (e.g. the Node SDK), which would otherwise drop children
-// that close after it. Every other setup keeps its synchronous capture.
-const DEFERRED_SEGMENT_SPAN_CAPTURES = new WeakMap<Client, (capture: () => void) => void>();
-
-// Spans already included in a captured transaction. Used so a child that ends after its root segment
-// was captured can be emitted as its own orphan transaction (see `_onSpanEnded`) without any span ever
-// being sent in more than one transaction.
-const CAPTURED_SPANS = new WeakSet<Span>();
-
-/**
- * Defer a client's segment-span transaction capture. Set once by the SDK during setup (e.g. the Node
- * SDK); see {@link DEFERRED_SEGMENT_SPAN_CAPTURES}. Idempotent, and deferral stays on for the client's
- * lifetime (there is no opt-out: deferral is a set-once-at-setup property, never toggled mid-session).
- *
- * The transaction is otherwise assembled from the live span tree the instant a root span ends, which
- * drops children whose async instrumentation closes them later (a diagnostics-channel `asyncEnd`
- * callback in the same tick, or engine spans replayed on a later tick). A debounced timer (the same one
- * the OpenTelemetry span exporter uses) delays the snapshot just enough for those later span ends to
- * land first. Pending captures are drained synchronously on the client's `flush` hook so
- * `Sentry.flush()` / `client.close()` cannot resolve before they run.
- */
-export function _INTERNAL_setDeferSegmentSpanCapture(client: Client): void {
-  if (DEFERRED_SEGMENT_SPAN_CAPTURES.has(client)) {
-    return;
-  }
-
-  const pendingCaptures = new Set<() => void>();
-  const debouncedDrain = debounce(
-    () => {
-      const captures = [...pendingCaptures];
-      pendingCaptures.clear();
-      for (const capture of captures) {
-        capture();
-      }
-    },
-    1,
-    { maxWait: 100 },
-  );
-
-  client.on('flush', () => {
-    debouncedDrain.flush();
-  });
-
-  DEFERRED_SEGMENT_SPAN_CAPTURES.set(client, capture => {
-    pendingCaptures.add(capture);
-    debouncedDrain();
-  });
-}
 
 /**
  * Span contains all data about a span
@@ -402,24 +347,6 @@ export class SentrySpan implements Span {
     const rootSpan = getRootSpan(this);
     const isSegmentSpan = this._isStandaloneSpan || this === rootSpan;
 
-    // A child span that ends after its root segment's transaction was already captured can no longer be
-    // part of it. Mirror the OpenTelemetry span exporter, which emits such a late child as its own
-    // (orphan) transaction in the same trace instead of dropping it. Only for clients that defer the
-    // segment capture (the SentryTracerProvider, the no-exporter native-assembly path); other setups
-    // keep the synchronous drop. `CAPTURED_SPANS` is only populated during a non-streaming capture, so
-    // this stays inert under span streaming (where late children stream individually).
-    const isOrphanSegment =
-      !isSegmentSpan &&
-      !!client &&
-      !!DEFERRED_SEGMENT_SPAN_CAPTURES.get(client) &&
-      !isBrowser() &&
-      !CAPTURED_SPANS.has(this) &&
-      CAPTURED_SPANS.has(rootSpan);
-
-    if (!isSegmentSpan && !isOrphanSegment) {
-      return;
-    }
-
     // if this is a standalone span, we send it immediately
     if (this._isStandaloneSpan) {
       if (this._sampled) {
@@ -432,7 +359,20 @@ export class SentrySpan implements Span {
         }
       }
       return;
-    } else if (client && hasSpanStreamingEnabled(client)) {
+    }
+
+    // Non-segment children aren't captured on their own. A registered strategy may re-emit a late child
+    // as its own orphan transaction; without one, it's dropped.
+    if (!isSegmentSpan) {
+      if (client) {
+        getSegmentSpanCaptureStrategy()?.onChildSpanEnded(this, rootSpan, client, options =>
+          this._convertSpanToTransaction(options),
+        );
+      }
+      return;
+    }
+
+    if (client && hasSpanStreamingEnabled(client)) {
       // TODO (spans): Remove standalone span custom logic in favor of sending simple v2 web vital spans
       client.emit('afterSegmentSpanEnd', this);
       return;
@@ -440,24 +380,11 @@ export class SentrySpan implements Span {
 
     const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
 
-    // The transaction is assembled synchronously from the live span tree the instant the root span
-    // ends, dropping children whose async instrumentation closes them after it (a diagnostics-channel
-    // `asyncEnd` callback in the same tick, or engine spans replayed on a later tick). Clients that
-    // opted in defer the snapshot via a debounced timer so those later span ends land first; every
-    // other setup keeps its synchronous capture. Never deferred in the browser, where there is no such
-    // pattern and a deferred capture could be lost on page unload.
-    const deferCapture = client && DEFERRED_SEGMENT_SPAN_CAPTURES.get(client);
-    if (client && deferCapture && !isBrowser()) {
-      deferCapture(() => {
-        const transactionEvent = this._convertSpanToTransaction({ orphanedFromSentParent: isOrphanSegment });
-        if (transactionEvent) {
-          // Capture through the client resolved when the span ended, not the scope: a capture that
-          // fires on a later tick must reach the client active at span end and never whatever client
-          // is current when the timer fires (e.g. a different client after re-init), and the scope's
-          // client reference can be reassigned. Only the snapshot is deferred, so late children land.
-          client.captureEvent(transactionEvent, undefined, scope);
-        }
-      });
+    // A registered strategy defers the snapshot so children closing just after the segment still land
+    // (and late ones can orphan); without one, assemble synchronously from the live tree.
+    const strategy = client && getSegmentSpanCaptureStrategy();
+    if (strategy) {
+      strategy.onSegmentSpanEnded(scope, client, options => this._convertSpanToTransaction(options));
     } else {
       const transactionEvent = this._convertSpanToTransaction();
       if (transactionEvent) {
@@ -469,7 +396,7 @@ export class SentrySpan implements Span {
   /**
    * Finish the transaction & prepare the event to send to Sentry.
    */
-  private _convertSpanToTransaction(options: { orphanedFromSentParent?: boolean } = {}): TransactionEvent | undefined {
+  private _convertSpanToTransaction(options: SegmentSpanCaptureConvertOptions = {}): TransactionEvent | undefined {
     // We can only convert finished spans
     if (!isFullFinishedSpan(spanToJSON(this))) {
       return undefined;
@@ -488,20 +415,19 @@ export class SentrySpan implements Span {
       return undefined;
     }
 
-    // Skip the transaction span itself, standalone spans, and spans already sent in another transaction.
-    // Marking everything we send as captured lets a child that ends later be emitted as its own orphan
-    // transaction (see `_onSpanEnded`) instead of being dropped or sent twice.
-    CAPTURED_SPANS.add(this);
+    // Skip the span itself, standalone spans, and (when a strategy tracks it) spans already sent. The
+    // synchronous default passes no hooks, so this bookkeeping stays out of SDKs that don't defer.
+    options.onSpanCaptured?.(this);
     const spans: SpanJSON[] = [];
     for (const descendant of getSpanDescendants(this)) {
-      if (descendant === this || isStandaloneSpan(descendant) || CAPTURED_SPANS.has(descendant)) {
+      if (descendant === this || isStandaloneSpan(descendant) || options.isSpanAlreadyCaptured?.(descendant)) {
         continue;
       }
       const spanJSON = spanToJSON(descendant);
       if (!isFullFinishedSpan(spanJSON)) {
         continue;
       }
-      CAPTURED_SPANS.add(descendant);
+      options.onSpanCaptured?.(descendant);
       spans.push(spanJSON);
     }
 
@@ -546,12 +472,6 @@ export class SentrySpan implements Span {
         },
       }),
     };
-
-    // Mirror the OpenTelemetry span exporter: tag a transaction whose parent span was already sent (an
-    // orphan emitted from `_onSpanEnded`) so it can be distinguished downstream.
-    if (options.orphanedFromSentParent && transaction.contexts?.trace?.data) {
-      transaction.contexts.trace.data['sentry.parent_span_already_sent'] = true;
-    }
 
     const measurements = timedEventsToMeasurements(this._events);
     const hasMeasurements = measurements && Object.keys(measurements).length;

--- a/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
+++ b/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { _INTERNAL_setDeferSegmentSpanCapture } from '../../../src/tracing/deferSegmentSpanCapture';
+import {
+  getSegmentSpanCaptureStrategy,
+  setSegmentSpanCaptureStrategy,
+} from '../../../src/tracing/segmentSpanCaptureStrategy';
+import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
+
+describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
+  afterEach(() => {
+    setSegmentSpanCaptureStrategy(undefined);
+  });
+
+  it('registers the global capture strategy', () => {
+    expect(getSegmentSpanCaptureStrategy()).toBeUndefined();
+
+    _INTERNAL_setDeferSegmentSpanCapture(new TestClient(getDefaultTestClientOptions()));
+
+    expect(getSegmentSpanCaptureStrategy()).toBeDefined();
+  });
+
+  it('registers the flush listener once and is idempotent on repeated enable', () => {
+    const client = new TestClient(getDefaultTestClientOptions());
+    const onSpy = vi.spyOn(client, 'on');
+
+    _INTERNAL_setDeferSegmentSpanCapture(client);
+    _INTERNAL_setDeferSegmentSpanCapture(client);
+
+    expect(onSpy.mock.calls.filter(([hook]) => hook === 'flush')).toHaveLength(1);
+  });
+});

--- a/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
+++ b/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
@@ -108,40 +108,6 @@ describe('deferred segment-span capture', () => {
     expect(transactions[1]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
   });
 
-  it('routes an orphan to the client that sent the segment, not the current client after re-init', () => {
-    const root = startInactiveSpan({ name: 'root' });
-    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
-
-    root.end();
-    vi.advanceTimersByTime(100);
-    expect(transactions).toHaveLength(1); // segment sent on the first client
-
-    // A second `Sentry.init()` swaps in a new client mid-trace, before the late child ends.
-    const reinitTransactions: Event[] = [];
-    const reinitClient = new TestClient(
-      getDefaultTestClientOptions({
-        dsn,
-        tracesSampleRate: 1,
-        beforeSendTransaction: event => {
-          reinitTransactions.push(event);
-          return null;
-        },
-      }),
-    );
-    setCurrentClient(reinitClient);
-    reinitClient.init();
-    _INTERNAL_setDeferSegmentSpanCapture(reinitClient);
-
-    child.end();
-    vi.advanceTimersByTime(100);
-
-    // The orphan lands on the segment's client, not the now-current one.
-    expect(reinitTransactions).toHaveLength(0);
-    expect(transactions).toHaveLength(2);
-    expect(transactions[1]!.transaction).toBe('child');
-    expect(transactions[1]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
-  });
-
   it('drains pending captures synchronously on flush', () => {
     const root = startInactiveSpan({ name: 'root' });
     root.end();

--- a/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
+++ b/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
@@ -1,10 +1,21 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  setCurrentClient,
+  startInactiveSpan,
+  withActiveSpan,
+} from '../../../src';
 import { _INTERNAL_setDeferSegmentSpanCapture } from '../../../src/tracing/deferSegmentSpanCapture';
 import {
   getSegmentSpanCaptureStrategy,
   setSegmentSpanCaptureStrategy,
 } from '../../../src/tracing/segmentSpanCaptureStrategy';
+import type { Event } from '../../../src/types/event';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
+
+const dsn = 'https://123@sentry.io/42';
 
 describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
   afterEach(() => {
@@ -27,5 +38,85 @@ describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
     _INTERNAL_setDeferSegmentSpanCapture(client);
 
     expect(onSpy.mock.calls.filter(([hook]) => hook === 'flush')).toHaveLength(1);
+  });
+});
+
+describe('deferred segment-span capture', () => {
+  let transactions: Event[];
+  let client: TestClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    transactions = [];
+    const options = getDefaultTestClientOptions({
+      dsn,
+      tracesSampleRate: 1,
+      beforeSendTransaction: event => {
+        transactions.push(event);
+        return null;
+      },
+    });
+    client = new TestClient(options);
+    setCurrentClient(client);
+    client.init();
+    _INTERNAL_setDeferSegmentSpanCapture(client);
+  });
+
+  afterEach(() => {
+    setSegmentSpanCaptureStrategy(undefined);
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('includes a child that ends after the segment but before the debounce fires', () => {
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    child.end();
+
+    // The snapshot is deferred, so nothing is captured until the debounce fires.
+    expect(transactions).toHaveLength(0);
+
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]!.spans).toEqual([expect.objectContaining({ description: 'child' })]);
+  });
+
+  it('emits a child that ends after the snapshot as its own orphan transaction', () => {
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    // Segment transaction assembled without the still-open child.
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]!.spans).toEqual([]);
+
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(2);
+    expect(transactions[1]!.transaction).toBe('child');
+    expect(transactions[1]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+  });
+
+  it('drains pending captures synchronously on flush', () => {
+    const root = startInactiveSpan({ name: 'root' });
+    root.end();
+
+    // Still queued behind the debounce timer.
+    expect(transactions).toHaveLength(0);
+
+    client.emit('flush');
+
+    expect(transactions).toHaveLength(1);
   });
 });

--- a/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
+++ b/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
@@ -6,6 +6,7 @@ import {
   setCurrentClient,
   startInactiveSpan,
   withActiveSpan,
+  withScope,
 } from '../../../src';
 import { _INTERNAL_setDeferSegmentSpanCapture } from '../../../src/tracing/deferSegmentSpanCapture';
 import {
@@ -118,5 +119,98 @@ describe('deferred segment-span capture', () => {
     client.emit('flush');
 
     expect(transactions).toHaveLength(1);
+  });
+
+  it("routes a deferred segment to the span's own client, not whichever client is current at end", () => {
+    const otherTransactions: Event[] = [];
+    const otherClient = new TestClient(
+      getDefaultTestClientOptions({
+        dsn,
+        tracesSampleRate: 1,
+        beforeSendTransaction: event => {
+          otherTransactions.push(event);
+          return null;
+        },
+      }),
+    );
+    otherClient.init();
+    _INTERNAL_setDeferSegmentSpanCapture(otherClient);
+
+    // Created while `client` is current, so its captured scope belongs to `client`.
+    const root = startInactiveSpan({ name: 'root' });
+
+    // A different client becomes current before the span ends.
+    withScope(scope => {
+      scope.setClient(otherClient);
+      root.end();
+    });
+
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(1);
+    expect(otherTransactions).toHaveLength(0);
+  });
+
+  it('emits a late orphan synchronously when its client has no defer queue', () => {
+    const orphanTransactions: Event[] = [];
+    const noQueueClient = new TestClient(
+      getDefaultTestClientOptions({
+        dsn,
+        tracesSampleRate: 1,
+        beforeSendTransaction: event => {
+          orphanTransactions.push(event);
+          return null;
+        },
+      }),
+    );
+    noQueueClient.init();
+    // Deliberately not enabling deferral on `noQueueClient`, so it has no queue.
+
+    // Root is captured via `client` (which defers), so it lands in `CAPTURED_SPANS`.
+    const root = startInactiveSpan({ name: 'root' });
+    // The child's captured scope belongs to the queue-less client.
+    const child = withScope(scope => {
+      scope.setClient(noQueueClient);
+      return withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+    });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    expect(transactions).toHaveLength(1);
+    expect(orphanTransactions).toHaveLength(0);
+
+    // Late child on a queue-less client: emitted right away instead of dropped.
+    child.end();
+
+    expect(orphanTransactions).toHaveLength(1);
+    expect(orphanTransactions[0]!.transaction).toBe('child');
+    expect(orphanTransactions[0]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+  });
+
+  it('binds the capturing client at span end, ignoring later reassignment of the scope client', () => {
+    const laterTransactions: Event[] = [];
+    const laterClient = new TestClient(
+      getDefaultTestClientOptions({
+        dsn,
+        tracesSampleRate: 1,
+        beforeSendTransaction: event => {
+          laterTransactions.push(event);
+          return null;
+        },
+      }),
+    );
+    laterClient.init();
+    _INTERNAL_setDeferSegmentSpanCapture(laterClient);
+
+    const root = startInactiveSpan({ name: 'root' });
+    root.end(); // enqueued and bound to `client` (the captured scope's client at span end)
+
+    // The captured scope's own client is reassigned before the debounce fires.
+    getCurrentScope().setClient(laterClient);
+
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(1);
+    expect(laterTransactions).toHaveLength(0);
   });
 });

--- a/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
+++ b/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
@@ -108,6 +108,40 @@ describe('deferred segment-span capture', () => {
     expect(transactions[1]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
   });
 
+  it('routes an orphan to the client that sent the segment, not the current client after re-init', () => {
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    expect(transactions).toHaveLength(1); // segment sent on the first client
+
+    // A second `Sentry.init()` swaps in a new client mid-trace, before the late child ends.
+    const reinitTransactions: Event[] = [];
+    const reinitClient = new TestClient(
+      getDefaultTestClientOptions({
+        dsn,
+        tracesSampleRate: 1,
+        beforeSendTransaction: event => {
+          reinitTransactions.push(event);
+          return null;
+        },
+      }),
+    );
+    setCurrentClient(reinitClient);
+    reinitClient.init();
+    _INTERNAL_setDeferSegmentSpanCapture(reinitClient);
+
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    // The orphan lands on the segment's client, not the now-current one.
+    expect(reinitTransactions).toHaveLength(0);
+    expect(transactions).toHaveLength(2);
+    expect(transactions[1]!.transaction).toBe('child');
+    expect(transactions[1]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+  });
+
   it('drains pending captures synchronously on flush', () => {
     const root = startInactiveSpan({ name: 'root' });
     root.end();

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, test, vi } from 'vitest';
 import { getCurrentScope } from '../../../src/currentScopes';
 import { setCurrentClient } from '../../../src/sdk';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../../../src/semanticAttributes';
-import { _INTERNAL_setDeferSegmentSpanCapture, SentrySpan } from '../../../src/tracing/sentrySpan';
+import { SentrySpan } from '../../../src/tracing/sentrySpan';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing/spanstatus';
 import { markSpanForOtelSourceInference, spanSourceWasExplicitlySet } from '../../../src/tracing/utils';
 import type { SpanJSON } from '../../../src/types/span';
@@ -129,18 +129,6 @@ describe('SentrySpan', () => {
       expect(serialized).toHaveProperty('parent_span_id', 'b');
       expect(serialized).toHaveProperty('span_id', 'd');
       expect(serialized).toHaveProperty('trace_id', 'c');
-    });
-  });
-
-  describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
-    it('registers the flush listener once and is idempotent on repeated enable', () => {
-      const client = new TestClient(getDefaultTestClientOptions());
-      const onSpy = vi.spyOn(client, 'on');
-
-      _INTERNAL_setDeferSegmentSpanCapture(client);
-      _INTERNAL_setDeferSegmentSpanCapture(client);
-
-      expect(onSpy.mock.calls.filter(([hook]) => hook === 'flush')).toHaveLength(1);
     });
   });
 

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, test, vi } from 'vitest';
 import { getCurrentScope } from '../../../src/currentScopes';
 import { setCurrentClient } from '../../../src/sdk';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../../../src/semanticAttributes';
-import { SentrySpan } from '../../../src/tracing/sentrySpan';
+import { _INTERNAL_setDeferSegmentSpanCapture, SentrySpan } from '../../../src/tracing/sentrySpan';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing/spanstatus';
 import { markSpanForOtelSourceInference, spanSourceWasExplicitlySet } from '../../../src/tracing/utils';
 import type { SpanJSON } from '../../../src/types/span';
@@ -129,6 +129,18 @@ describe('SentrySpan', () => {
       expect(serialized).toHaveProperty('parent_span_id', 'b');
       expect(serialized).toHaveProperty('span_id', 'd');
       expect(serialized).toHaveProperty('trace_id', 'c');
+    });
+  });
+
+  describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
+    it('registers the flush listener once and is idempotent on repeated enable', () => {
+      const client = new TestClient(getDefaultTestClientOptions());
+      const onSpy = vi.spyOn(client, 'on');
+
+      _INTERNAL_setDeferSegmentSpanCapture(client);
+      _INTERNAL_setDeferSegmentSpanCapture(client);
+
+      expect(onSpy.mock.calls.filter(([hook]) => hook === 'flush')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
# What

Adds the ability to defer the assembly of transactions to avoid dropping spans from transactions that end shortly after the segment span itself. Additionally, it also handles children that end after the debounce fired and transactions have already been sent. Spans that don't quite make it will end up as their own transaction in the same trace instead of being dropped .

This mimics what is already done today in the span exporter (a buffer + debounced flush).

# Why

SentrySpan assembles a transaction synchronously from the span tree the instant the segment span ends. But some child spans are closed by their instrumentation *after* the root ends.

For example:
- **Same tick:** diagnostics-channel instrumentations (HTTP, undici) end the child in an `asyncEnd`/response callback that runs after the root handler returns.
- **Later tick:** some instrumentations replay spans asynchronously, notably `@prisma/instrumentation` emits its engine spans on a later tick once it receives the engine trace data.

Without deferral those children aren't in the tree yet at root-end, so they're silently dropped from the transaction. With the OTel SDK, this never happened because the `SentrySpanExporter` already buffers finished spans and flushes on a debounced timer. The SentryTracerProvider has no exporter, so defer reinstates that buffering window so late-ending children land before the snapshot.

- **Orphan emission** handles the tail: a child that ends after the debounce fired and the transaction was already sent can't join it, so it is emitted as its own transaction in the same trace instead of being dropped (mirroring the exporter).

This is used and tested in #21680's integration/e2e tests.
