### PR TITLE
fix(core): Print getTraceMetaTags in 1 line to prevent hydration errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by @codr. Thank you for your contribution!
+Work in this release was contributed by @codr and @zenato. Thank you for your contribution!
 
 ## 10.63.0
 

--- a/packages/core/src/utils/meta.ts
+++ b/packages/core/src/utils/meta.ts
@@ -23,7 +23,11 @@ import { getTraceData } from './traceData';
  *
  */
 export function getTraceMetaTags(traceData?: SerializedTraceData): string {
-  return Object.entries(traceData || getTraceData())
-    .map(([key, value]) => `<meta name="${key}" content="${value}"/>`)
-    .join('\n');
+  return (
+    Object.entries(traceData || getTraceData())
+      .map(([key, value]) => `<meta name="${key}" content="${value}"/>`)
+      // Joined without whitespace on purpose: a separator between the tags becomes a text node when
+      // injected into `<head>`, which breaks React 19 whole-document hydration (#21915).
+      .join('')
+  );
 }

--- a/packages/core/test/lib/utils/meta.test.ts
+++ b/packages/core/test/lib/utils/meta.test.ts
@@ -9,9 +9,9 @@ describe('getTraceMetaTags', () => {
       baggage: 'sentry-environment=production',
     });
 
-    expect(getTraceMetaTags())
-      .toBe(`<meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456-1"/>
-<meta name="baggage" content="sentry-environment=production"/>`);
+    expect(getTraceMetaTags()).toBe(
+      '<meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456-1"/><meta name="baggage" content="sentry-environment=production"/>',
+    );
   });
 
   it('renders just sentry-trace values to stringified Html meta tags', () => {
@@ -39,9 +39,9 @@ describe('getTraceMetaTags', () => {
         'sentry-environment=test,sentry-public_key=public12345,sentry-trace_id=ab12345678901234567890123456789012,sentry-sample_rate=0.5',
     };
 
-    expect(getTraceMetaTags(customTraceData))
-      .toBe(`<meta name="sentry-trace" content="ab12345678901234567890123456789012-1234567890abcdef-1"/>
-<meta name="baggage" content="sentry-environment=test,sentry-public_key=public12345,sentry-trace_id=ab12345678901234567890123456789012,sentry-sample_rate=0.5"/>`);
+    expect(getTraceMetaTags(customTraceData)).toBe(
+      '<meta name="sentry-trace" content="ab12345678901234567890123456789012-1234567890abcdef-1"/><meta name="baggage" content="sentry-environment=test,sentry-public_key=public12345,sentry-trace_id=ab12345678901234567890123456789012,sentry-sample_rate=0.5"/>',
+    );
 
     expect(getTraceDataSpy).not.toHaveBeenCalled();
   });

--- a/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
+++ b/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
@@ -17,7 +17,7 @@ vi.mock('@sentry/node', async importOriginal => {
 const getTraceMetaTagsSpy = vi
   .fn()
   .mockReturnValue(
-    '<meta name="sentry-trace" content="abc123-def456-1"/>\n<meta name="baggage" content="sentry-trace_id=abc123"/>',
+    '<meta name="sentry-trace" content="abc123-def456-1"/><meta name="baggage" content="sentry-trace_id=abc123"/>',
   );
 
 vi.mock('@sentry/core', async importOriginal => {
@@ -84,6 +84,12 @@ describe('wrapFetchWithSentry', () => {
     expect(html).toContain('<meta name="sentry-trace" content="abc123-def456-1"/>');
     expect(html).toContain('<meta name="baggage" content="sentry-trace_id=abc123"/>');
     expect(html).toContain('<meta charset="utf-8"/>');
+
+    // No whitespace text node may appear directly after `<head>` or between the injected tags —
+    // React 19 whole-document hydration rejects unexpected text nodes in `<head>` (#21915).
+    expect(html).toContain(
+      '<head><meta name="sentry-trace" content="abc123-def456-1"/><meta name="baggage" content="sentry-trace_id=abc123"/>',
+    );
   });
 
   it('does not inject meta tags into non-HTML responses', async () => {


### PR DESCRIPTION
closes #21915
closes [JS-2897](https://linear.app/getsentry/issue/JS-2897)

It seems that new lines creating a React hydration error. By removing the newline it works again. IMO it wouldn't matter if there is a newline or not, as in Browsers the markdown is formatted anyways and in code this is anyways the used code. So I don't think there was a benefit of the newline anyways.