### PR TITLE
feat(bun): warn when externalizing instrumented deps

### DIFF
--- a/dev-packages/bun-integration-tests/suites/orchestrion-postgres/build-blanket-external.ts
+++ b/dev-packages/bun-integration-tests/suites/orchestrion-postgres/build-blanket-external.ts
@@ -1,0 +1,27 @@
+// Builds the scenario with a blanket externalization strategy
+// (`packages: 'external'`), which the plugin cannot strip. It must warn (to
+// stderr) that instrumented packages will ship un-transformed. Guards the
+// regression covered in test.ts; the built output is never run.
+
+// @ts-ignore -- subpath export resolved by Bun at runtime; the package
+// tsconfig's node module resolution can't see `exports` subpaths.
+import { sentryBunPlugin } from '@sentry/bun/plugin';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+void (async () => {
+  const outdir = join(tmpdir(), `sentry-bun-orchestrion-pg-blanket-${process.pid}-${Date.now()}`);
+  const result = await Bun.build({
+    entrypoints: [join(__dirname, 'scenario.ts')],
+    target: 'bun',
+    outdir,
+    // Externalize every dependency. Unlike an explicit `external: ['pg']`, the
+    // plugin cannot un-externalize this, so it should warn instead of silently
+    // shipping an un-instrumented `pg`.
+    packages: 'external',
+    plugins: [sentryBunPlugin()],
+  });
+
+  // eslint-disable-next-line no-console
+  console.log(result.success ? 'BUILD_OK' : 'BUILD_FAILED');
+})();

--- a/dev-packages/bun-integration-tests/suites/orchestrion-postgres/test.ts
+++ b/dev-packages/bun-integration-tests/suites/orchestrion-postgres/test.ts
@@ -33,6 +33,10 @@ describe('orchestrion pg instrumentation (Bun)', () => {
       const build = runBun(['run', join(dir, 'build.ts')]);
       expect(build.status, `build failed:\nstderr:\n${build.stderr}\nstdout:\n${build.stdout}`).toBe(0);
 
+      // A normal build (instrumented packages bundled) must NOT emit the
+      // blanket-externalization warning.
+      expect(build.stderr).not.toContain('[Sentry]');
+
       const outfile = build.stdout.match(/BUILD_OK outfile=(.+)/)?.[1]?.trim();
       expect(outfile, `no outfile in build output:\n${build.stdout}`).toBeTruthy();
 
@@ -61,5 +65,17 @@ describe('orchestrion pg instrumentation (Bun)', () => {
       // binding limit.
     },
     2 * SUBPROCESS_TIMEOUT_MS,
+  );
+
+  it(
+    'warns when a blanket externalization strategy leaves instrumented packages un-transformed',
+    () => {
+      const build = runBun(['run', join(dir, 'build-blanket-external.ts')]);
+      expect(build.status, `build failed:\nstderr:\n${build.stderr}\nstdout:\n${build.stdout}`).toBe(0);
+      expect(build.stderr).toContain('[Sentry]');
+      // names an affected instrumented package so the message is actionable
+      expect(build.stderr).toContain('pg');
+    },
+    SUBPROCESS_TIMEOUT_MS,
   );
 });

--- a/packages/bun/src/plugin.ts
+++ b/packages/bun/src/plugin.ts
@@ -37,7 +37,11 @@ type UnknownPlugin = any;
 // CJS build requires it. Bun resolves correctly for ESM modules in either
 // module system.
 import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/bun';
-import { SENTRY_INSTRUMENTATIONS, withoutInstrumentedExternals } from '@sentry/server-utils/orchestrion/config';
+import {
+  INSTRUMENTED_MODULE_NAMES,
+  SENTRY_INSTRUMENTATIONS,
+  withoutInstrumentedExternals,
+} from '@sentry/server-utils/orchestrion/config';
 
 const BUNDLER_MARKER_BANNER =
   ';(globalThis.__SENTRY_ORCHESTRION__=(globalThis.__SENTRY_ORCHESTRION__||{})).bundler=true;';
@@ -45,7 +49,7 @@ const BUNDLER_MARKER_BANNER =
 // Minimal shape of Bun's `PluginBuilder` that we touch. Typed locally instead
 // of depending on `bun-types`, which would pull Bun's globals.
 interface BunPluginBuilder {
-  config?: { banner?: string; external?: string[] };
+  config?: { banner?: string; external?: string[]; packages?: 'bundle' | 'external' };
 }
 
 /**
@@ -88,6 +92,31 @@ export function sentryBunPlugin(): UnknownPlugin {
         // be silently never injected. Bun has no runtime fallback here, so
         // bundling is the only injection path.
         build.config.external = withoutInstrumentedExternals(build.config.external);
+
+        // A blanket externalization strategy like `packages: 'external'` or
+        // `'*'` in `external` externalizes instrumented packages too, and
+        // `withoutInstrumentedExternals` only strips exact names/subpaths (not
+        // these), so those packages ship un-transformed with no runtime
+        // fallback. Forcing them back in via `onResolve` is not an option: Bun
+        // ignores `{ external: false }` against a blanket strategy, and
+        // returning a resolved `path` corrupts the package's ESM/CJS interop.
+        // So warn instead. This runs in the user's build script, where the
+        // Sentry debug logger isn't enabled, and `console` is the thing to use.
+        const blanketExternal =
+          build.config.packages === 'external'
+            ? "packages: 'external'"
+            : build.config.external?.includes('*')
+              ? "'*' in external"
+              : undefined;
+        if (blanketExternal) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[Sentry] This Bun build externalizes all dependencies (${blanketExternal}), so Sentry ` +
+              'cannot instrument bundled libraries. Instrumentation will be missing for any of ' +
+              `these packages your app uses: ${INSTRUMENTED_MODULE_NAMES.join(', ')}. To instrument them, ` +
+              'externalize only the specific packages you need external instead of all of them.',
+          );
+        }
       }
 
       // Delegate to the upstream code-transformer, which registers the `onLoad`


### PR DESCRIPTION
There's no way to prevent bun from externalizing the dependencies that we instrument with orchestrion when `external: '*'` or `packages: 'external'` is used in the bun build config.

Detect this situation, and warn the user about it.

fix: #21908
fix: JS-2894
