### PR TITLE
ref(nitro, nuxt): inline `== null` checks for nullish detection

### DIFF
--- a/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
@@ -99,10 +99,6 @@ function normalizeMethodName(methodName: string): string {
   return methodName.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
 }
 
-function isEmptyValue(value: unknown): value is null | undefined {
-  return value === null || value === undefined;
-}
-
 interface CacheEntry<T = unknown> {
   value?: T;
   expires?: number;
@@ -116,7 +112,7 @@ interface ResponseCacheEntry {
 
 function isCacheHit(key: unknown, value: unknown): boolean {
   try {
-    const isEmpty = isEmptyValue(value);
+    const isEmpty = value == null;
     if (isEmpty || typeof key !== 'string' || !CACHED_FN_HANDLERS_RE.test(key)) {
       return !isEmpty;
     }
@@ -133,7 +129,7 @@ function validateCacheEntry(
   key: string,
   entry: CacheEntry | CacheEntry<ResponseCacheEntry & { status: number }>,
 ): boolean {
-  if (isEmptyValue(entry.value)) {
+  if (entry.value == null) {
     return false;
   }
 

--- a/packages/nuxt/src/runtime/utils/instrumentStorage.ts
+++ b/packages/nuxt/src/runtime/utils/instrumentStorage.ts
@@ -210,13 +210,6 @@ function normalizeMethodName(methodName: string): string {
 }
 
 /**
- * Checks if the value is empty, used for cache hit detection.
- */
-function isEmptyValue(value: unknown): value is null | undefined {
-  return value === null || value === undefined;
-}
-
-/**
  * Creates the span start options for the storage method.
  */
 function createSpanStartOptions(
@@ -267,7 +260,7 @@ function normalizeKey(key: unknown, prefix: string): string {
     return `${prefix}${key.key}`;
   }
 
-  return `${prefix}${isEmptyValue(key) ? '' : String(key)}`;
+  return `${prefix}${key == null ? '' : String(key)}`;
 }
 
 const CACHED_FN_HANDLERS_RE = /^nitro:(functions|handlers):/i;
@@ -280,7 +273,7 @@ const CACHED_FN_HANDLERS_RE = /^nitro:(functions|handlers):/i;
  */
 function isCacheHit(key: unknown, value: unknown): boolean {
   try {
-    const isEmpty = isEmptyValue(value);
+    const isEmpty = value == null;
     // Empty value means no cache hit either way
     // Or if key doesn't match the cached function or handler patterns, we can return the empty value check
     if (isEmpty || typeof key !== 'string' || !CACHED_FN_HANDLERS_RE.test(key)) {
@@ -301,7 +294,7 @@ function validateCacheEntry(
   key: string,
   entry: CacheEntry | CacheEntry<ResponseCacheEntry & { status: number }>,
 ): boolean {
-  if (isEmptyValue(entry.value)) {
+  if (entry.value == null) {
     return false;
   }
 


### PR DESCRIPTION
Adds an `isNullish` type guard to `@sentry/core` and replaces the identical `isEmptyValue` copies in `@sentry/nitro` and `@sentry/nuxt` storage instrumentation. Both were `value === null || value === undefined` with the same `value is null | undefined` guard, so this is behavior-neutral.

Named `isNullish` rather than `isEmptyValue` since it only checks nullishness, not emptiness.