### PR TITLE
ci: Increase Node integration test timeout to 20 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -778,7 +778,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     if: needs.job_build.outputs.changed_node_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `job_node_integration_tests` job has a 15 minute `timeout-minutes`, which is too close to the combined time of dependency install plus the actual test runtime. This leaves no headroom and leads to occasional timeout failures. Bumping to 20 minutes.