### PR TITLE
ref(core): Add `@sentry/conventions` to `@sentry/core` and align versions

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -78,8 +78,6 @@ export function makeBaseNPMConfig(options = {}) {
         preset: 'es2015',
       },
 
-      hoistTransitiveImports: false,
-
       // don't add `"use strict"` to the top of cjs files
       strict: false,
 
@@ -106,7 +104,7 @@ export function makeBaseNPMConfig(options = {}) {
           return false;
         }
 
-        return false;
+        return true;
       },
     },
 

--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -78,6 +78,8 @@ export function makeBaseNPMConfig(options = {}) {
         preset: 'es2015',
       },
 
+      hoistTransitiveImports: false,
+
       // don't add `"use strict"` to the top of cjs files
       strict: false,
 
@@ -104,7 +106,7 @@ export function makeBaseNPMConfig(options = {}) {
           return false;
         }
 
-        return true;
+        return false;
       },
     },
 

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/node": "10.63.0",
     "@sentry/node-core": "10.63.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -106,5 +106,8 @@
   "sideEffects": false,
   "devDependencies": {
     "zod": "^3.24.1"
+  },
+  "dependencies": {
+    "@sentry/conventions": "^0.15.1"
   }
 }

--- a/packages/core/src/semanticAttributes.ts
+++ b/packages/core/src/semanticAttributes.ts
@@ -1,7 +1,7 @@
 /**
  * Use this attribute to represent the source of a span name.
  * Must be one of: custom, url, route, view, component, task
- * TODO(v11): rename this to sentry.span.source'
+ * TODO(v11): remove this export
  */
 export const SEMANTIC_ATTRIBUTE_SENTRY_SOURCE = 'sentry.source';
 

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -138,7 +138,7 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
   const dsc = getDynamicSamplingContextFromClient(span.spanContext().traceId, client);
 
   // We don't want to have a transaction name in the DSC if the source is "url" because URLs might contain PII
-  // TODO(v11): Only read `SEMANTIC_ATTRIBUTE_SENTRY_SOURCE` again, once we renamed it to `sentry.span.source`
+  // TODO(v11): Only read `SENTRY_SPAN_SOURCE` once we removed `SEMANTIC_ATTRIBUTE_SENTRY_SOURCE`
   const source = rootSpanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] ?? rootSpanAttributes[SENTRY_SPAN_SOURCE];
 
   // after JSON conversion, txn.name becomes jsonSpan.description

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -1,3 +1,4 @@
+import { SENTRY_SPAN_SOURCE } from '@sentry/conventions/attributes';
 import type { Client } from '../client';
 import { DEFAULT_ENVIRONMENT } from '../constants';
 import { getClient } from '../currentScopes';
@@ -138,7 +139,7 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
 
   // We don't want to have a transaction name in the DSC if the source is "url" because URLs might contain PII
   // TODO(v11): Only read `SEMANTIC_ATTRIBUTE_SENTRY_SOURCE` again, once we renamed it to `sentry.span.source`
-  const source = rootSpanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] ?? rootSpanAttributes['sentry.span.source'];
+  const source = rootSpanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] ?? rootSpanAttributes[SENTRY_SPAN_SOURCE];
 
   // after JSON conversion, txn.name becomes jsonSpan.description
   const name = rootSpanJson.description;

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -27,6 +27,7 @@ import { getCapturedScopesOnSpan } from '../utils';
 import { isStreamedBeforeSendSpanCallback } from './beforeSendSpan';
 import { scopeContextsToSpanAttributes } from './scopeContextAttributes';
 import { DEFAULT_ENVIRONMENT } from '../../constants';
