### PR TITLE
fix(opentelemetry): Strip leading ? and # from inferred http.query and http.fragment

### DIFF
--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -183,10 +183,12 @@ export function descriptionForHttpMethod(
     data.url = url;
   }
   if (query) {
-    data['http.query'] = query;
+    // Strip the leading `?`/`#` (the `URL.search`/`URL.hash` prefix) so the attribute matches the
+    // canonical format the OTel SDK exporter emits (`getData` in `spanExporter.ts` slices these too).
+    data['http.query'] = query.slice(1);
   }
   if (fragment) {
-    data['http.fragment'] = fragment;
+    data['http.fragment'] = fragment.slice(1);
   }
 
   // If the span kind is neither client nor server, we use the original name

--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -543,6 +543,27 @@ describe('descriptionForHttpMethod', () => {
         source: 'component',
       },
     ],
+    [
+      'strips the leading `?`/`#` from http.query and http.fragment',
+      'GET',
+      {
+        [HTTP_METHOD]: 'GET',
+        [HTTP_URL]: 'https://www.example.com/my-path?id=1#section',
+        [HTTP_TARGET]: '/my-path?id=1#section',
+      },
+      'test name',
+      SpanKind.CLIENT,
+      {
+        op: 'http.client',
+        description: 'GET https://www.example.com/my-path',
+        data: {
+          url: 'https://www.example.com/my-path',
+          'http.query': 'id=1',
+          'http.fragment': 'section',
+        },
+        source: 'url',
+      },
+    ],
   ])('%s', (_, httpMethod, attributes, name, kind, expected) => {
     const actual = descriptionForHttpMethod({ attributes, kind, name }, httpMethod);
     expect(actual).toEqual(expected);


### PR DESCRIPTION
## What

Strip the leading `?`/`#` from the inferred `http.query` and `http.fragment` span attributes in `descriptionForHttpMethod`.

## Why

The inferred values were taken straight from `URL.search`/`URL.hash`, which include the leading `?`/`#`. The OTel SDK span exporter (`getData` in `spanExporter.ts`) slices these off, so the same logical attribute ended up in two different formats depending on the code path. Stripping the prefix here makes both paths emit the same canonical format.
