### PR TITLE
chore: Add experimentalUseDiagnosticsChannelInjection in node size-limit

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -395,6 +395,15 @@ module.exports = [
     disablePlugins: ['@size-limit/esbuild'],
   },
   {
+    name: '@sentry/node (incl. diagnostics channel injection)',
+    path: 'packages/node/build/esm/index.js',
+    import: createImport('init', 'experimentalUseDiagnosticsChannelInjection'),
+    ignore: [...builtinModules, ...nodePrefixedBuiltinModules],
+    gzip: true,
+    limit: '132 KB',
+    disablePlugins: ['@size-limit/esbuild'],
+  },
+  {
     name: '@sentry/node/import (ESM hook with diagnostics-channel injection)',
     path: ['node_modules/@apm-js-collab/tracing-hooks/hook.mjs', 'packages/node/build/import-hook.mjs'],
     ignore: [...builtinModules, ...nodePrefixedBuiltinModules],


### PR DESCRIPTION
It appears that `experimentalUseDiagnosticsChannelInjection` is adding 5kb gzipped to the base bundle. This adds now the indicator for future PRs.