### PR TITLE
feat(cloudflare): Enable AI v7 support for Cloudflare in the /nodejs_compat entrypoint

### DIFF
--- a/dev-packages/cloudflare-integration-tests/package.json
+++ b/dev-packages/cloudflare-integration-tests/package.json
@@ -13,6 +13,7 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "ai": "^6.0.0",
     "@langchain/langgraph": "^1.0.1",
     "@prisma/adapter-d1": "6.15.0",
     "@prisma/client": "6.15.0",

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/index.ts
@@ -1,0 +1,37 @@
+import * as Sentry from '@sentry/cloudflare';
+import { generateText } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1,
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  {
+    async fetch(_request, _env, _ctx) {
+      await generateText({
+        experimental_telemetry: { isEnabled: true },
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              inputTokens: { total: 10, noCache: 10, cached: 0 },
+              outputTokens: { total: 20, noCache: 20, cached: 0 },
+              totalTokens: { total: 30, noCache: 30, cached: 0 },
+            },
+            content: [{ type: 'text', text: 'Hello from mock AI!' }],
+            warnings: [],
+          }),
+        }),
+        prompt: 'Where is the first span?',
+      });
+
+      return new Response('ok');
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/test.ts
@@ -4,7 +4,7 @@ import {
   GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
   GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
   GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
-} from '../../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
+} from '../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
 import { createRunner } from '../../../../runner';
 
 it('captures a transaction with Vercel AI v6 spans via @sentry/cloudflare vercelAIIntegration', async ({ signal }) => {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from 'vitest';
+import {
+  GEN_AI_OPERATION_NAME_ATTRIBUTE,
+  GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
+} from '../../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
+import { createRunner } from '../../../../runner';
+
+it('captures a transaction with Vercel AI v6 spans via @sentry/cloudflare vercelAIIntegration', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .ignore('event')
+    .expect(envelope => {
+      const transactionEvent = envelope[1]?.[0]?.[1] as any;
+      expect(transactionEvent.transaction).toBe('GET /');
+
+      const container = envelope[1]?.[1]?.[1] as any;
+      expect(container).toBeDefined();
+
+      expect(container.items).toHaveLength(2);
+      expect(container.items).toEqual(
+        expect.arrayContaining([
+          {
+            trace_id: expect.any(String),
+            span_id: expect.any(String),
+            parent_span_id: expect.any(String),
+            name: 'invoke_agent',
+            start_timestamp: expect.any(Number),
+            end_timestamp: expect.any(Number),
+            status: 'ok',
+            is_segment: false,
+            attributes: expect.objectContaining({
+              'sentry.op': { type: 'string', value: 'gen_ai.invoke_agent' },
+              'sentry.origin': { type: 'string', value: 'auto.vercelai.otel' },
+              [GEN_AI_OPERATION_NAME_ATTRIBUTE]: { type: 'string', value: 'invoke_agent' },
+              [GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]: { type: 'integer', value: 10 },
+              [GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]: { type: 'integer', value: 20 },
+              [GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]: { type: 'integer', value: 30 },
+            }),
+          },
+          {
+            trace_id: expect.any(String),
+            span_id: expect.any(String),
+            parent_span_id: expect.any(String),
+            name: 'generate_content mock-model-id',
+            start_timestamp: expect.any(Number),
+            end_timestamp: expect.any(Number),
+            status: 'ok',
+            is_segment: false,
+            attributes: expect.objectContaining({
+              'sentry.op': { type: 'string', value: 'gen_ai.generate_content' },
+              'sentry.origin': { type: 'string', value: 'auto.vercelai.otel' },
+              [GEN_AI_OPERATION_NAME_ATTRIBUTE]: { type: 'string', value: 'generate_content' },
+            }),
+          },
+        ]),
+      );
+    })
+    .start(signal);
+
+  await runner.makeRequest('get', '/');
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "vercelai-v6-worker",
+  "compatibility_date": "2026-04-26",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_als"],
+}

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/index.ts
@@ -1,0 +1,37 @@
+import * as Sentry from '@sentry/cloudflare/nodejs_compat';
+import { generateText } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1,
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  {
+    async fetch(_request, _env, _ctx) {
+      await generateText({
+        experimental_telemetry: { isEnabled: true },
+        model: new MockLanguageModelV3({
+          doGenerate: async () => ({
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              inputTokens: { total: 10, noCache: 10, cached: 0 },
+              outputTokens: { total: 20, noCache: 20, cached: 0 },
+              totalTokens: { total: 30, noCache: 30, cached: 0 },
+            },
+            content: [{ type: 'text', text: 'Hello from mock AI!' }],
+            warnings: [],
+          }),
+        }),
+        prompt: 'Where is the first span?',
+      });
+
+      return new Response('ok');
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/test.ts
@@ -1,0 +1,65 @@
+import { expect, it } from 'vitest';
+import {
+  GEN_AI_OPERATION_NAME_ATTRIBUTE,
+  GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
+  GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
+} from '../../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
+import { createRunner } from '../../../../runner';
+
+it('captures a transaction with Vercel AI v6 spans via @sentry/cloudflare/nodejs_compat vercelAIIntegration', async ({
+  signal,
+}) => {
+  const runner = createRunner(__dirname)
+    .ignore('event')
+    .expect(envelope => {
+      const transactionEvent = envelope[1]?.[0]?.[1] as any;
+      expect(transactionEvent.transaction).toBe('GET /');
+
+      const container = envelope[1]?.[1]?.[1] as any;
+      expect(container).toBeDefined();
+
+      expect(container.items).toHaveLength(2);
+      expect(container.items).toEqual(
+        expect.arrayContaining([
+          {
+            trace_id: expect.any(String),
+            span_id: expect.any(String),
+            parent_span_id: expect.any(String),
+            name: 'invoke_agent',
+            start_timestamp: expect.any(Number),
+            end_timestamp: expect.any(Number),
+            status: 'ok',
+            is_segment: false,
+            attributes: expect.objectContaining({
+              'sentry.op': { type: 'string', value: 'gen_ai.invoke_agent' },
+              'sentry.origin': { type: 'string', value: 'auto.vercelai.otel' },
+              [GEN_AI_OPERATION_NAME_ATTRIBUTE]: { type: 'string', value: 'invoke_agent' },
+              [GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE]: { type: 'integer', value: 10 },
+              [GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE]: { type: 'integer', value: 20 },
+              [GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE]: { type: 'integer', value: 30 },
+            }),
+          },
+          {
+            trace_id: expect.any(String),
+            span_id: expect.any(String),
+            parent_span_id: expect.any(String),
+            name: 'generate_content mock-model-id',
+            start_timestamp: expect.any(Number),
+            end_timestamp: expect.any(Number),
+            status: 'ok',
+            is_segment: false,
+            attributes: expect.objectContaining({
+              'sentry.op': { type: 'string', value: 'gen_ai.generate_content' },
+              'sentry.origin': { type: 'string', value: 'auto.vercelai.otel' },
+              [GEN_AI_OPERATION_NAME_ATTRIBUTE]: { type: 'string', value: 'generate_content' },
+            }),
+          },
+        ]),
+      );
+    })
+    .start(signal);
+
+  await runner.makeRequest('get', '/');
+  await runner.completed();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/test.ts
@@ -4,7 +4,7 @@ import {
   GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
   GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
   GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
-} from '../../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
+} from '../../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
 import { createRunner } from '../../../../runner';
 
 it('captures a transaction with Vercel AI v6 spans via @sentry/cloudflare/nodejs_compat vercelAIIntegration', async ({

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "vercelai-v6-nodejs-compat-worker",
+  "compatibility_date": "2026-04-26",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "cloudflare-vercelai-v7-als",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --var \"E2E_TEST_DSN:$E2E_TEST_DSN\" --log-level=$(test $CI && echo 'none' || echo 'log')",
+    "build": "wrangler deploy --dry-run",
+    "typecheck": "tsc --noEmit",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm test:prod",
+    "test:prod": "TEST_ENV=production playwright test",
+    "test:dev": "TEST_ENV=development playwright test"
+  },
+  "dependencies": {
+    "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",
+    "ai": "^7.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.56.0",
+    "@cloudflare/workers-types": "^4.20240725.0",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "typescript": "^5.5.2",
+    "wrangler": "^4.61.0",
+    "ws": "^8.18.3"
+  },
+  "volta": {
+    "node": "24.15.0",
+    "extends": "../../package.json"
+  },
+  "pnpm": {
+    "overrides": {
+      "strip-literal": "~2.0.0"
+    }
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/playwright.config.ts
@@ -1,0 +1,21 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+const testEnv = process.env.TEST_ENV;
+
+if (!testEnv) {
+  throw new Error('No test env defined');
+}
+
+const APP_PORT = 38787;
+
+const config = getPlaywrightConfig(
+  {
+    startCommand: `pnpm dev --port ${APP_PORT}`,
+    port: APP_PORT,
+  },
+  {
+    workers: '100%',
+    retries: 0,
+  },
+);
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/env.d.ts
@@ -1,0 +1,3 @@
+interface Env {
+  E2E_TEST_DSN: '';
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/index.ts
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/cloudflare';
+import { generateText } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.E2E_TEST_DSN,
+    environment: 'qa',
+    tunnel: 'http://localhost:3031/',
+    streamGenAiSpans: false,
+    tracesSampleRate: 1.0,
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  {
+    async fetch(request, _env, _ctx) {
+      const url = new URL(request.url);
+
+      if (url.pathname === '/generate') {
+        await generateText({
+          experimental_telemetry: { isEnabled: true },
+          model: new MockLanguageModelV3({
+            doGenerate: async () => ({
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: { total: 10, noCache: 10, cached: 0 },
+                outputTokens: { total: 20, noCache: 20, cached: 0 },
+                totalTokens: { total: 30, noCache: 30, cached: 0 },
+              },
+              content: [{ type: 'text', text: 'Hello from mock AI!' }],
+              warnings: [],
+            }),
+          }),
+          prompt: 'Where is the first span?',
+        });
+
+        return new Response('ok');
+      }
+
+      return new Response('Not found', { status: 404 });
+    },
+  } satisfies ExportedHandler<Env>,
+);

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'cloudflare-vercelai-v7-als',
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/tests/index.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('does not capture Vercel AI v7 spans without nodejs_compat', async ({ baseURL }) => {
+  const transactionPromise = waitForTransaction('cloudflare-vercelai-v7-als', txn => {
+    return txn.transaction === 'GET /generate';
+  });
+
+  const response = await fetch(`${baseURL}/generate`);
+  expect(response.status).toBe(200);
+
+  const transaction = await transactionPromise;
+
+  expect(transaction.transaction).toBe('GET /generate');
+  expect(transaction.contexts?.trace?.op).toBe('http.server');
+
+  // v7 uses diagnostics_channel which is not available with nodejs_als,
+  // so no AI spans should be present.
+  const aiSpans = (transaction.spans || []).filter(
+    (span: any) => span.op?.startsWith('gen_ai.') || span.description?.includes('generateText'),
+  );
+  expect(aiSpans).toHaveLength(0);
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types/experimental"]
+  },
+  "exclude": ["test"],
+  "include": ["src/**/*.ts"]
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/wrangler.toml
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/wrangler.toml
@@ -1,0 +1,5 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "cloudflare-vercelai-v7-als"
+main = "src/index.ts"
+compatibility_date = "2026-04-26"
+compatibility_flags = ["nodejs_als"]

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "cloudflare-vercelai-v7-compat",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --var \"E2E_TEST_DSN:$E2E_TEST_DSN\" --log-level=$(test $CI && echo 'none' || echo 'log')",
+    "build": "wrangler deploy --dry-run",
+    "typecheck": "tsc --noEmit",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm test:prod",
+    "test:prod": "TEST_ENV=production playwright test",
+    "test:dev": "TEST_ENV=development playwright test"
+  },
+  "dependencies": {
+    "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",
+    "ai": "^7.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.56.0",
+    "@cloudflare/workers-types": "^4.20260426.0",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "typescript": "^5.5.2",
+    "wrangler": "4.86.0",
+    "ws": "^8.18.3"
+  },
+  "volta": {
+    "node": "24.15.0",
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/playwright.config.ts
@@ -1,0 +1,21 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+const testEnv = process.env.TEST_ENV;
+
+if (!testEnv) {
+  throw new Error('No test env defined');
+}
+
+const APP_PORT = 38787;
+
+const config = getPlaywrightConfig(
+  {
+    startCommand: `pnpm dev --port ${APP_PORT}`,
+    port: APP_PORT,
+  },
+  {
+    workers: '100%',
+    retries: 0,
+  },
+);
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/env.d.ts
@@ -1,0 +1,3 @@
+interface Env {
+  E2E_TEST_DSN: '';
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/index.ts
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/cloudflare/nodejs_compat';
+import { generateText } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.E2E_TEST_DSN,
+    environment: 'qa',
+    tunnel: 'http://localhost:3031/',
+    tracesSampleRate: 1.0,
+    streamGenAiSpans: false,
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  {
+    async fetch(request, _env, _ctx) {
+      const url = new URL(request.url);
+
+      if (url.pathname === '/generate') {
+        await generateText({
+          experimental_telemetry: { isEnabled: true },
+          model: new MockLanguageModelV3({
+            doGenerate: async () => ({
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: {
+                inputTokens: { total: 10, noCache: 10, cached: 0 },
+                outputTokens: { total: 20, noCache: 20, cached: 0 },
+                totalTokens: { total: 30, noCache: 30, cached: 0 },
+              },
+              content: [{ type: 'text', text: 'Hello from mock AI!' }],
+              warnings: [],
+            }),
+          }),
+          prompt: 'How much is the fish?',
+        });
+
+        return new Response('Here we go, here we go, here we go again');
+      }
+
+      return new Response('Not found', { status: 404 });
+    },
+  } satisfies ExportedHandler<Env>,
+);

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'cloudflare-vercelai-v7-compat',
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/tests/index.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('captures Vercel AI v7 spans with nodejs_compat using tracing channels', async ({ baseURL }) => {
+  const transactionPromise = waitForTransaction('cloudflare-vercelai-v7-compat', txn => {
+    return txn.transaction === 'GET /generate';
+  });
+
+  const response = await fetch(`${baseURL}/generate`);
+
+  expect(response.status).toBe(200);
+
+  const transaction = await transactionPromise;
+
+  expect(transaction.transaction).toBe('GET /generate');
+  expect(transaction.contexts?.trace?.op).toBe('http.server');
+  expect(transaction.spans).toHaveLength(2);
+
+  expect(transaction.spans).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        description: 'invoke_agent',
+        op: 'gen_ai.invoke_agent',
+        origin: 'auto.vercelai.channel',
+        parent_span_id: expect.any(String),
+        span_id: expect.any(String),
+        start_timestamp: expect.any(Number),
+        timestamp: expect.any(Number),
+        trace_id: expect.any(String),
+        data: expect.objectContaining({
+          'gen_ai.operation.name': 'invoke_agent',
+          'gen_ai.usage.input_tokens': 10,
+          'gen_ai.usage.output_tokens': 20,
+          'gen_ai.usage.total_tokens': 30,
+          'sentry.op': 'gen_ai.invoke_agent',
+          'sentry.origin': 'auto.vercelai.channel',
+        }),
+      }),
+      expect.objectContaining({
+        description: 'generate_content mock-model-id',
+        op: 'gen_ai.generate_content',
+        origin: 'auto.vercelai.channel',
+        parent_span_id: expect.any(String),
+        span_id: expect.any(String),
+        start_timestamp: expect.any(Number),
+        timestamp: expect.any(Number),
+        trace_id: expect.any(String),
+        data: expect.objectContaining({
+          'gen_ai.operation.name': 'generate_content',
+          'gen_ai.usage.input_tokens': 10,
+          'gen_ai.usage.output_tokens': 20,
+          'gen_ai.usage.total_tokens': 30,
+          'sentry.op': 'gen_ai.generate_content',
+          'sentry.origin': 'auto.vercelai.channel',
+        }),
+      }),
+    ]),
+  );
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2021",
+    "lib": ["es2021"],
+    "module": "es2022",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["@cloudflare/workers-types/experimental"]
+  },
+  "exclude": ["test"],
+  "include": ["src/**/*.ts"]
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/wrangler.toml
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/wrangler.toml
@@ -1,0 +1,5 @@
+#:schema node_modules/wrangler/config-schema.json
+name = "cloudflare-vercelai-v7-compat"
+main = "src/index.ts"
+compatibility_date = "2026-04-26"
+compatibility_flags = ["nodejs_compat"]

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -61,7 +61,8 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/core": "10.63.0",
-    "@sentry/node": "10.63.0"
+    "@sentry/node": "10.63.0",
+    "@sentry/server-utils": "10.63.0"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.x"

--- a/packages/cloudflare/src/nodejs_compat/index.ts
+++ b/packages/cloudflare/src/nodejs_compat/index.ts
@@ -1,2 +1,3 @@
 export * from '../index';
 export { prismaIntegration } from '@sentry/node';
+export { vercelAIIntegration } from './integrations/tracing/vercelai';

--- a/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
+++ b/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
@@ -1,5 +1,5 @@
 /**
- * This is a copy of the Vercel AI integration from the Cloudflare SDK.
+ * This is a copy of the Vercel AI integration from the Cloudflare SDK (src/integrations/tracing/vercelai.ts).
  *
  * The only difference is that it includes tracing channel support
  * because the default Vercel AI integration needs `nodejs_als`, while this one uses `nodejs_compat`.

--- a/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
+++ b/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
@@ -1,0 +1,57 @@
+/**
+ * This is a copy of the Vercel AI integration from the Cloudflare SDK.
+ *
+ * The only difference is that it includes tracing channel support
+ * because the default Vercel AI integration needs `nodejs_als`, while this one uses `nodejs_compat`.
+ */
+
+import type { IntegrationFn } from '@sentry/core';
+import { defineIntegration } from '@sentry/core';
+import { vercelAiIntegration as serverUtilsVercelAiIntegration } from '@sentry/server-utils';
+import { vercelAIIntegration as cloudflareVercelAIIntegration } from '../../../integrations/tracing/vercelai';
+
+interface VercelAiOptions {
+  /**
+   * Enable or disable truncation of recorded input messages.
+   * Defaults to `true`.
+   */
+  enableTruncation?: boolean;
+}
+
+const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
+  const inner = serverUtilsVercelAiIntegration(options);
+  const instrumentation = cloudflareVercelAIIntegration(options);
+
+  return {
+    ...inner,
+    ...instrumentation,
+  };
+}) satisfies IntegrationFn;
+
+/**
+ * Adds Sentry tracing instrumentation for the [ai](https://www.npmjs.com/package/ai) library.
+ * This integration is not enabled by default, you need to manually add it.
+ *
+ * For more information, see the [`ai` documentation](https://sdk.vercel.ai/docs/ai-sdk-core/telemetry).
+ *
+ *  You need to enable collecting spans for a specific call by setting
+ * `experimental_telemetry.isEnabled` to `true` in the first argument of the function call.
+ *
+ * ```javascript
+ * const result = await generateText({
+ *   model: openai('gpt-4-turbo'),
+ *   experimental_telemetry: { isEnabled: true },
+ * });
+ * ```
+ *
+ * If you want to collect inputs and outputs for a specific call, you must specifically opt-in to each
+ * function call by setting `experimental_telemetry.recordInputs` and `experimental_telemetry.recordOutputs`
+ * to `true`.
+ *
+ * ```javascript
+ * const result = await generateText({
+ *  model: openai('gpt-4-turbo'),
+ *  experimental_telemetry: { isEnabled: true, recordInputs: true, recordOutputs: true },
+ * });
+ */
+export const vercelAIIntegration = defineIntegration(_vercelAIIntegration);

--- a/yarn.lock
+++ b/yarn.lock
@@ -122,6 +122,15 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.3.tgz#beebbefb0264fdeb32d3052acae0e0d94315a9a2"
   integrity sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==
 
+"@ai-sdk/gateway@3.0.142":
+  version "3.0.142"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/gateway/-/gateway-3.0.142.tgz#d06b52db8237d49fb42bef77daa1396390c1f5be"
+  integrity sha512-Y1iwdxdebYXpoK5y/4CrcCfJGeFwEJWlEx+pMWIg/ZVWGi9KA+JXM7YBkhxcshpq/jAXx8YyQeFMyZr0TGfXZQ==
+  dependencies:
+    "@ai-sdk/provider" "3.0.13"
+    "@ai-sdk/provider-utils" "4.0.35"
+    "@vercel/oidc" "3.2.0"
+
 "@ai-sdk/provider-utils@2.2.8":
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz#ad11b92d5a1763ab34ba7b5fc42494bfe08b76d1"
@@ -131,10 +140,26 @@
     nanoid "^3.3.8"
     secure-json-parse "^2.7.0"
 
+"@ai-sdk/provider-utils@4.0.35":
+  version "4.0.35"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-4.0.35.tgz#bd32efdd5e4ac4f5c2ac42924d960a1d8bf0b4e2"
+  integrity sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg==
+  dependencies:
+    "@ai-sdk/provider" "3.0.13"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.8"
+
 "@ai-sdk/provider@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.1.3.tgz#ebdda8077b8d2b3f290dcba32c45ad19b2704681"
   integrity sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==
+  dependencies:
+    json-schema "^0.4.0"
+
+"@ai-sdk/provider@3.0.13":
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.13.tgz#8d2d64bcf5bd077133c82cc1eeefad3bee0b192d"
+  integrity sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==
   dependencies:
     json-schema "^0.4.0"
 
@@ -6074,7 +6099,7 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.0.tgz#d03eba68273dc0f7509e2a3d5cba21eae10379fe"
   integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
-"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.1":
+"@opentelemetry/api@^1.3.0", "@opentelemetry/api@^1.9.0", "@opentelemetry/api@^1.9.1":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
   integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
@@ -9830,6 +9855,11 @@
     picomatch "^4.0.2"
     resolve-from "^5.0.0"
 
+"@vercel/oidc@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/oidc/-/oidc-3.2.0.tgz#5782a4d4904443f015808705b5537cf9c3b68528"
+  integrity sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==
+
 "@vinxi/listhen@^1.5.6":
   version "1.5.6"
   resolved "https://registry.yarnpkg.com/@vinxi/listhen/-/listhen-1.5.6.tgz#78a01eb6d92016b646f3b468433e7bbb8c9957ab"
@@ -10664,6 +10694,16 @@ ai@^4.3.16:
     "@ai-sdk/ui-utils" "1.2.11"
     "@opentelemetry/api" "1.9.0"
     jsondiffpatch "0.6.0"
+
+ai@^6.0.0:
+  version "6.0.218"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-6.0.218.tgz#3f01d61313eee34469bc79fe3af540e097db42a1"
+  integrity sha512-HsyCUNaaYgX/b/kGOoYfKkqfT1HvpUKKDb8YkN1FKeCNZjKdqXLGY+cKBpYGIRAvsPuOHskxLxZ46cK1dTBWQQ==
+  dependencies:
+    "@ai-sdk/gateway" "3.0.142"
+    "@ai-sdk/provider" "3.0.13"
+    "@ai-sdk/provider-utils" "4.0.35"
+    "@opentelemetry/api" "^1.9.0"
 
 ajv-formats@2.1.1, ajv-formats@^2.1.1:
   version "2.1.1"
@@ -16472,6 +16512,11 @@ events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+eventsource-parser@^3.0.8:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-3.1.0.tgz#4e198eb91cd333d0a8ddcc036502b3618a25f449"
+  integrity sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==
 
 exact-mirror@^0.2.7:
   version "0.2.7"


### PR DESCRIPTION
re-implementing #21793 with tests, but in the `/nodejs_compat` entrypoint. The docs will be updated to clarify that AI v7 would only work in this entrypoint. I didn't want to name the integration differently, as then, the "drop-in replacement" would not work properly.

The majority of the PR is tests, and the actual code implementation is just a copy from the base entrypoint including #21793.


## Test info

Unfortunately AI v7 cannot be installed as cloudflare-integration-test dependency, as it requires Node v22. It forced me to add 2 e2e-tests instead.

The test matrix is as follows:
- Vercel AI v6 with `nodejs_als` (cloudflare-integration-test)
- Vercel AI v6 with `nodejs_compat` (cloudflare-integration-test)
- Vercel AI v7 with `nodejs_als` (e2e-test, confirming that it doesn't work)
- Vercel AI v7 with `nodejs_compat` (e2e-test)

If v7 support would be added by accident to the base entrypoint, then the Vercel AI v6 with `nodejs_als` will fail. That should have prevented #21793 to exist actually.