### PR TITLE
test(anr): Use pure-JS busy work so ANR stack samples capture longWork

### DIFF
--- a/dev-packages/node-core-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/app-path.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node-core';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import * as path from 'path';
 import * as url from 'url';
 import { setupOtel } from '../../utils/setupOtel.js';
@@ -26,11 +24,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-core-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic-multiple.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node-core';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import { setupOtel } from '../../utils/setupOtel.js';
 import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
@@ -22,11 +20,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-core-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic-session.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../utils/setupOtel.js');
 const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
@@ -21,11 +18,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-core-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../utils/setupOtel.js');
 const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
@@ -23,11 +20,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-core-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/basic.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node-core';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import { setupOtel } from '../../utils/setupOtel.js';
 import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
@@ -22,11 +20,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-core-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/forked.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../utils/setupOtel.js');
 const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
@@ -22,11 +19,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-core-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/indefinite.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node-core';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import { setupOtel } from '../../utils/setupOtel.js';
 import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
@@ -20,12 +18,11 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  // This loop will run almost indefinitely
+  let n = 1;
   for (let i = 0; i < 2000000000; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-core-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-core-integration-tests/suites/anr/isolated.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node-core';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import { setupOtel } from '../../utils/setupOtel.js';
 
 setTimeout(() => {
@@ -18,11 +16,16 @@ setupOtel(client);
 async function longWork() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 function neverResolve() {

--- a/dev-packages/node-core-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-core-integration-tests/suites/anr/stop-and-start.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node-core');
 const { setupOtel } = require('../../utils/setupOtel.js');
 
@@ -23,19 +20,29 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWorkIgnored() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 function longWork() {
-  for (let i = 0; i < 50; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 setTimeout(() => {

--- a/dev-packages/node-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/app-path.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import * as path from 'path';
 import * as url from 'url';
 import { waitForDebuggerReady } from '@sentry-internal/test-utils';
@@ -23,11 +21,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
@@ -19,11 +17,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node');
 const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
@@ -18,11 +15,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node');
 const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
@@ -20,11 +17,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 global._sentryDebugIds = { [new Error().stack]: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' };
@@ -19,11 +17,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node');
 const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
@@ -19,11 +16,16 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 import { waitForDebuggerReady } from '@sentry-internal/test-utils';
 
 setTimeout(() => {
@@ -17,12 +15,11 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWork() {
-  // This loop will run almost indefinitely
+  let n = 1;
   for (let i = 0; i < 2000000000; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 waitForDebuggerReady(() => {

--- a/dev-packages/node-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/isolated.mjs
@@ -1,6 +1,4 @@
 import * as Sentry from '@sentry/node';
-import * as assert from 'assert';
-import * as crypto from 'crypto';
 
 setTimeout(() => {
   process.exit();
@@ -15,11 +13,16 @@ Sentry.init({
 async function longWork() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 function neverResolve() {

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -1,6 +1,3 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const Sentry = require('@sentry/node');
 
 setTimeout(() => {
@@ -20,19 +17,29 @@ Sentry.setUser({ email: 'person@home.com' });
 Sentry.addBreadcrumb({ message: 'important message!' });
 
 function longWorkIgnored() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 function longWork() {
-  for (let i = 0; i < 20; i++) {
-    const salt = crypto.randomBytes(128).toString('base64');
-    const hash = crypto.pbkdf2Sync('myPassword', salt, 10000, 512, 'sha512');
-    assert.ok(hash);
+  // Busy-block the event loop with pure-JS work. The ANR worker samples the main thread via the
+  // inspector, which can only pause at a JS safepoint; inside a native call like `crypto.pbkdf2Sync`
+  // the pause resolves only after the call returns, so the sample can miss `longWork` and land in
+  // timer internals instead. Pure-JS work keeps `longWork` on the sampled stack for the whole block.
+  const start = Date.now();
+  let n = 1;
+  while (Date.now() - start < 1000) {
+    n = (n * 1103515245 + 12345) % 2147483648;
   }
+  return n;
 }
 
 setTimeout(() => {


### PR DESCRIPTION
The ANR integration tests intermittently failed because the captured stacktrace was missing the required `longWork` frame — the sample showed only `node:internal/timers` frames (`processTimers`/`listOnTimeout`/`insert`) instead, and `debug_meta` was absent.

_Root cause_: `longWork` blocked the event loop via `crypto.pbkdf2Sync`, a native addon call. The ANR worker samples the main thread through the inspector, which can only pause at a JS safepoint — V8 cannot pause inside a native call, so the pause resolves only after `pbkdf2Sync` returns. When ANR fired near the tail of `longWork`, the pause landed after the call had returned and control had popped back to the timer dispatch, so the sampled stack missed `longWork` entirely. `longWork` blocks ~880ms locally (well over the 100ms threshold), so this was a sampling-boundary race, not a too-short block.

This replaces the native crypto busy-work with a pure-JS CPU loop in every ANR scenario, across both the node-core and node integration test suites. V8 can now sample inside `longWork`, so it reliably appears on the captured stack. `longWork` stays defined locally in each scenario to preserve the per-file `filename` assertions (e.g. `isolated.mjs`).

Verified locally: both suites pass 12/12 across repeated runs.

Fixes #21702

🤖 Generated with [Claude Code](https://claude.com/claude-code)