### PR TITLE
test(node): Wait for Postgres readiness in pg integration test scenarios

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/scenario-native.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/scenario-native.mjs
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import pg from 'pg';
+import { waitForPostgres } from './wait-for-postgres.js';
 
 const { native } = pg;
 const { Client } = native;
@@ -7,9 +8,11 @@ const { Client } = native;
 // `pg-native` uses libpq, which resolves `localhost` to IPv6 (`::1`) first and does not
 // fall back to IPv4. Docker Desktop only forwards the mapped port over IPv4, so we connect
 // to the IPv4 loopback explicitly to avoid an `ECONNREFUSED` on `::1`.
-const client = new Client({ host: '127.0.0.1', port: 5495, user: 'test', password: 'test', database: 'tests' });
+const connectionConfig = { host: '127.0.0.1', port: 5495, user: 'test', password: 'test', database: 'tests' };
+const client = new Client(connectionConfig);
 
 async function run() {
+  await waitForPostgres(connectionConfig);
   await Sentry.startSpan(
     {
       name: 'Test Span',

--- a/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/scenario.mjs
@@ -1,9 +1,12 @@
 import * as Sentry from '@sentry/node';
 import { Client } from 'pg';
+import { waitForPostgres } from './wait-for-postgres.js';
 
-const client = new Client({ port: 5495, user: 'test', password: 'test', database: 'tests' });
+const connectionConfig = { port: 5495, user: 'test', password: 'test', database: 'tests' };
+const client = new Client(connectionConfig);
 
 async function run() {
+  await waitForPostgres(connectionConfig);
   await Sentry.startSpan(
     {
       name: 'Test Span',

--- a/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/test.ts
@@ -165,68 +165,80 @@ describe('postgres auto instrumentation (streamed)', () => {
   });
 
   describe('default', () => {
-    createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createTestRunner, test) => {
-      test('should auto-instrument `pg` package with span streaming enabled', { timeout: 90_000 }, async () => {
-        await createTestRunner()
-          .withDockerCompose({
-            workingDirectory: [__dirname],
-          })
-          .expect({
-            span: container => {
-              const segmentSpan = container.items.find(item => item.is_segment);
-              expect(segmentSpan?.name).toBe('Test Span');
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario.mjs',
+      'instrument.mjs',
+      (createTestRunner, test) => {
+        test('should auto-instrument `pg` package with span streaming enabled', { timeout: 90_000 }, async () => {
+          await createTestRunner()
+            .withDockerCompose({
+              workingDirectory: [__dirname],
+            })
+            .expect({
+              span: container => {
+                const segmentSpan = container.items.find(item => item.is_segment);
+                expect(segmentSpan?.name).toBe('Test Span');
 
-              const dbSpans = getDbSpans(container);
-              expect(dbSpans.length).toBe(4);
+                const dbSpans = getDbSpans(container);
+                expect(dbSpans.length).toBe(4);
 
-              expect(dbSpans).toEqual([
-                expectedDbSpan({ name: 'pg.connect' }),
-                expectedDbSpan({ name: CREATE_USER_TABLE_STATEMENT, statement: CREATE_USER_TABLE_STATEMENT }),
-                expectedDbSpan({
-                  name: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
-                  statement: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
-                }),
-                expectedDbSpan({ name: 'SELECT * FROM "User"', statement: 'SELECT * FROM "User"' }),
-              ]);
-            },
-          })
-          .start()
-          .completed();
-      });
-    });
+                expect(dbSpans).toEqual([
+                  expectedDbSpan({ name: 'pg.connect' }),
+                  expectedDbSpan({ name: CREATE_USER_TABLE_STATEMENT, statement: CREATE_USER_TABLE_STATEMENT }),
+                  expectedDbSpan({
+                    name: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
+                    statement: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
+                  }),
+                  expectedDbSpan({ name: 'SELECT * FROM "User"', statement: 'SELECT * FROM "User"' }),
+                ]);
+              },
+            })
+            .start()
+            .completed();
+        });
+      },
+      { copyPaths: ['wait-for-postgres.js'] },
+    );
   });
 
   describe('ignoreConnectSpans', () => {
-    createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-ignoreConnect.mjs', (createTestRunner, test) => {
-      test("doesn't emit connect spans if ignoreConnectSpans is true", { timeout: 90_000 }, async () => {
-        await createTestRunner()
-          .withDockerCompose({
-            workingDirectory: [__dirname],
-          })
-          .expect({
-            span: container => {
-              const dbSpans = getDbSpans(container);
-              expect(dbSpans.find(span => span.name.includes('connect'))).toBeUndefined();
-              expect(dbSpans.length).toBe(3);
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario.mjs',
+      'instrument-ignoreConnect.mjs',
+      (createTestRunner, test) => {
+        test("doesn't emit connect spans if ignoreConnectSpans is true", { timeout: 90_000 }, async () => {
+          await createTestRunner()
+            .withDockerCompose({
+              workingDirectory: [__dirname],
+            })
+            .expect({
+              span: container => {
+                const dbSpans = getDbSpans(container);
+                expect(dbSpans.find(span => span.name.includes('connect'))).toBeUndefined();
+                expect(dbSpans.length).toBe(3);
 
-              // This block passes an explicit `postgresIntegration({ ignoreConnectSpans: true })`, which
-              // survives the orchestrion swap, so query spans keep the OTel origin even under INJECT_ORCHESTRION.
-              const origin = 'auto.db.otel.postgres';
-              expect(dbSpans).toEqual([
-                expectedDbSpan({ name: CREATE_USER_TABLE_STATEMENT, statement: CREATE_USER_TABLE_STATEMENT, origin }),
-                expectedDbSpan({
-                  name: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
-                  statement: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
-                  origin,
-                }),
-                expectedDbSpan({ name: 'SELECT * FROM "User"', statement: 'SELECT * FROM "User"', origin }),
-              ]);
-            },
-          })
-          .start()
-          .completed();
-      });
-    });
+                // This block passes an explicit `postgresIntegration({ ignoreConnectSpans: true })`, which
+                // survives the orchestrion swap, so query spans keep the OTel origin even under INJECT_ORCHESTRION.
+                const origin = 'auto.db.otel.postgres';
+                expect(dbSpans).toEqual([
+                  expectedDbSpan({ name: CREATE_USER_TABLE_STATEMENT, statement: CREATE_USER_TABLE_STATEMENT, origin }),
+                  expectedDbSpan({
+                    name: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
+                    statement: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
+                    origin,
+                  }),
+                  expectedDbSpan({ name: 'SELECT * FROM "User"', statement: 'SELECT * FROM "User"', origin }),
+                ]);
+              },
+            })
+            .start()
+            .completed();
+        });
+      },
+      { copyPaths: ['wait-for-postgres.js'] },
+    );
   });
 
   conditionalTest({ max: 25 })('pg-native', () => {
@@ -276,7 +288,7 @@ describe('postgres auto instrumentation (streamed)', () => {
           },
         );
       },
-      { additionalDependencies: { 'pg-native': '3.7.0', pg: '8.20.0' } },
+      { additionalDependencies: { 'pg-native': '3.7.0', pg: '8.20.0' }, copyPaths: ['wait-for-postgres.js'] },
     );
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/wait-for-postgres.js
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/wait-for-postgres.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { Client } = require('pg');
+
+/**
+ * Retries a real connection until Postgres accepts it. `docker compose up --wait` only blocks on the
+ * in-container `pg_isready` healthcheck; on busy CI the host port-forward can still lag behind, so a
+ * scenario's first `connect()` can hit `ECONNREFUSED`/`ECONNRESET` and flake the whole run.
+ *
+ * Must be awaited *before* opening the scenario's own span: the SDK requires a parent span, so this
+ * probe (running with no active span) produces no spans/transactions and can't pollute the asserted
+ * envelope. A fresh client is created per attempt because a `pg.Client` is single-use once its
+ * connection fails.
+ */
+async function waitForPostgres(connectionConfig, maxWaitMs = 60_000) {
+  const deadline = Date.now() + maxWaitMs;
+  for (;;) {
+    const client = new Client(connectionConfig);
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      await client.end();
+      return;
+    } catch {
+      await client.end().catch(() => {
+        // ignore: the connection never opened
+      });
+      if (Date.now() > deadline) {
+        throw new Error('Timed out waiting for Postgres to accept connections');
+      }
+      await new Promise(r => setTimeout(r, 250));
+    }
+  }
+}
+
+module.exports = { waitForPostgres };

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-connect-then.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-connect-then.mjs
@@ -1,7 +1,11 @@
 import * as Sentry from '@sentry/node';
 import { Client } from 'pg';
