### PR TITLE
ref: remove unused addOriginToSpan copies

### DIFF
--- a/packages/cloudflare/src/utils/addOriginToSpan.ts
+++ b/packages/cloudflare/src/utils/addOriginToSpan.ts
@@ -1,8 +1,0 @@
-import type { Span } from '@opentelemetry/api';
-import type { SpanOrigin } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
-
-/** Adds an origin to an OTEL Span. */
-export function addOriginToSpan(span: Span, origin: SpanOrigin): void {
-  span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
-}

--- a/packages/opentelemetry/src/utils/addOriginToSpan.ts
+++ b/packages/opentelemetry/src/utils/addOriginToSpan.ts
@@ -1,8 +1,0 @@
-import type { Span } from '@opentelemetry/api';
-import type { SpanOrigin } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
-
-/** Adds an origin to an OTEL Span. */
-export function addOriginToSpan(span: Span, origin: SpanOrigin): void {
-  span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, origin);
-}


### PR DESCRIPTION
Removes the `addOriginToSpan` copies in `@sentry/cloudflare` and `@sentry/opentelemetry`, which are dead code: neither is exported or imported anywhere. The only live copy is in `@sentry/node-core` (consumed by node's postgresjs instrumentation), and it stays put.

This started as a plan to consolidate the three identical copies into core, but core has no `@opentelemetry/api` dependency and the helper takes an OTEL `Span`.