### PR TITLE
chore: Mark http.query/http.fragment stripping for v11 url.query migration

### DIFF
--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -453,6 +453,9 @@ function getData(span: ReadableSpan): Record<string, unknown> {
     data.url = requestData.url;
   }
 
+  // TODO(v11): emit `url.query`/`url.fragment` (OTel-standard, no leading `?`/`#`) and drop
+  // this stripping + the `http.query`/`http.fragment` attributes. `http.query` is actually specced to
+  // keep the leading `?`, so stripping diverges from our own conventions; `url.query` sidesteps it.
   if (requestData['http.query']) {
     data['http.query'] = requestData['http.query'].slice(1);
   }

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -185,6 +185,8 @@ export function descriptionForHttpMethod(
   if (query) {
     // Strip the leading `?`/`#` (the `URL.search`/`URL.hash` prefix) so the attribute matches the
     // canonical format the OTel SDK exporter emits (`getData` in `spanExporter.ts` slices these too).
+    // TODO(v11): emit `url.query`/`url.fragment` (OTel-standard, no leading `?`/`#`) and drop
+    // this stripping + `http.query`/`http.fragment`; `http.query` is specced to keep the leading `?`.
     data['http.query'] = query.slice(1);
   }
   if (fragment) {


### PR DESCRIPTION
Adds `TODO(v11)` markers at the two spots that strip the leading `?`/`#` from `http.query`/`http.fragment` — the span exporter's `getData` and `parseSpanDescription`'s `descriptionForHttpMethod`.

Per the [discussion on #21848](https://github.com/getsentry/sentry-javascript/pull/21848#issuecomment-4836775085), `http.query` is specced to *keep* the leading `?`, so the stripping diverges from our own conventions. The v11 direction is to emit the OTel-standard `url.query`/`url.fragment` (no leading char, already in `@sentry/conventions`) and drop `http.query`/`http.fragment`.

Comment-only, no behavior change.