### PR TITLE
test(node-integration-tests): Retry transient docker compose up failures

### DIFF
--- a/dev-packages/node-integration-tests/utils/runner/createRunner.ts
+++ b/dev-packages/node-integration-tests/utils/runner/createRunner.ts
@@ -563,10 +563,22 @@ async function runDockerCompose(options: DockerOptions): Promise<VoidFunction> {
   // ensure we're starting fresh
   close();
 
-  const result = spawnSync('docker', ['compose', 'up', '-d', '--wait'], {
-    cwd,
-    stdio: process.env.DEBUG ? 'inherit' : 'pipe',
-  });
+  const composeUp = (): ReturnType<typeof spawnSync> =>
+    spawnSync('docker', ['compose', 'up', '-d', '--wait'], {
+      cwd,
+      stdio: process.env.DEBUG ? 'inherit' : 'pipe',
+    });
+
+  // `docker compose up` occasionally fails on CI with transient daemon races
+  // (e.g. "failed to set up container networking: network <x>_default not
+  // found" right after the network was created). A clean teardown plus retry
+  // clears these, while genuine healthcheck failures stay red on every attempt.
+  const maxAttempts = 3;
+  let result = composeUp();
+  for (let attempt = 1; attempt < maxAttempts && result.status !== 0; attempt++) {
+    close();
+    result = composeUp();
+  }
 
   if (result.status !== 0) {
     const stderr = result.stderr?.toString() ?? '';


### PR DESCRIPTION
Docker-backed integration suites intermittently go red before any test logic runs. `runDockerCompose` executed `docker compose up --wait` exactly once and threw on the first non-zero exit, so transient Docker daemon races became build failures.

This retries `up` up to 3 times, tearing down between attempts. Real healthcheck failures stay red on every attempt, so only the transient infra races are absorbed.

### Root cause

The flake surfaces as the daemon creating the compose network and then losing it as the container starts:

```
 Network mysql2_default  Created
 Container integration-tests-knex-mysql2  Starting
Error response from daemon: failed to set up container networking: network mysql2_default not found
```

This is a containerd/libnetwork race (more likely with 16 docker suites running concurrently under vitest threads), not a problem with the instrumentation under test.

Fixes #21752
Fixes #21751