### PR TITLE
feat(browser): Set `url.path` and `url.full` on pageload and navigation spans

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/multiple-redirects/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/multiple-redirects/test.ts
@@ -57,6 +57,8 @@ sentryTest(
           'sentry.op': 'navigation.redirect',
           'sentry.origin': 'auto.navigation.browser',
           'sentry.source': 'url',
+          'url.full': expect.any(String),
+          'url.path': expect.any(String),
         },
         description: expect.stringContaining('/sub-page-redirect-'),
         op: 'navigation.redirect',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/multiple-redirects/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/multiple-redirects/test.ts
@@ -7,6 +7,7 @@ import {
 } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+import { URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
 
 sentryTest(
   'creates a pageload and navigation root spans each with multiple navigation.redirect childspans',
@@ -57,8 +58,8 @@ sentryTest(
           'sentry.op': 'navigation.redirect',
           'sentry.origin': 'auto.navigation.browser',
           'sentry.source': 'url',
-          'url.full': expect.any(String),
-          'url.path': expect.any(String),
+          [URL_FULL]: expect.any(String),
+          [URL_PATH]: expect.any(String),
         },
         description: expect.stringContaining('/sub-page-redirect-'),
         op: 'navigation.redirect',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-redirect/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-redirect/test.ts
@@ -7,6 +7,7 @@ import {
 } from '@sentry/core';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { envelopeRequestParser, shouldSkipTracingTest, waitForTransactionRequest } from '../../../../../utils/helpers';
+import { URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
 
 sentryTest('creates a pageload root span with navigation.redirect childspan', async ({ getLocalTestUrl, page }) => {
   if (shouldSkipTracingTest()) {
@@ -53,8 +54,8 @@ sentryTest('creates a pageload root span with navigation.redirect childspan', as
       'sentry.op': 'navigation.redirect',
       'sentry.origin': 'auto.navigation.browser',
       'sentry.source': 'url',
-      'url.full': 'http://sentry-test.io/sub-page',
-      'url.path': '/sub-page',
+      [URL_FULL]: 'http://sentry-test.io/sub-page',
+      [URL_PATH]: '/sub-page',
     },
     description: '/sub-page',
     op: 'navigation.redirect',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-redirect/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-redirect/test.ts
@@ -53,6 +53,8 @@ sentryTest('creates a pageload root span with navigation.redirect childspan', as
       'sentry.op': 'navigation.redirect',
       'sentry.origin': 'auto.navigation.browser',
       'sentry.source': 'url',
+      'url.full': 'http://sentry-test.io/sub-page',
+      'url.path': '/sub-page',
     },
     description: '/sub-page',
     op: 'navigation.redirect',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -96,6 +96,10 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ brow
         type: 'string',
         value: expect.any(String),
       },
+      'url.path': {
+        type: 'string',
+        value: expect.any(String),
+      },
       'device.processor_count': {
         type: expect.stringMatching(/^(integer)|(double)$/),
         value: expect.any(Number),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -8,7 +8,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
-import { SENTRY_TRACE_LIFECYCLE } from '@sentry/conventions/attributes';
+import { SENTRY_TRACE_LIFECYCLE, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import {
@@ -92,11 +92,11 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ brow
         type: 'string',
         value: expect.any(String),
       },
-      'url.full': {
+      [URL_FULL]: {
         type: 'string',
         value: expect.any(String),
       },
-      'url.path': {
+      [URL_PATH]: {
         type: 'string',
         value: expect.any(String),
       },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -87,6 +87,10 @@ sentryTest(
           type: 'string',
           value: expect.any(String),
         },
+        'url.path': {
+          type: 'string',
+          value: expect.any(String),
+        },
         // formerly known as 'hardwareConcurrency'
         'device.processor_count': {
           type: expect.stringMatching(/^(integer)|(double)$/),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -14,6 +14,8 @@ import {
   SENTRY_SDK_NAME,
   SENTRY_SDK_VERSION,
   SENTRY_TRACE_LIFECYCLE,
+  URL_FULL,
+  URL_PATH,
 } from '@sentry/conventions/attributes';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
@@ -83,11 +85,11 @@ sentryTest(
           type: 'string',
           value: expect.any(String),
         },
-        'url.full': {
+        [URL_FULL]: {
           type: 'string',
           value: expect.any(String),
         },
-        'url.path': {
+        [URL_PATH]: {
           type: 'string',
           value: expect.any(String),
         },

--- a/dev-packages/e2e-tests/test-applications/default-browser/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/default-browser/tests/performance.test.ts
@@ -19,6 +19,8 @@ test('captures a pageload transaction', async ({ page }) => {
           'sentry.origin': 'auto.pageload.browser',
           'sentry.sample_rate': 1,
           'sentry.source': 'url',
+          'url.full': 'http://localhost:3030/',
+          'url.path': '/',
         }),
         op: 'pageload',
         origin: 'auto.pageload.browser',
@@ -83,6 +85,10 @@ test('captures a navigation transaction', async ({ page }) => {
       trace: {
         op: 'navigation',
         origin: 'auto.navigation.browser',
+        data: expect.objectContaining({
+          'url.full': 'http://localhost:3030/#navigation-target',
+          'url.path': '/',
+        }),
       },
     },
     transaction: '/',

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
@@ -26,6 +26,8 @@ test('Captures a pageload transaction', async ({ page }) => {
       'performance.activationStart': expect.any(Number),
       'lcp.renderTime': expect.any(Number),
       'lcp.loadTime': expect.any(Number),
+      'url.full': 'http://localhost:3030/',
+      'url.path': '/',
     },
     op: 'pageload',
     span_id: expect.stringMatching(/[a-f0-9]{16}/),

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@sentry/browser-utils": "10.64.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/feedback": "10.64.0",
     "@sentry/replay": "10.64.0",
     "@sentry/replay-canvas": "10.64.0",

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -24,6 +24,7 @@ import {
   GLOBAL_OBJ,
   hasSpansEnabled,
   hasSpanStreamingEnabled,
+  isURLObjectRelative,
   parseStringToURLObject,
   propagationContextFromHeaders,
   registerSpanErrorInstrumentation,
@@ -424,14 +425,21 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       ? beforeStartSpan(startSpanOptions)
       : startSpanOptions;
 
-    const attributes = finalStartSpanOptions.attributes || {};
+    const urlObject = parseStringToURLObject(getLocationHref());
+
+    const attributes = {
+      ...(urlObject?.pathname && { 'url.path': urlObject.pathname }),
+      ...(urlObject && !isURLObjectRelative(urlObject) && { 'url.full': urlObject.href }),
+      ...finalStartSpanOptions.attributes,
+    };
 
     // If `finalStartSpanOptions.name` is different than `startSpanOptions.name`
     // it is because `beforeStartSpan` set a custom name. Therefore we set the source to 'custom'.
     if (initialSpanName !== finalStartSpanOptions.name) {
       attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] = 'custom';
-      finalStartSpanOptions.attributes = attributes;
     }
+
+    finalStartSpanOptions.attributes = attributes;
 
     if (!makeActive) {
       // We want to ensure this has 0s duration

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -52,6 +52,7 @@ import { WEB_VITALS_INTEGRATION_NAME, webVitalsIntegration } from '../integratio
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
+import { URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
 
 export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 
@@ -417,7 +418,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
   let _pageloadSpan: Span | undefined;
 
   /** Create routing idle transaction. */
-  function _createRouteSpan(client: Client, startSpanOptions: StartSpanOptions, makeActive = true): void {
+  function _createRouteSpan(client: Client, startSpanOptions: StartSpanOptions, makeActive = true, url?: string): void {
     const isPageloadSpan = startSpanOptions.op === 'pageload';
 
     const initialSpanName = startSpanOptions.name;
@@ -425,11 +426,13 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       ? beforeStartSpan(startSpanOptions)
       : startSpanOptions;
 
-    const urlObject = parseStringToURLObject(getLocationHref());
+    // For navigations, `url` is the destination URL, so we use it to reflect the post-navigation location.
+    // For pageloads (and manual navigation spans without a URL) we fall back to the current location.
+    const urlObject = parseStringToURLObject(url || getLocationHref());
 
     const attributes = {
-      ...(urlObject?.pathname && { 'url.path': urlObject.pathname }),
-      ...(urlObject && !isURLObjectRelative(urlObject) && { 'url.full': urlObject.href }),
+      ...(urlObject?.pathname && { [URL_PATH]: urlObject.pathname }),
+      ...(urlObject && !isURLObjectRelative(urlObject) && { [URL_FULL]: urlObject.href }),
       ...finalStartSpanOptions.attributes,
     };
 
@@ -571,6 +574,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
               ...startSpanOptions,
             },
             false,
+            navigationOptions.url,
           );
           return;
         }
@@ -601,13 +605,18 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
           normalizedRequest: undefined,
         });
 
-        _createRouteSpan(client, {
-          op: 'navigation',
-          ...startSpanOptions,
-          // Navigation starts a new trace and is NOT parented under any active interaction (e.g. ui.action.click)
-          parentSpan: null,
-          forceTransaction: true,
-        });
+        _createRouteSpan(
+          client,
+          {
+            op: 'navigation',
+            ...startSpanOptions,
+            // Navigation starts a new trace and is NOT parented under any active interaction (e.g. ui.action.click)
+            parentSpan: null,
+            forceTransaction: true,
+          },
+          true,
+          navigationOptions?.url,
+        );
       });
 
       client.on('startPageLoadSpan', (startSpanOptions, traceOptions = {}) => {
@@ -787,8 +796,8 @@ export function startBrowserTracingNavigationSpan(
   options?: { url?: string; isRedirect?: boolean },
 ): Span | undefined {
   const { url, isRedirect } = options || {};
-  client.emit('beforeStartNavigationSpan', spanOptions, { isRedirect });
-  client.emit('startNavigationSpan', spanOptions, { isRedirect });
+  client.emit('beforeStartNavigationSpan', spanOptions, { isRedirect, url });
+  client.emit('startNavigationSpan', spanOptions, { isRedirect, url });
 
   const scope = getCurrentScope();
   scope.setTransactionName(spanOptions.name);

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -33,6 +33,7 @@ import {
 } from '../../src/tracing/browserTracingIntegration';
 import { PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE } from '../../src/tracing/linkedTraces';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
+import { URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
 
 const oldTextEncoder = global.window.TextEncoder;
 const oldTextDecoder = global.window.TextDecoder;
@@ -65,10 +66,16 @@ describe('browserTracingIntegration', () => {
     getCurrentScope().clear();
     getIsolationScope().clear();
     getCurrentScope().setClient(undefined);
-    document.head.innerHTML = '';
 
+    // Reset document and location to a fresh JSDOM for every test. `getLocationHref()` reads
+    // `WINDOW.document.location.href`, so leaving `document` bound to a shared instance leaks URL state
+    // (e.g. `/test`) from `pushState` in earlier tests into later ones. `history` must stay bound to the
+    // shared instance because the history instrumentation patches it once globally on `client.init()`.
     const dom = new JSDOM(undefined, { url: 'https://example.com/' });
+    Object.defineProperty(global, 'document', { value: dom.window.document, writable: true });
     Object.defineProperty(global, 'location', { value: dom.window.document.location, writable: true });
+
+    document.head.innerHTML = '';
 
     // We want to suppress the "Multiple browserTracingIntegration instances are not supported." warnings
     vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -174,6 +181,8 @@ describe('browserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [URL_FULL]: 'https://example.com/',
+        [URL_PATH]: '/',
       },
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
@@ -258,6 +267,8 @@ describe('browserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [URL_FULL]: 'https://example.com/',
+        [URL_PATH]: '/',
       },
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
@@ -286,6 +297,8 @@ describe('browserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [URL_FULL]: 'https://example.com/test',
+        [URL_PATH]: '/test',
         [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: `${span?.spanContext().traceId}-${span?.spanContext().spanId}-1`,
       },
       links: [
@@ -325,6 +338,8 @@ describe('browserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [URL_FULL]: 'https://example.com/test2',
+        [URL_PATH]: '/test2',
         [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: `${span2?.spanContext().traceId}-${span2?.spanContext().spanId}-1`,
       },
       links: [
@@ -366,6 +381,8 @@ describe('browserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [URL_FULL]: 'https://example.com/',
+        [URL_PATH]: '/',
       },
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
@@ -394,6 +411,8 @@ describe('browserTracingIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation.redirect',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+          [URL_FULL]: 'https://example.com/test',
+          [URL_PATH]: '/test',
         },
         description: '/test',
         op: 'navigation.redirect',
@@ -456,6 +475,8 @@ describe('browserTracingIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
+          [URL_FULL]: 'https://example.com/',
+          [URL_PATH]: '/',
         },
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
@@ -492,6 +513,8 @@ describe('browserTracingIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
+          [URL_FULL]: 'https://example.com/',
+          [URL_PATH]: '/',
           testy: 'yes',
         },
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
@@ -733,6 +756,8 @@ describe('browserTracingIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
           [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: expect.stringMatching(/[a-f0-9]{32}-[a-f0-9]{16}-1/),
+          [URL_FULL]: 'https://example.com/',
+          [URL_PATH]: '/',
         },
         links: [
           {
@@ -785,8 +810,8 @@ describe('browserTracingIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
-          ['url.full']: 'https://example.com/',
-          ['url.path']: '/',
+          [URL_FULL]: 'https://example.com/',
+          [URL_PATH]: '/',
           testy: 'yes',
         },
         span_id: expect.stringMatching(/[a-f0-9]{16}/),

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -785,6 +785,8 @@ describe('browserTracingIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
+          ['url.full']: 'https://example.com/',
+          ['url.path']: '/',
           testy: 'yes',
         },
         span_id: expect.stringMatching(/[a-f0-9]{16}/),

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -815,7 +815,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    */
   public on(
     hook: 'beforeStartNavigationSpan',
-    callback: (options: StartSpanOptions, navigationOptions?: { isRedirect?: boolean }) => void,
+    callback: (options: StartSpanOptions, navigationOptions?: { isRedirect?: boolean; url?: string }) => void,
   ): () => void;
 
   /**
@@ -824,7 +824,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    */
   public on(
     hook: 'startNavigationSpan',
-    callback: (options: StartSpanOptions, navigationOptions?: { isRedirect?: boolean }) => void,
+    callback: (options: StartSpanOptions, navigationOptions?: { isRedirect?: boolean; url?: string }) => void,
   ): () => void;
 
   /**
@@ -1100,7 +1100,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public emit(
     hook: 'beforeStartNavigationSpan',
     options: StartSpanOptions,
-    navigationOptions?: { isRedirect?: boolean },
+    navigationOptions?: { isRedirect?: boolean; url?: string },
   ): void;
 
   /**
@@ -1109,7 +1109,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public emit(
     hook: 'startNavigationSpan',
     options: StartSpanOptions,
-    navigationOptions?: { isRedirect?: boolean },
+    navigationOptions?: { isRedirect?: boolean; url?: string },
   ): void;
 
   /**


### PR DESCRIPTION
Adds high-cardinality `url.path` and `url.full` attributes to pageload and navigation spans. We need them for span description inference in Relay: https://getsentry.github.io/sentry-conventions/descriptions/#browser-pageload

More specific router instrumentations who can set a parameterized route will also set `url.template` which is the preferred attribute.

ref #21921 