### PR TITLE
fix(cloudflare): Honor newTarget in instrumentDurableObjectWithSentry construct trap

### DIFF
--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -51,13 +51,16 @@ export function instrumentDurableObjectWithSentry<
   C extends new (state: DurableObjectState, env: E) => T,
 >(optionsCallback: (env: E) => CloudflareOptions, DurableObjectClass: C): C {
   return new Proxy(DurableObjectClass, {
-    construct(target, [ctx, env]) {
+    construct(target, [ctx, env], newTarget) {
       setAsyncLocalStorageAsyncContextStrategy();
       const context = instrumentContext(ctx);
       const options = getFinalOptions(optionsCallback(env), env);
       const instrumentedEnv = instrumentEnv(env, options);
 
-      const obj = new target(context, instrumentedEnv);
+      // Pass `newTarget` so that subclasses of the instrumented class (e.g. the wrapper classes
+      // created by wrangler's local dev tooling or `@cloudflare/vitest-pool-workers`) keep their
+      // own prototype — otherwise subclass methods disappear and `instanceof` checks break.
+      const obj = Reflect.construct(target, [context, instrumentedEnv], newTarget) as T;
 
       // These are the methods that are available on a Durable Object
       // ref: https://developers.cloudflare.com/durable-objects/api/base/

--- a/packages/cloudflare/test/durableobject.test.ts
+++ b/packages/cloudflare/test/durableobject.test.ts
@@ -232,6 +232,35 @@ describe('instrumentDurableObjectWithSentry', () => {
     expect(obj.constructor).toBe(testClass);
   });
 
+  it('honors newTarget so that subclasses of the instrumented class keep their prototype', () => {
+    const testClass = class {
+      fetch() {
+        return new Response('fetch');
+      }
+
+      alarm() {}
+    };
+    const instrumented = instrumentDurableObjectWithSentry(vi.fn().mockReturnValue({}), testClass as any);
+
+    // Dev tooling such as wrangler or `@cloudflare/vitest-pool-workers` subclasses the exported
+    // (instrumented) class, so the construct trap is invoked with the subclass as `newTarget`.
+    class Subclass extends instrumented {
+      subclassMethod() {
+        return 'subclass-result';
+      }
+    }
+
+    const obj = Reflect.construct(Subclass, []);
+
+    // The subclass prototype must be preserved
+    expect(obj).toBeInstanceOf(Subclass);
+    expect(obj.subclassMethod()).toBe('subclass-result');
+
+    // Built-in DO methods are still instrumented
+    expect(getInstrumented(obj.fetch)).toBeTruthy();
+    expect(getInstrumented(obj.alarm)).toBeTruthy();
+  });
+
   it('Does not instrument RPC methods when instrumentPrototypeMethods is not set', () => {
     const testClass = class {
       rpcMethod() {


### PR DESCRIPTION
`instrumentDurableObjectWithSentry` returns a `Proxy` whose `construct` trap creates the instance with `new target(context, instrumentedEnv)`, ignoring the trap's `newTarget` argument.

When a *subclass* of the instrumented class is constructed, the instance therefore gets the base class's prototype instead of the subclass's: subclass prototype methods disappear and `instanceof Subclass` is false. This breaks tooling that subclasses the exported (instrumented) Durable Object class — for example miniflare's local-explorer wrapper ([`do-wrapper.worker.ts`](https://github.com/cloudflare/workers-sdk/blob/main/packages/miniflare/src/workers/core/do-wrapper.worker.ts) wraps every user Durable Object class in `class Wrapper extends UserClass` with introspection methods on the wrapper prototype), whose methods become unreachable when the wrapped class is Sentry-instrumented.

Fix: construct through `Reflect.construct(target, [context, instrumentedEnv], newTarget)` so the subclass prototype is preserved. The instrumented Durable Object methods (`fetch`, `alarm`, `webSocket*`) are assigned as own properties on the instance, so instrumentation behavior is unchanged; the existing "preserves constructor identity on the proxy" test still passes.

Added a regression test that subclasses the instrumented class and asserts the subclass method is callable, `instanceof` holds, and the built-in handlers remain instrumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)