### PR TITLE
feat(core): add isObjectLike guard and consolidate non-null-object checks

### DIFF
--- a/packages/browser/src/integrations/graphqlClient.ts
+++ b/packages/browser/src/integrations/graphqlClient.ts
@@ -1,6 +1,7 @@
 import type { Client, IntegrationFn } from '@sentry/core/browser';
 import {
   defineIntegration,
+  isObject,
   isString,
   SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -215,9 +216,6 @@ export function parseGraphQLQuery(query: string): GraphQLOperation {
 /**
  * Helper to safely check if a value is a non-null object
  */
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 /**
  * Type guard to check if a request is a standard GraphQL request

--- a/packages/browser/src/integrations/graphqlClient.ts
+++ b/packages/browser/src/integrations/graphqlClient.ts
@@ -1,7 +1,7 @@
 import type { Client, IntegrationFn } from '@sentry/core/browser';
 import {
   defineIntegration,
-  isObject,
+  isObjectLike,
   isString,
   SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -221,7 +221,7 @@ export function parseGraphQLQuery(query: string): GraphQLOperation {
  * Type guard to check if a request is a standard GraphQL request
  */
 function isStandardRequest(payload: unknown): payload is GraphQLStandardRequest {
-  return isObject(payload) && typeof payload.query === 'string';
+  return isObjectLike(payload) && typeof payload.query === 'string';
 }
 
 /**
@@ -229,10 +229,10 @@ function isStandardRequest(payload: unknown): payload is GraphQLStandardRequest 
  */
 function isPersistedRequest(payload: unknown): payload is GraphQLPersistedRequest {
   return (
-    isObject(payload) &&
+    isObjectLike(payload) &&
     typeof payload.operationName === 'string' &&
-    isObject(payload.extensions) &&
-    isObject(payload.extensions.persistedQuery) &&
+    isObjectLike(payload.extensions) &&
+    isObjectLike(payload.extensions.persistedQuery) &&
     typeof payload.extensions.persistedQuery.sha256Hash === 'string' &&
     typeof payload.extensions.persistedQuery.version === 'number'
   );

--- a/packages/bundler-plugins/src/core/component-annotation-vite-ast.ts
+++ b/packages/bundler-plugins/src/core/component-annotation-vite-ast.ts
@@ -1,6 +1,9 @@
+import { isObject } from '@sentry/core';
 import type { SourceMap } from 'magic-string';
 
 import type { ComponentAnnotationAttribute } from '../babel-plugin/component-annotation';
+
+export { isObject };
 
 export type AstNode = {
   type: string;
@@ -63,10 +66,6 @@ export type ComponentAnnotationTransformResult =
     }
   | null
   | undefined;
-
-export function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 export function isAstNode(value: unknown): value is AstNode {
   return isObject(value) && typeof value.type === 'string';

--- a/packages/bundler-plugins/src/core/component-annotation-vite-ast.ts
+++ b/packages/bundler-plugins/src/core/component-annotation-vite-ast.ts
@@ -1,9 +1,9 @@
-import { isObject } from '@sentry/core';
+import { isObjectLike } from '@sentry/core';
 import type { SourceMap } from 'magic-string';
 
 import type { ComponentAnnotationAttribute } from '../babel-plugin/component-annotation';
 
-export { isObject };
+export { isObjectLike };
 
 export type AstNode = {
   type: string;
@@ -68,7 +68,7 @@ export type ComponentAnnotationTransformResult =
   | undefined;
 
 export function isAstNode(value: unknown): value is AstNode {
-  return isObject(value) && typeof value.type === 'string';
+  return isObjectLike(value) && typeof value.type === 'string';
 }
 
 export function walkAst(node: unknown, visit: (node: AstNode) => void): void {

--- a/packages/bundler-plugins/src/core/component-annotation-vite-fragments.ts
+++ b/packages/bundler-plugins/src/core/component-annotation-vite-fragments.ts
@@ -1,5 +1,5 @@
 import type { AstNode, FragmentContext } from './component-annotation-vite-ast';
-import { isAstNode, isObject, walkAst } from './component-annotation-vite-ast';
+import { isAstNode, isObjectLike, walkAst } from './component-annotation-vite-ast';
 import { getStringName } from './component-annotation-vite-jsx';
 
 export function collectFragmentContext(ast: AstNode): FragmentContext {
@@ -17,7 +17,7 @@ export function collectFragmentContext(ast: AstNode): FragmentContext {
 }
 
 function collectFragmentAliasesFromImport(node: AstNode, context: FragmentContext): void {
-  if (node.type !== 'ImportDeclaration' || !isObject(node.source)) {
+  if (node.type !== 'ImportDeclaration' || !isObjectLike(node.source)) {
     return;
   }
 
@@ -29,7 +29,7 @@ function collectFragmentAliasesFromImport(node: AstNode, context: FragmentContex
   const specifiers = Array.isArray(node.specifiers) ? node.specifiers : [];
 
   for (const specifier of specifiers) {
-    if (!isAstNode(specifier) || !isObject(specifier.local)) {
+    if (!isAstNode(specifier) || !isObjectLike(specifier.local)) {
       continue;
     }
 
@@ -47,7 +47,7 @@ function collectFragmentAliasesFromImport(node: AstNode, context: FragmentContex
 }
 
 function collectFragmentAliasesFromVariableDeclarator(node: AstNode, context: FragmentContext): void {
-  if (node.type !== 'VariableDeclarator' || !isObject(node.id) || !isObject(node.init)) {
+  if (node.type !== 'VariableDeclarator' || !isObjectLike(node.id) || !isObjectLike(node.init)) {
     return;
   }
 
@@ -108,7 +108,7 @@ function collectFragmentAliasFromObjectPattern(
 function isImportedReactFragment(specifier: AstNode): boolean {
   return (
     specifier.type === 'ImportSpecifier' &&
-    isObject(specifier.imported) &&
+    isObjectLike(specifier.imported) &&
     getStringName(specifier.imported) === 'Fragment'
   );
 }
@@ -116,8 +116,8 @@ function isImportedReactFragment(specifier: AstNode): boolean {
 function isReactFragmentMemberExpression(init: Record<string, unknown>, context: FragmentContext): boolean {
   return (
     init.type === 'MemberExpression' &&
-    isObject(init.object) &&
-    isObject(init.property) &&
+    isObjectLike(init.object) &&
+    isObjectLike(init.property) &&
     context.reactNamespaceAliases.has(getStringName(init.object) ?? '') &&
     getStringName(init.property) === 'Fragment'
   );
@@ -125,10 +125,10 @@ function isReactFragmentMemberExpression(init: Record<string, unknown>, context:
 
 function isFragmentObjectPatternProperty(property: unknown): property is { value: unknown } {
   return (
-    isObject(property) &&
+    isObjectLike(property) &&
     (property.type === 'Property' || property.type === 'ObjectProperty') &&
-    isObject(property.key) &&
+    isObjectLike(property.key) &&
     getStringName(property.key) === 'Fragment' &&
-    isObject(property.value)
+    isObjectLike(property.value)
   );
 }

--- a/packages/bundler-plugins/src/core/component-annotation-vite-jsx.ts
+++ b/packages/bundler-plugins/src/core/component-annotation-vite-jsx.ts
@@ -13,7 +13,7 @@ import type {
   JSXOpeningElementNode,
   JSXRootNode,
 } from './component-annotation-vite-ast';
-import { isAstNode, isObject } from './component-annotation-vite-ast';
+import { isAstNode, isObjectLike } from './component-annotation-vite-ast';
 
 const UNKNOWN_ELEMENT_NAME = 'unknown';
 const WEB_ATTRIBUTE_NAMES = [WEB_ELEMENT_NAME, WEB_COMPONENT_NAME, WEB_SOURCE_FILE_NAME] as const;
@@ -37,7 +37,7 @@ export function isJSXRoot(value: unknown): value is JSXRootNode {
 }
 
 export function getStringName(node: unknown): string | null {
-  return isObject(node) && typeof node.name === 'string' ? node.name : null;
+  return isObjectLike(node) && typeof node.name === 'string' ? node.name : null;
 }
 
 export function getJSXName(name: unknown): string {
@@ -92,7 +92,7 @@ export function isReactFragment(openingElement: JSXOpeningElementNode, fragmentC
     return true;
   }
 
-  if (isObject(openingElement.name) && openingElement.name.type === 'JSXMemberExpression') {
+  if (isObjectLike(openingElement.name) && openingElement.name.type === 'JSXMemberExpression') {
     const objectName = getJSXName(openingElement.name.object);
     const propertyName = getJSXName(openingElement.name.property);
 

--- a/packages/bundler-plugins/src/core/component-annotation-vite-walk.ts
+++ b/packages/bundler-plugins/src/core/component-annotation-vite-walk.ts
@@ -6,7 +6,7 @@ import {
   isJSXRoot,
   toAttributeInsertions,
 } from './component-annotation-vite-jsx';
-import { isAstNode, isObject, walkAst } from './component-annotation-vite-ast';
+import { isAstNode, isObjectLike, walkAst } from './component-annotation-vite-ast';
 import { collectFragmentContext } from './component-annotation-vite-fragments';
 
 type ComponentJSXRoots = { name: string; roots: JSXRootNode[] };
@@ -35,7 +35,7 @@ function getJSXRootsFromReturnArgument(argument: unknown): JSXRootNode[] {
     return [argument];
   }
 
-  if (isObject(argument) && argument.type === 'ConditionalExpression') {
+  if (isObjectLike(argument) && argument.type === 'ConditionalExpression') {
     return [argument.consequent, argument.alternate].filter(isJSXRoot);
   }
 
@@ -49,7 +49,7 @@ function getReturnedJSXFromFunction(functionNode: AstNode): JSXRootNode[] {
     return [body];
   }
 
-  if (!isObject(body) || body.type !== 'BlockStatement') {
+  if (!isObjectLike(body) || body.type !== 'BlockStatement') {
     return [];
   }
 
@@ -58,7 +58,7 @@ function getReturnedJSXFromFunction(functionNode: AstNode): JSXRootNode[] {
     return isAstNode(statement) && statement.type === 'ReturnStatement';
   });
 
-  return isObject(returnStatement) ? getJSXRootsFromReturnArgument(returnStatement.argument) : [];
+  return isObjectLike(returnStatement) ? getJSXRootsFromReturnArgument(returnStatement.argument) : [];
 }
 
 function pushFunctionComponent(components: ComponentJSXRoots[], nameNode: unknown, functionNode: AstNode): void {
@@ -76,12 +76,12 @@ function collectComponentJSXRoots(ast: AstNode): ComponentJSXRoots[] {
   const components: ComponentJSXRoots[] = [];
 
   walkAst(ast, node => {
-    if (node.type === 'FunctionDeclaration' && isObject(node.id)) {
+    if (node.type === 'FunctionDeclaration' && isObjectLike(node.id)) {
       pushFunctionComponent(components, node.id, node);
       return;
     }
 
-    if (node.type === 'VariableDeclarator' && isObject(node.id)) {
+    if (node.type === 'VariableDeclarator' && isObjectLike(node.id)) {
       if (isAstNode(node.init) && node.init.type === 'ArrowFunctionExpression') {
         pushFunctionComponent(components, node.id, node.init);
       }
@@ -119,20 +119,20 @@ function pushClassComponent(components: ComponentJSXRoots[], node: AstNode): voi
 }
 
 function getClassRenderMethodBody(node: AstNode): AstNode | null {
-  if (!isObject(node.body) || !Array.isArray(node.body.body)) {
+  if (!isObjectLike(node.body) || !Array.isArray(node.body.body)) {
     return null;
   }
 
   const renderMethod = node.body.body.find(member => {
     return (
-      isObject(member) &&
-      isObject(member.key) &&
+      isObjectLike(member) &&
+      isObjectLike(member.key) &&
       getStringName(member.key) === 'render' &&
-      (isObject(member.value) || isObject(member.body))
+      (isObjectLike(member.value) || isObjectLike(member.body))
     );
   });
 
-  if (!isObject(renderMethod)) {
+  if (!isObjectLike(renderMethod)) {
     return null;
   }
 

--- a/packages/cloudflare/src/instrument.ts
+++ b/packages/cloudflare/src/instrument.ts
@@ -3,6 +3,8 @@
 // separately for workers and Durable Objects, but they share the same global scope.
 // The WeakMap stores original -> instrumented mappings so we can retrieve the
 // instrumented version even if we only have a reference to the original.
+import { isObjectLike } from '@sentry/core';
+
 const GLOBAL_KEY = '__SENTRY_INSTRUMENTED_MAP__' as const;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -20,7 +22,7 @@ function getInstrumentedMap(): WeakMap<any, any> {
  * WeakMap keys must be objects or non-registered symbols.
  */
 function isWeakMapKey(value: unknown): value is object {
-  return (typeof value === 'object' && value !== null) || typeof value === 'function';
+  return isObjectLike(value) || typeof value === 'function';
 }
 
 /**

--- a/packages/cloudflare/src/instrumentations/worker/instrumentEnv.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentEnv.ts
@@ -1,3 +1,4 @@
+import { isObjectLike } from '@sentry/core';
 import type { CloudflareOptions } from '../../client';
 import { isD1Database, isDurableObjectNamespace, isJSRPC, isQueue, isR2Bucket } from '../../utils/isBinding';
 import { instrumentD1 } from './instrumentD1';
@@ -9,7 +10,7 @@ import { instrumentQueueProducer } from './instrumentQueueProducer';
 import { instrumentR2Bucket } from './instrumentR2';
 
 function isProxyable(item: unknown): item is object {
-  return item !== null && (typeof item === 'object' || typeof item === 'function');
+  return isObjectLike(item) || typeof item === 'function';
 }
 
 const instrumentedBindings = new WeakMap<object, unknown>();

--- a/packages/cloudflare/src/instrumentations/worker/instrumentR2.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentR2.ts
@@ -1,5 +1,5 @@
 import type { R2Bucket, R2ListOptions, R2MultipartUpload } from '@cloudflare/workers-types';
-import { isObject, SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+import { isObjectLike, SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 
 const ORIGIN = 'auto.faas.cloudflare.r2';
 
@@ -30,7 +30,7 @@ const R2_OPERATIONS = {
 type R2OperationKey = keyof typeof R2_OPERATIONS;
 
 function isR2ListOptions(key: unknown): key is R2ListOptions {
-  return isObject(key) && !Array.isArray(key);
+  return isObjectLike(key) && !Array.isArray(key);
 }
 
 function createSpanOptions(bindingName: string, r2Op: R2OperationKey, key?: string | string[] | R2ListOptions) {

--- a/packages/cloudflare/src/instrumentations/worker/instrumentR2.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentR2.ts
@@ -1,5 +1,5 @@
 import type { R2Bucket, R2ListOptions, R2MultipartUpload } from '@cloudflare/workers-types';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+import { isObject, SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 
 const ORIGIN = 'auto.faas.cloudflare.r2';
 
@@ -30,7 +30,7 @@ const R2_OPERATIONS = {
 type R2OperationKey = keyof typeof R2_OPERATIONS;
 
 function isR2ListOptions(key: unknown): key is R2ListOptions {
-  return typeof key === 'object' && key !== null && !Array.isArray(key);
+  return isObject(key) && !Array.isArray(key);
 }
 
 function createSpanOptions(bindingName: string, r2Op: R2OperationKey, key?: string | string[] | R2ListOptions) {

--- a/packages/cloudflare/src/integrations/hono.ts
+++ b/packages/cloudflare/src/integrations/hono.ts
@@ -1,5 +1,6 @@
 import type { IntegrationFn } from '@sentry/core';
 import {
+  isObject,
   captureException,
   debug,
   defineIntegration,
@@ -39,7 +40,7 @@ function isHonoError(err: unknown): err is HonoError {
   if (err instanceof Error) {
     return true;
   }
-  return typeof err === 'object' && err !== null && 'status' in (err as Record<string, unknown>);
+  return isObject(err) && 'status' in (err as Record<string, unknown>);
 }
 
 // Vendored from https://github.com/honojs/hono/blob/d3abeb1f801aaa1b334285c73da5f5f022dbcadb/src/helper/route/index.ts#L58-L59

--- a/packages/cloudflare/src/integrations/hono.ts
+++ b/packages/cloudflare/src/integrations/hono.ts
@@ -1,6 +1,6 @@
 import type { IntegrationFn } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   captureException,
   debug,
   defineIntegration,
@@ -40,7 +40,7 @@ function isHonoError(err: unknown): err is HonoError {
   if (err instanceof Error) {
     return true;
   }
-  return isObject(err) && 'status' in (err as Record<string, unknown>);
+  return isObjectLike(err) && 'status' in (err as Record<string, unknown>);
 }
 
 // Vendored from https://github.com/honojs/hono/blob/d3abeb1f801aaa1b334285c73da5f5f022dbcadb/src/helper/route/index.ts#L58-L59

--- a/packages/cloudflare/src/options.ts
+++ b/packages/cloudflare/src/options.ts
@@ -1,4 +1,4 @@
-import { isObject, envToBool } from '@sentry/core';
+import { isObjectLike, envToBool } from '@sentry/core';
 import type { CloudflareOptions } from './client';
 
 /**
@@ -15,11 +15,11 @@ interface CfVersionMetadata {
  * Checks if the value is a valid CF_VERSION_METADATA binding.
  */
 function isVersionMetadata(value: unknown): value is CfVersionMetadata {
-  return isObject(value) && 'id' in value && typeof value.id === 'string';
+  return isObjectLike(value) && 'id' in value && typeof value.id === 'string';
 }
 
 function getEnvVar<T extends Record<string, unknown>>(env: unknown, varName: keyof T): string | undefined {
-  return isObject(env) && varName in env && typeof (env as T)[varName] === 'string'
+  return isObjectLike(env) && varName in env && typeof (env as T)[varName] === 'string'
     ? ((env as T)[varName] as string)
     : undefined;
 }

--- a/packages/cloudflare/src/options.ts
+++ b/packages/cloudflare/src/options.ts
@@ -1,4 +1,4 @@
-import { envToBool } from '@sentry/core';
+import { isObject, envToBool } from '@sentry/core';
 import type { CloudflareOptions } from './client';
 
 /**
@@ -15,11 +15,11 @@ interface CfVersionMetadata {
  * Checks if the value is a valid CF_VERSION_METADATA binding.
  */
 function isVersionMetadata(value: unknown): value is CfVersionMetadata {
-  return typeof value === 'object' && value !== null && 'id' in value && typeof value.id === 'string';
+  return isObject(value) && 'id' in value && typeof value.id === 'string';
 }
 
 function getEnvVar<T extends Record<string, unknown>>(env: unknown, varName: keyof T): string | undefined {
-  return typeof env === 'object' && env !== null && varName in env && typeof (env as T)[varName] === 'string'
+  return isObject(env) && varName in env && typeof (env as T)[varName] === 'string'
     ? ((env as T)[varName] as string)
     : undefined;
 }

--- a/packages/cloudflare/src/utils/rpcMeta.ts
+++ b/packages/cloudflare/src/utils/rpcMeta.ts
@@ -1,4 +1,4 @@
-import { getTraceData, type SerializedTraceData } from '@sentry/core';
+import { getTraceData, isObject, type SerializedTraceData } from '@sentry/core';
 
 /**
  * Key used to identify Sentry RPC metadata in a trailing argument.
@@ -12,11 +12,10 @@ interface SentryRpcMeta {
 }
 
 function isSentryRpcMeta(value: unknown): value is SentryRpcMeta {
-  if (typeof value !== 'object' || value === null || !(SENTRY_RPC_META_KEY in value)) {
+  if (!isObject(value) || !(SENTRY_RPC_META_KEY in value)) {
     return false;
   }
-  const sentry = (value as SentryRpcMeta).__sentry_rpc_meta__;
-  return typeof sentry === 'object' && sentry !== null;
+  return isObject(value[SENTRY_RPC_META_KEY]);
 }
 
 /**

--- a/packages/cloudflare/src/utils/rpcMeta.ts
+++ b/packages/cloudflare/src/utils/rpcMeta.ts
@@ -1,4 +1,4 @@
-import { getTraceData, isObject, type SerializedTraceData } from '@sentry/core';
+import { getTraceData, isObjectLike, type SerializedTraceData } from '@sentry/core';
 
 /**
  * Key used to identify Sentry RPC metadata in a trailing argument.
@@ -12,10 +12,10 @@ interface SentryRpcMeta {
 }
 
 function isSentryRpcMeta(value: unknown): value is SentryRpcMeta {
-  if (!isObject(value) || !(SENTRY_RPC_META_KEY in value)) {
+  if (!isObjectLike(value) || !(SENTRY_RPC_META_KEY in value)) {
     return false;
   }
-  return isObject(value[SENTRY_RPC_META_KEY]);
+  return isObjectLike(value[SENTRY_RPC_META_KEY]);
 }
 
 /**

--- a/packages/cloudflare/src/wrapMethodWithSentry.ts
+++ b/packages/cloudflare/src/wrapMethodWithSentry.ts
@@ -1,7 +1,7 @@
 import type { DurableObjectStorage } from '@cloudflare/workers-types';
 import type { SerializedTraceData } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   captureException,
   continueTrace,
   getClient,
@@ -35,7 +35,7 @@ function resolveOriginalStorage(
   context: ExecutionContext | InstrumentedDurableObjectState | undefined,
   thisArg: unknown,
 ): DurableObjectStorage | undefined {
-  if (isObject(thisArg) && 'ctx' in thisArg) {
+  if (isObjectLike(thisArg) && 'ctx' in thisArg) {
     const doCtx = (thisArg as { ctx: InstrumentedDurableObjectState }).ctx;
     if (doCtx?.originalStorage) {
       return doCtx.originalStorage;

--- a/packages/cloudflare/src/wrapMethodWithSentry.ts
+++ b/packages/cloudflare/src/wrapMethodWithSentry.ts
@@ -1,6 +1,7 @@
 import type { DurableObjectStorage } from '@cloudflare/workers-types';
 import type { SerializedTraceData } from '@sentry/core';
 import {
+  isObject,
   captureException,
   continueTrace,
   getClient,
@@ -34,7 +35,7 @@ function resolveOriginalStorage(
   context: ExecutionContext | InstrumentedDurableObjectState | undefined,
   thisArg: unknown,
 ): DurableObjectStorage | undefined {
-  if (thisArg && typeof thisArg === 'object' && 'ctx' in thisArg) {
+  if (isObject(thisArg) && 'ctx' in thisArg) {
     const doCtx = (thisArg as { ctx: InstrumentedDurableObjectState }).ctx;
     if (doCtx?.originalStorage) {
       return doCtx.originalStorage;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -43,7 +43,7 @@ import { debug } from './utils/debug-logger';
 import { dsnToString, makeDsn } from './utils/dsn';
 import { addItemToEnvelope, createAttachmentEnvelopeItem } from './utils/envelope';
 import { getPossibleEventMessages } from './utils/eventUtils';
-import { isParameterizedString, isPlainObject, isPrimitive, isThenable } from './utils/is';
+import { isObject, isParameterizedString, isPlainObject, isPrimitive, isThenable } from './utils/is';
 import { merge } from './utils/merge';
 import { checkOrSetAlreadyCaught, uuid4 } from './utils/misc';
 import { parseSampleRate } from './utils/parseSampleRate';
@@ -91,11 +91,11 @@ function _makeDoNotSendEventError(message: string): DoNotSendEventError {
 }
 
 function _isInternalError(error: unknown): error is InternalError {
-  return !!error && typeof error === 'object' && INTERNAL_ERROR_SYMBOL in error;
+  return isObject(error) && INTERNAL_ERROR_SYMBOL in error;
 }
 
 function _isDoNotSendEventError(error: unknown): error is DoNotSendEventError {
-  return !!error && typeof error === 'object' && DO_NOT_SEND_EVENT_SYMBOL in error;
+  return isObject(error) && DO_NOT_SEND_EVENT_SYMBOL in error;
 }
 
 /**

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -43,7 +43,7 @@ import { debug } from './utils/debug-logger';
 import { dsnToString, makeDsn } from './utils/dsn';
 import { addItemToEnvelope, createAttachmentEnvelopeItem } from './utils/envelope';
 import { getPossibleEventMessages } from './utils/eventUtils';
-import { isObject, isParameterizedString, isPlainObject, isPrimitive, isThenable } from './utils/is';
+import { isObjectLike, isParameterizedString, isPlainObject, isPrimitive, isThenable } from './utils/is';
 import { merge } from './utils/merge';
 import { checkOrSetAlreadyCaught, uuid4 } from './utils/misc';
 import { parseSampleRate } from './utils/parseSampleRate';
@@ -91,11 +91,11 @@ function _makeDoNotSendEventError(message: string): DoNotSendEventError {
 }
 
 function _isInternalError(error: unknown): error is InternalError {
-  return isObject(error) && INTERNAL_ERROR_SYMBOL in error;
+  return isObjectLike(error) && INTERNAL_ERROR_SYMBOL in error;
 }
 
 function _isDoNotSendEventError(error: unknown): error is DoNotSendEventError {
-  return isObject(error) && DO_NOT_SEND_EVENT_SYMBOL in error;
+  return isObjectLike(error) && DO_NOT_SEND_EVENT_SYMBOL in error;
 }
 
 /**

--- a/packages/core/src/instrument/fetch.ts
+++ b/packages/core/src/instrument/fetch.ts
@@ -2,7 +2,7 @@
 import { getClient } from '../currentScopes';
 import type { HandlerDataFetch } from '../types/instrument';
 import type { WebFetchHeaders } from '../types/webfetchapi';
-import { isError, isObject, isRequest } from '../utils/is';
+import { isError, isObjectLike, isRequest } from '../utils/is';
 import { addNonEnumerableProperty, fill } from '../utils/object';
 import { supportsNativeFetch } from '../utils/supports';
 import { timestampInSeconds } from '../utils/time';
@@ -226,7 +226,7 @@ function streamHandler(response: Response): void {
 }
 
 function hasProp<T extends string>(obj: unknown, prop: T): obj is Record<string, string> {
-  return isObject(obj) && !!(obj as Record<string, string>)[prop];
+  return isObjectLike(obj) && !!(obj as Record<string, string>)[prop];
 }
 
 function getUrlFromResource(resource: FetchResource): string {

--- a/packages/core/src/instrument/fetch.ts
+++ b/packages/core/src/instrument/fetch.ts
@@ -2,7 +2,7 @@
 import { getClient } from '../currentScopes';
 import type { HandlerDataFetch } from '../types/instrument';
 import type { WebFetchHeaders } from '../types/webfetchapi';
-import { isError, isRequest } from '../utils/is';
+import { isError, isObject, isRequest } from '../utils/is';
 import { addNonEnumerableProperty, fill } from '../utils/object';
 import { supportsNativeFetch } from '../utils/supports';
 import { timestampInSeconds } from '../utils/time';
@@ -226,7 +226,7 @@ function streamHandler(response: Response): void {
 }
 
 function hasProp<T extends string>(obj: unknown, prop: T): obj is Record<string, string> {
-  return !!obj && typeof obj === 'object' && !!(obj as Record<string, string>)[prop];
+  return isObject(obj) && !!(obj as Record<string, string>)[prop];
 }
 
 function getUrlFromResource(resource: FetchResource): string {

--- a/packages/core/src/integrations/mcp-server/handlers.ts
+++ b/packages/core/src/integrations/mcp-server/handlers.ts
@@ -7,6 +7,7 @@
 
 import { DEBUG_BUILD } from '../../debug-build';
 import { debug } from '../../utils/debug-logger';
+import { isObject } from '../../utils/is';
 import { fill } from '../../utils/object';
 import { captureError } from './errorCapture';
 import type { MCPHandler, MCPServerInstance } from './types';
@@ -71,7 +72,7 @@ function createErrorCapturingHandler(
   try {
     const result = originalHandler.apply(this, handlerArgs);
 
-    if (result && typeof result === 'object' && typeof (result as { then?: unknown }).then === 'function') {
+    if (isObject(result) && typeof (result as { then?: unknown }).then === 'function') {
       return Promise.resolve(result).catch(error => {
         captureHandlerError(error, methodName, handlerName);
         throw error;
@@ -193,7 +194,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Tools: MCP SDK calls registeredTool.executor (generated from handler at registration time)
   const registeredTools = server['_registeredTools'];
-  if (registeredTools && typeof registeredTools === 'object') {
+  if (isObject(registeredTools)) {
     for (const [name, tool] of Object.entries(registeredTools as Record<string, Record<string, unknown>>)) {
       if (typeof tool['executor'] === 'function') {
         tool['executor'] = createWrappedHandler(tool['executor'] as MCPHandler, 'registerTool', name);
@@ -203,7 +204,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Resources: MCP SDK calls registeredResource.readCallback
   const registeredResources = server['_registeredResources'];
-  if (registeredResources && typeof registeredResources === 'object') {
+  if (isObject(registeredResources)) {
     for (const [name, resource] of Object.entries(registeredResources as Record<string, Record<string, unknown>>)) {
       if (typeof resource['readCallback'] === 'function') {
         resource['readCallback'] = createWrappedHandler(
@@ -217,7 +218,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Resource templates: MCP SDK calls registeredResourceTemplate.readCallback
   const registeredResourceTemplates = server['_registeredResourceTemplates'];
-  if (registeredResourceTemplates && typeof registeredResourceTemplates === 'object') {
+  if (isObject(registeredResourceTemplates)) {
     for (const [name, template] of Object.entries(
       registeredResourceTemplates as Record<string, Record<string, unknown>>,
     )) {
@@ -233,7 +234,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Prompts: MCP SDK calls registeredPrompt.handler
   const registeredPrompts = server['_registeredPrompts'];
-  if (registeredPrompts && typeof registeredPrompts === 'object') {
+  if (isObject(registeredPrompts)) {
     for (const [name, prompt] of Object.entries(registeredPrompts as Record<string, Record<string, unknown>>)) {
       if (typeof prompt['handler'] === 'function') {
         prompt['handler'] = createWrappedHandler(prompt['handler'] as MCPHandler, 'registerPrompt', name);

--- a/packages/core/src/integrations/mcp-server/handlers.ts
+++ b/packages/core/src/integrations/mcp-server/handlers.ts
@@ -7,7 +7,7 @@
 
 import { DEBUG_BUILD } from '../../debug-build';
 import { debug } from '../../utils/debug-logger';
-import { isObject } from '../../utils/is';
+import { isObjectLike } from '../../utils/is';
 import { fill } from '../../utils/object';
 import { captureError } from './errorCapture';
 import type { MCPHandler, MCPServerInstance } from './types';
@@ -72,7 +72,7 @@ function createErrorCapturingHandler(
   try {
     const result = originalHandler.apply(this, handlerArgs);
 
-    if (isObject(result) && typeof (result as { then?: unknown }).then === 'function') {
+    if (isObjectLike(result) && typeof (result as { then?: unknown }).then === 'function') {
       return Promise.resolve(result).catch(error => {
         captureHandlerError(error, methodName, handlerName);
         throw error;
@@ -194,7 +194,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Tools: MCP SDK calls registeredTool.executor (generated from handler at registration time)
   const registeredTools = server['_registeredTools'];
-  if (isObject(registeredTools)) {
+  if (isObjectLike(registeredTools)) {
     for (const [name, tool] of Object.entries(registeredTools as Record<string, Record<string, unknown>>)) {
       if (typeof tool['executor'] === 'function') {
         tool['executor'] = createWrappedHandler(tool['executor'] as MCPHandler, 'registerTool', name);
@@ -204,7 +204,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Resources: MCP SDK calls registeredResource.readCallback
   const registeredResources = server['_registeredResources'];
-  if (isObject(registeredResources)) {
+  if (isObjectLike(registeredResources)) {
     for (const [name, resource] of Object.entries(registeredResources as Record<string, Record<string, unknown>>)) {
       if (typeof resource['readCallback'] === 'function') {
         resource['readCallback'] = createWrappedHandler(
@@ -218,7 +218,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Resource templates: MCP SDK calls registeredResourceTemplate.readCallback
   const registeredResourceTemplates = server['_registeredResourceTemplates'];
-  if (isObject(registeredResourceTemplates)) {
+  if (isObjectLike(registeredResourceTemplates)) {
     for (const [name, template] of Object.entries(
       registeredResourceTemplates as Record<string, Record<string, unknown>>,
     )) {
@@ -234,7 +234,7 @@ export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
 
   // Prompts: MCP SDK calls registeredPrompt.handler
   const registeredPrompts = server['_registeredPrompts'];
-  if (isObject(registeredPrompts)) {
+  if (isObjectLike(registeredPrompts)) {
     for (const [name, prompt] of Object.entries(registeredPrompts as Record<string, Record<string, unknown>>)) {
       if (typeof prompt['handler'] === 'function') {
         prompt['handler'] = createWrappedHandler(prompt['handler'] as MCPHandler, 'registerPrompt', name);

--- a/packages/core/src/integrations/mcp-server/methodConfig.ts
+++ b/packages/core/src/integrations/mcp-server/methodConfig.ts
@@ -2,6 +2,7 @@
  * Method configuration and request processing for MCP server instrumentation
  */
 
+import { isObject } from '../../utils/is';
 import {
   MCP_PROMPT_NAME_ATTRIBUTE,
   MCP_REQUEST_ARGUMENT,
@@ -88,7 +89,7 @@ export function getRequestArguments(method: string, params: Record<string, unkno
 
   if (config.captureArguments && config.argumentsField && params?.[config.argumentsField]) {
     const argumentsObj = params[config.argumentsField];
-    if (typeof argumentsObj === 'object' && argumentsObj !== null) {
+    if (isObject(argumentsObj)) {
       for (const [key, value] of Object.entries(argumentsObj as Record<string, unknown>)) {
         args[`${MCP_REQUEST_ARGUMENT}.${key.toLowerCase()}`] = JSON.stringify(value);
       }

--- a/packages/core/src/integrations/mcp-server/methodConfig.ts
+++ b/packages/core/src/integrations/mcp-server/methodConfig.ts
@@ -2,7 +2,7 @@
  * Method configuration and request processing for MCP server instrumentation
  */
 
-import { isObject } from '../../utils/is';
+import { isObjectLike } from '../../utils/is';
 import {
   MCP_PROMPT_NAME_ATTRIBUTE,
   MCP_REQUEST_ARGUMENT,
@@ -89,7 +89,7 @@ export function getRequestArguments(method: string, params: Record<string, unkno
 
   if (config.captureArguments && config.argumentsField && params?.[config.argumentsField]) {
     const argumentsObj = params[config.argumentsField];
-    if (isObject(argumentsObj)) {
+    if (isObjectLike(argumentsObj)) {
       for (const [key, value] of Object.entries(argumentsObj as Record<string, unknown>)) {
         args[`${MCP_REQUEST_ARGUMENT}.${key.toLowerCase()}`] = JSON.stringify(value);
       }

--- a/packages/core/src/integrations/mcp-server/transport.ts
+++ b/packages/core/src/integrations/mcp-server/transport.ts
@@ -7,6 +7,7 @@
 
 import { getIsolationScope, withIsolationScope } from '../../currentScopes';
 import { startInactiveSpan, withActiveSpan } from '../../tracing';
+import { isObject } from '../../utils/is';
 import { fill } from '../../utils/object';
 import { MCP_PROTOCOL_VERSION_ATTRIBUTE } from './attributes';
 import { cleanupPendingSpansForTransport, completeSpanWithResults, storeSpanForRequest } from './correlation';
@@ -170,7 +171,7 @@ export function wrapTransportError(transport: MCPTransport): void {
  */
 function captureJsonRpcErrorResponse(errorResponse: unknown): void {
   try {
-    if (errorResponse && typeof errorResponse === 'object' && 'code' in errorResponse && 'message' in errorResponse) {
+    if (isObject(errorResponse) && 'code' in errorResponse && 'message' in errorResponse) {
       const jsonRpcError = errorResponse as { code: number; message: string; data?: unknown };
 
       const isServerError =

--- a/packages/core/src/integrations/mcp-server/transport.ts
+++ b/packages/core/src/integrations/mcp-server/transport.ts
@@ -7,7 +7,7 @@
 
 import { getIsolationScope, withIsolationScope } from '../../currentScopes';
 import { startInactiveSpan, withActiveSpan } from '../../tracing';
-import { isObject } from '../../utils/is';
+import { isObjectLike } from '../../utils/is';
 import { fill } from '../../utils/object';
 import { MCP_PROTOCOL_VERSION_ATTRIBUTE } from './attributes';
 import { cleanupPendingSpansForTransport, completeSpanWithResults, storeSpanForRequest } from './correlation';
@@ -171,7 +171,7 @@ export function wrapTransportError(transport: MCPTransport): void {
  */
 function captureJsonRpcErrorResponse(errorResponse: unknown): void {
   try {
-    if (isObject(errorResponse) && 'code' in errorResponse && 'message' in errorResponse) {
+    if (isObjectLike(errorResponse) && 'code' in errorResponse && 'message' in errorResponse) {
       const jsonRpcError = errorResponse as { code: number; message: string; data?: unknown };
 
       const isServerError =

--- a/packages/core/src/integrations/mcp-server/validation.ts
+++ b/packages/core/src/integrations/mcp-server/validation.ts
@@ -6,6 +6,7 @@
 
 import { DEBUG_BUILD } from '../../debug-build';
 import { debug } from '../../utils/debug-logger';
+import { isObject } from '../../utils/is';
 import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './types';
 
 /**
@@ -15,10 +16,9 @@ import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './typ
  */
 export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
   return (
-    typeof message === 'object' &&
-    message !== null &&
+    isObject(message) &&
     'jsonrpc' in message &&
-    (message as JsonRpcRequest).jsonrpc === '2.0' &&
+    message.jsonrpc === '2.0' &&
     'method' in message &&
     'id' in message
   );
@@ -31,10 +31,9 @@ export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
  */
 export function isJsonRpcNotification(message: unknown): message is JsonRpcNotification {
   return (
-    typeof message === 'object' &&
-    message !== null &&
+    isObject(message) &&
     'jsonrpc' in message &&
-    (message as JsonRpcNotification).jsonrpc === '2.0' &&
+    message.jsonrpc === '2.0' &&
     'method' in message &&
     !('id' in message)
   );
@@ -47,10 +46,9 @@ export function isJsonRpcNotification(message: unknown): message is JsonRpcNotif
  */
 export function isJsonRpcResponse(message: unknown): message is JsonRpcResponse {
   return (
-    typeof message === 'object' &&
-    message !== null &&
+    isObject(message) &&
     'jsonrpc' in message &&
-    (message as { jsonrpc: string }).jsonrpc === '2.0' &&
+    message.jsonrpc === '2.0' &&
     'id' in message &&
     ('result' in message || 'error' in message)
   );
@@ -66,8 +64,7 @@ export function isJsonRpcResponse(message: unknown): message is JsonRpcResponse 
  */
 export function validateMcpServerInstance(instance: unknown): boolean {
   if (
-    typeof instance === 'object' &&
-    instance !== null &&
+    isObject(instance) &&
     'connect' in instance &&
     (('tool' in instance && 'resource' in instance && 'prompt' in instance) ||
       ('registerTool' in instance && 'registerResource' in instance && 'registerPrompt' in instance))
@@ -84,5 +81,5 @@ export function validateMcpServerInstance(instance: unknown): boolean {
  * @returns True if the item is a valid content item, false otherwise
  */
 export function isValidContentItem(item: unknown): item is Record<string, unknown> {
-  return item != null && typeof item === 'object';
+  return isObject(item);
 }

--- a/packages/core/src/integrations/mcp-server/validation.ts
+++ b/packages/core/src/integrations/mcp-server/validation.ts
@@ -16,11 +16,7 @@ import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './typ
  */
 export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
   return (
-    isObject(message) &&
-    'jsonrpc' in message &&
-    message.jsonrpc === '2.0' &&
-    'method' in message &&
-    'id' in message
+    isObject(message) && 'jsonrpc' in message && message.jsonrpc === '2.0' && 'method' in message && 'id' in message
   );
 }
 
@@ -31,11 +27,7 @@ export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
  */
 export function isJsonRpcNotification(message: unknown): message is JsonRpcNotification {
   return (
-    isObject(message) &&
-    'jsonrpc' in message &&
-    message.jsonrpc === '2.0' &&
-    'method' in message &&
-    !('id' in message)
+    isObject(message) && 'jsonrpc' in message && message.jsonrpc === '2.0' && 'method' in message && !('id' in message)
   );
 }
 

--- a/packages/core/src/integrations/mcp-server/validation.ts
+++ b/packages/core/src/integrations/mcp-server/validation.ts
@@ -6,7 +6,7 @@
 
 import { DEBUG_BUILD } from '../../debug-build';
 import { debug } from '../../utils/debug-logger';
-import { isObject } from '../../utils/is';
+import { isObjectLike } from '../../utils/is';
 import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './types';
 
 /**
@@ -16,7 +16,7 @@ import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './typ
  */
 export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
   return (
-    isObject(message) && 'jsonrpc' in message && message.jsonrpc === '2.0' && 'method' in message && 'id' in message
+    isObjectLike(message) && 'jsonrpc' in message && message.jsonrpc === '2.0' && 'method' in message && 'id' in message
   );
 }
 
@@ -27,7 +27,11 @@ export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
  */
 export function isJsonRpcNotification(message: unknown): message is JsonRpcNotification {
   return (
-    isObject(message) && 'jsonrpc' in message && message.jsonrpc === '2.0' && 'method' in message && !('id' in message)
+    isObjectLike(message) &&
+    'jsonrpc' in message &&
+    message.jsonrpc === '2.0' &&
+    'method' in message &&
+    !('id' in message)
   );
 }
 
@@ -38,7 +42,7 @@ export function isJsonRpcNotification(message: unknown): message is JsonRpcNotif
  */
 export function isJsonRpcResponse(message: unknown): message is JsonRpcResponse {
   return (
-    isObject(message) &&
+    isObjectLike(message) &&
     'jsonrpc' in message &&
     message.jsonrpc === '2.0' &&
     'id' in message &&
@@ -56,7 +60,7 @@ export function isJsonRpcResponse(message: unknown): message is JsonRpcResponse 
  */
 export function validateMcpServerInstance(instance: unknown): boolean {
   if (
-    isObject(instance) &&
+    isObjectLike(instance) &&
     'connect' in instance &&
     (('tool' in instance && 'resource' in instance && 'prompt' in instance) ||
       ('registerTool' in instance && 'registerResource' in instance && 'registerPrompt' in instance))
@@ -73,5 +77,5 @@ export function validateMcpServerInstance(instance: unknown): boolean {
  * @returns True if the item is a valid content item, false otherwise
  */
 export function isValidContentItem(item: unknown): item is Record<string, unknown> {
-  return isObject(item);
+  return isObjectLike(item);
 }

--- a/packages/core/src/integrations/postgresjs.ts
+++ b/packages/core/src/integrations/postgresjs.ts
@@ -7,7 +7,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';
 import { SPAN_STATUS_ERROR, startSpanManual } from '../tracing';
 import type { Span } from '../types/span';
 import { debug } from '../utils/debug-logger';
-import { isObject } from '../utils/is';
+import { isObjectLike } from '../utils/is';
 import { getActiveSpan } from '../utils/spanUtils';
 
 const SQL_OPERATION_REGEX = /^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)/i;
@@ -90,7 +90,7 @@ function _instrumentSqlInstance(
     apply(target, thisArg, argumentsList: unknown[]) {
       const query = Reflect.apply(target, thisArg, argumentsList);
 
-      if (isObject(query) && 'handle' in query) {
+      if (isObjectLike(query) && 'handle' in query) {
         _wrapSingleQueryHandle(query as { handle: unknown; strings?: string[] }, proxiedSql, options);
       }
 
@@ -143,7 +143,7 @@ function _wrapQueryMethod(
   return function (this: unknown, ...args: unknown[]): unknown {
     const query = Reflect.apply(original, target, args);
 
-    if (isObject(query) && 'handle' in query) {
+    if (isObjectLike(query) && 'handle' in query) {
       _wrapSingleQueryHandle(query as { handle: unknown; strings?: string[] }, proxiedSql, options);
     }
 

--- a/packages/core/src/integrations/postgresjs.ts
+++ b/packages/core/src/integrations/postgresjs.ts
@@ -7,6 +7,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';
 import { SPAN_STATUS_ERROR, startSpanManual } from '../tracing';
 import type { Span } from '../types/span';
 import { debug } from '../utils/debug-logger';
+import { isObject } from '../utils/is';
 import { getActiveSpan } from '../utils/spanUtils';
 
 const SQL_OPERATION_REGEX = /^(SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)/i;
@@ -89,7 +90,7 @@ function _instrumentSqlInstance(
     apply(target, thisArg, argumentsList: unknown[]) {
       const query = Reflect.apply(target, thisArg, argumentsList);
 
-      if (query && typeof query === 'object' && 'handle' in query) {
+      if (isObject(query) && 'handle' in query) {
         _wrapSingleQueryHandle(query as { handle: unknown; strings?: string[] }, proxiedSql, options);
       }
 
@@ -142,7 +143,7 @@ function _wrapQueryMethod(
   return function (this: unknown, ...args: unknown[]): unknown {
     const query = Reflect.apply(original, target, args);
 
-    if (query && typeof query === 'object' && 'handle' in query) {
+    if (isObject(query) && 'handle' in query) {
       _wrapSingleQueryHandle(query as { handle: unknown; strings?: string[] }, proxiedSql, options);
     }
 

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -12,7 +12,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '
 import { setHttpStatus, SPAN_STATUS_ERROR, SPAN_STATUS_OK, startSpan } from '../tracing';
 import type { IntegrationFn } from '../types/integration';
 import { debug } from '../utils/debug-logger';
-import { isObject, isPlainObject } from '../utils/is';
+import { isObjectLike, isPlainObject } from '../utils/is';
 import { addExceptionMechanism } from '../utils/misc';
 
 const AUTH_OPERATIONS_TO_INSTRUMENT = [
@@ -252,7 +252,7 @@ function instrumentAuthOperation(operation: AuthOperationFn, isAdmin = false): A
         span => {
           return Reflect.apply(target, thisArg, argumentsList)
             .then((res: unknown) => {
-              if (isObject(res) && 'error' in res && res.error) {
+              if (isObjectLike(res) && 'error' in res && res.error) {
                 span.setStatus({ code: SPAN_STATUS_ERROR });
 
                 captureException(res.error, {

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -12,7 +12,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '
 import { setHttpStatus, SPAN_STATUS_ERROR, SPAN_STATUS_OK, startSpan } from '../tracing';
 import type { IntegrationFn } from '../types/integration';
 import { debug } from '../utils/debug-logger';
-import { isPlainObject } from '../utils/is';
+import { isObject, isPlainObject } from '../utils/is';
 import { addExceptionMechanism } from '../utils/misc';
 
 const AUTH_OPERATIONS_TO_INSTRUMENT = [
@@ -252,7 +252,7 @@ function instrumentAuthOperation(operation: AuthOperationFn, isAdmin = false): A
         span => {
           return Reflect.apply(target, thisArg, argumentsList)
             .then((res: unknown) => {
-              if (res && typeof res === 'object' && 'error' in res && res.error) {
+              if (isObject(res) && 'error' in res && res.error) {
                 span.setStatus({ code: SPAN_STATUS_ERROR });
 
                 captureException(res.error, {

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -270,6 +270,7 @@ export {
   isErrorEvent,
   isEvent,
   isInstanceOf,
+  isObject,
   isParameterizedString,
   isPlainObject,
   isPrimitive,

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -270,7 +270,7 @@ export {
   isErrorEvent,
   isEvent,
   isInstanceOf,
-  isObject,
+  isObjectLike,
   isParameterizedString,
   isPlainObject,
   isPrimitive,

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -123,12 +123,12 @@ export function isPlainObject(wat: unknown): wat is Record<string, unknown> {
  * Checks whether given value is a non-null object (i.e. `typeof` is `'object'` and it is not `null`).
  * Unlike {@link isPlainObject}, this also accepts arrays and class instances - it only rules out
  * `null`, primitives, and functions.
- * {@link isObject}.
+ * {@link isObjectLike}.
  *
  * @param wat A value to be checked.
  * @returns A boolean representing the result.
  */
-export function isObject(wat: unknown): wat is Record<PropertyKey, unknown> {
+export function isObjectLike(wat: unknown): wat is Record<PropertyKey, unknown> {
   return typeof wat === 'object' && wat !== null;
 }
 

--- a/packages/core/src/utils/is.ts
+++ b/packages/core/src/utils/is.ts
@@ -120,6 +120,19 @@ export function isPlainObject(wat: unknown): wat is Record<string, unknown> {
 }
 
 /**
+ * Checks whether given value is a non-null object (i.e. `typeof` is `'object'` and it is not `null`).
+ * Unlike {@link isPlainObject}, this also accepts arrays and class instances - it only rules out
+ * `null`, primitives, and functions.
+ * {@link isObject}.
+ *
+ * @param wat A value to be checked.
+ * @returns A boolean representing the result.
+ */
+export function isObject(wat: unknown): wat is Record<PropertyKey, unknown> {
+  return typeof wat === 'object' && wat !== null;
+}
+
+/**
  * Checks whether given value's type is an Event instance
  * {@link isEvent}.
  *

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -2,7 +2,7 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { WrappedFunction } from '../types/wrappedfunction';
 import { debug } from './debug-logger';
-import { isError, isEvent, isPrimitive } from './is';
+import { isError, isEvent, isObject, isPrimitive } from './is';
 
 /**
  * Replace a method in an object with a wrapped version of itself.
@@ -158,7 +158,7 @@ export function convertToPlainObject<V>(value: V): Record<string, unknown> | V {
 
 /** Filters out all but an object's own properties */
 function getOwnProperties(obj: unknown): { [key: string]: unknown } {
-  if (typeof obj === 'object' && obj !== null) {
+  if (isObject(obj)) {
     return Object.fromEntries(Object.entries(obj));
   }
   return {};

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -2,7 +2,7 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { WrappedFunction } from '../types/wrappedfunction';
 import { debug } from './debug-logger';
-import { isError, isEvent, isObject, isPrimitive } from './is';
+import { isError, isEvent, isObjectLike, isPrimitive } from './is';
 
 /**
  * Replace a method in an object with a wrapped version of itself.
@@ -158,7 +158,7 @@ export function convertToPlainObject<V>(value: V): Record<string, unknown> | V {
 
 /** Filters out all but an object's own properties */
 function getOwnProperties(obj: unknown): { [key: string]: unknown } {
-  if (isObject(obj)) {
+  if (isObjectLike(obj)) {
     return Object.fromEntries(Object.entries(obj));
   }
   return {};

--- a/packages/core/test/lib/utils/is.test.ts
+++ b/packages/core/test/lib/utils/is.test.ts
@@ -5,7 +5,7 @@ import {
   isError,
   isErrorEvent,
   isInstanceOf,
-  isObject,
+  isObjectLike,
   isPlainObject,
   isPrimitive,
   isThenable,
@@ -194,7 +194,7 @@ describe('isPlainObject', () => {
   });
 });
 
-describe('isObject', () => {
+describe('isObjectLike', () => {
   class MyClass {
     public foo: string = 'bar';
   }
@@ -217,6 +217,6 @@ describe('isObject', () => {
     [42, false],
     [() => undefined, false],
   ])('%s is %s', (value, expected) => {
-    expect(isObject(value)).toBe(expected);
+    expect(isObjectLike(value)).toBe(expected);
   });
 });

--- a/packages/core/test/lib/utils/is.test.ts
+++ b/packages/core/test/lib/utils/is.test.ts
@@ -5,6 +5,7 @@ import {
   isError,
   isErrorEvent,
   isInstanceOf,
+  isObject,
   isPlainObject,
   isPrimitive,
   isThenable,
@@ -190,5 +191,32 @@ describe('isPlainObject', () => {
     [{ ...new MyClass() }, true],
   ])('%s is %s', (value, expected) => {
     expect(isPlainObject(value)).toBe(expected);
+  });
+});
+
+describe('isObject', () => {
+  class MyClass {
+    public foo: string = 'bar';
+  }
+
+  it.each([
+    [{}, true],
+    [{ aha: 'yes' }, true],
+    [[], true],
+    [[1, 2, 3], true],
+    [new MyClass(), true],
+    [new Date(), true],
+    [/regex/, true],
+    [null, false],
+    [undefined, false],
+    [true, false],
+    [false, false],
+    ['', false],
+    ['foo', false],
+    [0, false],
+    [42, false],
+    [() => undefined, false],
+  ])('%s is %s', (value, expected) => {
+    expect(isObject(value)).toBe(expected);
   });
 });

--- a/packages/effect/src/logger.ts
+++ b/packages/effect/src/logger.ts
@@ -1,4 +1,4 @@
-import { logger as sentryLogger } from '@sentry/core';
+import { isObject, logger as sentryLogger } from '@sentry/core';
 import * as Logger from 'effect/Logger';
 import type * as LogLevel from 'effect/LogLevel';
 
@@ -9,7 +9,7 @@ function getLogLevelTag(logLevel: LogLevel.LogLevel): LogLevel.LogLevel | 'Warni
   }
 
   // Effect v3: logLevel has _tag property
-  if (logLevel && typeof logLevel === 'object' && '_tag' in logLevel) {
+  if (isObject(logLevel) && '_tag' in logLevel) {
     return (logLevel as { _tag: LogLevel.LogLevel })._tag;
   }
 

--- a/packages/effect/src/logger.ts
+++ b/packages/effect/src/logger.ts
@@ -1,4 +1,4 @@
-import { isObject, logger as sentryLogger } from '@sentry/core';
+import { isObjectLike, logger as sentryLogger } from '@sentry/core';
 import * as Logger from 'effect/Logger';
 import type * as LogLevel from 'effect/LogLevel';
 
@@ -9,7 +9,7 @@ function getLogLevelTag(logLevel: LogLevel.LogLevel): LogLevel.LogLevel | 'Warni
   }
 
   // Effect v3: logLevel has _tag property
-  if (isObject(logLevel) && '_tag' in logLevel) {
+  if (isObjectLike(logLevel) && '_tag' in logLevel) {
     return (logLevel as { _tag: LogLevel.LogLevel })._tag;
   }
 

--- a/packages/effect/src/tracer.ts
+++ b/packages/effect/src/tracer.ts
@@ -1,6 +1,6 @@
 import type { Span } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   getActiveSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startInactiveSpan,
@@ -46,7 +46,7 @@ function getErrorMessage(exit: Exit.Exit<unknown, unknown>): string | undefined 
   const cause = exit.cause as unknown;
 
   // Effect v4: cause.reasons is an array of Reason objects
-  if (isObject(cause) && 'reasons' in cause && Array.isArray((cause as { reasons: unknown }).reasons)) {
+  if (isObjectLike(cause) && 'reasons' in cause && Array.isArray((cause as { reasons: unknown }).reasons)) {
     const reasons = (cause as { reasons: Array<{ _tag?: string; error?: unknown; defect?: unknown }> }).reasons;
     for (const reason of reasons) {
       if (reason._tag === 'Fail' && reason.error !== undefined) {
@@ -60,7 +60,7 @@ function getErrorMessage(exit: Exit.Exit<unknown, unknown>): string | undefined 
   }
 
   // Effect v3: cause has _tag directly
-  if (isObject(cause) && '_tag' in cause) {
+  if (isObjectLike(cause) && '_tag' in cause) {
     const v3Cause = cause as { _tag: string; error?: unknown; defect?: unknown };
     if (v3Cause._tag === 'Fail') {
       return String(v3Cause.error);
@@ -188,7 +188,7 @@ const isEffectV4 = (() => {
     const testExit = Exit.fail('test') as unknown as { cause?: unknown };
     const cause = testExit.cause;
     // v4 causes have 'reasons' array, v3 causes have '_tag' directly
-    if (isObject(cause) && 'reasons' in cause) {
+    if (isObjectLike(cause) && 'reasons' in cause) {
       return true;
     }
     return false;

--- a/packages/effect/src/tracer.ts
+++ b/packages/effect/src/tracer.ts
@@ -1,5 +1,11 @@
 import type { Span } from '@sentry/core';
-import { getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan, withActiveSpan } from '@sentry/core';
+import {
+  isObject,
+  getActiveSpan,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  startInactiveSpan,
+  withActiveSpan,
+} from '@sentry/core';
 import type * as Context from 'effect/Context';
 import * as Exit from 'effect/Exit';
 import * as Option from 'effect/Option';
@@ -40,12 +46,7 @@ function getErrorMessage(exit: Exit.Exit<unknown, unknown>): string | undefined 
   const cause = exit.cause as unknown;
 
   // Effect v4: cause.reasons is an array of Reason objects
-  if (
-    cause &&
-    typeof cause === 'object' &&
-    'reasons' in cause &&
-    Array.isArray((cause as { reasons: unknown }).reasons)
-  ) {
+  if (isObject(cause) && 'reasons' in cause && Array.isArray((cause as { reasons: unknown }).reasons)) {
     const reasons = (cause as { reasons: Array<{ _tag?: string; error?: unknown; defect?: unknown }> }).reasons;
     for (const reason of reasons) {
       if (reason._tag === 'Fail' && reason.error !== undefined) {
@@ -59,7 +60,7 @@ function getErrorMessage(exit: Exit.Exit<unknown, unknown>): string | undefined 
   }
 
   // Effect v3: cause has _tag directly
-  if (cause && typeof cause === 'object' && '_tag' in cause) {
+  if (isObject(cause) && '_tag' in cause) {
     const v3Cause = cause as { _tag: string; error?: unknown; defect?: unknown };
     if (v3Cause._tag === 'Fail') {
       return String(v3Cause.error);
@@ -187,7 +188,7 @@ const isEffectV4 = (() => {
     const testExit = Exit.fail('test') as unknown as { cause?: unknown };
     const cause = testExit.cause;
     // v4 causes have 'reasons' array, v3 causes have '_tag' directly
-    if (cause && typeof cause === 'object' && 'reasons' in cause) {
+    if (isObject(cause) && 'reasons' in cause) {
       return true;
     }
     return false;

--- a/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
@@ -5,7 +5,7 @@ import {
   InstrumentationNodeModuleFile,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { isObject, captureException, SDK_VERSION, startSpan, withIsolationScope } from '@sentry/core';
+import { isObjectLike, captureException, SDK_VERSION, startSpan, withIsolationScope } from '@sentry/core';
 import { getEventSpanOptions } from './helpers';
 import type { OnEventTarget } from './types';
 
@@ -103,7 +103,7 @@ export class SentryNestEventInstrumentation extends InstrumentationBase {
               if (Array.isArray(eventData)) {
                 eventName = eventData
                   .map((data: unknown) => {
-                    if (isObject(data) && 'event' in data && data.event) {
+                    if (isObjectLike(data) && 'event' in data && data.event) {
                       return eventNameFromEvent(data.event);
                     }
                     return '';

--- a/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-event-instrumentation.ts
@@ -5,7 +5,7 @@ import {
   InstrumentationNodeModuleFile,
   isWrapped,
 } from '@opentelemetry/instrumentation';
-import { captureException, SDK_VERSION, startSpan, withIsolationScope } from '@sentry/core';
+import { isObject, captureException, SDK_VERSION, startSpan, withIsolationScope } from '@sentry/core';
 import { getEventSpanOptions } from './helpers';
 import type { OnEventTarget } from './types';
 
@@ -103,7 +103,7 @@ export class SentryNestEventInstrumentation extends InstrumentationBase {
               if (Array.isArray(eventData)) {
                 eventName = eventData
                   .map((data: unknown) => {
-                    if (data && typeof data === 'object' && 'event' in data && data.event) {
+                    if (isObject(data) && 'event' in data && data.event) {
                       return eventNameFromEvent(data.event);
                     }
                     return '';

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentryVercelCrons.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentryVercelCrons.ts
@@ -1,4 +1,4 @@
-import { isObject, _INTERNAL_safeDateNow, captureCheckIn } from '@sentry/core';
+import { isObjectLike, _INTERNAL_safeDateNow, captureCheckIn } from '@sentry/core';
 import type { NextApiRequest } from 'next';
 import type { VercelCronsConfig } from '../types';
 
@@ -75,7 +75,7 @@ export function wrapApiHandlerWithSentryVercelCrons<F extends (...args: any[]) =
         throw e;
       }
 
-      if (isObject(maybePromiseResult) && 'then' in maybePromiseResult) {
+      if (isObjectLike(maybePromiseResult) && 'then' in maybePromiseResult) {
         Promise.resolve(maybePromiseResult).then(
           () => {
             captureCheckIn({

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentryVercelCrons.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapApiHandlerWithSentryVercelCrons.ts
@@ -1,4 +1,4 @@
-import { _INTERNAL_safeDateNow, captureCheckIn } from '@sentry/core';
+import { isObject, _INTERNAL_safeDateNow, captureCheckIn } from '@sentry/core';
 import type { NextApiRequest } from 'next';
 import type { VercelCronsConfig } from '../types';
 
@@ -75,7 +75,7 @@ export function wrapApiHandlerWithSentryVercelCrons<F extends (...args: any[]) =
         throw e;
       }
 
-      if (typeof maybePromiseResult === 'object' && maybePromiseResult !== null && 'then' in maybePromiseResult) {
+      if (isObject(maybePromiseResult) && 'then' in maybePromiseResult) {
         Promise.resolve(maybePromiseResult).then(
           () => {
             captureCheckIn({

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapPageComponentWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapPageComponentWithSentry.ts
@@ -1,5 +1,5 @@
 import {
-  isObject,
+  isObjectLike,
   addNonEnumerableProperty,
   captureException,
   extractTraceparentData,
@@ -19,7 +19,7 @@ interface ClassComponent {
 }
 
 function storeCapturedEventIdOnError(error: unknown, eventId: string | undefined): void {
-  if (isObject(error)) {
+  if (isObjectLike(error)) {
     addNonEnumerableProperty(error as Record<string, unknown>, '__sentry_event_id__', eventId);
   }
 }
@@ -40,7 +40,9 @@ export function wrapPageComponentWithSentry(pageComponent: FunctionComponent | C
           const scope = getCurrentScope();
           // We extract the sentry trace data that is put in the component props by datafetcher wrappers
           const sentryTraceData =
-            isObject(this.props) && '_sentryTraceData' in this.props && typeof this.props._sentryTraceData === 'string'
+            isObjectLike(this.props) &&
+            '_sentryTraceData' in this.props &&
+            typeof this.props._sentryTraceData === 'string'
               ? this.props._sentryTraceData
               : undefined;
 

--- a/packages/nextjs/src/common/pages-router-instrumentation/wrapPageComponentWithSentry.ts
+++ b/packages/nextjs/src/common/pages-router-instrumentation/wrapPageComponentWithSentry.ts
@@ -1,4 +1,5 @@
 import {
+  isObject,
   addNonEnumerableProperty,
   captureException,
   extractTraceparentData,
@@ -18,7 +19,7 @@ interface ClassComponent {
 }
 
 function storeCapturedEventIdOnError(error: unknown, eventId: string | undefined): void {
-  if (error && typeof error === 'object') {
+  if (isObject(error)) {
     addNonEnumerableProperty(error as Record<string, unknown>, '__sentry_event_id__', eventId);
   }
 }
@@ -39,10 +40,7 @@ export function wrapPageComponentWithSentry(pageComponent: FunctionComponent | C
           const scope = getCurrentScope();
           // We extract the sentry trace data that is put in the component props by datafetcher wrappers
           const sentryTraceData =
-            typeof this.props === 'object' &&
-            this.props !== null &&
-            '_sentryTraceData' in this.props &&
-            typeof this.props._sentryTraceData === 'string'
+            isObject(this.props) && '_sentryTraceData' in this.props && typeof this.props._sentryTraceData === 'string'
               ? this.props._sentryTraceData
               : undefined;
 

--- a/packages/nextjs/src/common/utils/tracingUtils.ts
+++ b/packages/nextjs/src/common/utils/tracingUtils.ts
@@ -1,7 +1,7 @@
 import { HTTP_ROUTE } from '@sentry/conventions/attributes';
 import type { PropagationContext, Span, SpanAttributes } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   debug,
   getActiveSpan,
   getClient,
@@ -31,7 +31,7 @@ export function commonObjectToPropagationContext(
   commonObject: unknown,
   propagationContext: PropagationContext,
 ): PropagationContext {
-  if (isObject(commonObject)) {
+  if (isObjectLike(commonObject)) {
     const memoPropagationContext = commonPropagationContextMap.get(commonObject);
     if (memoPropagationContext) {
       return memoPropagationContext;
@@ -54,7 +54,7 @@ const commonIsolationScopeMap = new WeakMap<object, Scope>();
  * @returns the shared isolation scope.
  */
 export function commonObjectToIsolationScope(commonObject: unknown): Scope {
-  if (isObject(commonObject)) {
+  if (isObjectLike(commonObject)) {
     const memoIsolationScope = commonIsolationScopeMap.get(commonObject);
     if (memoIsolationScope) {
       return memoIsolationScope;

--- a/packages/nextjs/src/common/utils/tracingUtils.ts
+++ b/packages/nextjs/src/common/utils/tracingUtils.ts
@@ -1,6 +1,7 @@
 import { HTTP_ROUTE } from '@sentry/conventions/attributes';
 import type { PropagationContext, Span, SpanAttributes } from '@sentry/core';
 import {
+  isObject,
   debug,
   getActiveSpan,
   getClient,
@@ -30,7 +31,7 @@ export function commonObjectToPropagationContext(
   commonObject: unknown,
   propagationContext: PropagationContext,
 ): PropagationContext {
-  if (typeof commonObject === 'object' && commonObject) {
+  if (isObject(commonObject)) {
     const memoPropagationContext = commonPropagationContextMap.get(commonObject);
     if (memoPropagationContext) {
       return memoPropagationContext;
@@ -53,7 +54,7 @@ const commonIsolationScopeMap = new WeakMap<object, Scope>();
  * @returns the shared isolation scope.
  */
 export function commonObjectToIsolationScope(commonObject: unknown): Scope {
-  if (typeof commonObject === 'object' && commonObject) {
+  if (isObject(commonObject)) {
     const memoIsolationScope = commonIsolationScopeMap.get(commonObject);
     if (memoIsolationScope) {
       return memoIsolationScope;

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -1,5 +1,5 @@
 import {
-  isObject,
+  isObjectLike,
   captureException,
   getActiveSpan,
   getCurrentScope,
@@ -119,7 +119,7 @@ export function maybeExtractSynchronousParamsAndSearchParams(props: unknown): {
   searchParams: Record<string, string> | undefined;
 } {
   let params =
-    isObject(props) && 'params' in props
+    isObjectLike(props) && 'params' in props
       ? (props.params as Record<string, string> | Promise<Record<string, string>> | undefined)
       : undefined;
   if (isThenable(params)) {
@@ -127,7 +127,7 @@ export function maybeExtractSynchronousParamsAndSearchParams(props: unknown): {
   }
 
   let searchParams =
-    isObject(props) && 'searchParams' in props
+    isObjectLike(props) && 'searchParams' in props
       ? (props.searchParams as Record<string, string> | Promise<Record<string, string>> | undefined)
       : undefined;
   if (isThenable(searchParams)) {

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -1,4 +1,5 @@
 import {
+  isObject,
   captureException,
   getActiveSpan,
   getCurrentScope,
@@ -118,7 +119,7 @@ export function maybeExtractSynchronousParamsAndSearchParams(props: unknown): {
   searchParams: Record<string, string> | undefined;
 } {
   let params =
-    props && typeof props === 'object' && 'params' in props
+    isObject(props) && 'params' in props
       ? (props.params as Record<string, string> | Promise<Record<string, string>> | undefined)
       : undefined;
   if (isThenable(params)) {
@@ -126,7 +127,7 @@ export function maybeExtractSynchronousParamsAndSearchParams(props: unknown): {
   }
 
   let searchParams =
-    props && typeof props === 'object' && 'searchParams' in props
+    isObject(props) && 'searchParams' in props
       ? (props.searchParams as Record<string, string> | Promise<Record<string, string>> | undefined)
       : undefined;
   if (isThenable(searchParams)) {

--- a/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
@@ -1,5 +1,6 @@
 import * as dc from 'node:diagnostics_channel';
 import {
+  isObject,
   getActiveSpan,
   getClient,
   getHttpSpanDetailsFromUrlObject,
@@ -46,7 +47,7 @@ export function captureTracingEvents(): void {
  * and may or may not be a Response for h3.
  */
 function getResponseStatusCode(result: unknown): number | undefined {
-  if (result && typeof result === 'object' && 'status' in result && typeof result.status === 'number') {
+  if (isObject(result) && 'status' in result && typeof result.status === 'number') {
     return result.status;
   }
   return undefined;
@@ -250,7 +251,7 @@ function setParameterizedRouteAttributes(span: Span, event: H3TracingRequestEven
 
   const params = event.context?.params;
 
-  if (params && typeof params === 'object') {
+  if (isObject(params)) {
     Object.entries(params).forEach(([key, value]) => {
       // Based on this convention: https://getsentry.github.io/sentry-conventions/generated/attributes/url.html#urlpathparameterkey
       rootSpan.setAttributes({

--- a/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
@@ -1,6 +1,6 @@
 import * as dc from 'node:diagnostics_channel';
 import {
-  isObject,
+  isObjectLike,
   getActiveSpan,
   getClient,
   getHttpSpanDetailsFromUrlObject,
@@ -47,7 +47,7 @@ export function captureTracingEvents(): void {
  * and may or may not be a Response for h3.
  */
 function getResponseStatusCode(result: unknown): number | undefined {
-  if (isObject(result) && 'status' in result && typeof result.status === 'number') {
+  if (isObjectLike(result) && 'status' in result && typeof result.status === 'number') {
     return result.status;
   }
   return undefined;
@@ -251,7 +251,7 @@ function setParameterizedRouteAttributes(span: Span, event: H3TracingRequestEven
 
   const params = event.context?.params;
 
-  if (isObject(params)) {
+  if (isObjectLike(params)) {
     Object.entries(params).forEach(([key, value]) => {
       // Based on this convention: https://getsentry.github.io/sentry-conventions/generated/attributes/url.html#urlpathparameterkey
       rootSpan.setAttributes({

--- a/packages/node-core/src/integrations/childProcess.ts
+++ b/packages/node-core/src/integrations/childProcess.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { Worker } from 'node:worker_threads';
-import { addBreadcrumb, captureException, defineIntegration } from '@sentry/core';
+import { addBreadcrumb, captureException, defineIntegration, isObject } from '@sentry/core';
 
 interface Options {
   /**
@@ -29,13 +29,13 @@ export const childProcessIntegration = defineIntegration((options: Options = {})
     name: INTEGRATION_NAME,
     setup() {
       diagnosticsChannel.channel('child_process').subscribe((event: unknown) => {
-        if (event && typeof event === 'object' && 'process' in event) {
+        if (isObject(event) && 'process' in event) {
           captureChildProcessEvents(event.process as ChildProcess, options);
         }
       });
 
       diagnosticsChannel.channel('worker_threads').subscribe((event: unknown) => {
-        if (event && typeof event === 'object' && 'worker' in event) {
+        if (isObject(event) && 'worker' in event) {
           captureWorkerThreadEvents(event.worker as Worker, options);
         }
       });

--- a/packages/node-core/src/integrations/childProcess.ts
+++ b/packages/node-core/src/integrations/childProcess.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { Worker } from 'node:worker_threads';
-import { addBreadcrumb, captureException, defineIntegration, isObject } from '@sentry/core';
+import { addBreadcrumb, captureException, defineIntegration, isObjectLike } from '@sentry/core';
 
 interface Options {
   /**
@@ -29,13 +29,13 @@ export const childProcessIntegration = defineIntegration((options: Options = {})
     name: INTEGRATION_NAME,
     setup() {
       diagnosticsChannel.channel('child_process').subscribe((event: unknown) => {
-        if (isObject(event) && 'process' in event) {
+        if (isObjectLike(event) && 'process' in event) {
           captureChildProcessEvents(event.process as ChildProcess, options);
         }
       });
 
       diagnosticsChannel.channel('worker_threads').subscribe((event: unknown) => {
-        if (isObject(event) && 'worker' in event) {
+        if (isObjectLike(event) && 'worker' in event) {
           captureWorkerThreadEvents(event.worker as Worker, options);
         }
       });

--- a/packages/node-core/src/integrations/onunhandledrejection.ts
+++ b/packages/node-core/src/integrations/onunhandledrejection.ts
@@ -5,6 +5,7 @@ import {
   defineIntegration,
   getClient,
   isMatchingPattern,
+  isObject,
   withActiveSpan,
 } from '@sentry/core';
 import { logAndExitProcess } from '../utils/errorhandling';
@@ -53,7 +54,7 @@ export const onUnhandledRejectionIntegration = defineIntegration(_onUnhandledRej
 /** Extract error info safely */
 function extractErrorInfo(reason: unknown): { name: string; message: string } {
   // Check if reason is an object (including Error instances, not just plain objects)
-  if (typeof reason !== 'object' || reason === null) {
+  if (!isObject(reason)) {
     return { name: '', message: String(reason ?? '') };
   }
 
@@ -100,8 +101,9 @@ export function makeUnhandledPromiseHandler(
 
     // this can be set in places where we cannot reliably get access to the active span/error
     // when the error bubbles up to this handler, we can use this to set the active span
-    const activeSpanForError =
-      reason && typeof reason === 'object' ? (reason as { _sentry_active_span?: Span })._sentry_active_span : undefined;
+    const activeSpanForError = isObject(reason)
+      ? (reason as { _sentry_active_span?: Span })._sentry_active_span
+      : undefined;
 
     const activeSpanWrapper = activeSpanForError
       ? (fn: () => void) => withActiveSpan(activeSpanForError, fn)
@@ -140,7 +142,7 @@ function handleRejection(reason: unknown, mode: UnhandledRejectionMode): void {
   if (mode === 'warn') {
     consoleSandbox(() => {
       console.warn(rejectionWarning);
-      console.error(reason && typeof reason === 'object' && 'stack' in reason ? reason.stack : reason);
+      console.error(isObject(reason) && 'stack' in reason ? reason.stack : reason);
     });
   } else if (mode === 'strict') {
     consoleSandbox(() => {

--- a/packages/node-core/src/integrations/onunhandledrejection.ts
+++ b/packages/node-core/src/integrations/onunhandledrejection.ts
@@ -5,7 +5,7 @@ import {
   defineIntegration,
   getClient,
   isMatchingPattern,
-  isObject,
+  isObjectLike,
   withActiveSpan,
 } from '@sentry/core';
 import { logAndExitProcess } from '../utils/errorhandling';
@@ -54,7 +54,7 @@ export const onUnhandledRejectionIntegration = defineIntegration(_onUnhandledRej
 /** Extract error info safely */
 function extractErrorInfo(reason: unknown): { name: string; message: string } {
   // Check if reason is an object (including Error instances, not just plain objects)
-  if (!isObject(reason)) {
+  if (!isObjectLike(reason)) {
     return { name: '', message: String(reason ?? '') };
   }
 
@@ -101,7 +101,7 @@ export function makeUnhandledPromiseHandler(
 
     // this can be set in places where we cannot reliably get access to the active span/error
     // when the error bubbles up to this handler, we can use this to set the active span
-    const activeSpanForError = isObject(reason)
+    const activeSpanForError = isObjectLike(reason)
       ? (reason as { _sentry_active_span?: Span })._sentry_active_span
       : undefined;
 
@@ -142,7 +142,7 @@ function handleRejection(reason: unknown, mode: UnhandledRejectionMode): void {
   if (mode === 'warn') {
     consoleSandbox(() => {
       console.warn(rejectionWarning);
-      console.error(isObject(reason) && 'stack' in reason ? reason.stack : reason);
+      console.error(isObjectLike(reason) && 'stack' in reason ? reason.stack : reason);
     });
   } else if (mode === 'strict') {
     consoleSandbox(() => {

--- a/packages/node-core/src/integrations/pino.ts
+++ b/packages/node-core/src/integrations/pino.ts
@@ -6,7 +6,7 @@ import {
   captureException,
   captureMessage,
   defineIntegration,
-  isObject,
+  isObjectLike,
   severityLevelFromString,
   withScope,
 } from '@sentry/core';
@@ -236,12 +236,12 @@ interface PinoIntegrationFunction {
  */
 export const pinoIntegration = Object.assign(_pinoIntegration, {
   trackLogger(logger: unknown): void {
-    if (isObject(logger) && 'levels' in logger) {
+    if (isObjectLike(logger) && 'levels' in logger) {
       (logger as Pino)[SENTRY_TRACK_SYMBOL] = 'track';
     }
   },
   untrackLogger(logger: unknown): void {
-    if (isObject(logger) && 'levels' in logger) {
+    if (isObjectLike(logger) && 'levels' in logger) {
       (logger as Pino)[SENTRY_TRACK_SYMBOL] = 'ignore';
     }
   },

--- a/packages/node-core/src/integrations/pino.ts
+++ b/packages/node-core/src/integrations/pino.ts
@@ -6,6 +6,7 @@ import {
   captureException,
   captureMessage,
   defineIntegration,
+  isObject,
   severityLevelFromString,
   withScope,
 } from '@sentry/core';
@@ -235,12 +236,12 @@ interface PinoIntegrationFunction {
  */
 export const pinoIntegration = Object.assign(_pinoIntegration, {
   trackLogger(logger: unknown): void {
-    if (logger && typeof logger === 'object' && 'levels' in logger) {
+    if (isObject(logger) && 'levels' in logger) {
       (logger as Pino)[SENTRY_TRACK_SYMBOL] = 'track';
     }
   },
   untrackLogger(logger: unknown): void {
-    if (logger && typeof logger === 'object' && 'levels' in logger) {
+    if (isObject(logger) && 'levels' in logger) {
       (logger as Pino)[SENTRY_TRACK_SYMBOL] = 'ignore';
     }
   },

--- a/packages/node-core/src/integrations/winston.ts
+++ b/packages/node-core/src/integrations/winston.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { LogSeverityLevel } from '@sentry/core';
-import { debug, isObject } from '@sentry/core';
+import { debug, isObjectLike } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 import { captureLog } from '../logs/capture';
 
@@ -88,7 +88,7 @@ export function createSentryWinstonTransport<TransportStreamInstance extends obj
           this.emit('logged', info);
         });
 
-        if (!isObject(info)) {
+        if (!isObjectLike(info)) {
           return;
         }
 

--- a/packages/node-core/src/integrations/winston.ts
+++ b/packages/node-core/src/integrations/winston.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import type { LogSeverityLevel } from '@sentry/core';
-import { debug } from '@sentry/core';
+import { debug, isObject } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 import { captureLog } from '../logs/capture';
 
@@ -128,10 +128,6 @@ export function createSentryWinstonTransport<TransportStreamInstance extends obj
   }
 
   return SentryWinstonTransport as typeof TransportClass;
-}
-
-function isObject(anything: unknown): anything is Record<string | symbol, unknown> {
-  return typeof anything === 'object' && anything != null;
 }
 
 // npm

--- a/packages/node/src/integrations/tracing/graphql/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/graphql/vendored/utils.ts
@@ -23,7 +23,7 @@ import type {
   Token,
 } from './graphql-types';
 import type { Span, SpanAttributes } from '@sentry/core';
-import { SPAN_STATUS_ERROR, startInactiveSpan, withActiveSpan } from '@sentry/core';
+import { isObject, SPAN_STATUS_ERROR, startInactiveSpan, withActiveSpan } from '@sentry/core';
 import { AllowedOperationTypes, SpanNames, TokenKind } from './enum';
 import { AttributeNames } from './enums/AttributeNames';
 import { OTEL_GRAPHQL_DATA_SYMBOL, OTEL_PATCHED_SYMBOL } from './symbols';
@@ -35,11 +35,6 @@ const OPERATION_VALUES = Object.values(AllowedOperationTypes);
 // https://github.com/graphql/graphql-js/blob/main/src/jsutils/isPromise.ts
 export const isPromise = (value: any): value is Promise<unknown> => {
   return typeof value?.then === 'function';
-};
-
-// https://github.com/graphql/graphql-js/blob/main/src/jsutils/isObjectLike.ts
-const isObjectLike = (value: unknown): value is { [key: string]: unknown } => {
-  return typeof value == 'object' && value !== null;
 };
 
 export function addSpanSource(span: Span, loc?: Location, start?: number, end?: number): void {
@@ -322,11 +317,7 @@ export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(
 
     // follows what graphql is doing to decide if this is a trivial resolver
     // for which we don't need to create a resolve span
-    if (
-      config.ignoreTrivialResolveSpans &&
-      isDefaultResolver &&
-      (isObjectLike(source) || typeof source === 'function')
-    ) {
+    if (config.ignoreTrivialResolveSpans && isDefaultResolver && (isObject(source) || typeof source === 'function')) {
       const property = (source as any)[info.fieldName];
       // a function execution is not trivial and should be recorder.
       // property which is not a function is just a value and we don't want a "resolve" span for it

--- a/packages/node/src/integrations/tracing/graphql/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/graphql/vendored/utils.ts
@@ -23,7 +23,7 @@ import type {
   Token,
 } from './graphql-types';
 import type { Span, SpanAttributes } from '@sentry/core';
-import { isObject, SPAN_STATUS_ERROR, startInactiveSpan, withActiveSpan } from '@sentry/core';
+import { isObjectLike, SPAN_STATUS_ERROR, startInactiveSpan, withActiveSpan } from '@sentry/core';
 import { AllowedOperationTypes, SpanNames, TokenKind } from './enum';
 import { AttributeNames } from './enums/AttributeNames';
 import { OTEL_GRAPHQL_DATA_SYMBOL, OTEL_PATCHED_SYMBOL } from './symbols';
@@ -317,7 +317,11 @@ export function wrapFieldResolver<TSource = any, TContext = any, TArgs = any>(
 
     // follows what graphql is doing to decide if this is a trivial resolver
     // for which we don't need to create a resolve span
-    if (config.ignoreTrivialResolveSpans && isDefaultResolver && (isObject(source) || typeof source === 'function')) {
+    if (
+      config.ignoreTrivialResolveSpans &&
+      isDefaultResolver &&
+      (isObjectLike(source) || typeof source === 'function')
+    ) {
       const property = (source as any)[info.fieldName];
       // a function execution is not trivial and should be recorder.
       // property which is not a function is just a value and we don't want a "resolve" span for it

--- a/packages/node/src/integrations/tracing/mongo/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/mongo/vendored/utils.ts
@@ -11,6 +11,7 @@
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   getActiveSpan,
+  isObject,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_KIND,
   SPAN_STATUS_ERROR,
@@ -60,7 +61,7 @@ function scrubStatement(value: unknown): unknown {
 }
 
 function isCommandObj(value: Record<string, unknown> | unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !isBuffer(value);
+  return isObject(value) && !isBuffer(value);
 }
 
 function isBuffer(value: unknown): boolean {

--- a/packages/node/src/integrations/tracing/mongo/vendored/utils.ts
+++ b/packages/node/src/integrations/tracing/mongo/vendored/utils.ts
@@ -11,7 +11,7 @@
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   getActiveSpan,
-  isObject,
+  isObjectLike,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_KIND,
   SPAN_STATUS_ERROR,
@@ -61,7 +61,7 @@ function scrubStatement(value: unknown): unknown {
 }
 
 function isCommandObj(value: Record<string, unknown> | unknown): value is Record<string, unknown> {
-  return isObject(value) && !isBuffer(value);
+  return isObjectLike(value) && !isBuffer(value);
 }
 
 function isBuffer(value: unknown): boolean {

--- a/packages/nuxt/src/runtime/hooks/updateRouteBeforeResponse.ts
+++ b/packages/nuxt/src/runtime/hooks/updateRouteBeforeResponse.ts
@@ -1,4 +1,4 @@
-import { isObject, debug, getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
+import { isObjectLike, debug, getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import type { H3Event } from 'h3';
 
 type MatchedRoute = { path?: string; route?: string };
@@ -46,7 +46,7 @@ export function updateRouteBeforeResponse(event: EventWithMatchedRoute): void {
 
     const params = event.context?.params;
 
-    if (isObject(params)) {
+    if (isObjectLike(params)) {
       Object.entries(params).forEach(([key, value]) => {
         // Based on this convention: https://getsentry.github.io/sentry-conventions/generated/attributes/url.html#urlpathparameterkey
         rootSpan.setAttributes({

--- a/packages/nuxt/src/runtime/hooks/updateRouteBeforeResponse.ts
+++ b/packages/nuxt/src/runtime/hooks/updateRouteBeforeResponse.ts
@@ -1,4 +1,4 @@
-import { debug, getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
+import { isObject, debug, getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import type { H3Event } from 'h3';
 
 type MatchedRoute = { path?: string; route?: string };
@@ -46,7 +46,7 @@ export function updateRouteBeforeResponse(event: EventWithMatchedRoute): void {
 
     const params = event.context?.params;
 
-    if (params && typeof params === 'object') {
+    if (isObject(params)) {
       Object.entries(params).forEach(([key, value]) => {
         // Based on this convention: https://getsentry.github.io/sentry-conventions/generated/attributes/url.html#urlpathparameterkey
         rootSpan.setAttributes({

--- a/packages/nuxt/src/runtime/utils/instrumentStorage.ts
+++ b/packages/nuxt/src/runtime/utils/instrumentStorage.ts
@@ -1,5 +1,5 @@
 import {
-  isObject,
+  isObjectLike,
   captureException,
   debug,
   flushIfServerless,
@@ -264,7 +264,7 @@ function normalizeKey(key: unknown, prefix: string): string {
   }
 
   // Handles an object with a key property
-  if (isObject(key) && 'key' in key) {
+  if (isObjectLike(key) && 'key' in key) {
     return `${prefix}${key.key}`;
   }
 

--- a/packages/nuxt/src/runtime/utils/instrumentStorage.ts
+++ b/packages/nuxt/src/runtime/utils/instrumentStorage.ts
@@ -1,4 +1,5 @@
 import {
+  isObject,
   captureException,
   debug,
   flushIfServerless,
@@ -263,7 +264,7 @@ function normalizeKey(key: unknown, prefix: string): string {
   }
 
   // Handles an object with a key property
-  if (typeof key === 'object' && key !== null && 'key' in key) {
+  if (isObject(key) && 'key' in key) {
     return `${prefix}${key.key}`;
   }
 

--- a/packages/opentelemetry/src/utils/spanTypes.ts
+++ b/packages/opentelemetry/src/utils/spanTypes.ts
@@ -1,6 +1,7 @@
 import type { SpanKind, SpanStatus } from '@opentelemetry/api';
 import type { ReadableSpan, TimedEvent } from '@opentelemetry/sdk-trace-base';
 import type { AbstractSpan } from '../types';
+import { isObject } from '@sentry/core';
 import { getParentSpanId } from './getParentSpanId';
 
 /**
@@ -12,7 +13,7 @@ export function spanHasAttributes<SpanType extends AbstractSpan>(
   span: SpanType,
 ): span is SpanType & { attributes: ReadableSpan['attributes'] } {
   const castSpan = span as ReadableSpan;
-  return !!castSpan.attributes && typeof castSpan.attributes === 'object';
+  return isObject(castSpan.attributes);
 }
 
 /**

--- a/packages/opentelemetry/src/utils/spanTypes.ts
+++ b/packages/opentelemetry/src/utils/spanTypes.ts
@@ -1,7 +1,7 @@
 import type { SpanKind, SpanStatus } from '@opentelemetry/api';
 import type { ReadableSpan, TimedEvent } from '@opentelemetry/sdk-trace-base';
 import type { AbstractSpan } from '../types';
-import { isObject } from '@sentry/core';
+import { isObjectLike } from '@sentry/core';
 import { getParentSpanId } from './getParentSpanId';
 
 /**
@@ -13,7 +13,7 @@ export function spanHasAttributes<SpanType extends AbstractSpan>(
   span: SpanType,
 ): span is SpanType & { attributes: ReadableSpan['attributes'] } {
   const castSpan = span as ReadableSpan;
-  return isObject(castSpan.attributes);
+  return isObjectLike(castSpan.attributes);
 }
 
 /**

--- a/packages/replay-internal/src/coreHandlers/util/domUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/domUtils.ts
@@ -1,4 +1,5 @@
 import type { INode } from '@sentry/rrweb-snapshot';
+import { isObject } from '@sentry/core';
 
 const INTERACTIVE_SELECTOR = 'button,a';
 
@@ -34,5 +35,5 @@ export function getTargetNode(event: Node | { target: EventTarget | null }): Nod
 }
 
 function isEventWithTarget(event: unknown): event is { target: EventTarget | null } {
-  return typeof event === 'object' && !!event && 'target' in event;
+  return isObject(event) && 'target' in event;
 }

--- a/packages/replay-internal/src/coreHandlers/util/domUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/domUtils.ts
@@ -1,5 +1,5 @@
 import type { INode } from '@sentry/rrweb-snapshot';
-import { isObject } from '@sentry/core';
+import { isObjectLike } from '@sentry/core';
 
 const INTERACTIVE_SELECTOR = 'button,a';
 
@@ -35,5 +35,5 @@ export function getTargetNode(event: Node | { target: EventTarget | null }): Nod
 }
 
 function isEventWithTarget(event: unknown): event is { target: EventTarget | null } {
-  return isObject(event) && 'target' in event;
+  return isObjectLike(event) && 'target' in event;
 }

--- a/packages/replay-internal/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/xhrUtils.ts
@@ -1,4 +1,5 @@
 import type { Breadcrumb, XhrBreadcrumbData } from '@sentry/core';
+import { isObject } from '@sentry/core';
 import type { NetworkMetaWarning, XhrHint } from '@sentry/browser-utils';
 import { getBodyString, parseXhrResponseHeaders, SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
 import { DEBUG_BUILD } from '../../debug-build';
@@ -169,7 +170,7 @@ export function _parseXhrResponse(
       return [body.body.outerHTML];
     }
 
-    if (responseType === 'json' && body && typeof body === 'object') {
+    if (responseType === 'json' && isObject(body)) {
       return [JSON.stringify(body)];
     }
 
@@ -191,7 +192,7 @@ function _getBodySize(
   responseType: XMLHttpRequest['responseType'],
 ): number | undefined {
   try {
-    const bodyStr = responseType === 'json' && body && typeof body === 'object' ? JSON.stringify(body) : body;
+    const bodyStr = responseType === 'json' && isObject(body) ? JSON.stringify(body) : body;
     return getBodySize(bodyStr);
   } catch {
     return undefined;

--- a/packages/replay-internal/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay-internal/src/coreHandlers/util/xhrUtils.ts
@@ -1,5 +1,5 @@
 import type { Breadcrumb, XhrBreadcrumbData } from '@sentry/core';
-import { isObject } from '@sentry/core';
+import { isObjectLike } from '@sentry/core';
 import type { NetworkMetaWarning, XhrHint } from '@sentry/browser-utils';
 import { getBodyString, parseXhrResponseHeaders, SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
 import { DEBUG_BUILD } from '../../debug-build';
@@ -170,7 +170,7 @@ export function _parseXhrResponse(
       return [body.body.outerHTML];
     }
 
-    if (responseType === 'json' && isObject(body)) {
+    if (responseType === 'json' && isObjectLike(body)) {
       return [JSON.stringify(body)];
     }
 
@@ -192,7 +192,7 @@ function _getBodySize(
   responseType: XMLHttpRequest['responseType'],
 ): number | undefined {
   try {
-    const bodyStr = responseType === 'json' && isObject(body) ? JSON.stringify(body) : body;
+    const bodyStr = responseType === 'json' && isObjectLike(body) ? JSON.stringify(body) : body;
     return getBodySize(bodyStr);
   } catch {
     return undefined;

--- a/packages/server-utils/src/graphql/utils.ts
+++ b/packages/server-utils/src/graphql/utils.ts
@@ -1,6 +1,6 @@
 import { SENTRY_GRAPHQL_OPERATION } from '@sentry/conventions/attributes';
 import type { Span } from '@sentry/core';
-import { isObject, getRootSpan, spanToJSON } from '@sentry/core';
+import { isObjectLike, getRootSpan, spanToJSON } from '@sentry/core';
 
 // Same key the OTel path uses, so renames stay consistent across both.
 const ORIGINAL_DESCRIPTION_ATTRIBUTE = 'original-description';
@@ -100,7 +100,7 @@ export function getOperationSpanName(
 
 /** Whether a graphql execution result carries GraphQL errors (returned on `result.errors`). */
 export function hasResultErrors(result: unknown): boolean {
-  if (isObject(result) && 'errors' in result) {
+  if (isObjectLike(result) && 'errors' in result) {
     const errors = (result as { errors?: unknown }).errors;
 
     return Array.isArray(errors) && errors.length > 0;

--- a/packages/server-utils/src/graphql/utils.ts
+++ b/packages/server-utils/src/graphql/utils.ts
@@ -1,6 +1,6 @@
 import { SENTRY_GRAPHQL_OPERATION } from '@sentry/conventions/attributes';
 import type { Span } from '@sentry/core';
-import { getRootSpan, spanToJSON } from '@sentry/core';
+import { isObject, getRootSpan, spanToJSON } from '@sentry/core';
 
 // Same key the OTel path uses, so renames stay consistent across both.
 const ORIGINAL_DESCRIPTION_ATTRIBUTE = 'original-description';
@@ -100,7 +100,7 @@ export function getOperationSpanName(
 
 /** Whether a graphql execution result carries GraphQL errors (returned on `result.errors`). */
 export function hasResultErrors(result: unknown): boolean {
-  if (result && typeof result === 'object' && 'errors' in result) {
+  if (isObject(result) && 'errors' in result) {
     const errors = (result as { errors?: unknown }).errors;
 
     return Array.isArray(errors) && errors.length > 0;

--- a/packages/server-utils/src/integrations/tracing-channel/fastify/instrumentation.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/fastify/instrumentation.ts
@@ -18,7 +18,7 @@ import * as diagnosticsChannel from 'node:diagnostics_channel';
 import { HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, HTTP_ROUTE, URL_PATH } from '@sentry/conventions/attributes';
 import type { Span } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   debug,
   getActiveSpan,
   getIsolationScope,
@@ -89,7 +89,7 @@ function getRequestRouteConfig(request: any): { otel?: boolean } | undefined {
  * so we accept either shape.
  */
 function isFastifyRequest(arg: any): boolean {
-  return isObject(arg) && !!arg.method && !!arg.url && (!!arg.routeOptions || 'routerPath' in arg);
+  return isObjectLike(arg) && !!arg.method && !!arg.url && (!!arg.routeOptions || 'routerPath' in arg);
 }
 
 /**

--- a/packages/server-utils/src/integrations/tracing-channel/fastify/instrumentation.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/fastify/instrumentation.ts
@@ -18,6 +18,7 @@ import * as diagnosticsChannel from 'node:diagnostics_channel';
 import { HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, HTTP_ROUTE, URL_PATH } from '@sentry/conventions/attributes';
 import type { Span } from '@sentry/core';
 import {
+  isObject,
   debug,
   getActiveSpan,
   getIsolationScope,
@@ -88,7 +89,7 @@ function getRequestRouteConfig(request: any): { otel?: boolean } | undefined {
  * so we accept either shape.
  */
 function isFastifyRequest(arg: any): boolean {
-  return !!arg && typeof arg === 'object' && !!arg.method && !!arg.url && (!!arg.routeOptions || 'routerPath' in arg);
+  return isObject(arg) && !!arg.method && !!arg.url && (!!arg.routeOptions || 'routerPath' in arg);
 }
 
 /**

--- a/packages/server-utils/src/integrations/tracing-channel/graphql/resolvers.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/graphql/resolvers.ts
@@ -9,7 +9,7 @@
 import { WEB_SERVER_GRAPHQL_SPAN_OP } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
@@ -104,7 +104,11 @@ export function wrapFieldResolver(
 
     // Mirror graphql's own "trivial resolver" check: a default resolver that just reads a
     // non-function property is not worth a span.
-    if (config.ignoreTrivialResolveSpans && isDefaultResolver && (isObject(source) || typeof source === 'function')) {
+    if (
+      config.ignoreTrivialResolveSpans &&
+      isDefaultResolver &&
+      (isObjectLike(source) || typeof source === 'function')
+    ) {
       const property = (source as Record<string, unknown>)[info.fieldName];
       if (typeof property !== 'function') {
         return fieldResolver.call(this, source, args, contextValue, info);

--- a/packages/server-utils/src/integrations/tracing-channel/graphql/resolvers.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/graphql/resolvers.ts
@@ -9,6 +9,7 @@
 import { WEB_SERVER_GRAPHQL_SPAN_OP } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
+  isObject,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
@@ -43,10 +44,6 @@ import type {
 
 function isPromise(value: unknown): value is Promise<unknown> {
   return typeof (value as { then?: unknown } | undefined)?.then === 'function';
-}
-
-function isObjectLike(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 /**
@@ -107,11 +104,7 @@ export function wrapFieldResolver(
 
     // Mirror graphql's own "trivial resolver" check: a default resolver that just reads a
     // non-function property is not worth a span.
-    if (
-      config.ignoreTrivialResolveSpans &&
-      isDefaultResolver &&
-      (isObjectLike(source) || typeof source === 'function')
-    ) {
+    if (config.ignoreTrivialResolveSpans && isDefaultResolver && (isObject(source) || typeof source === 'function')) {
       const property = (source as Record<string, unknown>)[info.fieldName];
       if (typeof property !== 'function') {
         return fieldResolver.call(this, source, args, contextValue, info);

--- a/packages/server-utils/src/integrations/tracing-channel/mysql.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/mysql.ts
@@ -1,6 +1,7 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Scope } from '@sentry/core';
 import {
+  isObject,
   bindScopeToEmitter,
   debug,
   defineIntegration,
@@ -132,7 +133,7 @@ function extractSql(firstArg: unknown): string | undefined {
   if (typeof firstArg === 'string') {
     return firstArg;
   }
-  if (firstArg && typeof firstArg === 'object' && 'sql' in firstArg) {
+  if (isObject(firstArg) && 'sql' in firstArg) {
     const sql = (firstArg as { sql?: unknown }).sql;
     return typeof sql === 'string' ? sql : undefined;
   }

--- a/packages/server-utils/src/integrations/tracing-channel/mysql.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/mysql.ts
@@ -1,7 +1,7 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Scope } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   bindScopeToEmitter,
   debug,
   defineIntegration,
@@ -133,7 +133,7 @@ function extractSql(firstArg: unknown): string | undefined {
   if (typeof firstArg === 'string') {
     return firstArg;
   }
-  if (isObject(firstArg) && 'sql' in firstArg) {
+  if (isObjectLike(firstArg) && 'sql' in firstArg) {
     const sql = (firstArg as { sql?: unknown }).sql;
     return typeof sql === 'string' ? sql : undefined;
   }

--- a/packages/server-utils/src/integrations/tracing-channel/postgres.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/postgres.ts
@@ -1,6 +1,7 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Scope, SpanAttributes } from '@sentry/core';
 import {
+  isObject,
   bindScopeToEmitter,
   debug,
   defineIntegration,
@@ -208,7 +209,7 @@ function extractQueryConfig(args: unknown[]): { text: string; name?: unknown } |
   if (typeof arg0 === 'string') {
     return { text: arg0 };
   }
-  if (arg0 && typeof arg0 === 'object' && typeof (arg0 as { text?: unknown }).text === 'string') {
+  if (isObject(arg0) && typeof (arg0 as { text?: unknown }).text === 'string') {
     const obj = arg0 as { text: string; name?: unknown };
     return { text: obj.text, name: obj.name };
   }

--- a/packages/server-utils/src/integrations/tracing-channel/postgres.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/postgres.ts
@@ -1,7 +1,7 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Scope, SpanAttributes } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   bindScopeToEmitter,
   debug,
   defineIntegration,
@@ -209,7 +209,7 @@ function extractQueryConfig(args: unknown[]): { text: string; name?: unknown } |
   if (typeof arg0 === 'string') {
     return { text: arg0 };
   }
-  if (isObject(arg0) && typeof (arg0 as { text?: unknown }).text === 'string') {
+  if (isObjectLike(arg0) && typeof (arg0 as { text?: unknown }).text === 'string') {
     const obj = arg0 as { text: string; name?: unknown };
     return { text: obj.text, name: obj.name };
   }

--- a/packages/server-utils/src/integrations/tracing-channel/redis.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/redis.ts
@@ -14,6 +14,7 @@ import {
 } from '@sentry/conventions/attributes';
 import type { IntegrationFn, Span, SpanAttributes } from '@sentry/core';
 import {
+  isObject,
   debug,
   defineIntegration,
   getActiveSpan,
@@ -110,7 +111,7 @@ function runResponseHook(
 // deriving the wire arguments, mirroring `@redis/client`'s `transformCommandArguments`.
 function stripCommandOptions(args: unknown[]): unknown[] {
   const first = args[0];
-  if (first && typeof first === 'object' && Object.getOwnPropertySymbols(first).length > 0) {
+  if (isObject(first) && Object.getOwnPropertySymbols(first).length > 0) {
     return args.slice(1);
   }
   return args;

--- a/packages/server-utils/src/integrations/tracing-channel/redis.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/redis.ts
@@ -14,7 +14,7 @@ import {
 } from '@sentry/conventions/attributes';
 import type { IntegrationFn, Span, SpanAttributes } from '@sentry/core';
 import {
-  isObject,
+  isObjectLike,
   debug,
   defineIntegration,
   getActiveSpan,
@@ -111,7 +111,7 @@ function runResponseHook(
 // deriving the wire arguments, mirroring `@redis/client`'s `transformCommandArguments`.
 function stripCommandOptions(args: unknown[]): unknown[] {
   const first = args[0];
-  if (isObject(first) && Object.getOwnPropertySymbols(first).length > 0) {
+  if (isObjectLike(first) && Object.getOwnPropertySymbols(first).length > 0) {
     return args.slice(1);
   }
   return args;

--- a/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
@@ -9,7 +9,13 @@ import {
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
-import { debug, SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
+import {
+  isObject,
+  debug,
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  startInactiveSpan,
+} from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 import { bindTracingChannelToSpan } from '../tracing-channel';
 
@@ -177,7 +183,7 @@ function redactValue(value: unknown, depth: number): unknown {
     return value.map(item => redactValue(item, depth + 1));
   }
 
-  if (value && typeof value === 'object') {
+  if (isObject(value)) {
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>)) {
       out[key] = redactValue((value as Record<string, unknown>)[key], depth + 1);

--- a/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/mongoose/mongoose-dc-subscriber.ts
@@ -10,7 +10,7 @@ import {
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
 import {
-  isObject,
+  isObjectLike,
   debug,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -183,7 +183,7 @@ function redactValue(value: unknown, depth: number): unknown {
     return value.map(item => redactValue(item, depth + 1));
   }
 
-  if (isObject(value)) {
+  if (isObjectLike(value)) {
     const out: Record<string, unknown> = {};
     for (const key of Object.keys(value as Record<string, unknown>)) {
       out[key] = redactValue((value as Record<string, unknown>)[key], depth + 1);

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -4,7 +4,7 @@ import type { ExclusiveEventHintOrCaptureContext, Span } from '@sentry/core';
 import {
   debug,
   captureException,
-  isObject,
+  isObjectLike,
   SPAN_STATUS_ERROR,
   getAsyncContextStrategy,
   getMainCarrier,
@@ -283,7 +283,7 @@ type ErrorInfo = {
  * Best-effort message and attribute extraction for thrown/rejected values.
  */
 function getErrorInfo(error: unknown): ErrorInfo {
-  const errorIsObject = isObject(error);
+  const errorIsObject = isObjectLike(error);
   const raw = errorIsObject ? ('message' in error ? error.message : undefined) : error;
 
   // Leave the status message unset if not set (e.g. an `AggregateError` from

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -4,6 +4,7 @@ import type { ExclusiveEventHintOrCaptureContext, Span } from '@sentry/core';
 import {
   debug,
   captureException,
+  isObject,
   SPAN_STATUS_ERROR,
   getAsyncContextStrategy,
   getMainCarrier,
@@ -282,13 +283,13 @@ type ErrorInfo = {
  * Best-effort message and attribute extraction for thrown/rejected values.
  */
 function getErrorInfo(error: unknown): ErrorInfo {
-  const isObject = !!error && typeof error === 'object';
-  const raw = isObject ? ('message' in error ? error.message : undefined) : error;
+  const errorIsObject = isObject(error);
+  const raw = errorIsObject ? ('message' in error ? error.message : undefined) : error;
 
   // Leave the status message unset if not set (e.g. an `AggregateError` from
   // ECONNREFUSED, whose `.message` is empty). Otherwise cast to string.
   const message = raw ? String(raw) : undefined;
-  const type = isObject && 'name' in error ? String(error.name) : 'unknown';
+  const type = errorIsObject && 'name' in error ? String(error.name) : 'unknown';
 
   return {
     message,

--- a/packages/server-utils/src/vercel-ai/util.ts
+++ b/packages/server-utils/src/vercel-ai/util.ts
@@ -1,5 +1,7 @@
 /** Shared, state-free helpers for the Vercel AI (`ai`) channel subscribers, plus the streamed model-call tap. */
 
+import { isObject } from '@sentry/core';
+
 /** Narrow to a string, or `undefined` for anything else. */
 export function asString(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
@@ -13,11 +15,6 @@ export function asNumber(value: unknown): number | undefined {
 /** Add two optional numbers, treating a missing operand as `0` but returning `undefined` when both are absent. */
 export function sum(a: number | undefined, b: number | undefined): number | undefined {
   return a === undefined && b === undefined ? undefined : (a ?? 0) + (b ?? 0);
-}
-
-/** Narrow to a non-null object (records and arrays alike). */
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 /** Stringify a value, passing strings through and falling back to a placeholder on circular/unserializable input. */
@@ -78,7 +75,7 @@ export interface StreamedModelCallResult {
 /** A minimal structural check — the streamed model call exposes a web `ReadableStream` on `result.stream`. */
 export function isReadableStream(value: unknown): value is ReadableStream<unknown> {
   return (
-    isRecord(value) &&
+    isObject(value) &&
     typeof (value as { pipeThrough?: unknown }).pipeThrough === 'function' &&
     typeof (value as { getReader?: unknown }).getReader === 'function'
   );
@@ -154,7 +151,7 @@ export function tapModelCallStream(
  * accumulate it (kept out of `state` until the end to avoid re-joining on every chunk).
  */
 function accumulateChunk(state: StreamedModelCallResult, chunk: unknown): string | undefined {
-  if (!isRecord(chunk)) {
+  if (!isObject(chunk)) {
     return undefined;
   }
   const { type, delta, id, modelId, toolCallId, toolName, input, args, finishReason, usage, providerMetadata } =

--- a/packages/server-utils/src/vercel-ai/util.ts
+++ b/packages/server-utils/src/vercel-ai/util.ts
@@ -1,6 +1,6 @@
 /** Shared, state-free helpers for the Vercel AI (`ai`) channel subscribers, plus the streamed model-call tap. */
 
-import { isObject } from '@sentry/core';
+import { isObjectLike } from '@sentry/core';
 
 /** Narrow to a string, or `undefined` for anything else. */
 export function asString(value: unknown): string | undefined {
@@ -75,7 +75,7 @@ export interface StreamedModelCallResult {
 /** A minimal structural check — the streamed model call exposes a web `ReadableStream` on `result.stream`. */
 export function isReadableStream(value: unknown): value is ReadableStream<unknown> {
   return (
-    isObject(value) &&
+    isObjectLike(value) &&
     typeof (value as { pipeThrough?: unknown }).pipeThrough === 'function' &&
     typeof (value as { getReader?: unknown }).getReader === 'function'
   );
@@ -151,7 +151,7 @@ export function tapModelCallStream(
  * accumulate it (kept out of `state` until the end to avoid re-joining on every chunk).
  */
 function accumulateChunk(state: StreamedModelCallResult, chunk: unknown): string | undefined {
-  if (!isObject(chunk)) {
+  if (!isObjectLike(chunk)) {
     return undefined;
   }
   const { type, delta, id, modelId, toolCallId, toolName, input, args, finishReason, usage, providerMetadata } =

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -35,6 +35,7 @@ import {
   getClient,
   getProviderMetadataAttributes,
   getTruncatedJsonString,
+  isObject,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   shouldEnableTruncation,
   SPAN_STATUS_ERROR,
@@ -49,7 +50,6 @@ import {
   asNumber,
   asString,
   isReadableStream,
-  isRecord,
   safeStringify,
   type StreamedModelCallResult,
   sum,
@@ -134,7 +134,7 @@ function recordToolDescriptions(callId: string | undefined, tools: unknown): voi
   }
   let descriptions = toolDescriptionsByCallId.get(callId);
   for (const tool of tools) {
-    if (isRecord(tool) && typeof tool.name === 'string' && typeof tool.description === 'string') {
+    if (isObject(tool) && typeof tool.name === 'string' && typeof tool.description === 'string') {
       descriptions = descriptions ?? new Map();
       if (!descriptions.has(tool.name)) {
         descriptions.set(tool.name, tool.description);
@@ -157,12 +157,12 @@ function resolveToolDescription(callId: string | undefined, toolName: string, to
     return fromMap;
   }
   if (Array.isArray(tools)) {
-    const match = tools.find(tool => isRecord(tool) && tool.name === toolName);
-    return isRecord(match) ? asString(match.description) : undefined;
+    const match = tools.find(tool => isObject(tool) && tool.name === toolName);
+    return isObject(match) ? asString(match.description) : undefined;
   }
-  if (isRecord(tools)) {
+  if (isObject(tools)) {
     const tool = tools[toolName];
-    return isRecord(tool) ? asString(tool.description) : undefined;
+    return isObject(tool) ? asString(tool.description) : undefined;
   }
   return undefined;
 }
@@ -253,7 +253,7 @@ function deferStreamedModelCallEnd(
   options: VercelAiChannelOptions,
   end: (error?: unknown) => void,
 ): boolean {
-  if (data.type !== 'languageModelCall' || !isRecord(data.result)) {
+  if (data.type !== 'languageModelCall' || !isObject(data.result)) {
     return false;
   }
   const result = data.result;
@@ -321,7 +321,7 @@ function enrichInvokeAgentFromStream(
     return;
   }
 
-  const usage = isRecord(final.usage) ? final.usage : undefined;
+  const usage = isObject(final.usage) ? final.usage : undefined;
   if (usage) {
     const input = tokenCount(usage.inputTokens) ?? tokenCount(usage.tokens);
     const output = tokenCount(usage.outputTokens);
@@ -471,7 +471,7 @@ function buildModelCallSpan(
 }
 
 function buildToolSpan(event: Record<string, unknown>, recordInputs: boolean): Span {
-  const toolCall = isRecord(event.toolCall) ? event.toolCall : {};
+  const toolCall = isObject(event.toolCall) ? event.toolCall : {};
   const toolName = asString(toolCall.toolName);
   const toolCallId = asString(event.toolCallId) ?? asString(toolCall.toolCallId);
   const toolInput = toolCall.input ?? toolCall.args;
@@ -500,7 +500,7 @@ export function enrichSpanOnEnd(
   channelOptions: VercelAiChannelOptions,
 ): void {
   const { type, result } = data;
-  if (!isRecord(result)) {
+  if (!isObject(result)) {
     return;
   }
 
@@ -513,7 +513,7 @@ export function enrichSpanOnEnd(
     // From V5 on, tool errors are not rejected (so the `error` channel verb never fires) — they
     // surface as `tool-error` content on the resolved result. Mirror the OTel path by marking the
     // span and capturing the error.
-    const output = isRecord(result.output) ? result.output : undefined;
+    const output = isObject(result.output) ? result.output : undefined;
     if (output?.type === 'tool-error') {
       captureToolError(span, data, output.error);
     }
@@ -522,7 +522,7 @@ export function enrichSpanOnEnd(
 
   // `languageModelCall` results report usage as `{ total }` objects; top-level/step results report
   // flat numbers. `tokenCount` handles both.
-  const usage = isRecord(result.usage) ? result.usage : undefined;
+  const usage = isObject(result.usage) ? result.usage : undefined;
   if (usage) {
     const inputTokens = tokenCount(usage.inputTokens) ?? tokenCount(usage.tokens);
     const outputTokens = tokenCount(usage.outputTokens);
@@ -545,7 +545,7 @@ export function enrichSpanOnEnd(
     span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, safeStringify([finishReason]));
   }
 
-  const response = isRecord(result.response) ? result.response : undefined;
+  const response = isObject(result.response) ? result.response : undefined;
   const responseId = asString(response?.id) ?? asString(result.responseId);
   if (responseId) {
     span.setAttribute(GEN_AI_RESPONSE_ID, responseId);
@@ -596,12 +596,12 @@ function getFinishReason(result: Record<string, unknown>): string | undefined {
   if (typeof finishReason === 'string') {
     return finishReason;
   }
-  return isRecord(finishReason) ? asString(finishReason.unified) : undefined;
+  return isObject(finishReason) ? asString(finishReason.unified) : undefined;
 }
 
 /** Reads a token count that may be a plain number or a `{ total }` object (model-call usage). */
 function tokenCount(value: unknown): number | undefined {
-  return asNumber(value) ?? (isRecord(value) ? asNumber(value.total) : undefined);
+  return asNumber(value) ?? (isObject(value) ? asNumber(value.total) : undefined);
 }
 
 function buildOutputMessages(
@@ -627,7 +627,7 @@ function toolCallPart(toolCall: Record<string, unknown>): Record<string, unknown
 function partsFromContent(content: unknown[]): Array<Record<string, unknown>> {
   const parts: Array<Record<string, unknown>> = [];
   for (const item of content) {
-    if (!isRecord(item)) {
+    if (!isObject(item)) {
       continue;
     }
     if (item.type === 'text' && typeof item.text === 'string') {
@@ -646,7 +646,7 @@ function partsFromTextAndToolCalls(text: unknown, toolCalls: unknown): Array<Rec
   }
   if (Array.isArray(toolCalls)) {
     for (const toolCall of toolCalls) {
-      if (isRecord(toolCall)) {
+      if (isObject(toolCall)) {
         parts.push(toolCallPart(toolCall));
       }
     }
@@ -660,7 +660,7 @@ export function captureToolError(span: Span, data: VercelAiChannelMessage, error
     message: error instanceof Error ? error.message : 'tool_error',
   });
 
-  const toolCall = isRecord(data.event.toolCall) ? data.event.toolCall : {};
+  const toolCall = isObject(data.event.toolCall) ? data.event.toolCall : {};
   const toolName = asString(toolCall.toolName);
   const toolCallId = asString(data.event.toolCallId) ?? asString(toolCall.toolCallId);
 

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -35,7 +35,7 @@ import {
   getClient,
   getProviderMetadataAttributes,
   getTruncatedJsonString,
-  isObject,
+  isObjectLike,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   shouldEnableTruncation,
   SPAN_STATUS_ERROR,
@@ -134,7 +134,7 @@ function recordToolDescriptions(callId: string | undefined, tools: unknown): voi
   }
   let descriptions = toolDescriptionsByCallId.get(callId);
   for (const tool of tools) {
-    if (isObject(tool) && typeof tool.name === 'string' && typeof tool.description === 'string') {
+    if (isObjectLike(tool) && typeof tool.name === 'string' && typeof tool.description === 'string') {
       descriptions = descriptions ?? new Map();
       if (!descriptions.has(tool.name)) {
         descriptions.set(tool.name, tool.description);
@@ -157,12 +157,12 @@ function resolveToolDescription(callId: string | undefined, toolName: string, to
     return fromMap;
   }
   if (Array.isArray(tools)) {
-    const match = tools.find(tool => isObject(tool) && tool.name === toolName);
-    return isObject(match) ? asString(match.description) : undefined;
+    const match = tools.find(tool => isObjectLike(tool) && tool.name === toolName);
+    return isObjectLike(match) ? asString(match.description) : undefined;
   }
-  if (isObject(tools)) {
+  if (isObjectLike(tools)) {
     const tool = tools[toolName];
-    return isObject(tool) ? asString(tool.description) : undefined;
+    return isObjectLike(tool) ? asString(tool.description) : undefined;
   }
   return undefined;
 }
@@ -253,7 +253,7 @@ function deferStreamedModelCallEnd(
   options: VercelAiChannelOptions,
   end: (error?: unknown) => void,
 ): boolean {
-  if (data.type !== 'languageModelCall' || !isObject(data.result)) {
+  if (data.type !== 'languageModelCall' || !isObjectLike(data.result)) {
     return false;
   }
   const result = data.result;
@@ -321,7 +321,7 @@ function enrichInvokeAgentFromStream(
     return;
   }
 
-  const usage = isObject(final.usage) ? final.usage : undefined;
+  const usage = isObjectLike(final.usage) ? final.usage : undefined;
   if (usage) {
     const input = tokenCount(usage.inputTokens) ?? tokenCount(usage.tokens);
     const output = tokenCount(usage.outputTokens);
@@ -471,7 +471,7 @@ function buildModelCallSpan(
 }
 
 function buildToolSpan(event: Record<string, unknown>, recordInputs: boolean): Span {
-  const toolCall = isObject(event.toolCall) ? event.toolCall : {};
+  const toolCall = isObjectLike(event.toolCall) ? event.toolCall : {};
   const toolName = asString(toolCall.toolName);
   const toolCallId = asString(event.toolCallId) ?? asString(toolCall.toolCallId);
   const toolInput = toolCall.input ?? toolCall.args;
@@ -500,7 +500,7 @@ export function enrichSpanOnEnd(
   channelOptions: VercelAiChannelOptions,
 ): void {
   const { type, result } = data;
-  if (!isObject(result)) {
+  if (!isObjectLike(result)) {
     return;
   }
 
@@ -513,7 +513,7 @@ export function enrichSpanOnEnd(
     // From V5 on, tool errors are not rejected (so the `error` channel verb never fires) — they
     // surface as `tool-error` content on the resolved result. Mirror the OTel path by marking the
     // span and capturing the error.
-    const output = isObject(result.output) ? result.output : undefined;
+    const output = isObjectLike(result.output) ? result.output : undefined;
     if (output?.type === 'tool-error') {
       captureToolError(span, data, output.error);
     }
@@ -522,7 +522,7 @@ export function enrichSpanOnEnd(
 
   // `languageModelCall` results report usage as `{ total }` objects; top-level/step results report
   // flat numbers. `tokenCount` handles both.
-  const usage = isObject(result.usage) ? result.usage : undefined;
+  const usage = isObjectLike(result.usage) ? result.usage : undefined;
   if (usage) {
     const inputTokens = tokenCount(usage.inputTokens) ?? tokenCount(usage.tokens);
     const outputTokens = tokenCount(usage.outputTokens);
@@ -545,7 +545,7 @@ export function enrichSpanOnEnd(
     span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, safeStringify([finishReason]));
   }
 
-  const response = isObject(result.response) ? result.response : undefined;
+  const response = isObjectLike(result.response) ? result.response : undefined;
   const responseId = asString(response?.id) ?? asString(result.responseId);
   if (responseId) {
     span.setAttribute(GEN_AI_RESPONSE_ID, responseId);
@@ -596,12 +596,12 @@ function getFinishReason(result: Record<string, unknown>): string | undefined {
   if (typeof finishReason === 'string') {
     return finishReason;
   }
-  return isObject(finishReason) ? asString(finishReason.unified) : undefined;
+  return isObjectLike(finishReason) ? asString(finishReason.unified) : undefined;
 }
 
 /** Reads a token count that may be a plain number or a `{ total }` object (model-call usage). */
 function tokenCount(value: unknown): number | undefined {
-  return asNumber(value) ?? (isObject(value) ? asNumber(value.total) : undefined);
+  return asNumber(value) ?? (isObjectLike(value) ? asNumber(value.total) : undefined);
 }
 
 function buildOutputMessages(
@@ -627,7 +627,7 @@ function toolCallPart(toolCall: Record<string, unknown>): Record<string, unknown
 function partsFromContent(content: unknown[]): Array<Record<string, unknown>> {
   const parts: Array<Record<string, unknown>> = [];
   for (const item of content) {
-    if (!isObject(item)) {
+    if (!isObjectLike(item)) {
       continue;
     }
     if (item.type === 'text' && typeof item.text === 'string') {
@@ -646,7 +646,7 @@ function partsFromTextAndToolCalls(text: unknown, toolCalls: unknown): Array<Rec
   }
   if (Array.isArray(toolCalls)) {
     for (const toolCall of toolCalls) {
-      if (isObject(toolCall)) {
+      if (isObjectLike(toolCall)) {
         parts.push(toolCallPart(toolCall));
       }
     }
@@ -660,7 +660,7 @@ export function captureToolError(span: Span, data: VercelAiChannelMessage, error
     message: error instanceof Error ? error.message : 'tool_error',
   });
 
-  const toolCall = isObject(data.event.toolCall) ? data.event.toolCall : {};
+  const toolCall = isObjectLike(data.event.toolCall) ? data.event.toolCall : {};
   const toolName = asString(toolCall.toolName);
   const toolCallId = asString(data.event.toolCallId) ?? asString(toolCall.toolCallId);
 

--- a/packages/server-utils/src/vercel-ai/vercel-ai-orchestrion-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-orchestrion-subscriber.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import type { Span } from '@sentry/core';
-import { debug, getActiveSpan, isObject, SPAN_STATUS_ERROR, withActiveSpan } from '@sentry/core';
+import { debug, getActiveSpan, isObjectLike, SPAN_STATUS_ERROR, withActiveSpan } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 import { CHANNELS } from '../orchestrion/channels';
 import { bindTracingChannelToSpan, type TracingChannelPayloadWithSpan } from '../tracing-channel';
@@ -202,8 +202,8 @@ function bindOperation(
   // the returned span the active async context for the operation's duration — that active span is what
   // `resolveModelCallParent` reads. It also sets `data._sentrySpan`, so we don't here.
   const buildOperationSpan = (data: TracingChannelPayloadWithSpan<OrchestrionContext>): Span | undefined => {
-    const callOptions = isObject(data.arguments[0]) ? data.arguments[0] : {};
-    const telemetry = isObject(callOptions.experimental_telemetry) ? callOptions.experimental_telemetry : {};
+    const callOptions = isObjectLike(data.arguments[0]) ? data.arguments[0] : {};
+    const telemetry = isObjectLike(callOptions.experimental_telemetry) ? callOptions.experimental_telemetry : {};
     // `isEnabled === false` means the user opted out — emit no span. But `isEnabled` is also `false` on
     // the telemetry object we swap in to suppress native spans, so don't mistake our own object for a
     // user opt-out (which would drop the span on a call whose options we already neutralized).
@@ -231,7 +231,7 @@ function bindOperation(
       recordingBySpan.set(span, recording(telemetry));
       // v5 has no `executeToolCall` channel, so patch each tool's `execute` to emit the tool-call span.
       // Inert on v6 (guarded inside `patchToolExecute` when the parent is `executeToolCall`'s own span).
-      if (isObject(callOptions.tools)) {
+      if (isObjectLike(callOptions.tools)) {
         patchOperationTools(callOptions.tools, options);
       }
     }
@@ -307,11 +307,11 @@ function deferStreamTextOperationEnd(
 
 /** A `StreamTextResult` exposes its aggregates as promises (`totalUsage`/`usage`); a settled result does not. */
 function isStreamingResult(result: unknown): result is Record<string, PromiseLike<unknown> | undefined> {
-  return isObject(result) && (isThenable(result.totalUsage) || isThenable(result.usage));
+  return isObjectLike(result) && (isThenable(result.totalUsage) || isThenable(result.usage));
 }
 
 function isThenable(value: unknown): boolean {
-  return isObject(value) && typeof value.then === 'function';
+  return isObjectLike(value) && typeof value.then === 'function';
 }
 
 /**
@@ -350,7 +350,7 @@ function subscribeResolveLanguageModel(
   tracingChannel<OrchestrionContext>(channelName).subscribe({
     end(rawCtx) {
       const ctx = rawCtx as OrchestrionContext;
-      if (!isObject(ctx.result)) {
+      if (!isObjectLike(ctx.result)) {
         return;
       }
       const model = ctx.result as PatchableModel;
@@ -416,7 +416,7 @@ function patchModelMethod(
       return Promise.resolve(original.apply(this, args));
     }
 
-    const callArgs = isObject(args[0]) ? args[0] : {};
+    const callArgs = isObjectLike(args[0]) ? args[0] : {};
     // Carry the operation's `callId` so the shared core can name the span after it
     // (`ai.generateText.doGenerate` / `ai.streamText.doStream`).
     const callId = callIdBySpan.get(parent);
@@ -463,7 +463,7 @@ function patchModelMethod(
         // usage/finish/output only arrive as the stream drains. Tap it (same helper as the v7 path) and
         // defer ending this model-call span until then. The parent `invoke_agent` span is enriched
         // separately by `deferStreamTextOperationEnd`, which awaits the operation's own result promises.
-        if (method === 'doStream' && isObject(value) && isReadableStream(value.stream)) {
+        if (method === 'doStream' && isObjectLike(value) && isReadableStream(value.stream)) {
           value.stream = tapModelCallStream(
             value.stream,
             final => {
@@ -511,7 +511,7 @@ function patchOperationTools(tools: Record<string, unknown>, options: VercelAiCh
   // the user's `ai` call. Instrumentation must never do that — degrade to no tool span instead.
   try {
     for (const [toolName, tool] of Object.entries(tools)) {
-      if (isObject(tool)) {
+      if (isObjectLike(tool)) {
         patchToolExecute(toolName, tool as PatchableTool, tools, options);
       }
     }
@@ -542,7 +542,7 @@ function patchToolExecute(
     }
 
     // v5 passes `{ toolCallId, messages, abortSignal, ... }` as the second argument to `execute`.
-    const callOptions = isObject(rest[0]) ? rest[0] : {};
+    const callOptions = isObjectLike(rest[0]) ? rest[0] : {};
     const message: VercelAiChannelMessage = {
       type: 'executeTool',
       event: {
@@ -629,5 +629,5 @@ function modelFields(model: unknown): { provider?: string; modelId?: string } {
 }
 
 function modelField(model: unknown, field: 'modelId' | 'provider'): string | undefined {
-  return isObject(model) ? asString(model[field]) : undefined;
+  return isObjectLike(model) ? asString(model[field]) : undefined;
 }

--- a/packages/server-utils/src/vercel-ai/vercel-ai-orchestrion-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-orchestrion-subscriber.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import type { Span } from '@sentry/core';
-import { debug, getActiveSpan, SPAN_STATUS_ERROR, withActiveSpan } from '@sentry/core';
+import { debug, getActiveSpan, isObject, SPAN_STATUS_ERROR, withActiveSpan } from '@sentry/core';
 import { DEBUG_BUILD } from '../debug-build';
 import { CHANNELS } from '../orchestrion/channels';
 import { bindTracingChannelToSpan, type TracingChannelPayloadWithSpan } from '../tracing-channel';
@@ -15,7 +15,7 @@ import {
   type VercelAiChannelOptions,
   type VercelAiTracingChannelFactory,
 } from './vercel-ai-dc-subscriber';
-import { asString, isReadableStream, isRecord, tapModelCallStream } from './util';
+import { asString, isReadableStream, tapModelCallStream } from './util';
 
 /**
  * v5 & v6 channel adapter for the Vercel AI (`ai`) SDK.
@@ -202,8 +202,8 @@ function bindOperation(
   // the returned span the active async context for the operation's duration — that active span is what
   // `resolveModelCallParent` reads. It also sets `data._sentrySpan`, so we don't here.
   const buildOperationSpan = (data: TracingChannelPayloadWithSpan<OrchestrionContext>): Span | undefined => {
-    const callOptions = isRecord(data.arguments[0]) ? data.arguments[0] : {};
-    const telemetry = isRecord(callOptions.experimental_telemetry) ? callOptions.experimental_telemetry : {};
+    const callOptions = isObject(data.arguments[0]) ? data.arguments[0] : {};
+    const telemetry = isObject(callOptions.experimental_telemetry) ? callOptions.experimental_telemetry : {};
     // `isEnabled === false` means the user opted out — emit no span. But `isEnabled` is also `false` on
     // the telemetry object we swap in to suppress native spans, so don't mistake our own object for a
     // user opt-out (which would drop the span on a call whose options we already neutralized).
@@ -231,7 +231,7 @@ function bindOperation(
       recordingBySpan.set(span, recording(telemetry));
       // v5 has no `executeToolCall` channel, so patch each tool's `execute` to emit the tool-call span.
       // Inert on v6 (guarded inside `patchToolExecute` when the parent is `executeToolCall`'s own span).
-      if (isRecord(callOptions.tools)) {
+      if (isObject(callOptions.tools)) {
         patchOperationTools(callOptions.tools, options);
       }
     }
@@ -307,11 +307,11 @@ function deferStreamTextOperationEnd(
 
 /** A `StreamTextResult` exposes its aggregates as promises (`totalUsage`/`usage`); a settled result does not. */
 function isStreamingResult(result: unknown): result is Record<string, PromiseLike<unknown> | undefined> {
-  return isRecord(result) && (isThenable(result.totalUsage) || isThenable(result.usage));
+  return isObject(result) && (isThenable(result.totalUsage) || isThenable(result.usage));
 }
 
 function isThenable(value: unknown): boolean {
-  return isRecord(value) && typeof value.then === 'function';
+  return isObject(value) && typeof value.then === 'function';
 }
 
 /**
@@ -350,7 +350,7 @@ function subscribeResolveLanguageModel(
   tracingChannel<OrchestrionContext>(channelName).subscribe({
     end(rawCtx) {
       const ctx = rawCtx as OrchestrionContext;
-      if (!isRecord(ctx.result)) {
+      if (!isObject(ctx.result)) {
         return;
       }
       const model = ctx.result as PatchableModel;
@@ -416,7 +416,7 @@ function patchModelMethod(
       return Promise.resolve(original.apply(this, args));
     }
 
-    const callArgs = isRecord(args[0]) ? args[0] : {};
+    const callArgs = isObject(args[0]) ? args[0] : {};
     // Carry the operation's `callId` so the shared core can name the span after it
     // (`ai.generateText.doGenerate` / `ai.streamText.doStream`).
     const callId = callIdBySpan.get(parent);
@@ -463,7 +463,7 @@ function patchModelMethod(
         // usage/finish/output only arrive as the stream drains. Tap it (same helper as the v7 path) and
         // defer ending this model-call span until then. The parent `invoke_agent` span is enriched
         // separately by `deferStreamTextOperationEnd`, which awaits the operation's own result promises.
-        if (method === 'doStream' && isRecord(value) && isReadableStream(value.stream)) {
+        if (method === 'doStream' && isObject(value) && isReadableStream(value.stream)) {
           value.stream = tapModelCallStream(
             value.stream,
             final => {
@@ -511,7 +511,7 @@ function patchOperationTools(tools: Record<string, unknown>, options: VercelAiCh
   // the user's `ai` call. Instrumentation must never do that — degrade to no tool span instead.
   try {
     for (const [toolName, tool] of Object.entries(tools)) {
-      if (isRecord(tool)) {
+      if (isObject(tool)) {
         patchToolExecute(toolName, tool as PatchableTool, tools, options);
       }
     }
@@ -542,7 +542,7 @@ function patchToolExecute(
     }
 
     // v5 passes `{ toolCallId, messages, abortSignal, ... }` as the second argument to `execute`.
-    const callOptions = isRecord(rest[0]) ? rest[0] : {};
+    const callOptions = isObject(rest[0]) ? rest[0] : {};
     const message: VercelAiChannelMessage = {
       type: 'executeTool',
       event: {
@@ -629,5 +629,5 @@ function modelFields(model: unknown): { provider?: string; modelId?: string } {
 }
 
 function modelField(model: unknown, field: 'modelId' | 'provider'): string | undefined {
-  return isRecord(model) ? asString(model[field]) : undefined;
+  return isObject(model) ? asString(model[field]) : undefined;
 }

--- a/packages/sveltekit/src/client/handleError.ts
+++ b/packages/sveltekit/src/client/handleError.ts
@@ -1,4 +1,4 @@
-import { consoleSandbox } from '@sentry/core';
+import { isObject, consoleSandbox } from '@sentry/core';
 import { captureException } from '@sentry/svelte';
 import type { HandleClientError } from '@sveltejs/kit';
 
@@ -58,10 +58,7 @@ function is4xxError(input: SafeHandleServerErrorInput): boolean {
   // SvelteKit __data.json requests return HTTP 200 with errors embedded in JSON,
   // so get_status() may resolve to 500 for a deserialized plain error object.
   // Fall back to checking input.error.status directly.
-  const errorStatus =
-    typeof input.error === 'object' && input.error !== null
-      ? (input.error as Record<string, unknown>)['status']
-      : undefined;
+  const errorStatus = isObject(input.error) ? (input.error as Record<string, unknown>)['status'] : undefined;
 
   return typeof errorStatus === 'number' && errorStatus >= 400 && errorStatus < 500;
 }

--- a/packages/sveltekit/src/client/handleError.ts
+++ b/packages/sveltekit/src/client/handleError.ts
@@ -1,4 +1,4 @@
-import { isObject, consoleSandbox } from '@sentry/core';
+import { isObjectLike, consoleSandbox } from '@sentry/core';
 import { captureException } from '@sentry/svelte';
 import type { HandleClientError } from '@sveltejs/kit';
 
@@ -58,7 +58,7 @@ function is4xxError(input: SafeHandleServerErrorInput): boolean {
   // SvelteKit __data.json requests return HTTP 200 with errors embedded in JSON,
   // so get_status() may resolve to 500 for a deserialized plain error object.
   // Fall back to checking input.error.status directly.
-  const errorStatus = isObject(input.error) ? (input.error as Record<string, unknown>)['status'] : undefined;
+  const errorStatus = isObjectLike(input.error) ? (input.error as Record<string, unknown>)['status'] : undefined;
 
   return typeof errorStatus === 'number' && errorStatus >= 400 && errorStatus < 500;
 }

--- a/packages/sveltekit/src/common/utils.ts
+++ b/packages/sveltekit/src/common/utils.ts
@@ -1,5 +1,5 @@
 import type { HttpError, Redirect } from '@sveltejs/kit';
-import { isObject } from '@sentry/core';
+import { isObjectLike } from '@sentry/core';
 
 export const WRAPPED_MODULE_SUFFIX = '?sentry-auto-wrap';
 
@@ -62,5 +62,5 @@ export function isRedirect(error: unknown): error is Redirect {
  * Determines if a thrown "error" is a HttpError
  */
 export function isHttpError(err: unknown): err is HttpError {
-  return isObject(err) && 'status' in err && 'body' in err;
+  return isObjectLike(err) && 'status' in err && 'body' in err;
 }

--- a/packages/sveltekit/src/common/utils.ts
+++ b/packages/sveltekit/src/common/utils.ts
@@ -1,4 +1,5 @@
 import type { HttpError, Redirect } from '@sveltejs/kit';
+import { isObject } from '@sentry/core';
 
 export const WRAPPED_MODULE_SUFFIX = '?sentry-auto-wrap';
 
@@ -61,5 +62,5 @@ export function isRedirect(error: unknown): error is Redirect {
  * Determines if a thrown "error" is a HttpError
  */
 export function isHttpError(err: unknown): err is HttpError {
-  return typeof err === 'object' && err !== null && 'status' in err && 'body' in err;
+  return isObject(err) && 'status' in err && 'body' in err;
 }

--- a/packages/tanstackstart-react/src/server/middleware.ts
+++ b/packages/tanstackstart-react/src/server/middleware.ts
@@ -1,4 +1,4 @@
-import { addNonEnumerableProperty } from '@sentry/core';
+import { isObject, addNonEnumerableProperty } from '@sentry/core';
 import type { Span } from '@sentry/node';
 import { getActiveSpan, startSpanManual, withActiveSpan } from '@sentry/node';
 import type { MiddlewareWrapperOptions, TanStackMiddlewareBase } from '../common/types';
@@ -60,7 +60,7 @@ function wrapMiddlewareWithSentry<T extends TanStackMiddlewareBase>(
           // The server function receives { next, context, request } as first argument
           // Users call next() inside their middleware to move down the middleware chain. We proxy next() to end the span when it is called.
           const middlewareArgs = argsServer[0] as { next?: (...args: unknown[]) => unknown } | undefined;
-          if (middlewareArgs && typeof middlewareArgs === 'object' && typeof middlewareArgs.next === 'function') {
+          if (isObject(middlewareArgs) && typeof middlewareArgs.next === 'function') {
             middlewareArgs.next = getNextProxy(middlewareArgs.next, span, prevSpan, nextState);
           }
 

--- a/packages/tanstackstart-react/src/server/middleware.ts
+++ b/packages/tanstackstart-react/src/server/middleware.ts
@@ -1,4 +1,4 @@
-import { isObject, addNonEnumerableProperty } from '@sentry/core';
+import { isObjectLike, addNonEnumerableProperty } from '@sentry/core';
 import type { Span } from '@sentry/node';
 import { getActiveSpan, startSpanManual, withActiveSpan } from '@sentry/node';
 import type { MiddlewareWrapperOptions, TanStackMiddlewareBase } from '../common/types';
@@ -60,7 +60,7 @@ function wrapMiddlewareWithSentry<T extends TanStackMiddlewareBase>(
           // The server function receives { next, context, request } as first argument
           // Users call next() inside their middleware to move down the middleware chain. We proxy next() to end the span when it is called.
           const middlewareArgs = argsServer[0] as { next?: (...args: unknown[]) => unknown } | undefined;
-          if (isObject(middlewareArgs) && typeof middlewareArgs.next === 'function') {
+          if (isObjectLike(middlewareArgs) && typeof middlewareArgs.next === 'function') {
             middlewareArgs.next = getNextProxy(middlewareArgs.next, span, prevSpan, nextState);
           }
 


### PR DESCRIPTION
Adds an `isObjectLike` type guard to `@sentry/core` (`typeof x === 'object' && x !== null`) and routes the duplicated and inline non-null-object checks across the SDK through it.

Named `isObjectLike` rather than `isObject` on purpose. This guard only rules out null, primitives, and functions (arrays and class instances pass). I took a look at some examples in the ecosystem and GraphQL and Lodash do use this name for this exact type of check, so I'm sticking with that.