### PR TITLE
test(e2e/nitro-3): Pin rolldown to 1.1.3 to fix build

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nitro-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/package.json
@@ -20,7 +20,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "latest || *",
     "nitro": "^3.0.260522-beta",
-    "rolldown": "latest",
+    "rolldown": "1.1.3",
     "vite": "latest"
   },
   "volta": {


### PR DESCRIPTION
The `E2E nitro-3 Test` job fails at the **Build E2E app** step with:

```
SyntaxError: Named export 'nodeFileTrace' not found. The requested module '@vercel/nft' is a CommonJS module…
```

**Trigger:** `rolldown@1.1.4`, published 2026-07-01 (the failing run has `rolldown@1.1.4` in its stack). It tightened CJS→ESM named-export interop, so nitro's `import { nodeFileTrace }` from the CommonJS `@vercel/nft` no longer resolves at build time. The nitro-3 app tracked `rolldown: latest` with no committed lockfile, so a fresh CI install grabbed 1.1.4 hours after publish. `nitro` (3 weeks old, resolves to the exact pinned beta) and `@vercel/nft` (5+ weeks) did not move.

Pins `rolldown` to the last-good `1.1.3`. **Verified locally**: `pnpm build` fails on `1.1.4`, succeeds on `1.1.3` (`✓ built`). Scoped to nitro-3 — the only app that pins `rolldown` directly and the only E2E job that failed.

Unrelated to any SDK change; unblocks the E2E gate for all open PRs. Cleanup debt: revert to `latest` once rolldown restores the interop (or nitro/@vercel/nft adapt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)