### PR TITLE
test(e2e): Gate hydrogen-react-router-7 client clicks on hydration

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/tests/client-errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/tests/client-errors.test.ts
@@ -1,12 +1,21 @@
 import { expect, test } from '@playwright/test';
-import { waitForError } from '@sentry-internal/test-utils';
+import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
 
 test('Sends a client-side exception to Sentry', async ({ page }) => {
+  // The pageload transaction only completes once the client SDK and the router have hydrated.
+  // Awaiting it before clicking guarantees the button's onClick handler is attached — a click that
+  // lands before hydration would do nothing, and the exception would never be captured.
+  const pageloadTransactionPromise = waitForTransaction('hydrogen-react-router-7', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.transaction === '/';
+  });
+
   const errorPromise = waitForError('hydrogen-react-router-7', errorEvent => {
     return errorEvent.exception?.values?.[0].value === 'I am an error!';
   });
 
   await page.goto('/');
+
+  await pageloadTransactionPromise;
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();
@@ -17,11 +26,18 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
 });
 
 test('Sends a client-side ErrorBoundary exception to Sentry', async ({ page }) => {
+  // Wait for hydration (see above) before clicking, so the button's onClick handler is attached.
+  const pageloadTransactionPromise = waitForTransaction('hydrogen-react-router-7', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.transaction === '/client-error';
+  });
+
   const errorPromise = waitForError('hydrogen-react-router-7', errorEvent => {
     return errorEvent.exception?.values?.[0].value === 'Sentry React Component Error';
   });
 
   await page.goto('/client-error');
+
+  await pageloadTransactionPromise;
 
   const throwButton = page.locator('id=throw-on-click');
   await throwButton.click();

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/tests/client-transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/tests/client-transactions.test.ts
@@ -14,11 +14,21 @@ test('Sends a pageload transaction to Sentry', async ({ page }) => {
 });
 
 test('Sends a navigation transaction to Sentry', async ({ page }) => {
+  // Wait for the initial pageload transaction first. This ensures the client SDK and router are fully
+  // hydrated before we click the link. Clicking before hydration completes makes the `<Link>` behave
+  // like a plain anchor, triggering a full page navigation (a `pageload` transaction) instead of a
+  // client-side `navigation` one, which makes this test flaky.
+  const pageloadTransactionPromise = waitForTransaction('hydrogen-react-router-7', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.transaction === '/';
+  });
+
   const transactionPromise = waitForTransaction('hydrogen-react-router-7', transactionEvent => {
     return transactionEvent.contexts?.trace?.op === 'navigation' && transactionEvent.transaction === '/user/:id';
   });
 
   await page.goto('/');
+
+  await pageloadTransactionPromise;
 
   const linkElement = page.locator('id=navigation');
   await linkElement.click();


### PR DESCRIPTION
Companion to #22051 (remix-hydrogen): the sibling hydrogen-react-router-7 app has the same click-before-hydration flakiness in its client tests.

### Root cause

Three client tests click an element immediately after `page.goto()`. Playwright's `click()` waits for actionability but **not** React hydration, so the click can land before the element's `onClick` handler is attached:
- the exception / ErrorBoundary buttons then capture no error, and
- the `<Link>` behaves like a plain anchor, producing a full-page `pageload` instead of the expected client-side `navigation` transaction.

### Fix

Await the pageload transaction — which only completes once the client SDK and router have hydrated — before clicking, in the exception, ErrorBoundary and navigation tests. This is the exact mitigation the remix-hydrogen navigation test already uses. This app already omits Replay/`debug`, so no SDK-config change is needed.

The two remaining tests in the group (`pageload`, `meta tags`) are load-only with no click; they were swept into the same flaky-run batch and have no per-test hydration race to fix here. These E2E tests require the packed SDK tarballs + Shopify Hydrogen toolchain to run, so they're validated in CI rather than locally.

Fixes #21737
Fixes #21736
Fixes #21710
Fixes #21735
Fixes #21734

🤖 Generated with [Claude Code](https://claude.com/claude-code)