### PR TITLE
fix(opentelemetry): Fall back to `sentry.origin: manual` when backfilling OTel data

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
@@ -91,6 +91,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SENTRY_SDK_VERSION]: { type: 'string', value: SDK_VERSION },
             [SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
+            [SENTRY_ORIGIN]: { type: 'string', value: 'manual' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
             [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: { type: 'string', value: 'custom' },
@@ -128,6 +129,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SENTRY_SDK_VERSION]: { type: 'string', value: SDK_VERSION },
             [SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
+            [SENTRY_ORIGIN]: { type: 'string', value: 'manual' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
             [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: { type: 'string', value: 'custom' },
@@ -145,6 +147,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
 
         const expectedAttributes: Record<string, unknown> = {
           [SENTRY_TRACE_LIFECYCLE]: { type: 'string', value: 'stream' },
+          [SENTRY_ORIGIN]: { type: 'string', value: 'manual' },
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'test' },
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: { type: 'integer', value: 1 },
           [SENTRY_SDK_NAME]: { type: 'string', value: 'sentry.javascript.node-core' },

--- a/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
+++ b/dev-packages/node-core-integration-tests/suites/public-api/startSpan/basic-usage-streamed/test.ts
@@ -13,6 +13,7 @@ import {
   SENTRY_SDK_NAME,
   SENTRY_SDK_VERSION,
   SENTRY_TRACE_LIFECYCLE,
+  SENTRY_ORIGIN,
 } from '@sentry/conventions/attributes';
 import { expect, test } from 'vitest';
 import { createRunner } from '../../../../utils/runner';
@@ -65,6 +66,7 @@ test('sends a streamed span envelope with correct spans for a manually started s
             [SENTRY_SDK_VERSION]: { type: 'string', value: SDK_VERSION },
             [SENTRY_SEGMENT_ID]: { type: 'string', value: segmentSpanId },
             [SENTRY_SEGMENT_NAME]: { type: 'string', value: 'test-span' },
+            [SENTRY_ORIGIN]: { type: 'string', value: 'manual' },
             [SEMANTIC_ATTRIBUTE_SENTRY_RELEASE]: { type: 'string', value: '1.0.0' },
             [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: { type: 'string', value: 'production' },
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: { type: 'string', value: 'custom' },

--- a/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
+++ b/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
@@ -7,6 +7,7 @@ import {
   spanKindToName,
 } from '@sentry/core';
 import { inferSpanData } from './parseSpanDescription';
+import { SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 
 /**
  * Backfill op, source, name and data on a streamed span JSON from OTel semantic conventions.
@@ -30,6 +31,11 @@ export function backfillStreamedSpanDataFromOtel(spanJSON: StreamedSpanJSON, hin
   safeSetSpanJSONAttributes(spanJSON, {
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
     [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
+    // If nothing in the chain previously set an origin, we now default it to 'manual'
+    // For transactions, this is done in the SpanExporter.
+    // TODO (v11): Remove this again once we fully moved away from OTel's TracerProvider.
+    // at this point, we use `SentrySpan` everywhere, which defaults its origin to 'manual'.
+    [SENTRY_ORIGIN]: 'manual',
     ...data,
   });
 


### PR DESCRIPTION
Default `sentry.origin` to `manual` when backfilling streamed span data from OpenTelemetry.

Streamed spans created via the OTel `TracerProvider` path did not always carry a `sentry.origin` attribute after backfill. Transactions already get this default in `SpanExporter`, but streamed spans went through `backfillStreamedSpanDataFromOtel` without the same fallback. This aligns streamed spans with transaction behavior and with `SentrySpan`, which defaults origin to `manual`.