### PR TITLE
test(node): Increase TS3.8 node integration test timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -778,7 +778,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     if: needs.job_build.outputs.changed_node_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
-    timeout-minutes: 15
+    timeout-minutes: ${{ (matrix.node == 24 && matrix.typescript == '3.8') && 20 || 15 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This test keeps timing out because installing TS3.8 dependencies takes 3-4 minutes. Node integration tests run ~10 minutes. Seems like this just pushes it over the edge.