### PR TITLE
test(e2e): Revert nf3 dependency override in nitro-3 e2e test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nitro-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/package.json
@@ -25,10 +25,5 @@
   },
   "volta": {
     "extends": "../../package.json"
-  },
-  "pnpm": {
-    "overrides": {
-      "nf3": "0.3.17"
-    }
   }
 }


### PR DESCRIPTION
This reverts commit 21462b1965afe1ad8c1ca2450e1ebed05f97f1a1 after nf3 released a new version with the fix: https://github.com/unjs/nf3/releases/tag/v0.3.19

jr reminder worked but apparently it can't commit or create PRs on a scheduled job
