### PR TITLE
chore: Make @sentry/conventions sideEffect free during bundling

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -100,7 +100,13 @@ export function makeBaseNPMConfig(options = {}) {
     treeshake: {
       moduleSideEffects: (id, external) => {
         if (external === false && ignoreSideEffects.test(id)) {
-          // Tell Rollup this module has no side effects, so it can be tree-shaken
+            // Tell Rollup this module has no side effects, so it can be tree-shaken
+          return false;
+        }
+
+        // @sentry/conventions only exports constants (sideEffects: false),
+        // so Rollup shouldn't emit bare side-effect imports for it.
+        if (external && id.startsWith('@sentry/conventions')) {
           return false;
         }
 

--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -100,7 +100,7 @@ export function makeBaseNPMConfig(options = {}) {
     treeshake: {
       moduleSideEffects: (id, external) => {
         if (external === false && ignoreSideEffects.test(id)) {
-            // Tell Rollup this module has no side effects, so it can be tree-shaken
+          // Tell Rollup this module has no side effects, so it can be tree-shaken
           return false;
         }
 


### PR DESCRIPTION
`@sentry/conventions` are marked with `sideEffects`. That leads to having `@sentry/conventions/attributes` as side effect import in the bundled output:

<img width="626" height="268" alt="Screenshot 2026-07-07 at 13 46 44" src="https://github.com/user-attachments/assets/109371e8-57d4-43d5-8ced-fe1af07d4ea8" />

By telling rollup that `@sentry/conventions` is side effect free, the side effect import from the output is being removed (it also reflects the `package.json#sideEffect` field

<img width="631" height="246" alt="Screenshot 2026-07-07 at 13 47 14" src="https://github.com/user-attachments/assets/e128dc37-98e7-44b3-a1f3-9ef7904671e0" />


---

Originally I came to this fix as the Cloudflare integration tests were quite verbose in this warning:

<img width="1177" height="294" alt="Screenshot 2026-07-07 at 13 50 42" src="https://github.com/user-attachments/assets/5120f63d-a072-466c-9c48-2e188c526e1a" />


