### PR TITLE
test(node): Retry initial tedious connection until the DB is ready

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/tedious/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/scenario.mjs
@@ -24,11 +24,38 @@ const BULK_TABLE = 'test_bulk';
 function connect() {
   return new Promise((resolve, reject) => {
     const connection = new Connection(config);
-    connection.on('connect', err => (err ? reject(err) : resolve(connection)));
+    connection.on('connect', err => {
+      if (err) {
+        connection.close();
+        reject(err);
+      } else {
+        resolve(connection);
+      }
+    });
     if (connection.state !== connection.STATE.CONNECTING) {
       connection.connect();
     }
   });
+}
+
+/**
+ * Retries the initial connection until the DB accepts it. `docker compose up --wait` only blocks on
+ * the in-container healthcheck; on busy CI the host port-forward can lag behind, and MSSQL is slow to
+ * start accepting connections even after that. Without this, the first `connect()` intermittently
+ * rejects with a connection error, `run()` throws, and no transaction is sent — flaking the test.
+ */
+async function connectWithRetry(maxWaitMs = 60_000) {
+  const deadline = Date.now() + maxWaitMs;
+  for (;;) {
+    try {
+      return await connect();
+    } catch (err) {
+      if (Date.now() > deadline) {
+        throw err;
+      }
+      await new Promise(r => setTimeout(r, 500));
+    }
+  }
 }
 
 function query(connection, sql, method = 'execSql') {
@@ -77,7 +104,7 @@ function bulkLoad(connection) {
 }
 
 async function run() {
-  const connection = await connect();
+  const connection = await connectWithRetry();
 
   await Sentry.startSpan({ name: 'Test Transaction' }, async () => {
     await query(connection, 'SELECT 1 + 1 AS solution');


### PR DESCRIPTION
The `tedious` node-integration-test flakes on CI for the same reason the postgres suites did: it opens its DB connection before the database is actually reachable.

### Root cause

`docker compose up -d --wait` blocks only on the container's **internal** healthcheck. On busy CI the **host-side port forward** (`1433`) can lag behind, and MSSQL is especially slow to start accepting connections even after the container reports healthy (the compose file uses `start_period: 20s`). The scenario called `await connect()` at the top of `run()`, **before** `Sentry.startSpan(...)` — so a failed initial connect rejected `run()` outright, no transaction was ever sent, and the test timed out.

### Fix

Wrap the initial connect in a small retry loop (`connectWithRetry`) that keeps trying with a fresh `Connection` per attempt until the DB accepts it or a 60s deadline elapses. `connect()` now also closes the failed connection before rejecting so retries don't leak sockets. This is the `tedious` analogue of the readiness gate the postgres/postgresjs suites use.

Verified locally against the MSSQL container: the suite passes in both ESM and CJS.

Fixes #21620
Fixes #21765
Fixes #21766

🤖 Generated with [Claude Code](https://claude.com/claude-code)