### PR TITLE
test: Remove fixed container_name from node integration test docker-compose files

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: redis:latest
     restart: always
-    container_name: integration-tests-ioredis-dc
     ports:
       - '6382:6379'
     healthcheck:

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   db:
     image: apache/kafka:latest
     restart: always
-    container_name: integration-tests-kafka
     ports:
       - '9092:9092'
     healthcheck:

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db_mysql2:
     image: mysql:8
     restart: always
-    container_name: integration-tests-knex-mysql2
     ports:
       - '3307:3306'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db_postgres:
     image: postgres:13
     restart: always
-    container_name: integration-tests-knex-postgres
     ports:
       - '5445:5432'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   db:
     image: mysql:8
     restart: always
-    container_name: integration-tests-mysql2-dc
     ports:
       - '3308:3306'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   db:
     image: mysql:8
     restart: always
-    container_name: integration-tests-mysql
     ports:
       - '3306:3306'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres-streamed/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: postgres:13
     restart: always
-    container_name: integration-tests-postgres-streamed
     ports:
       - '5495:5432'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: postgres:13
     restart: always
-    container_name: integration-tests-postgres
     ports:
       - '5494:5432'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: postgres:13
     restart: always
-    container_name: integration-tests-postgresjs
     ports:
       - '5444:5432'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: postgres:13
     restart: always
-    container_name: integration-tests-prisma-v5
     ports:
       - '5433:5432'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: postgres:13
     restart: always
-    container_name: integration-tests-prisma-v6
     ports:
       - '5434:5432'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: postgres:13
     restart: always
-    container_name: integration-tests-prisma-v7
     ports:
       - '5435:5432'
     environment:

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: redis:latest
     restart: always
-    container_name: integration-tests-redis-cache
     ports:
       - '6383:6379'
     healthcheck:

--- a/dev-packages/node-integration-tests/suites/tracing/redis-dc/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-dc/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: redis:latest
     restart: always
-    container_name: integration-tests-redis-dc
     ports:
       - '6381:6379'
     healthcheck:

--- a/dev-packages/node-integration-tests/suites/tracing/redis/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/redis/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: redis:latest
     restart: always
-    container_name: integration-tests-redis
     ports:
       - '6380:6379'
     healthcheck:

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/docker-compose.yml
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/docker-compose.yml
@@ -4,7 +4,6 @@ services:
   db:
     image: mcr.microsoft.com/mssql/server:2022-latest
     restart: always
-    container_name: integration-tests-tedious
     ports:
       - '1433:1433'
     environment:


### PR DESCRIPTION
A fixed `container_name` is a **global** name on the Docker daemon, not scoped to the Compose project. When a suite's teardown was skipped (process killed, crash, `--wait` timeout, etc.), the orphaned container kept holding that name, and the next run's project-scoped `docker compose down` could not remove it — so the subsequent `docker compose up` failed with:

> Conflict. The container name "/integration-tests-postgres-streamed" is already in use by container ...

Nothing connects by container name — the scenario apps reach the DB via the published host port, and healthchecks run inside the container — so dropping `container_name` from all 16 tracing suite compose files lets Compose auto-name containers per (stable, cwd-derived) project. Startup becomes resilient to a leftover container without any change to the existing teardown behaviour.

_Root cause_: container names are a daemon-global namespace; a fixed name plus project-scoped teardown means an orphan from an aborted run collides with the next run and can't be cleaned up by that run's `down`.