### PR TITLE
test(node): Improve tests for Prisma v5

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/scenario.mjs
@@ -20,6 +20,18 @@ async function run() {
 
       await client.user.findMany();
 
+      // Interactive transaction: exercises `prisma:client:transaction` and its nested engine spans.
+      await client.$transaction(async tx => {
+        await tx.user.create({
+          data: {
+            name: 'Burt',
+            email: `burt_${randomBytes(4).toString('hex')}@sentry.io`,
+          },
+        });
+
+        await tx.user.findMany();
+      });
+
       await client.user.deleteMany({
         where: {
           email: {

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -29,8 +29,7 @@ describe('Prisma ORM v5 Tests', () => {
               expect(operationSpans.length).toBeGreaterThanOrEqual(1);
 
               // The db-query spans are materialized from the raw engine event; assert they nest inside the
-              // transaction (their parent is another span in it) rather than dangling as orphans — a flat
-              // `toContainEqual` check below would pass for an orphaned span too.
+              // transaction (their parent is another span in it) rather than dangling as orphans.
               const dbSpans = spans.filter(s => s.op === 'db');
               expect(dbSpans.length).toBeGreaterThanOrEqual(1);
               dbSpans.forEach(dbSpan => {

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -23,34 +23,19 @@ describe('Prisma ORM v5 Tests', () => {
               const spans = transaction.spans || [];
               expect(spans.length).toBeGreaterThanOrEqual(5);
 
-              const rootSpanId = transaction.contexts?.trace?.span_id;
-              expect(rootSpanId).toBeDefined();
-
-              const spansById = new Map(spans.map(s => [s.span_id, s]));
-
-              // A flat `toContainEqual` check passes even for an orphaned span, so also assert every span
-              // reaches the transaction root. Transitive, not parent equality: `$transaction` operations
-              // nest under `prisma:client:transaction`, not directly under the root.
-              const reachesRoot = (span: (typeof spans)[number]): boolean => {
-                let current: (typeof spans)[number] | undefined = span;
-                for (let hops = 0; current && hops < 50; hops++) {
-                  if (current.parent_span_id === rootSpanId) {
-                    return true;
-                  }
-                  current = spansById.get(current.parent_span_id!);
-                }
-                return false;
-              };
-
-              spans.forEach(span => {
-                expect(reachesRoot(span)).toBe(true);
-              });
+              const spanIds = new Set(spans.map(s => s.span_id));
 
               const operationSpans = spans.filter(s => s.description === 'prisma:client:operation');
               expect(operationSpans.length).toBeGreaterThanOrEqual(1);
 
+              // The db-query spans are materialized from the raw engine event; assert they nest inside the
+              // transaction (their parent is another span in it) rather than dangling as orphans — a flat
+              // `toContainEqual` check below would pass for an orphaned span too.
               const dbSpans = spans.filter(s => s.op === 'db');
               expect(dbSpans.length).toBeGreaterThanOrEqual(1);
+              dbSpans.forEach(dbSpan => {
+                expect(spanIds.has(dbSpan.parent_span_id!)).toBe(true);
+              });
 
               const txSpan = spans.find(s => s.description === 'prisma:client:transaction');
               expect(txSpan).toBeDefined();

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -23,6 +23,38 @@ describe('Prisma ORM v5 Tests', () => {
               const spans = transaction.spans || [];
               expect(spans.length).toBeGreaterThanOrEqual(5);
 
+              const rootSpanId = transaction.contexts?.trace?.span_id;
+              expect(rootSpanId).toBeDefined();
+
+              const spansById = new Map(spans.map(s => [s.span_id, s]));
+
+              // A flat `toContainEqual` check passes even for an orphaned span, so also assert every span
+              // reaches the transaction root. Transitive, not parent equality: `$transaction` operations
+              // nest under `prisma:client:transaction`, not directly under the root.
+              const reachesRoot = (span: (typeof spans)[number]): boolean => {
+                let current: (typeof spans)[number] | undefined = span;
+                for (let hops = 0; current && hops < 50; hops++) {
+                  if (current.parent_span_id === rootSpanId) {
+                    return true;
+                  }
+                  current = spansById.get(current.parent_span_id!);
+                }
+                return false;
+              };
+
+              spans.forEach(span => {
+                expect(reachesRoot(span)).toBe(true);
+              });
+
+              const operationSpans = spans.filter(s => s.description === 'prisma:client:operation');
+              expect(operationSpans.length).toBeGreaterThanOrEqual(1);
+
+              const dbSpans = spans.filter(s => s.op === 'db');
+              expect(dbSpans.length).toBeGreaterThanOrEqual(1);
+
+              const txSpan = spans.find(s => s.description === 'prisma:client:transaction');
+              expect(txSpan).toBeDefined();
+
               expect(spans).toContainEqual(
                 expect.objectContaining({
                   data: {

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -23,17 +23,18 @@ describe('Prisma ORM v5 Tests', () => {
               const spans = transaction.spans || [];
               expect(spans.length).toBeGreaterThanOrEqual(5);
 
-              const spanIds = new Set(spans.map(s => s.span_id));
+              // Valid parents are the transaction root or any other span within the transaction.
+              const validParentIds = new Set([transaction.contexts?.trace?.span_id, ...spans.map(s => s.span_id)]);
 
               const operationSpans = spans.filter(s => s.description === 'prisma:client:operation');
               expect(operationSpans.length).toBeGreaterThanOrEqual(1);
 
               // The db-query spans are materialized from the raw engine event; assert they nest inside the
-              // transaction (their parent is another span in it) rather than dangling as orphans.
+              // transaction rather than dangling as orphans.
               const dbSpans = spans.filter(s => s.op === 'db');
               expect(dbSpans.length).toBeGreaterThanOrEqual(1);
               dbSpans.forEach(dbSpan => {
-                expect(spanIds.has(dbSpan.parent_span_id!)).toBe(true);
+                expect(validParentIds.has(dbSpan.parent_span_id)).toBe(true);
               });
 
               const txSpan = spans.find(s => s.description === 'prisma:client:transaction');


### PR DESCRIPTION
Improve tests for Prisma v5. Add a transaction scenario and assert all spans have parents within the transaction.