### PR TITLE
test(nextjs): Add orchestrion e2e test app

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -20,12 +20,3 @@ allow-ghsas:
   - GHSA-v2wj-q39q-566r
   # esbuil, used in browser bundler plugin E2E tests
   - GHSA-gv7w-rqvm-qjhr
-  # next@16.2.3, pinned across the nextjs-16-* E2E test apps (only flagged when a
-  # new app's package.json is added, since dependency review scans added manifests)
-  - GHSA-8h8q-6873-q5fj
-  - GHSA-36qx-fr4f-26g5
-  - GHSA-267c-6grr-h53f
-  - GHSA-492v-c6pp-mqqv
-  - GHSA-c4j6-fc7j-m34r
-  - GHSA-mg66-mrh9-m8jx
-  - GHSA-26hh-7cqf-hhc6

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -20,3 +20,12 @@ allow-ghsas:
   - GHSA-v2wj-q39q-566r
   # esbuil, used in browser bundler plugin E2E tests
   - GHSA-gv7w-rqvm-qjhr
+  # next@16.2.3, pinned across the nextjs-16-* E2E test apps (only flagged when a
+  # new app's package.json is added, since dependency review scans added manifests)
+  - GHSA-8h8q-6873-q5fj
+  - GHSA-36qx-fr4f-26g5
+  - GHSA-267c-6grr-h53f
+  - GHSA-492v-c6pp-mqqv
+  - GHSA-c4j6-fc7j-m34r
+  - GHSA-mg66-mrh9-m8jx
+  - GHSA-26hh-7cqf-hhc6

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/.gitignore
@@ -1,0 +1,44 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# Sentry Config File
+.env.sentry-build-plugin

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/api/db-mysql/route.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/api/db-mysql/route.ts
@@ -1,0 +1,20 @@
+import mysql from 'mysql';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const connection = mysql.createConnection({
+    user: 'root',
+    password: 'docker',
+  });
+
+  return new Promise<Response>(resolve => {
+    connection.query('SELECT 1 + 1 AS solution', () => {
+      connection.query('SELECT NOW()', ['1', '2'], () => {
+        connection.end();
+        resolve(NextResponse.json({ status: 'ok' }));
+      });
+    });
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/api/db-pg/route.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/api/db-pg/route.ts
@@ -1,0 +1,24 @@
+import { Client } from 'pg';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const client = new Client({
+    host: 'localhost',
+    port: 5432,
+    user: 'postgres',
+    password: 'docker',
+    database: 'postgres',
+  });
+
+  await client.connect();
+
+  try {
+    await client.query('SELECT 1 + 1 AS solution');
+    await client.query('SELECT NOW()');
+    return NextResponse.json({ status: 'ok' });
+  } finally {
+    await client.end();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/api/db-redis/route.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/api/db-redis/route.ts
@@ -1,0 +1,20 @@
+import Redis from 'ioredis';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const redis = new Redis({
+    // Don't keep retrying forever if Redis goes away (e.g. on test teardown)
+    maxRetriesPerRequest: 1,
+    retryStrategy: () => null,
+  });
+
+  try {
+    await redis.set('test-key', 'test-value');
+    const value = await redis.get('test-key');
+    return NextResponse.json({ value });
+  } finally {
+    redis.disconnect();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/db-page/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/db-page/page.tsx
@@ -1,0 +1,52 @@
+import Redis from 'ioredis';
+import { Client } from 'pg';
+
+export const dynamic = 'force-dynamic';
+
+async function queryDatabases(): Promise<{ answer: string; cached: string | null }> {
+  const client = new Client({
+    host: 'localhost',
+    port: 5432,
+    user: 'postgres',
+    password: 'docker',
+    database: 'postgres',
+  });
+
+  await client.connect();
+
+  let answer: string;
+  try {
+    const result = await client.query('SELECT 40 + 2 AS answer');
+    answer = String(result.rows[0]?.answer);
+  } finally {
+    await client.end();
+  }
+
+  const redis = new Redis({
+    // Don't keep retrying forever if Redis goes away (e.g. on test teardown)
+    maxRetriesPerRequest: 1,
+    retryStrategy: () => null,
+  });
+
+  let cached: string | null;
+  try {
+    await redis.set('page-key', answer);
+    cached = await redis.get('page-key');
+  } finally {
+    redis.disconnect();
+  }
+
+  return { answer, cached };
+}
+
+export default async function DbPage() {
+  const { answer, cached } = await queryDatabases();
+
+  return (
+    <div>
+      <h1>DB page</h1>
+      <p id="answer">answer: {answer}</p>
+      <p id="cached">cached: {cached}</p>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/layout.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Next 16 orchestrion test app</p>;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/docker-compose.yml
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: always
+    container_name: e2e-tests-nextjs-16-orchestrion-postgres
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_PASSWORD: docker
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  redis:
+    image: redis:7
+    restart: always
+    container_name: e2e-tests-nextjs-16-orchestrion-redis
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+
+  mysql:
+    image: mysql:8.0
+    restart: always
+    container_name: e2e-tests-nextjs-16-orchestrion-mysql
+    # The `mysql` 2.x driver doesn't speak MySQL 8's default
+    # `caching_sha2_password` auth, so force the legacy plugin.
+    command: ['--default-authentication-plugin=mysql_native_password']
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: docker
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -uroot -pdocker']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/eslint.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/eslint.config.mjs
@@ -1,0 +1,19 @@
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    ignores: ['node_modules/**', '.next/**', 'out/**', 'build/**', 'next-env.d.ts'],
+  },
+];
+
+export default eslintConfig;

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/global-setup.mjs
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/global-setup.mjs
@@ -1,0 +1,14 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function globalSetup() {
+  // Start Postgres + Redis via Docker Compose. `--wait` blocks until the
+  // healthchecks in docker-compose.yml pass, so the app can connect immediately.
+  execSync('docker compose up -d --wait', {
+    cwd: __dirname,
+    stdio: 'inherit',
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/global-teardown.mjs
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/global-teardown.mjs
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function globalTeardown() {
+  execSync('docker compose down --volumes', {
+    cwd: __dirname,
+    stdio: 'inherit',
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/instrumentation.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/nextjs';
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config');
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError;

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/next.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/next.config.ts
@@ -1,0 +1,9 @@
+import { withSentryConfig } from '@sentry/nextjs';
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default withSentryConfig(nextConfig, {
+  silent: true,
+  _experimental: { useDiagnosticsChannelInjection: true },
+});

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/package.json
@@ -20,7 +20,7 @@
     "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
     "ioredis": "5.10.1",
     "mysql": "^2.18.1",
-    "next": "16.2.3",
+    "next": "16.2.10",
     "pg": "^8.13.1",
     "react": "19.1.0",
     "react-dom": "19.1.0"

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/package.json
@@ -1,0 +1,52 @@
+{
+  "name": "nextjs-16-orchestrion",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build > .tmp_build_stdout 2> .tmp_build_stderr || (cat .tmp_build_stdout && cat .tmp_build_stderr && exit 1)",
+    "build-webpack": "next build --webpack > .tmp_build_stdout 2> .tmp_build_stderr || (cat .tmp_build_stdout && cat .tmp_build_stderr && exit 1)",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "start": "next start",
+    "lint": "eslint",
+    "test:prod": "TEST_ENV=production playwright test",
+    "test:build": "pnpm install && pnpm build",
+    "test:build-webpack": "pnpm install && pnpm build-webpack",
+    "test:assert": "pnpm test:prod"
+  },
+  "//": "Pin `ioredis` to 5.10.1 because that's the last version before it publishes its own `ioredis:*` diagnostics channels; orchestrion's ioredis config covers `<5.11.0`.",
+  "dependencies": {
+    "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
+    "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
+    "ioredis": "5.10.1",
+    "mysql": "^2.18.1",
+    "next": "16.2.3",
+    "pg": "^8.13.1",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.56.0",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "@types/mysql": "^2.15.26",
+    "@types/node": "^20",
+    "@types/pg": "^8.11.10",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "^16",
+    "typescript": "^5"
+  },
+  "volta": {
+    "extends": "../../package.json",
+    "node": "22.20.0"
+  },
+  "sentryTest": {
+    "variants": [
+      {
+        "build-command": "pnpm test:build-webpack",
+        "label": "nextjs-16-orchestrion (webpack)"
+      }
+    ]
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/playwright.config.mjs
@@ -1,0 +1,12 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: 'pnpm next start -p 3030',
+  port: 3030,
+});
+
+export default {
+  ...config,
+  globalSetup: './global-setup.mjs',
+  globalTeardown: './global-teardown.mjs',
+};

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/sentry.server.config.ts
@@ -1,0 +1,15 @@
+import * as Sentry from '@sentry/nextjs';
+
+// Opt into diagnostics-channel-based auto-instrumentation. This registers the
+// channel subscribers (e.g. for `pg` and `ioredis`) that turn the
+// diagnostics-channel events — injected at build time by the orchestrion transform
+// (the Turbopack loader / webpack plugin, see `next.config.ts`) — into Sentry spans.
+// Must run before `Sentry.init()`.
+Sentry.experimentalUseDiagnosticsChannelInjection();
+
+Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  tunnel: 'http://localhost:3031/', // proxy server
+  tracesSampleRate: 1.0,
+});

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'nextjs-16-orchestrion',
+});

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/tests/db.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/tests/db.test.ts
@@ -1,0 +1,192 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Instruments ioredis automatically via orchestrion', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('nextjs-16-orchestrion', transactionEvent => {
+    return (
+      transactionEvent.contexts?.trace?.op === 'http.server' && transactionEvent.transaction === 'GET /api/db-redis'
+    );
+  });
+
+  await fetch(`${baseURL}/api/db-redis`);
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent.contexts?.trace?.op).toEqual('http.server');
+  expect(transactionEvent.transaction).toEqual('GET /api/db-redis');
+
+  const spans = transactionEvent.spans || [];
+
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.redis',
+      description: 'set test-key [1 other arguments]',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'redis',
+        'db.statement': 'set test-key [1 other arguments]',
+      }),
+    }),
+  );
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.redis',
+      description: 'get test-key',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'redis',
+        'db.statement': 'get test-key',
+      }),
+    }),
+  );
+});
+
+test('Instruments pg automatically via orchestrion', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('nextjs-16-orchestrion', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'http.server' && transactionEvent.transaction === 'GET /api/db-pg';
+  });
+
+  await fetch(`${baseURL}/api/db-pg`);
+
+  const transactionEvent = await transactionEventPromise;
+
+  const spans = transactionEvent.spans || [];
+
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.postgres',
+      description: 'SELECT 1 + 1 AS solution',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'postgresql',
+        'db.statement': 'SELECT 1 + 1 AS solution',
+        'db.user': 'postgres',
+        'db.name': 'postgres',
+        'db.connection_string': expect.any(String),
+        'net.peer.name': expect.any(String),
+        'net.peer.port': 5432,
+      }),
+    }),
+  );
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.postgres',
+      description: 'SELECT NOW()',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'postgresql',
+        'db.statement': 'SELECT NOW()',
+        'db.user': 'postgres',
+        'db.name': 'postgres',
+        'db.connection_string': expect.any(String),
+        'net.peer.name': expect.any(String),
+        'net.peer.port': 5432,
+      }),
+    }),
+  );
+});
+
+test('Instruments DB calls made during server-side rendering of a page', async ({ page }) => {
+  const transactionEventPromise = waitForTransaction('nextjs-16-orchestrion', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'http.server' && transactionEvent.transaction === 'GET /db-page';
+  });
+
+  await page.goto('/db-page');
+  await expect(page.locator('#answer')).toHaveText('answer: 42');
+  await expect(page.locator('#cached')).toHaveText('cached: 42');
+
+  const transactionEvent = await transactionEventPromise;
+
+  const spans = transactionEvent.spans || [];
+
+  // One page render produces spans from both injection paths: pg (externalized → runtime module
+  // hook) and ioredis (bundle-safe allowlisted → build-time loader).
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.postgres',
+      description: 'SELECT 40 + 2 AS answer',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'postgresql',
+        'db.statement': 'SELECT 40 + 2 AS answer',
+      }),
+    }),
+  );
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.redis',
+      description: 'set page-key [1 other arguments]',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'redis',
+        'db.statement': 'set page-key [1 other arguments]',
+      }),
+    }),
+  );
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.redis',
+      description: 'get page-key',
+      status: 'ok',
+    }),
+  );
+});
+
+// Unlike ioredis (bundle-safe allowlisted → bundled + transformed by the build-time loader),
+// `pg` and `mysql` stay externalized and are instrumented by the orchestrion runtime module hook
+// on require — which works because the SDK also externalizes the `@apm-js-collab/*` transformer
+// packages. Same spans either way, different injection path. (`mysql` in particular MUST stay
+// external: Turbopack cannot bundle it correctly — its wire protocol breaks even untransformed.)
+test('Instruments mysql automatically via orchestrion', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('nextjs-16-orchestrion', transactionEvent => {
+    return (
+      transactionEvent.contexts?.trace?.op === 'http.server' && transactionEvent.transaction === 'GET /api/db-mysql'
+    );
+  });
+
+  await fetch(`${baseURL}/api/db-mysql`);
+
+  const transactionEvent = await transactionEventPromise;
+
+  const spans = transactionEvent.spans || [];
+
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.mysql',
+      description: 'SELECT 1 + 1 AS solution',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'mysql',
+        'db.statement': 'SELECT 1 + 1 AS solution',
+        'db.user': 'root',
+        'db.connection_string': expect.any(String),
+        'net.peer.name': expect.any(String),
+        'net.peer.port': 3306,
+      }),
+    }),
+  );
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.mysql',
+      description: 'SELECT NOW()',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'mysql',
+        'db.statement': 'SELECT NOW()',
+        'db.user': 'root',
+        'db.connection_string': expect.any(String),
+        'net.peer.name': expect.any(String),
+        'net.peer.port': 3306,
+      }),
+    }),
+  );
+});

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts", "**/*.mts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Adds an e2e test for nextjs-16 with opt-in for orchestrion.

Tests both webpack+turbopack paths

closes https://github.com/getsentry/sentry-javascript/issues/21993