### PR TITLE
fix(ci): Improve flaky test issue deduplication

### DIFF
--- a/scripts/report-ci-failures.mjs
+++ b/scripts/report-ci-failures.mjs
@@ -19,31 +19,44 @@ import { readFileSync } from 'node:fs';
 
 /**
  * Collapse matrix variants of a job name so the same test failing across the matrix dedupes to a
- * single issue instead of one per node/TS version. We strip only version-like parenthetical groups
- * — a bare number (e.g. node version) or a `TS x.y` bracket — leaving other parentheticals (e.g.
- * `(nextjs-app, 20)`) intact:
+ * single issue instead of one per variant. We strip version-like parenthetical groups — a bare
+ * number (node version), a `TS x.y` bracket, a `Node xx` bracket, or a `n/m` shard — and fold the
+ * Playwright bundle/esm build configs and E2E `-node-xx` app suffixes into a single bucket, leaving
+ * other parentheticals (e.g. `(nextjs-app, 20)`) intact:
  *
- *   "Node (22) Integration Tests"          -> "Node Integration Tests"
- *   "Node (24) Integration Tests"          -> "Node Integration Tests"
- *   "Node (24) (TS 3.8) Integration Tests" -> "Node Integration Tests"
+ *   "Node (22) Integration Tests"              -> "Node Integration Tests"
+ *   "Node (24) (TS 3.8) Integration Tests"     -> "Node Integration Tests"
+ *   "aws-serverless-layer (Node 22) Test"      -> "aws-serverless-layer Test"
+ *   "Playwright bundle_tracing_replay Tests"   -> "Playwright Tests"
+ *   "Playwright esm (1/4) Tests"               -> "Playwright Tests"
+ *   "E2E react-router-7-framework-node-20-18 Test" -> "E2E react-router-7-framework Test"
  */
 function normalizeJobName(name) {
   return name
-    .replace(/\(\s*(?:\d+|TS\s+[\d.]+)\s*\)/gi, ' ')
+    .replace(/\(\s*(?:\d+|TS\s+[\d.]+|Node\s+\d+|\d+\/\d+)\s*\)/gi, ' ')
+    .replace(/Playwright\s+(?:bundle\w*|esm|cjs)\s+Tests/gi, 'Playwright Tests')
+    .replace(/-node-\d+(?:-\d+)*/gi, '')
     .replace(/\s+/g, ' ')
     .trim();
 }
 
 /**
- * Collapse esm/cjs variants of a test name so the same test failing in both module formats dedupes
- * to a single issue instead of one per variant:
+ * Collapse variants of a test name so the same test failing under different module formats, browser
+ * projects, or (for Playwright) at a different source line dedupes to a single issue. We strip:
  *
- *   "... > esm/cjs > esm > should send messages" -> "... > esm/cjs > should send messages"
- *   "... > esm/cjs > cjs > should send messages" -> "... > esm/cjs > should send messages"
+ *   - Playwright browser prefix:   "[chromium] › suites/... " -> "suites/... "
+ *   - Playwright file line/column: "test.ts:33:11 › ..."      -> "test.ts › ..." (drifts on edits)
+ *   - old esm/cjs describe block:  "... > esm/cjs > esm > x"  -> "... > x"
+ *   - bare esm/cjs describe block: "... > esm/cjs > x"        -> "... > x"
+ *   - trailing module suffix:      "... should send [esm]"    -> "... should send"
  */
 function normalizeTestName(name) {
   return name
+    .replace(/^\[(?:chromium|firefox|webkit)\]\s*›\s*/i, '')
+    .replace(/(\.[cm]?[jt]sx?):\d+:\d+/gi, '$1')
     .replace(/esm\/cjs\s*>\s*(?:esm|cjs)\b/gi, 'esm/cjs')
+    .replace(/\besm\/cjs\s*>\s*/gi, '')
+    .replace(/\s*\[(?:esm|cjs)\]/gi, '')
     .replace(/\s+/g, ' ')
     .trim();
 }


### PR DESCRIPTION
`report-ci-failures.mjs` opens one GitHub issue per failing test, keyed on a normalized job + test name. Several variant patterns weren't being stripped, so the same flaky test kept opening duplicate issues. This widens both normalizers.

**`normalizeJobName`** now also collapses:
- `(Node 22)` and `(n/m)` shard groups (in addition to the existing `(22)` / `(TS 3.8)`)
- All Playwright bundle/esm build configs into a single `Playwright Tests` bucket (e.g. `bundle_tracing`, `bundle_tracing_replay`, `esm (1/4)`) — the same profiling flake was filing an issue per config
- E2E `-node-20-18` app-name version suffixes

Non-version parentheticals such as `(Orchestrion)` are preserved.

**`normalizeTestName`** now also strips:
- The `[chromium] ›` browser project prefix
- Playwright `test.ts:33:11` line/column locations — these drift whenever the test file is edited, silently reopening the same flaky issue under a new title
- The trailing `[esm]` / `[cjs]` module-format suffix (the main gap — the old describe-block form was handled but the newer suffix form was not) and the bare `esm/cjs >` describe segment, so both forms converge

Verified against current open `Flaky Test` issues: the `[esm]`/`[cjs]` postgres/mysql pairs collapse to one, the profiling test across `bundle_tracing` / `bundle_tracing_replay` / `esm (1/4)` collapses to one, and line-drift variants merge.

_Note:_ dedup still matches on exact issue title, so existing issues (which carry the old normalized titles) won't retroactively merge — the next run files them once under the new canonical titles. Bulk-closing the current flaky issues after merge is recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)