### PR TITLE
test(node-core): Fix flaky withMonitor span order assertion

### DIFF
--- a/packages/node-core/test/integration/transactions.test.ts
+++ b/packages/node-core/test/integration/transactions.test.ts
@@ -722,12 +722,12 @@ describe('Integration | Transactions', () => {
     expect(beforeSend).toHaveBeenCalledTimes(1);
     expect(transactionEvents).toHaveLength(1);
     expect(transactionTraceId).toBe(errorTraceId);
-    expect(transactionEvents[0]?.spans).toHaveLength(3);
-    expect(transactionEvents).toMatchObject([
-      {
-        spans: [{ description: 'inner span 1' }, { description: 'span inside error' }, { description: 'inner span 2' }],
-      },
-    ]);
+    const spans = transactionEvents[0]?.spans || [];
+
+    expect(spans).toHaveLength(3);
+    expect(spans).toContainEqual(expect.objectContaining({ description: 'inner span 1' }));
+    expect(spans).toContainEqual(expect.objectContaining({ description: 'span inside error' }));
+    expect(spans).toContainEqual(expect.objectContaining({ description: 'inner span 2' }));
     expect(sendEvents).toMatchObject([
       {
         exception: {


### PR DESCRIPTION
This PR fixes a flaky `withMonitor` unit test reported in  #22121

The test asserted child span order via `toMatchObject`, but the span exporter does not guarantee ordering by timestamp. The failure in #22121 showed all three expected spans were present with matching trace IDs but only their order differed.

Replace the order-sensitive assertion with `toContainEqual` checks, matching the pattern used elsewhere in the same test file.

Fixes #22121
