### PR TITLE
chore(cloudflare): Ignore import patterns

### DIFF
--- a/packages/cloudflare/.oxlintrc.json
+++ b/packages/cloudflare/.oxlintrc.json
@@ -36,7 +36,7 @@
               {
                 "group": ["@sentry/server-utils/*"],
                 "message": "Do not import from `@sentry/server-utils` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
-              },
+              }
             ]
           }
         ]

--- a/packages/cloudflare/.oxlintrc.json
+++ b/packages/cloudflare/.oxlintrc.json
@@ -27,6 +27,16 @@
                 "name": "@sentry/server-utils",
                 "message": "Do not import from `@sentry/server-utils` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
               }
+            ],
+            "patterns": [
+              {
+                "group": ["@sentry/node/*"],
+                "message": "Do not import from `@sentry/node` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
+              },
+              {
+                "group": ["@sentry/server-utils/*"],
+                "message": "Do not import from `@sentry/server-utils` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
+              },
             ]
           }
         ]


### PR DESCRIPTION
Apparently patterns are not covered by normal names so `@sentry/server-utils/orchestrion` was not shown as error before. That fixes it.