### PR TITLE
chore(opentelemetry): Add worker as export | sort exports

### DIFF
--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -18,29 +18,20 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": {
-        "node": {
-          "types": "./build/types/index.d.ts",
-          "default": "./build/esm/index.js"
-        },
-        "browser": {
-          "types": "./build/types/index.d.ts",
-          "default": "./build/esm/index.browser.js"
-        },
-        "types": "./build/types/index.d.ts",
-        "default": "./build/esm/index.js"
+      "types": "./build/types/index.d.ts",
+      "import": "./build/esm/index.js",
+      "require": "./build/cjs/index.js",
+      "node": {
+        "import": "./build/esm/index.js",
+        "require": "./build/cjs/index.js"
       },
-      "require": {
-        "node": {
-          "types": "./build/types/index.d.ts",
-          "default": "./build/cjs/index.js"
-        },
-        "browser": {
-          "types": "./build/types/index.d.ts",
-          "default": "./build/cjs/index.browser.js"
-        },
-        "types": "./build/types/index.d.ts",
-        "default": "./build/cjs/index.js"
+      "worker": {
+        "import": "./build/esm/index.js",
+        "require": "./build/cjs/index.js"
+      },
+      "browser": {
+        "import": "./build/esm/index.browser.js",
+        "require": "./build/cjs/index.browser.js"
       }
     }
   },

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -19,8 +19,6 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./build/types/index.d.ts",
-      "import": "./build/esm/index.js",
-      "require": "./build/cjs/index.js",
       "node": {
         "import": "./build/esm/index.js",
         "require": "./build/cjs/index.js"
@@ -32,7 +30,9 @@
       "browser": {
         "import": "./build/esm/index.browser.js",
         "require": "./build/cjs/index.browser.js"
-      }
+      },
+      "import": "./build/esm/index.js",
+      "require": "./build/cjs/index.js"
     }
   },
   "typesVersions": {

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -31,8 +31,10 @@
         "import": "./build/esm/index.browser.js",
         "require": "./build/cjs/index.browser.js"
       },
-      "import": "./build/esm/index.js",
-      "require": "./build/cjs/index.js"
+      "default": {
+        "import": "./build/esm/index.js",
+        "require": "./build/cjs/index.js"
+      }
     }
   },
   "typesVersions": {


### PR DESCRIPTION
In the future we need to import from `@sentry/opentelemetry`. As there is now a `browser` export we go into that path, based on [the wrangler's build preferences](https://github.com/cloudflare/workers-sdk/blob/3f39c7e48c76fbba06dd921beae9d0949573eaa8/packages/wrangler/src/deployment-bundle/bundle.ts#L74). As of now, the browser entrypoint is only here to print a warning - which would also happen on Cloudflare. 

In order to use the correct entrypoint in Cloudflare the `worker` entry has been added.

---

On top I also sorted the exports to match the other `package.json`s. Instead of `import -> node -> default` it is now `node -> import` (so it is one depth less)

