### PR TITLE
feat(core): Require `attributes` on `SerializedStreamedSpan`

### DIFF
--- a/packages/core/src/types/span.ts
+++ b/packages/core/src/types/span.ts
@@ -61,7 +61,7 @@ export interface StreamedSpanJSON {
  * Main difference: Attributes are converted to {@link Attributes}, thus including the `type` annotation.
  */
 export type SerializedStreamedSpan = Omit<StreamedSpanJSON, 'attributes' | 'links'> & {
-  attributes?: Attributes;
+  attributes: Attributes;
   links?: SpanLinkJSON<Attributes>[];
 };
 

--- a/packages/core/test/lib/tracing/spans/envelope.test.ts
+++ b/packages/core/test/lib/tracing/spans/envelope.test.ts
@@ -22,6 +22,7 @@ function createMockSerializedSpan(overrides: Partial<SerializedStreamedSpan> = {
     end_timestamp: 1713859201,
     status: 'ok',
     is_segment: false,
+    attributes: {},
     ...overrides,
   };
 }

--- a/packages/core/test/lib/tracing/spans/estimateSize.test.ts
+++ b/packages/core/test/lib/tracing/spans/estimateSize.test.ts
@@ -16,13 +16,14 @@ describe('estimateSerializedSpanSizeInBytes', () => {
       end_timestamp: 1740000001.456,
       status: 'ok',
       is_segment: true,
+      attributes: {},
     };
 
     const estimate = estimateSerializedSpanSizeInBytes(span);
     const actual = JSON.stringify(span).length;
 
     expect(estimate).toBe(184);
-    expect(actual).toBe(196);
+    expect(actual).toBe(212);
 
     expect(estimate).toBeLessThanOrEqual(actual * 1.2);
     expect(estimate).toBeGreaterThanOrEqual(actual * 0.8);
@@ -38,13 +39,14 @@ describe('estimateSerializedSpanSizeInBytes', () => {
       end_timestamp: 1740000000.05,
       status: 'ok',
       is_segment: false,
+      attributes: {},
     };
 
     const estimate = estimateSerializedSpanSizeInBytes(span);
     const actual = JSON.stringify(span).length;
 
     expect(estimate).toBe(172);
-    expect(actual).toBe(222);
+    expect(actual).toBe(238);
 
     expect(estimate).toBeLessThanOrEqual(actual * 1.1);
     expect(estimate).toBeGreaterThanOrEqual(actual * 0.7);
@@ -152,6 +154,7 @@ describe('estimateSerializedSpanSizeInBytes', () => {
       end_timestamp: 1740000001.0,
       status: 'ok',
       is_segment: true,
+      attributes: {},
       links: [
         {
           trace_id: 'b2c3d4e5f607189a0b1c2d3e4f506070',

--- a/packages/core/test/lib/tracing/spans/spanBuffer.test.ts
+++ b/packages/core/test/lib/tracing/spans/spanBuffer.test.ts
@@ -48,6 +48,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan1,
     });
 
@@ -59,6 +60,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan2,
     });
 
@@ -82,6 +84,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan1,
     };
 
@@ -94,6 +97,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan2,
     };
 
@@ -124,6 +128,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan,
     });
 
@@ -137,6 +142,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan,
     });
 
@@ -150,6 +156,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan,
     });
 
@@ -174,6 +181,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan,
     });
 
@@ -198,6 +206,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan1,
     });
 
@@ -209,6 +218,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan2,
     });
 
@@ -232,6 +242,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan1,
     });
 
@@ -243,6 +254,7 @@ describe('SpanBuffer', () => {
       end_timestamp: Date.now() / 1000,
       status: 'ok',
       is_segment: false,
+      attributes: {},
       _segmentSpan: segmentSpan2,
     });
 
@@ -275,6 +287,7 @@ describe('SpanBuffer', () => {
         end_timestamp: Date.now() / 1000,
         status: 'ok',
         is_segment: false,
+        attributes: {},
         _segmentSpan: segmentSpan,
         ...overrides,
       };


### PR DESCRIPTION
Make `attributes` a required field on `SerializedStreamedSpan` so tests and downstream code can rely on it always being present, without optional chaining.

Production code already guarantees this: `streamedSpanJsonToSerializedSpan` always sets attributes via `serializeAttributes()`, which returns `{}` when the intermediate `StreamedSpanJSON` has no attributes. Only test mocks needed updating to include `attributes: {}`.

We likely can adjust the `StreamedSpanJson` type in a similar way to gain some production code benefits as well. Gonna look at this in a follow-up