+import { waitForPostgres } from './wait-for-postgres.js';
+
+const connectionConfig = { port: 5494, user: 'test', password: 'test', database: 'tests' };
 
 async function run() {
+  await waitForPostgres(connectionConfig);
   await Sentry.startSpan(
     {
       name: 'Test Transaction',
@@ -12,7 +16,7 @@ async function run() {
       // issued from the continuation must still be parented to the active
       // transaction, proving the trace context survives the connect promise.
       new Promise((resolve, reject) => {
-        const client = new Client({ port: 5494, user: 'test', password: 'test', database: 'tests' });
+        const client = new Client(connectionConfig);
         client
           .connect()
           .then(() => client.query('SELECT 1 AS connect_then'))

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-native.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-native.mjs
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 import pg from 'pg';
+import { waitForPostgres } from './wait-for-postgres.js';
 
 const { native } = pg;
 const { Client } = native;
@@ -7,9 +8,11 @@ const { Client } = native;
 // `pg-native` uses libpq, which resolves `localhost` to IPv6 (`::1`) first and does not
 // fall back to IPv4. Docker Desktop only forwards the mapped port over IPv4, so we connect
 // to the IPv4 loopback explicitly to avoid an `ECONNREFUSED` on `::1`.
-const client = new Client({ host: '127.0.0.1', port: 5494, user: 'test', password: 'test', database: 'tests' });
+const connectionConfig = { host: '127.0.0.1', port: 5494, user: 'test', password: 'test', database: 'tests' };
+const client = new Client(connectionConfig);
 
 async function run() {
+  await waitForPostgres(connectionConfig);
   await Sentry.startSpan(
     {
       name: 'Test Transaction',

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-no-parent.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-no-parent.mjs
@@ -1,9 +1,13 @@
 import * as Sentry from '@sentry/node';
 import { Client } from 'pg';
+import { waitForPostgres } from './wait-for-postgres.js';
 
-const client = new Client({ port: 5494, user: 'test', password: 'test', database: 'tests' });
+const connectionConfig = { port: 5494, user: 'test', password: 'test', database: 'tests' };
+const client = new Client(connectionConfig);
 
 async function run() {
+  await waitForPostgres(connectionConfig);
+
   // No active span here: `requireParentSpan` means the connect and this query
   // must NOT produce spans.
   await client.connect();

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-pool.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/scenario-pool.mjs
@@ -1,13 +1,16 @@
 import * as Sentry from '@sentry/node';
 import pg from 'pg';
+import { waitForPostgres } from './wait-for-postgres.js';
 
 const { Pool } = pg;
 
 // The connection string carries credentials so we can assert they are masked
 // out of the `db.connection_string` span attribute.
-const pool = new Pool({ connectionString: 'postgresql://test:test@localhost:5494/tests' });
+const connectionString = 'postgresql://test:test@localhost:5494/tests';
+const pool = new Pool({ connectionString });
 
 async function run() {
+  await waitForPostgres({ connectionString });
   await Sentry.startSpan(
     {
       name: 'Test Transaction',

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/scenario.mjs
@@ -1,9 +1,12 @@
 import * as Sentry from '@sentry/node';
 import { Client } from 'pg';
+import { waitForPostgres } from './wait-for-postgres.js';
 
-const client = new Client({ port: 5494, user: 'test', password: 'test', database: 'tests' });
+const connectionConfig = { port: 5494, user: 'test', password: 'test', database: 'tests' };
+const client = new Client(connectionConfig);
 
 async function run() {
+  await waitForPostgres(connectionConfig);
   await Sentry.startSpan(
     {
       name: 'Test Transaction',

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/test.ts
@@ -84,67 +84,79 @@ describe('postgres auto instrumentation', () => {
       ]),
     };
 
-    createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createTestRunner, test) => {
-      test('should auto-instrument `pg` package', { timeout: 90_000 }, async () => {
-        await createTestRunner()
-          .withDockerCompose({
-            workingDirectory: [__dirname],
-          })
-          .expect({ transaction: EXPECTED_TRANSACTION })
-          .start()
-          .completed();
-      });
-    });
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario.mjs',
+      'instrument.mjs',
+      (createTestRunner, test) => {
+        test('should auto-instrument `pg` package', { timeout: 90_000 }, async () => {
+          await createTestRunner()
+            .withDockerCompose({
+              workingDirectory: [__dirname],
+            })
+            .expect({ transaction: EXPECTED_TRANSACTION })
+            .start()
+            .completed();
+        });
+      },
+      { copyPaths: ['wait-for-postgres.js'] },
+    );
   });
 
   describe('ignoreConnectSpans', () => {
-    createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-ignoreConnect.mjs', (createTestRunner, test) => {
-      test("doesn't emit connect spans if ignoreConnectSpans is true", { timeout: 90_000 }, async () => {
-        await createTestRunner()
-          .withDockerCompose({
-            workingDirectory: [__dirname],
-          })
-          .expect({
-            transaction: txn => {
-              const spanNames = txn.spans?.map(span => span.description);
-              expect(spanNames?.find(name => name?.includes('connect'))).toBeUndefined();
-              expect(txn).toMatchObject({
-                transaction: 'Test Transaction',
-                spans: expect.arrayContaining([
-                  expect.objectContaining({
-                    data: expect.objectContaining({
-                      'db.system': 'postgresql',
-                      'db.name': 'tests',
-                      'db.statement': 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
-                      'sentry.origin': 'auto.db.otel.postgres',
-                      'sentry.op': 'db',
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario.mjs',
+      'instrument-ignoreConnect.mjs',
+      (createTestRunner, test) => {
+        test("doesn't emit connect spans if ignoreConnectSpans is true", { timeout: 90_000 }, async () => {
+          await createTestRunner()
+            .withDockerCompose({
+              workingDirectory: [__dirname],
+            })
+            .expect({
+              transaction: txn => {
+                const spanNames = txn.spans?.map(span => span.description);
+                expect(spanNames?.find(name => name?.includes('connect'))).toBeUndefined();
+                expect(txn).toMatchObject({
+                  transaction: 'Test Transaction',
+                  spans: expect.arrayContaining([
+                    expect.objectContaining({
+                      data: expect.objectContaining({
+                        'db.system': 'postgresql',
+                        'db.name': 'tests',
+                        'db.statement': 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
+                        'sentry.origin': 'auto.db.otel.postgres',
+                        'sentry.op': 'db',
+                      }),
+                      description: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
+                      op: 'db',
+                      status: 'ok',
+                      origin: 'auto.db.otel.postgres',
                     }),
-                    description: 'INSERT INTO "User" ("email", "name") VALUES ($1, $2)',
-                    op: 'db',
-                    status: 'ok',
-                    origin: 'auto.db.otel.postgres',
-                  }),
-                  expect.objectContaining({
-                    data: expect.objectContaining({
-                      'db.system': 'postgresql',
-                      'db.name': 'tests',
-                      'db.statement': 'SELECT * FROM "User"',
-                      'sentry.origin': 'auto.db.otel.postgres',
-                      'sentry.op': 'db',
+                    expect.objectContaining({
+                      data: expect.objectContaining({
+                        'db.system': 'postgresql',
+                        'db.name': 'tests',
+                        'db.statement': 'SELECT * FROM "User"',
+                        'sentry.origin': 'auto.db.otel.postgres',
+                        'sentry.op': 'db',
+                      }),
+                      description: 'SELECT * FROM "User"',
+                      op: 'db',
+                      status: 'ok',
+                      origin: 'auto.db.otel.postgres',
                     }),
-                    description: 'SELECT * FROM "User"',
-                    op: 'db',
-                    status: 'ok',
-                    origin: 'auto.db.otel.postgres',
-                  }),
-                ]),
-              });
-            },
-          })
-          .start()
-          .completed();
-      });
-    });
+                  ]),
+                });
+              },
+            })
+            .start()
+            .completed();
+        });
+      },
+      { copyPaths: ['wait-for-postgres.js'] },
+    );
   });
 
   describe('pool', () => {
@@ -182,21 +194,27 @@ describe('postgres auto instrumentation', () => {
       ]),
     };
 
-    createEsmAndCjsTests(__dirname, 'scenario-pool.mjs', 'instrument.mjs', (createTestRunner, test) => {
-      test(
-        'auto-instruments `pg.Pool`, masks connection-string credentials, and handles callback-style queries',
-        { timeout: 90_000 },
-        async () => {
-          await createTestRunner()
-            .withDockerCompose({
-              workingDirectory: [__dirname],
-            })
-            .expect({ transaction: EXPECTED_TRANSACTION })
-            .start()
-            .completed();
-        },
-      );
-    });
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario-pool.mjs',
+      'instrument.mjs',
+      (createTestRunner, test) => {
+        test(
+          'auto-instruments `pg.Pool`, masks connection-string credentials, and handles callback-style queries',
+          { timeout: 90_000 },
+          async () => {
+            await createTestRunner()
+              .withDockerCompose({
+                workingDirectory: [__dirname],
+              })
+              .expect({ transaction: EXPECTED_TRANSACTION })
+              .start()
+              .completed();
+          },
+        );
+      },
+      { copyPaths: ['wait-for-postgres.js'] },
+    );
   });
 
   describe('connect error', () => {
@@ -249,57 +267,69 @@ describe('postgres auto instrumentation', () => {
       ]),
     };
 
-    createEsmAndCjsTests(__dirname, 'scenario-connect-then.mjs', 'instrument.mjs', (createTestRunner, test) => {
-      test('parents a query chained off connect() to the active transaction', { timeout: 90_000 }, async () => {
-        await createTestRunner()
-          .withDockerCompose({
-            workingDirectory: [__dirname],
-          })
-          .expect({ transaction: EXPECTED_TRANSACTION })
-          .start()
-          .completed();
-      });
-    });
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario-connect-then.mjs',
+      'instrument.mjs',
+      (createTestRunner, test) => {
+        test('parents a query chained off connect() to the active transaction', { timeout: 90_000 }, async () => {
+          await createTestRunner()
+            .withDockerCompose({
+              workingDirectory: [__dirname],
+            })
+            .expect({ transaction: EXPECTED_TRANSACTION })
+            .start()
+            .completed();
+        });
+      },
+      { copyPaths: ['wait-for-postgres.js'] },
+    );
   });
 
   describe('requireParentSpan', () => {
-    createEsmAndCjsTests(__dirname, 'scenario-no-parent.mjs', 'instrument.mjs', (createTestRunner, test) => {
-      test('does not instrument queries or connects without an active parent span', { timeout: 90_000 }, async () => {
-        await createTestRunner()
-          .withDockerCompose({
-            workingDirectory: [__dirname],
-          })
-          .expect({
-            transaction: txn => {
-              const descriptions = txn.spans?.map(span => span.description) ?? [];
-              // The unparented connect + query must not have produced spans
-              expect(descriptions).not.toContain('SELECT 1 AS unparented');
-              expect(descriptions.find(name => name?.includes('connect'))).toBeUndefined();
-              // Only the parented query is instrumented
-              expect(txn).toMatchObject({
-                transaction: 'Test Transaction',
-                spans: expect.arrayContaining([
-                  expect.objectContaining({
-                    data: expect.objectContaining({
-                      'db.system': 'postgresql',
-                      'db.name': 'tests',
-                      'db.statement': 'SELECT 2 AS parented',
-                      'sentry.origin': QUERY_ORIGIN,
-                      'sentry.op': 'db',
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario-no-parent.mjs',
+      'instrument.mjs',
+      (createTestRunner, test) => {
+        test('does not instrument queries or connects without an active parent span', { timeout: 90_000 }, async () => {
+          await createTestRunner()
+            .withDockerCompose({
+              workingDirectory: [__dirname],
+            })
+            .expect({
+              transaction: txn => {
+                const descriptions = txn.spans?.map(span => span.description) ?? [];
+                // The unparented connect + query must not have produced spans
+                expect(descriptions).not.toContain('SELECT 1 AS unparented');
+                expect(descriptions.find(name => name?.includes('connect'))).toBeUndefined();
+                // Only the parented query is instrumented
+                expect(txn).toMatchObject({
+                  transaction: 'Test Transaction',
+                  spans: expect.arrayContaining([
+                    expect.objectContaining({
+                      data: expect.objectContaining({
+                        'db.system': 'postgresql',
+                        'db.name': 'tests',
+                        'db.statement': 'SELECT 2 AS parented',
+                        'sentry.origin': QUERY_ORIGIN,
+                        'sentry.op': 'db',
+                      }),
+                      description: 'SELECT 2 AS parented',
+                      op: 'db',
+                      status: 'ok',
+                      origin: QUERY_ORIGIN,
                     }),
-                    description: 'SELECT 2 AS parented',
-                    op: 'db',
-                    status: 'ok',
-                    origin: QUERY_ORIGIN,
-                  }),
-                ]),
-              });
-            },
-          })
-          .start()
-          .completed();
-      });
-    });
+                  ]),
+                });
+              },
+            })
+            .start()
+            .completed();
+        });
+      },
+      { copyPaths: ['wait-for-postgres.js'] },
+    );
   });
 
   conditionalTest({ max: 25 })('pg-native', () => {
@@ -361,7 +391,7 @@ describe('postgres auto instrumentation', () => {
             .completed();
         });
       },
-      { additionalDependencies: { 'pg-native': '3.7.0', pg: '8.20.0' } },
+      { additionalDependencies: { 'pg-native': '3.7.0', pg: '8.20.0' }, copyPaths: ['wait-for-postgres.js'] },
     );
   });
 
@@ -445,7 +475,7 @@ describe('postgres auto instrumentation', () => {
         },
         // This block enables orchestrion itself via its instrument file, so opt out of the generic
         // INJECT_ORCHESTRION auto-injection to avoid enabling it twice.
-        { injectOrchestrion: false },
+        { injectOrchestrion: false, copyPaths: ['wait-for-postgres.js'] },
       );
     });
 
@@ -495,7 +525,7 @@ describe('postgres auto instrumentation', () => {
           });
         },
         // Enables orchestrion itself; opt out of the generic INJECT_ORCHESTRION auto-injection.
-        { injectOrchestrion: false },
+        { injectOrchestrion: false, copyPaths: ['wait-for-postgres.js'] },
       );
     });
 
