### PR TITLE
feat(sveltekit): Set url.template, url.path and url.full on pageload and navigation spans

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/tests/tracing.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/tests/tracing.client.test.ts
@@ -36,6 +36,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/nav1',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/nav1$/),
+            'url.template': '/nav1',
+          },
         },
       },
     });
@@ -49,6 +54,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
+            'url.template': '/',
+          },
         },
       },
     });
@@ -62,6 +72,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/nav2',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/nav2$/),
+            'url.template': '/nav2',
+          },
         },
       },
     });

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/tests/tracing.test.ts
@@ -26,6 +26,11 @@ test('capture a distributed pageload trace', async ({ page }) => {
       trace: {
         op: 'pageload',
         origin: 'auto.pageload.sveltekit',
+        data: {
+          'url.path': '/users/123xyz',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/123xyz$/),
+          'url.template': '/users/[id]',
+        },
       },
     },
   });
@@ -88,6 +93,11 @@ test('capture a distributed navigation trace', async ({ page }) => {
       trace: {
         op: 'navigation',
         origin: 'auto.navigation.sveltekit',
+        data: {
+          'url.path': '/users',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users$/),
+          'url.template': '/users',
+        },
       },
     },
   });
@@ -139,6 +149,11 @@ test('record client-side universal load fetch span and trace', async ({ page }) 
       trace: {
         op: 'navigation',
         origin: 'auto.navigation.sveltekit',
+        data: {
+          'url.path': '/universal-load-fetch',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/universal-load-fetch$/),
+          'url.template': '/universal-load-fetch',
+        },
       },
     },
   });
@@ -212,6 +227,11 @@ test('captures a navigation transaction directly after pageload', async ({ page 
       trace: {
         op: 'pageload',
         origin: 'auto.pageload.sveltekit',
+        data: {
+          'url.path': '/',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
+          'url.template': '/',
+        },
       },
     },
   });
@@ -228,6 +248,9 @@ test('captures a navigation transaction directly after pageload', async ({ page 
           'sentry.sveltekit.navigation.from': '/',
           'sentry.sveltekit.navigation.to': '/users/[id]',
           'sentry.sveltekit.navigation.type': 'link',
+          'url.path': '/users/123abc',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/123abc$/),
+          'url.template': '/users/[id]',
         },
       },
     },
@@ -290,6 +313,9 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
           'sentry.sveltekit.navigation.from': '/',
           'sentry.sveltekit.navigation.to': '/redirect1',
           'sentry.sample_rate': 1,
+          'url.path': '/redirect1',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/redirect1$/),
+          'url.template': '/redirect1',
         },
       },
     },
@@ -327,6 +353,9 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
           'sentry.sveltekit.navigation.from': '/',
           'sentry.sveltekit.navigation.to': '/redirect2',
           'sentry.sample_rate': 1,
+          'url.path': '/redirect2',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/redirect2$/),
+          'url.template': '/redirect2',
         },
       },
     },
@@ -364,6 +393,9 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
           'sentry.sveltekit.navigation.from': '/',
           'sentry.sveltekit.navigation.to': '/users/[id]',
           'sentry.sample_rate': 1,
+          'url.path': '/users/789',
+          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/789$/),
+          'url.template': '/users/[id]',
         },
       },
     },

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.client.test.ts
@@ -36,6 +36,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/nav1',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/nav1$/),
+            'url.template': '/nav1',
+          },
         },
       },
     });
@@ -49,6 +54,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
+            'url.template': '/',
+          },
         },
       },
     });
@@ -62,6 +72,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/nav2',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/nav2$/),
+            'url.template': '/nav2',
+          },
         },
       },
     });

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
@@ -27,6 +27,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'pageload',
           origin: 'auto.pageload.sveltekit',
+          data: {
+            'url.path': '/users/123xyz',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/123xyz$/),
+            'url.template': '/users/[id]',
+          },
         },
       },
     });
@@ -81,6 +86,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
+          data: {
+            'url.path': '/users',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users$/),
+            'url.template': '/users',
+          },
         },
       },
     });
@@ -132,6 +142,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
+          data: {
+            'url.path': '/universal-load-fetch',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/universal-load-fetch$/),
+            'url.template': '/universal-load-fetch',
+          },
         },
       },
     });
@@ -205,6 +220,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'pageload',
           origin: 'auto.pageload.sveltekit',
+          data: {
+            'url.path': '/',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
+            'url.template': '/',
+          },
         },
       },
     });
@@ -221,6 +241,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/users/[id]',
             'sentry.sveltekit.navigation.type': 'link',
+            'url.path': '/users/123abc',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/123abc$/),
+            'url.template': '/users/[id]',
           },
         },
       },
@@ -283,6 +306,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/redirect1',
             'sentry.sample_rate': 1,
