### PR TITLE
chore: Reinstate changelog anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+
 ## 10.64.0
 
 ### Important Changes


### PR DESCRIPTION
We need this quote as it acts as anchor for attributions.