@@ -573,7 +603,7 @@ describe('postgres auto instrumentation', () => {
           );
         },
         // Enables orchestrion itself; opt out of the generic INJECT_ORCHESTRION auto-injection.
-        { injectOrchestrion: false },
+        { injectOrchestrion: false, copyPaths: ['wait-for-postgres.js'] },
       );
     });
 
@@ -634,7 +664,7 @@ describe('postgres auto instrumentation', () => {
           );
         },
         // Enables orchestrion itself; opt out of the generic INJECT_ORCHESTRION auto-injection.
-        { injectOrchestrion: false },
+        { injectOrchestrion: false, copyPaths: ['wait-for-postgres.js'] },
       );
     });
   });

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/wait-for-postgres.js
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/wait-for-postgres.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { Client } = require('pg');
+
+/**
+ * Retries a real connection until Postgres accepts it. `docker compose up --wait` only blocks on the
+ * in-container `pg_isready` healthcheck; on busy CI the host port-forward can still lag behind, so a
+ * scenario's first `connect()` can hit `ECONNREFUSED`/`ECONNRESET` and flake the whole run.
+ *
+ * Must be awaited *before* opening the scenario's own span: the SDK requires a parent span, so this
+ * probe (running with no active span) produces no spans/transactions and can't pollute the asserted
+ * envelope. A fresh client is created per attempt because a `pg.Client` is single-use once its
+ * connection fails.
+ */
+async function waitForPostgres(connectionConfig, maxWaitMs = 60_000) {
+  const deadline = Date.now() + maxWaitMs;
+  for (;;) {
+    const client = new Client(connectionConfig);
+    try {
+      await client.connect();
+      await client.query('SELECT 1');
+      await client.end();
+      return;
+    } catch {
+      await client.end().catch(() => {
+        // ignore: the connection never opened
+      });
+      if (Date.now() > deadline) {
+        throw new Error('Timed out waiting for Postgres to accept connections');
+      }
+      await new Promise(r => setTimeout(r, 250));
+    }
+  }
+}
+
+module.exports = { waitForPostgres };


