### PR TITLE
test(e2e): Pin @cloudflare/vite-plugin to 1.43.1 in Cloudflare E2E test apps

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
@@ -21,6 +21,11 @@
     "astro": "^6.0.0",
     "wrangler": "^4.72.0"
   },
+  "pnpm": {
+    "overrides": {
+      "@cloudflare/vite-plugin": "1.43.1"
+    }
+  },
   "volta": {
     "node": "24.15.0",
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@playwright/test": "~1.56.0",
-    "@cloudflare/vite-plugin": "^1.37.2",
+    "@cloudflare/vite-plugin": "1.43.1",
     "@cloudflare/workers-types": "^4.20260520.1",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^24.12.4",

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "^1.35.0",
+    "@cloudflare/vite-plugin": "1.43.1",
     "@cloudflare/workers-types": "^4.20260504.0",
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",


### PR DESCRIPTION
`@cloudflare/vite-plugin@1.43.2` peer-requires `wrangler ^4.108.0`, but `wrangler@4.108.0` is **deprecated** ("causing deployment failures in CI, downgrade to 4.107.1") so `latest` stays at `4.107.1`. Installs resolve the healthy 4.107.1 and the plugin throws at build. Fails on `develop` and every PR.

Pins the plugin to `1.43.1` (last version whose peer is `wrangler ^4.107.1`) rather than adopting the deprecated wrangler; astro-6-cf-workers gets it transitively so uses a pnpm override. Temporary; #22116 reverts once upstream ships a plugin compatible with a non-deprecated wrangler.