### PR TITLE
chore(cloudflare): Disallow Node SDK usage outside of nodejs_compat

### DIFF
--- a/packages/cloudflare/.oxlintrc.json
+++ b/packages/cloudflare/.oxlintrc.json
@@ -14,7 +14,24 @@
     {
       "files": ["**/src/**"],
       "rules": {
-        "sdk/no-class-field-initializers": "off"
+        "sdk/no-class-field-initializers": "off",
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "@sentry/node",
+                "message": "Do not import from `@sentry/node` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": ["**/src/nodejs_compat/**"],
+      "rules": {
+        "no-restricted-imports": "off"
       }
     }
   ]


### PR DESCRIPTION
To not by accident import `@sentry/node` somewhere in the main entrypoint, the linting rule should allow the usage of the node SDK only within the `nodejs_compat` folder