### PR DESCRIPTION
The `postgres` and `postgres-streamed` node-integration-test scenarios are a persistent source of CI flakiness. This ports the readiness gate the `postgresjs` suite already uses to the `pg`-based scenarios.

### Root cause

The runner starts the DB with `docker compose up -d --wait`, which blocks only on the container's **internal** `pg_isready` healthcheck. On busy CI the **host-side port forward** (e.g. `5494:5432`) can lag behind that — so the scenario's first `client.connect()` intermittently hits `ECONNREFUSED`/`ECONNRESET` and flakes the whole run.

Every flaky subtest is DB-dependent; the one postgres test that needs no DB (`connect error`) never shows up in the flaky reports. The `postgresjs` suite already guards against this exact race with a `waitForPostgres()` retry loop (its helper even documents *"docker compose up --wait can report healthy before the port forward on the host is ready"*), and is far less flaky as a result.

### Fix

- Add a `wait-for-postgres.js` helper to the `postgres` and `postgres-streamed` suites that retries a real `connect()` + `SELECT 1` (a fresh `pg.Client` per attempt, since a failed client is single-use) until Postgres accepts connections.
- Scenarios `await waitForPostgres(...)` **before** `Sentry.startSpan(...)`. Because the SDK requires a parent span (`shouldSkipInstrumentation()` returns true with no active span), the probe emits no spans/transactions and can't pollute the asserted envelopes — important for the streamed suite's strict `toEqual`/exact-count assertions and the `requireParentSpan`/`ignoreConnectSpans` "no connect span" checks.
- Wire the helper into each DB-using `createEsmAndCjsTests` call via `copyPaths: ['wait-for-postgres.js']` so it lands in the per-run tmp dir. The `connect error` blocks (no DB) are left untouched.

Verified locally against Docker: all runnable subtests pass across ESM/CJS and both the OTel and orchestrion (diagnostics-channel) paths. `pg-native` variants are `conditionalTest({ max: 25 })` and skip on Node > 25, but use the identical helper + `copyPaths` mechanism.

Fixes #22032
Fixes #21935
Fixes #21934
Fixes #21926
Fixes #21927
Fixes #21942
Fixes #21941
Fixes #21937
Fixes #21933
Fixes #21928
Fixes #21931
Fixes #21930
Fixes #21936
Fixes #21932
Fixes #21929

🤖 Generated with [Claude Code](https://claude.com/claude-code)