+import { SENTRY_SPAN_SOURCE } from '@sentry/conventions/attributes';
 
 export type SerializedStreamedSpanWithSegmentSpan = SerializedStreamedSpan & {
   _segmentSpan: Span;
@@ -85,9 +86,7 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
   const spanNameSource = processedSpan.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
   if (spanNameSource) {
     safeSetSpanJSONAttributes(processedSpan, {
-      // Purposefully not using a constant defined here like in other attributes:
-      // This will be the name for SEMANTIC_ATTRIBUTE_SENTRY_SOURCE in v11
-      'sentry.span.source': spanNameSource,
+      [SENTRY_SPAN_SOURCE]: spanNameSource,
     });
   }
 

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -25,6 +25,7 @@ import {
 import { safeSetSpanJSONAttributes } from '../../../../src/tracing/spans/captureSpan';
 import { scopeContextsToSpanAttributes } from '../../../../src/tracing/spans/scopeContextAttributes';
 import { getDefaultTestClientOptions, TestClient } from '../../../mocks/client';
+import { SENTRY_SPAN_SOURCE } from '@sentry/conventions/attributes';
 
 describe('captureSpan', () => {
   it.each([true, false, undefined])(
@@ -86,7 +87,7 @@ describe('captureSpan', () => {
             value: span.spanContext().spanId,
             type: 'string',
           },
-          'sentry.span.source': {
+          [SENTRY_SPAN_SOURCE]: {
             value: 'custom',
             type: 'string',
           },
@@ -187,7 +188,7 @@ describe('captureSpan', () => {
           value: span.spanContext().spanId,
           type: 'string',
         },
-        'sentry.span.source': {
+        [SENTRY_SPAN_SOURCE]: {
           value: 'custom',
           type: 'string',
         },
@@ -283,7 +284,7 @@ describe('captureSpan', () => {
           value: span.spanContext().spanId,
           type: 'string',
         },
-        'sentry.span.source': {
+        [SENTRY_SPAN_SOURCE]: {
           value: 'custom',
           type: 'string',
         },
@@ -348,7 +349,7 @@ describe('captureSpan', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: { type: 'integer', value: 1 },
         [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: { value: 'my-span', type: 'string' },
         [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_ID]: { value: span.spanContext().spanId, type: 'string' },
-        'sentry.span.source': { value: 'custom', type: 'string' },
+        [SENTRY_SPAN_SOURCE]: { value: 'custom', type: 'string' },
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: { value: 'custom', type: 'string' },
         [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { value: '1.0.0', type: 'string' },
         [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { value: 'staging', type: 'string' },

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.214.0",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/node": "10.63.0"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -80,7 +80,7 @@
     "@rollup/plugin-commonjs": "28.0.1",
     "@sentry/browser-utils": "10.63.0",
     "@sentry/bundler-plugin-core": "^5.3.0",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/node": "10.63.0",
     "@sentry/opentelemetry": "10.63.0",

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -101,7 +101,7 @@
     }
   },
   "dependencies": {
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/opentelemetry": "10.63.0",
     "import-in-the-middle": "^3.0.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -68,7 +68,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.214.0",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/node-core": "10.63.0",
     "@sentry/opentelemetry": "10.63.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0"
   },
   "peerDependencies": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/instrumentation": "^0.214.0",
     "@sentry/browser": "10.63.0",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/node": "10.63.0",
     "@sentry/react": "10.63.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -68,7 +68,7 @@
     "@opentelemetry/instrumentation": "^0.214.0",
     "@remix-run/router": "^1.23.3",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/node": "10.63.0",
     "@sentry/react": "10.63.0",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -85,7 +85,7 @@
     "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
     "@apm-js-collab/code-transformer": "^0.15.0",
     "@apm-js-collab/tracing-hooks": "^0.10.1",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "magic-string": "~0.30.0"
   },

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser-utils": "10.63.0",
-    "@sentry/conventions": "^0.12.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.63.0",
     "@sentry/node": "10.63.0",
     "@sentry/react": "10.63.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7482,10 +7482,10 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
-"@sentry/conventions@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.12.0.tgz#e963cf928ac4d1585b1dcc196e767df3ac45ca5c"
-  integrity sha512-z1JQrl/1SLY+8wpzvork6vl+fpsg/oCCxM7HWWhUnI/R+OGNyoIzieQuggX3uUMY7NBtp8UWCQx6FeFazzOF9g==
+"@sentry/conventions@^0.15.1":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.15.1.tgz#5b8888862d1e444678938f5afdd7842bca42f7cc"
+  integrity sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==
 
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"


### PR DESCRIPTION
Adds the `@sentry/conventions` package to core and bumps it everywhere to the latest 0.15.1 version. To make use of the new dependency, this also replaces the `sentry.span.source` constant with the new convention-based export.

We should replace our usage of our own `semanticAttributes.ts` export over time but I'd prefer doing this in follow-up PRs, case-by-case since this will change a lot of files for each attribute. 

ref https://github.com/getsentry/sentry-javascript/issues/18895