### PR TITLE
test(e2e): Fix failing nitro-3 e2e test due to broken dependency

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nitro-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/package.json
@@ -25,5 +25,10 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "nf3": "0.3.17"
+    }
   }
 }


### PR DESCRIPTION
Latest `nf3` release breaks due to it importing `@vercel/nft` which is CJS only: https://github.com/unjs/nf3/issues/52

 This causes our `nitro-3` e2e test to fail. This PR overrides `nf3` to the last good version. We should revert this PR once nf3 ships a fix.