### PR TITLE
test(e2e): De-flake remix-hydrogen client tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/entry.client.tsx
@@ -8,22 +8,15 @@ Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Could not find a working way to set the DSN in the browser side from the environment variables
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  debug: true,
   integrations: [
     Sentry.browserTracingIntegration({
       useEffect,
       useLocation,
       useMatches,
     }),
-    Sentry.replayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
-    }),
   ],
 
   tracesSampleRate: 1.0,
-  replaysSessionSampleRate: 0.1,
-  replaysOnErrorSampleRate: 1.0,
   tunnel: 'http://localhost:3031/', // proxy server
 });
 

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/tests/client-errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/tests/client-errors.test.ts
@@ -1,12 +1,21 @@
 import { expect, test } from '@playwright/test';
-import { waitForError } from '@sentry-internal/test-utils';
+import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
 
 test('Sends a client-side exception to Sentry', async ({ page }) => {
+  // The pageload transaction only completes once the client SDK and Remix have hydrated.
+  // Awaiting it before clicking guarantees the button's onClick handler is attached — a click
+  // that lands before hydration would do nothing, and the exception would never be captured.
+  const pageloadTransactionPromise = waitForTransaction('remix-hydrogen', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.transaction === '/';
+  });
+
   const errorPromise = waitForError('remix-hydrogen', errorEvent => {
     return errorEvent.exception?.values?.[0].value === 'I am an error!';
   });
 
   await page.goto('/');
+
+  await pageloadTransactionPromise;
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();


### PR DESCRIPTION
The remix-hydrogen E2E client tests are a recurring source of flaky-CI reports — all five below were filed from a single run. CI runs this app with `retries: 0`, so any transient client-side hiccup surfaces as a flaky failure.

### Root cause

Every one of the flaky tests exercises the client (`page.goto` + wait for an envelope or click). The remix-hydrogen client SDK differs from the leaner, more reliable `hydrogen-react-router-7` sibling app in two ways that add timing variance:

- **Session Replay is enabled.** `replaysSessionSampleRate: 0.1` records a replay in ~10% of runs, and `replaysOnErrorSampleRate: 1.0` records one on *both* error tests. When it records, it spins up the replay worker and pushes extra envelopes through the same `localhost:3031` tunnel the tests wait on — intermittent, timing-sensitive load that **no test here asserts on**. Intermittent-by-sample-rate behavior is a classic flakiness signature.
- **Click-before-hydration race.** The "client-side exception" test clicks `#exception-button` immediately after `goto('/')`. Playwright's `click()` waits for actionability but not React hydration, so the click can land before the `onClick` handler is attached — the exception is then never captured and the test times out. The navigation test already worked around exactly this by awaiting the pageload transaction first.

### Fix

- Remove `replayIntegration` (and `debug`) from `entry.client.tsx`, matching the `hydrogen-react-router-7` app.
- Await the pageload transaction before clicking in the exception test (same hydration gate the navigation test uses).

The hydration gate directly fixes the exception test; trimming Replay reduces the intermittent client-side load behind the broader batch of client-test flakes. These E2E tests can't be run against real CI infra locally, so the changes are conservative and reduce known flake surface rather than depending on unverifiable timing.

Fixes #21742
Fixes #21739
Fixes #21740
Fixes #21741
Fixes #21738

🤖 Generated with [Claude Code](https://claude.com/claude-code)