### PR TITLE
test(node): Ensure logs are auto-printed when a test fails

### DIFF
--- a/dev-packages/node-integration-tests/utils/runner/createEsmAndCjsTests.ts
+++ b/dev-packages/node-integration-tests/utils/runner/createEsmAndCjsTests.ts
@@ -50,14 +50,28 @@ export function createEsmAndCjsTests(
   const createdRunners = new Set<ReturnType<typeof createRunner>>();
 
   callback(
-    () => trackRunner(createdRunners, createRunner(paths.esm.scenario).withFlags('--import', paths.esm.instrument)),
+    () => {
+      const runner = createRunner(paths.esm.scenario).withFlags('--import', paths.esm.instrument);
+      // Expected failure — don't dump the child's captured output for these.
+      if (options?.failsOnEsm) {
+        runner.suppressErrorLogs();
+      }
+      return trackRunner(createdRunners, runner);
+    },
     esmTestFn,
     'esm',
     tmpDirPath,
   );
 
   callback(
-    () => trackRunner(createdRunners, createRunner(paths.cjs.scenario).withFlags('--require', paths.cjs.instrument)),
+    () => {
+      const runner = createRunner(paths.cjs.scenario).withFlags('--require', paths.cjs.instrument);
+      // Expected failure — don't dump the child's captured output for these.
+      if (options?.failsOnCjs) {
+        runner.suppressErrorLogs();
+      }
+      return trackRunner(createdRunners, runner);
+    },
     cjsTestFn,
     'cjs',
     tmpDirPath,

--- a/dev-packages/node-integration-tests/utils/runner/createRunner.ts
+++ b/dev-packages/node-integration-tests/utils/runner/createRunner.ts
@@ -248,6 +248,32 @@ export function createRunner(...paths: string[]) {
         child?.kill();
       }
 
+      /**
+       * Print everything the child process wrote to stdout/stderr. Called when a test fails or
+       * times out so the captured output is visible in CI logs. Skipped when `DEBUG` is set, since
+       * that already streams the same lines live as they arrive.
+       */
+      function dumpCapturedLogs(): void {
+        // When in debug mode, this is already printed anyhow
+        if (process.env.DEBUG) {
+          return;
+        }
+
+        // eslint-disable-next-line no-console
+        console.log(`\n--- Captured child process output for ${testPath} ---`);
+        if (logs.length === 0) {
+          // eslint-disable-next-line no-console
+          console.log('(no output captured)');
+        } else {
+          for (const line of logs) {
+            // eslint-disable-next-line no-console
+            console.log(line);
+          }
+        }
+        // eslint-disable-next-line no-console
+        console.log('--- End of captured child process output ---\n');
+      }
+
       /** Called after each expect callback to check if we're complete */
       function expectCallbackCalled(): void {
         envelopeCount++;
@@ -472,9 +498,18 @@ export function createRunner(...paths: string[]) {
 
       return {
         completed: async function (): Promise<void> {
-          await waitFor(() => isComplete, 120_000, 'Timed out waiting for test to complete');
+          try {
+            await waitFor(() => isComplete, 120_000, 'Timed out waiting for test to complete');
+          } catch (e) {
+            // On timeout, dump the captured child output (same info `DEBUG=1` would have streamed live)
+            // so CI failures are diagnosable without re-running locally with DEBUG enabled.
+            dumpCapturedLogs();
+            throw e;
+          }
 
           if (completeError) {
+            // Same rationale as the timeout branch: surface what the child actually logged before failing.
+            dumpCapturedLogs();
             throw completeError;
           }
         },

--- a/dev-packages/node-integration-tests/utils/runner/createRunner.ts
+++ b/dev-packages/node-integration-tests/utils/runner/createRunner.ts
@@ -136,6 +136,10 @@ export function createRunner(...paths: string[]) {
   let withSentryServer = false;
   let dockerOptions: DockerOptions | undefined;
   let ensureNoErrorOutput = false;
+  // When set, the test using this runner expects `completed()` to reject (e.g. `test.fails` variants
+  // created via `createEsmAndCjsTests` with `failsOnEsm`/`failsOnCjs`). We suppress the captured-log
+  // dump in that case, since the failure is expected and the output would just be noise.
+  let suppressErrorLogs = false;
   const logs: string[] = [];
 
   if (testPath.endsWith('.ts')) {
@@ -227,6 +231,14 @@ export function createRunner(...paths: string[]) {
       ensureNoErrorOutput = true;
       return this;
     },
+    /**
+     * Mark this runner's test as expected to fail (i.e. `completed()` is expected to reject).
+     * Suppresses the captured-log dump so expected failures don't emit noisy output.
+     */
+    suppressErrorLogs: function () {
+      suppressErrorLogs = true;
+      return this;
+    },
     start: function (): StartResult {
       let isComplete = false;
       let completeError: Error | undefined;
@@ -254,8 +266,9 @@ export function createRunner(...paths: string[]) {
        * that already streams the same lines live as they arrive.
        */
       function dumpCapturedLogs(): void {
-        // When in debug mode, this is already printed anyhow
-        if (process.env.DEBUG) {
+        // Skip when the failure is expected (`test.fails` variants) — the output would just be noise.
+        // In debug mode the same lines are already streamed live, so skip then too.
+        if (process.env.DEBUG || suppressErrorLogs) {
           return;
         }
 


### PR DESCRIPTION
We can opt-in to show sub process logs in node-integration-tests with `DEBUG=1`. This PR adjusts this so that we automatically show logs when a test fails. For example, in addition to this:

```
 FAIL  suites/express/tracing/test.ts > express tracing > should create and send transactions for Express routes and spans for middlewares. xxxx [esm]
 FAIL  suites/express/tracing/test.ts > express tracing > should create and send transactions for Express routes and spans for middlewares. xxxx [cjs]
Error: Timed out waiting for server port
 ❯ waitFor utils/runner/createRunner.ts:648:13
    646|     remaining -= 100;
    647|     if (remaining < 0) {
    648|       throw new Error(message);
       |             ^
    649|     }
    650|   }
 ❯ Object.makeRequest utils/runner/createRunner.ts:533:13
```


You may see:

```
stdout | suites/express/tracing/test.ts > express tracing > should create and send transactions for Express routes and spans for middlewares. xxxx [esm]

--- Captured child process output for /Users/francesco/git/sentry-javascript-2/dev-packages/node-integration-tests/suites/express/tracing/tmp_mr21unou_f00oan/scenario.mjs ---
file:///Users/francesco/git/sentry-javascript-2/dev-packages/node-integration-tests/suites/express/tracing/tmp_mr21unou_f00oan/instrument.mjs:5
Sentry.blasdabs();
       ^

TypeError: Sentry.blasdabs is not a function
    at file:///Users/francesco/git/sentry-javascript-2/dev-packages/node-integration-tests/suites/express/tracing/tmp_mr21unou_f00oan/instrument.mjs:5:8
    at ModuleJob.run (node:internal/modules/esm/module_job:325:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:112:9)

Node.js v20.19.5
--- End of captured child process output ---
```

Which should hopefully make it easier to figure out some test failures etc.