### PR TITLE
test(cloudflare): Add headroom for wrangler cold-start in integration tests

### DIFF
--- a/dev-packages/cloudflare-integration-tests/runner.ts
+++ b/dev-packages/cloudflare-integration-tests/runner.ts
@@ -20,7 +20,9 @@ process.on('exit', cleanupChildProcesses);
 
 // Wrangler can report "Ready" before it can actually handle requests.
 // This retries fetch on connection errors and transient 500 responses to handle this race condition.
-async function fetchWithRetry(url: string, init: RequestInit, maxRetries = 10, retryDelayMs = 200): Promise<Response> {
+// The budget (maxRetries * retryDelayMs) must cover the "ready-but-not-serving" window, which can be
+// several seconds on a loaded CI runner — hence a generous default.
+async function fetchWithRetry(url: string, init: RequestInit, maxRetries = 25, retryDelayMs = 200): Promise<Response> {
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
       const res = await fetch(url, init);

--- a/dev-packages/cloudflare-integration-tests/vite.config.mts
+++ b/dev-packages/cloudflare-integration-tests/vite.config.mts
@@ -10,7 +10,10 @@ export default defineConfig({
     },
     isolate: false,
     include: ['./suites/**/test.ts'],
-    testTimeout: 30_000,
+    // Each test spawns its own `wrangler dev` (cold workerd boot) and waits for envelopes to be
+    // delivered — there is no internal runner timeout, so this ceiling covers cold-start + async work +
+    // delivery. Cold-start is slow and highly variable on CI, so give it generous headroom to de-flake.
+    testTimeout: 60_000,
     // Ensure we can see debug output when DEBUG=true
     ...(process.env.DEBUG
       ? {


### PR DESCRIPTION
The Cloudflare integration tests are a recurring source of flaky-CI reports across several suites.

### Root cause

Every test spawns its own `wrangler dev` (cold workerd boot), makes a request, and waits for envelopes to be delivered to the mock server. Two ceilings are tight for how slow and variable wrangler cold-start is on a loaded CI runner:

- The runner has **no internal timeout**, so it relies entirely on Vitest's `testTimeout` (was **30s**). Cold-start + async work (Durable Objects, Workflows) + envelope delivery must all fit in that budget.
- `fetchWithRetry` — which the runner already uses to paper over wrangler's "reports Ready before it can serve" race — only tolerated a **~2s** window.

Locally these tests finish in <5s and I could not reproduce a failure across 80+ runs, which is consistent with a low-rate, load-dependent cold-start stall rather than a logic bug.

### Fix

- Raise `testTimeout` 30s → 60s.
- Raise the `fetchWithRetry` budget 10 → 25 attempts (~2s → ~5s).

Both are pure ceilings — tests complete as soon as the worker serves and envelopes arrive, so there's no happy-path cost and no assertion changes.

Since I couldn't reproduce locally or retrieve the (expired) CI logs, these target the two documented/architectural races of the spawn-wrangler-per-test setup. If a specific suite keeps flaking afterwards with a fast, deterministic failure (e.g. a 500 response or a wrong assertion), that would indicate a genuine intermittent bug in that suite needing its own investigation.

Fixes #22047
Fixes #21916
Fixes #21831
Fixes #21665

🤖 Generated with [Claude Code](https://claude.com/claude-code)