+            'url.path': '/redirect1',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/redirect1$/),
+            'url.template': '/redirect1',
           },
         },
       },
@@ -320,6 +346,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/redirect2',
             'sentry.sample_rate': 1,
+            'url.path': '/redirect2',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/redirect2$/),
+            'url.template': '/redirect2',
           },
         },
       },
@@ -357,6 +386,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/users/[id]',
             'sentry.sample_rate': 1,
+            'url.path': '/users/789',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/789$/),
+            'url.template': '/users/[id]',
           },
         },
       },

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/tests/performance.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/tests/performance.client.test.ts
@@ -31,6 +31,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/nav1',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/nav1$/),
+            'url.template': '/nav1',
+          },
         },
       },
     });
@@ -44,6 +49,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
+            'url.template': '/',
+          },
         },
       },
     });
@@ -57,6 +67,11 @@ test.describe('client-specific performance events', () => {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
           trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'url.path': '/nav2',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/nav2$/),
+            'url.template': '/nav2',
+          },
         },
       },
     });

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/tests/performance.test.ts
@@ -27,6 +27,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'pageload',
           origin: 'auto.pageload.sveltekit',
+          data: {
+            'url.path': '/users/123xyz',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/123xyz$/),
+            'url.template': '/users/[id]',
+          },
         },
       },
     });
@@ -81,6 +86,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
+          data: {
+            'url.path': '/users',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users$/),
+            'url.template': '/users',
+          },
         },
       },
     });
@@ -132,6 +142,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'navigation',
           origin: 'auto.navigation.sveltekit',
+          data: {
+            'url.path': '/universal-load-fetch',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/universal-load-fetch$/),
+            'url.template': '/universal-load-fetch',
+          },
         },
       },
     });
@@ -205,6 +220,11 @@ test.describe('performance events', () => {
         trace: {
           op: 'pageload',
           origin: 'auto.pageload.sveltekit',
+          data: {
+            'url.path': '/',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
+            'url.template': '/',
+          },
         },
       },
     });
@@ -221,6 +241,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/users/[id]',
             'sentry.sveltekit.navigation.type': 'link',
+            'url.path': '/users/123abc',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/123abc$/),
+            'url.template': '/users/[id]',
           },
         },
       },
@@ -283,6 +306,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/redirect1',
             'sentry.sample_rate': 1,
+            'url.path': '/redirect1',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/redirect1$/),
+            'url.template': '/redirect1',
           },
         },
       },
@@ -320,6 +346,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/redirect2',
             'sentry.sample_rate': 1,
+            'url.path': '/redirect2',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/redirect2$/),
+            'url.template': '/redirect2',
           },
         },
       },
@@ -357,6 +386,9 @@ test.describe('performance events', () => {
             'sentry.sveltekit.navigation.from': '/',
             'sentry.sveltekit.navigation.to': '/users/[id]',
             'sentry.sample_rate': 1,
+            'url.path': '/users/789',
+            'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/users\/789$/),
+            'url.template': '/users/[id]',
           },
         },
       },

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "@sentry/cloudflare": "10.64.0",
     "@sentry/core": "10.64.0",
+    "@sentry/conventions": "^0.15.1",
     "@sentry/node": "10.64.0",
     "@sentry/svelte": "10.64.0",
     "@sentry/vite-plugin": "^5.3.0",

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -9,6 +9,7 @@ import {
   WINDOW,
 } from '@sentry/svelte';
 import { navigating, page } from '$app/stores';
