### PR TITLE
feat(cloudflare): Add nodejs_compat entrypoint

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -36,6 +36,16 @@
         "types": "./build/types/request.d.ts",
         "default": "./build/cjs/request.js"
       }
+    },
+    "./nodejs_compat": {
+      "import": {
+        "types": "./build/types/nodejs_compat/index.d.ts",
+        "default": "./build/esm/nodejs_compat/index.js"
+      },
+      "require": {
+        "types": "./build/types/nodejs_compat/index.d.ts",
+        "default": "./build/cjs/nodejs_compat/index.js"
+      }
     }
   },
   "typesVersions": {

--- a/packages/cloudflare/rollup.npm.config.mjs
+++ b/packages/cloudflare/rollup.npm.config.mjs
@@ -1,3 +1,7 @@
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '@sentry-internal/rollup-utils';
 
-export default makeNPMConfigVariants(makeBaseNPMConfig());
+export default makeNPMConfigVariants(
+  makeBaseNPMConfig({
+    entrypoints: ['src/index.ts', 'src/nodejs_compat/index.ts'],
+  }),
+);

--- a/packages/cloudflare/src/nodejs_compat/index.ts
+++ b/packages/cloudflare/src/nodejs_compat/index.ts
@@ -1,0 +1,1 @@
+export * from '../index';


### PR DESCRIPTION
This adds a new `/nodejs_compat` export, which will be used for all features which requires the `nodejs_compat` compatibility flag in wrangler. In v11 this will all be merged into the default entrypoint `@sentry/cloudflare`. But currently in v10 we suggested to use `nodejs_als`, which is way to little featues and it would simply throw on startup if we wouldn't have a different entrypoint.

It will have everything the normal entrypoint has, so it is easier to switch to this entrypoint by just using doing the following:

```diff
- import * as Sentry from '@sentry/cloudflare';
+ import * as Sentry from '@sentry/cloudflare/nodejs_compat';
```

The name of the entrypoint (`nodejs_compat`) is not final - so if there are better suggestions, please go ahead