### PR TITLE
feat(core): Make `attributes` required on serialized streamed spans

### DIFF
--- a/packages/core/src/types/span.ts
+++ b/packages/core/src/types/span.ts
@@ -61,7 +61,7 @@ export interface StreamedSpanJSON {
  * Main difference: Attributes are converted to {@link Attributes}, thus including the `type` annotation.
  */
 export type SerializedStreamedSpan = Omit<StreamedSpanJSON, 'attributes' | 'links'> & {
-  attributes?: Attributes;
+  attributes: Attributes;
   links?: SpanLinkJSON<Attributes>[];
 };
 


### PR DESCRIPTION
`SerializedStreamedSpan.attributes` (an exported type) was declared optional (`attributes?: Attributes`), but a serialized streamed span always carries an `attributes` object:

- `streamedSpanJsonToSerializedSpan()` always sets `attributes: serializeAttributes(...)`.
- `serializeAttributes()` always returns an object (an empty `{}` at worst), never `undefined`.

This makes the field required so the type matches what is actually produced. Consumers can now read `span.attributes[...]` directly without redundant optional chaining or non-null assertions.

Only `@sentry/core` constructs this type; every other package consumes it read-only, so the change is safe for them — verified that the `@sentry/core` and `@sentry/node` type builds still pass.

---

This is the base of a stack:

- **#22053** (this PR) — make `attributes` required on `SerializedStreamedSpan`
- #22054 — type-check the node integration test suites in CI (depends on this)