+import { URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 /**
  * A custom `BrowserTracing` integration for SvelteKit.
@@ -66,7 +67,7 @@ function _instrumentPageload(client: Client): void {
 
     if (routeId) {
       pageloadSpan.updateName(routeId);
-      pageloadSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+      pageloadSpan.setAttributes({ [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route', [URL_TEMPLATE]: routeId });
       getCurrentScope().setTransactionName(routeId);
     }
   });
@@ -127,15 +128,20 @@ function _instrumentNavigations(client: Client): void {
       'sentry.sveltekit.navigation.to': parameterizedRouteDestination || undefined,
     };
 
-    startBrowserTracingNavigationSpan(client, {
-      name: parameterizedRouteDestination || rawRouteDestination || 'unknown',
-      op: 'navigation',
-      attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
-        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: parameterizedRouteDestination ? 'route' : 'url',
-        ...navigationInfo,
+    startBrowserTracingNavigationSpan(
+      client,
+      {
+        name: parameterizedRouteDestination || rawRouteDestination || 'unknown',
+        op: 'navigation',
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: parameterizedRouteDestination ? 'route' : 'url',
+          ...(parameterizedRouteDestination && { [URL_TEMPLATE]: parameterizedRouteDestination }),
+          ...navigationInfo,
+        },
       },
-    });
+      { url: to?.url.href },
+    );
 
     routingSpan = startInactiveSpan({
       op: 'ui.sveltekit.routing',

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -10,6 +10,7 @@ import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { navigating, page } from '$app/stores';
 import { browserTracingIntegration } from '../../src/client';
+import { URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 // we have to overwrite the global mock from `vitest.setup.ts` here to reset the
 // `navigating` store for each test.
@@ -41,6 +42,7 @@ describe('browserTracingIntegration', () => {
         ...txnCtx,
         updateName: vi.fn(),
         setAttribute: vi.fn(),
+        setAttributes: vi.fn(),
       };
       return createdRootSpan as Span;
     });
@@ -52,6 +54,7 @@ describe('browserTracingIntegration', () => {
         ...txnCtx,
         updateName: vi.fn(),
         setAttribute: vi.fn(),
+        setAttributes: vi.fn(),
       };
       return createdRootSpan as Span;
     });
@@ -125,7 +128,10 @@ describe('browserTracingIntegration', () => {
     // This should update the transaction name with the parameterized route:
     expect(createdRootSpan?.updateName).toHaveBeenCalledTimes(1);
     expect(createdRootSpan?.updateName).toHaveBeenCalledWith('testRoute');
-    expect(createdRootSpan?.setAttribute).toHaveBeenCalledWith(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
+    expect(createdRootSpan?.setAttributes).toHaveBeenCalledWith({
+      [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+      [URL_TEMPLATE]: 'testRoute',
+    });
   });
 
   it("doesn't start a pageload span if `instrumentPageLoad` is false", () => {
@@ -196,23 +202,28 @@ describe('browserTracingIntegration', () => {
     // eslint-disable-next-line typescript/no-deprecated
     navigating.set({
       from: { route: { id: '/users' }, url: { pathname: '/users' } },
-      to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
+      to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762', href: 'https://sentry-test.io/users/7762' } },
       type: 'link',
     });
 
     // This should update the transaction name with the parameterized route:
     expect(startBrowserTracingNavigationSpanSpy).toHaveBeenCalledTimes(1);
-    expect(startBrowserTracingNavigationSpanSpy).toHaveBeenCalledWith(fakeClient, {
-      name: '/users/[id]',
-      op: 'navigation',
-      attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
-        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
-        'sentry.sveltekit.navigation.from': '/users',
-        'sentry.sveltekit.navigation.to': '/users/[id]',
-        'sentry.sveltekit.navigation.type': 'link',
+    expect(startBrowserTracingNavigationSpanSpy).toHaveBeenCalledWith(
+      fakeClient,
+      {
+        name: '/users/[id]',
+        op: 'navigation',
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+          [URL_TEMPLATE]: '/users/[id]',
+          'sentry.sveltekit.navigation.from': '/users',
+          'sentry.sveltekit.navigation.to': '/users/[id]',
+          'sentry.sveltekit.navigation.type': 'link',
+        },
       },
-    });
+      { url: 'https://sentry-test.io/users/7762' },
+    );
 
     expect(startInactiveSpanSpy).toHaveBeenCalledWith({
       op: 'ui.sveltekit.routing',
@@ -267,20 +278,28 @@ describe('browserTracingIntegration', () => {
       // eslint-disable-next-line typescript/no-deprecated
       navigating.set({
         from: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
-        to: { route: { id: '/users/[id]' }, url: { pathname: '/users/223412' } },
+        to: {
+          route: { id: '/users/[id]' },
+          url: { pathname: '/users/223412', href: 'https://sentry-test.io/users/223412' },
+        },
       });
 
       expect(startBrowserTracingNavigationSpanSpy).toHaveBeenCalledTimes(1);
-      expect(startBrowserTracingNavigationSpanSpy).toHaveBeenCalledWith(fakeClient, {
-        name: '/users/[id]',
-        op: 'navigation',
-        attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
-          'sentry.sveltekit.navigation.from': '/users/[id]',
-          'sentry.sveltekit.navigation.to': '/users/[id]',
+      expect(startBrowserTracingNavigationSpanSpy).toHaveBeenCalledWith(
+        fakeClient,
+        {
+          name: '/users/[id]',
+          op: 'navigation',
+          attributes: {
+            [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
+            [URL_TEMPLATE]: '/users/[id]',
+            'sentry.sveltekit.navigation.from': '/users/[id]',
+            'sentry.sveltekit.navigation.to': '/users/[id]',
+          },
         },
-      });
+        { url: 'https://sentry-test.io/users/223412' },
+      );
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         op: 'ui.sveltekit.routing',


### PR DESCRIPTION
Applies `url.template` to pageload and navigation root spans in the SvelteKit client integration, and adds e2e coverage for `url.full`, `url.path` and `url.template` across the SvelteKit test applications.

part of https://github.com/getsentry/sentry-javascript/issues/21921