### PR TITLE
test(bun-integration-tests): Type-check test suites in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,9 +337,8 @@ jobs:
         run: yarn lint
       - name: Lint for ES compatibility
         run: yarn lint:es-compatibility
-      - name: Type check cloudflare integration test suites
-        working-directory: dev-packages/cloudflare-integration-tests
-        run: yarn type-check
+      - name: Lint types
+        run: yarn lint:types
 
   job_check_lockfile:
     name: Check lockfile

--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -12,7 +12,7 @@
     "install-browsers": "[[ -z \"$SKIP_PLAYWRIGHT_BROWSER_INSTALL\" ]] && npx playwright install --with-deps || echo 'Skipping browser installation'",
     "lint": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --type-aware",
     "lint:fix": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --fix --type-aware",
-    "type-check": "tsc",
+    "lint:types": "tsc --noEmit",
     "postinstall": "yarn install-browsers",
     "pretest": "yarn clean && yarn type-check",
     "test": "yarn test:all --project='chromium'",

--- a/dev-packages/bun-integration-tests/package.json
+++ b/dev-packages/bun-integration-tests/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --type-aware",
     "lint:fix": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --fix --type-aware",
-    "type-check": "tsc --noEmit",
+    "lint:types": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "yarn test --watch"
   },

--- a/dev-packages/bun-integration-tests/package.json
+++ b/dev-packages/bun-integration-tests/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "lint": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --type-aware",
     "lint:fix": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --fix --type-aware",
+    "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "yarn test --watch"
   },

--- a/dev-packages/cloudflare-integration-tests/package.json
+++ b/dev-packages/cloudflare-integration-tests/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --type-aware",
     "lint:fix": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --fix --type-aware",
-    "type-check": "tsc --noEmit",
+    "lint:types": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "yarn test --watch"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint .",
     "lint:fix": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --fix",
     "lint:es-compatibility": "nx run-many -t lint:es-compatibility",
+    "lint:types": "nx run-many -t lint:types",
     "dedupe-deps:check": "yarn-deduplicate yarn.lock --list --fail",
     "dedupe-deps:fix": "yarn-deduplicate yarn.lock",
     "postpublish": "nx run-many -t postpublish --parallel=1",


### PR DESCRIPTION
The `suites/**` test files were never type-checked in CI: there was no `type-check` script, and vitest transpiles with esbuild (no type-checking). The suites are already covered by `tsconfig.json`, so this just adds the gate.

- Add a `type-check` script (`tsc --noEmit`).
- Run `yarn type-check` for the package in the **Lint** CI job.

The suites are already type-clean, so no source changes were needed.

Part of a small series adding suite type-checking to the integration-test packages (alongside `node-integration-tests`).
