### PR TITLE
ref(server-utils): Ensure ts3.8 has diagnostics channel shim

### DIFF
--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -99,7 +99,7 @@
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "run-s build:types:core build:types:downlevel",
     "build:types:core": "tsc -p tsconfig.types.json",
-    "build:types:downlevel": "yarn downlevel-dts build/types build/types-ts3.8 --to ts3.8",
+    "build:types:downlevel": "yarn downlevel-dts build/types build/types-ts3.8 --to ts3.8 && node scripts/inject-ts38-shims.mjs",
     "build:watch": "run-p build:transpile:watch",
     "build:dev:watch": "run-p build:transpile:watch",
     "build:transpile:watch": "rollup -c rollup.npm.config.mjs --watch",

--- a/packages/server-utils/scripts/inject-ts38-shims.mjs
+++ b/packages/server-utils/scripts/inject-ts38-shims.mjs
@@ -1,0 +1,28 @@
+/**
+ * Injects ambient type shims into the downleveled TS 3.8 declarations.
+ *
+ * `server-utils` re-exports types that reference `node:diagnostics_channel`, a module missing from
+ * the `@types/node@14` the TS 3.8 compatibility check uses. We copy a shim declaring that module into
+ * the ts3.8 output and reference it from the entry point so it is loaded by downstream consumers.
+ * Scoped to ts3.8 only — the modern build resolves the module from `@types/node` directly.
+ */
+import { copyFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const ts38Dir = join(packageRoot, 'build', 'types-ts3.8');
+
+const SHIM_FILENAME = 'node-diagnostics-channel.d.ts';
+const shimSource = join(packageRoot, 'types-shims', SHIM_FILENAME);
+const shimTarget = join(ts38Dir, SHIM_FILENAME);
+
+copyFileSync(shimSource, shimTarget);
+
+const entry = join(ts38Dir, 'index.d.ts');
+const reference = `/// <reference path="./${SHIM_FILENAME}" />\n`;
+const contents = readFileSync(entry, 'utf8');
+
+if (!contents.startsWith(reference)) {
+  writeFileSync(entry, reference + contents);
+}

--- a/packages/server-utils/types-shims/node-diagnostics-channel.d.ts
+++ b/packages/server-utils/types-shims/node-diagnostics-channel.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Ambient shim for `node:diagnostics_channel`, injected into the TS 3.8 type output only
+ * (see `scripts/inject-ts38-shims.mjs`).
+ *
+ * `@types/node@14` — used by the SDK's TS 3.8 compatibility check — predates this module, so the
+ * published declarations that re-export `TracingChannel`/`TracingChannelSubscribers` fail to resolve
+ * it (`TS2307`). The real shapes are irrelevant here: TS 3.8 consumers only need these to type-check,
+ * never to call. This file is deliberately kept out of `src/` so it never participates in the modern
+ * build, where `@types/node` already declares the module.
+ */
+declare module 'node:diagnostics_channel' {
+  export interface TracingChannelSubscribers<ContextType = unknown> {
+    [key: string]: unknown;
+  }
+
+  export interface TracingChannel<StoreType = unknown, ContextType = unknown> {
+    [key: string]: unknown;
+  }
+}


### PR DESCRIPTION
This fails on CI as soon as anything touching DC is exported (type wise) from server-utils, e.g. https://github.com/getsentry/sentry-javascript/actions/runs/28358230203/job/84050855524

This PR injects a minimal type shim for the diagnostics channel module into the 3.8 d.ts file so this works there as well. We can remove this in v11.