### PR TITLE
test(browser): Fix web worker route-registration race in debug ID test

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
@@ -11,10 +11,7 @@ sentryTest('Assigns web worker debug IDs when using webWorkerIntegration', async
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  // `init.js` creates the worker (`new Worker('/worker.js')`) during page load, so the
-  // route must be registered (and awaited) before navigation is triggered. Otherwise the
-  // worker request can race the route setup, load the real worker without a debug ID, and
-  // the expected error envelope never arrives.
+  // `init.js` creates the worker at page load, so the route must be registered before navigating.
   await page.route('**/worker.js', route => {
     return route.fulfill({
       path: `${__dirname}/assets/worker.js`,
@@ -53,10 +50,7 @@ sentryTest('Captures unhandled rejections from web workers', async ({ getLocalTe
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  // `init.js` creates the worker (`new Worker('/worker.js')`) during page load, so the
-  // route must be registered (and awaited) before navigation is triggered. Otherwise the
-  // worker request can race the route setup, load the real worker without a debug ID, and
-  // the expected error envelope never arrives.
+  // `init.js` creates the worker at page load, so the route must be registered before navigating.
   await page.route('**/worker.js', route => {
     return route.fulfill({
       path: `${__dirname}/assets/worker.js`,
@@ -74,7 +68,6 @@ sentryTest('Captures unhandled rejections from web workers', async ({ getLocalTe
 
   const errorEvent = envelopeRequestParser<Event>(await errorEventPromise);
 
-  // Verify the unhandled rejection was captured
   expect(errorEvent.exception?.values?.[0]?.value).toContain('Worker unhandled rejection');
   expect(errorEvent.exception?.values?.[0]?.mechanism?.type).toBe('auto.browser.web_worker.onunhandledrejection');
   expect(errorEvent.exception?.values?.[0]?.mechanism?.handled).toBe(false);

--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 import type { Event } from '@sentry/core';
 import { sentryTest } from '../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+import { envelopeRequestParser, waitForErrorRequest } from '../../../utils/helpers';
 
 sentryTest('Assigns web worker debug IDs when using webWorkerIntegration', async ({ getLocalTestUrl, page }) => {
   const bundle = process.env.PW_BUNDLE;
@@ -21,12 +21,16 @@ sentryTest('Assigns web worker debug IDs when using webWorkerIntegration', async
     });
   });
 
-  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page, url);
+  const errorEventPromise = waitForErrorRequest(
+    page,
+    event => !!event.exception?.values?.[0]?.value?.includes('Worker error for testing'),
+  );
 
-  const button = page.locator('#errWorker');
-  await button.click();
+  await page.goto(url);
 
-  const errorEvent = await errorEventPromise;
+  await page.locator('#errWorker').click();
+
+  const errorEvent = envelopeRequestParser<Event>(await errorEventPromise);
 
   expect(errorEvent.debug_meta?.images).toBeDefined();
 
@@ -59,12 +63,16 @@ sentryTest('Captures unhandled rejections from web workers', async ({ getLocalTe
     });
   });
 
-  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page, url);
+  const errorEventPromise = waitForErrorRequest(
+    page,
+    event => !!event.exception?.values?.[0]?.value?.includes('Worker unhandled rejection'),
+  );
 
-  const button = page.locator('#rejectionWorker');
-  await button.click();
+  await page.goto(url);
 
-  const errorEvent = await errorEventPromise;
+  await page.locator('#rejectionWorker').click();
+
+  const errorEvent = envelopeRequestParser<Event>(await errorEventPromise);
 
   // Verify the unhandled rejection was captured
   expect(errorEvent.exception?.values?.[0]?.value).toContain('Worker unhandled rejection');

--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/test.ts
@@ -11,13 +11,17 @@ sentryTest('Assigns web worker debug IDs when using webWorkerIntegration', async
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page, url);
-
-  page.route('**/worker.js', route => {
-    route.fulfill({
+  // `init.js` creates the worker (`new Worker('/worker.js')`) during page load, so the
+  // route must be registered (and awaited) before navigation is triggered. Otherwise the
+  // worker request can race the route setup, load the real worker without a debug ID, and
+  // the expected error envelope never arrives.
+  await page.route('**/worker.js', route => {
+    return route.fulfill({
       path: `${__dirname}/assets/worker.js`,
     });
   });
+
+  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page, url);
 
   const button = page.locator('#errWorker');
   await button.click();
@@ -45,13 +49,17 @@ sentryTest('Captures unhandled rejections from web workers', async ({ getLocalTe
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page, url);
-
-  page.route('**/worker.js', route => {
-    route.fulfill({
+  // `init.js` creates the worker (`new Worker('/worker.js')`) during page load, so the
+  // route must be registered (and awaited) before navigation is triggered. Otherwise the
+  // worker request can race the route setup, load the real worker without a debug ID, and
+  // the expected error envelope never arrives.
+  await page.route('**/worker.js', route => {
+    return route.fulfill({
       path: `${__dirname}/assets/worker.js`,
     });
   });
+
+  const errorEventPromise = getFirstSentryEnvelopeRequest<Event>(page, url);
 
   const button = page.locator('#rejectionWorker');
   await button.click();


### PR DESCRIPTION
Register and await the `**/worker.js` mock route before navigation in the webWorker integration tests. Previously the route was set up after navigation and never awaited, so the worker request (created at page-load in `init.js`) could race the route setup, load the real worker without a debug ID, and time out waiting for the error envelope.

Also refactors the tests to use `waitForErrorRequest` for good practise
