### PR TITLE
chore(node-core): Move isCjs to its own file to prevent sideEffects

### DIFF
--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -138,5 +138,7 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/nodeVersion.js"
+  ]
 }

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -138,7 +138,5 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": [
-    "**/nodeVersion.js"
-  ]
+  "sideEffects": false
 }

--- a/packages/node-core/src/common-exports.ts
+++ b/packages/node-core/src/common-exports.ts
@@ -34,7 +34,7 @@ export { getSentryRelease, defaultStackParser } from './sdk/api';
 export { createGetModuleFromFilename } from './utils/module';
 export { addOriginToSpan } from './utils/addOriginToSpan';
 export { initializeEsmLoader } from './sdk/esmLoader';
-export { isCjs } from './utils/detection';
+export { isCjs } from './utils/isCjs';
 export { createMissingInstrumentationContext } from './utils/createMissingInstrumentationContext';
 export { makeNodeTransport, type NodeTransportOptions } from './transports';
 export type { HTTPModuleRequestIncomingMessage } from './transports/http-module';

--- a/packages/node-core/src/integrations/modules.ts
+++ b/packages/node-core/src/integrations/modules.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { GLOBAL_OBJ, type IntegrationFn } from '@sentry/core';
-import { isCjs } from '../utils/detection';
+import { isCjs } from '../utils/isCjs';
 
 type ModuleInfo = Record<string, string>;
 

--- a/packages/node-core/src/light/sdk.ts
+++ b/packages/node-core/src/light/sdk.ts
@@ -28,7 +28,7 @@ import { systemErrorIntegration } from '../integrations/systemError';
 import { defaultStackParser, getSentryRelease } from '../sdk/api';
 import { makeNodeTransport } from '../transports';
 import type { NodeClientOptions, NodeOptions } from '../types';
-import { isCjs } from '../utils/detection';
+import { isCjs } from '../utils/isCjs';
 import { getSpotlightConfig } from '../utils/spotlight';
 import { setAsyncLocalStorageAsyncContextStrategy } from './asyncLocalStorageStrategy';
 import { LightNodeClient } from './client';

--- a/packages/node-core/src/sdk/index.ts
+++ b/packages/node-core/src/sdk/index.ts
@@ -37,7 +37,7 @@ import { consoleIntegration } from '../integrations/console';
 import { systemErrorIntegration } from '../integrations/systemError';
 import { makeNodeTransport } from '../transports';
 import type { NodeClientOptions, NodeOptions } from '../types';
-import { isCjs } from '../utils/detection';
+import { isCjs } from '../utils/isCjs';
 import { getSpotlightConfig } from '../utils/spotlight';
 import { defaultStackParser, getSentryRelease } from './api';
 import { NodeClient } from './client';

--- a/packages/node-core/src/utils/createMissingInstrumentationContext.ts
+++ b/packages/node-core/src/utils/createMissingInstrumentationContext.ts
@@ -1,5 +1,5 @@
 import type { MissingInstrumentationContext } from '@sentry/core';
-import { isCjs } from './detection';
+import { isCjs } from './isCjs';
 
 export const createMissingInstrumentationContext = (pkg: string): MissingInstrumentationContext => ({
   package: pkg,

--- a/packages/node-core/src/utils/detection.ts
+++ b/packages/node-core/src/utils/detection.ts
@@ -1,16 +1,6 @@
 import { consoleSandbox } from '@sentry/core';
 import { NODE_MAJOR, NODE_MINOR } from '../nodeVersion';
-
-/** Detect CommonJS. */
-export function isCjs(): boolean {
-  /*! rollup-include-cjs-only */
-  return true;
-  /*! rollup-include-cjs-only-end */
-
-  /*! rollup-include-esm-only */
-  return false;
-  /*! rollup-include-esm-only-end */
-}
+import { isCjs } from './isCjs';
 
 let hasWarnedAboutNodeVersion: boolean | undefined;
 

--- a/packages/node-core/src/utils/ensureIsWrapped.ts
+++ b/packages/node-core/src/utils/ensureIsWrapped.ts
@@ -10,7 +10,7 @@ import {
 } from '@sentry/core';
 import type { NodeClient } from '../sdk/client';
 import { createMissingInstrumentationContext } from './createMissingInstrumentationContext';
-import { isCjs } from './detection';
+import { isCjs } from './isCjs';
 
 /**
  * Checks and warns if a framework isn't wrapped by opentelemetry.

--- a/packages/node-core/src/utils/isCjs.ts
+++ b/packages/node-core/src/utils/isCjs.ts
@@ -1,0 +1,10 @@
+/** Detect CommonJS. */
+export function isCjs(): boolean {
+  /*! rollup-include-cjs-only */
+  return true;
+  /*! rollup-include-cjs-only-end */
+
+  /*! rollup-include-esm-only */
+  return false;
+  /*! rollup-include-esm-only-end */
+}


### PR DESCRIPTION
It seems that `node-core` has `../nodeVersion.js` as a sideEffect: https://unpkg.com/@sentry/node-core@10.62.0/build/esm/integrations/modules.js

Actually `nodeVersion` doesn't do anything, so it is not really a side effect. But I also couldn't get rid of that import with the [__PURE__](https://rollupjs.org/configuration-options/#pure) comments - so if someone has a better idea, I'm up for it

This came up while implementing a test for Cloudflare, where I used the Prisma integration within Cloudflare:

<img width="698" height="194" alt="Screenshot 2026-06-30 at 10 54 39" src="https://github.com/user-attachments/assets/6bcaa13c-229f-4a52-86cd-62799a3d2ab6" />
