### PR TITLE
feat(core): add stringify helper and make AI-tracing serializers safe

### DIFF
--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -322,7 +322,7 @@ export {
   stackParserFromStackParserOptions,
   stripSentryFramesAndReverse,
 } from './utils/stacktrace';
-export { isMatchingPattern, safeJoin, snipLine, stringMatchesSomePattern, truncate } from './utils/string';
+export { isMatchingPattern, safeJoin, stringify, snipLine, stringMatchesSomePattern, truncate } from './utils/string';
 export {
   isNativeFunction,
   supportsDOMException,

--- a/packages/core/src/tracing/ai/utils.ts
+++ b/packages/core/src/tracing/ai/utils.ts
@@ -192,20 +192,9 @@ export function endStreamSpan(span: Span, state: StreamResponseState, recordOutp
 }
 
 /**
- * Serialize a value to a JSON string without truncation.
- * Strings are returned as-is, arrays and objects are JSON-stringified.
- */
-export function getJsonString<T>(value: T | T[]): string {
-  if (typeof value === 'string') {
-    return value;
-  }
-  return JSON.stringify(value);
-}
-
-/**
- * Get the truncated JSON string for a string or array of strings.
+ * Get the truncated JSON string for a string, an array of messages, or an object.
  *
- * @param value - The string or array of strings to truncate
+ * @param value - The value to truncate and serialize
  * @returns The truncated JSON string
  */
 export function getTruncatedJsonString<T>(value: T | T[]): string {
@@ -213,13 +202,13 @@ export function getTruncatedJsonString<T>(value: T | T[]): string {
     // Some values are already JSON strings, so we don't need to duplicate the JSON parsing
     return truncateGenAiStringInput(value);
   }
-  if (Array.isArray(value)) {
-    // truncateGenAiMessages returns an array of strings, so we need to stringify it
-    const truncatedMessages = truncateGenAiMessages(value);
-    return JSON.stringify(truncatedMessages);
+  // Both truncation (media stripping recurses the value) and `JSON.stringify` can throw on
+  // circular refs or non-serializable values (e.g. BigInt); never let that crash instrumentation.
+  try {
+    return JSON.stringify(Array.isArray(value) ? truncateGenAiMessages(value) : value);
+  } catch {
+    return '[unserializable]';
   }
-  // value is an object, so we need to stringify it
-  return JSON.stringify(value);
 }
 
 /**

--- a/packages/core/src/tracing/anthropic-ai/utils.ts
+++ b/packages/core/src/tracing/anthropic-ai/utils.ts
@@ -7,7 +7,8 @@ import {
   GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE,
   GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
-import { extractSystemInstructions, getJsonString, getTruncatedJsonString } from '../ai/utils';
+import { extractSystemInstructions, getTruncatedJsonString } from '../ai/utils';
+import { stringify } from '../../utils/string';
 import type { AnthropicAiResponse } from './types';
 
 /**
@@ -31,7 +32,7 @@ export function setMessagesAttribute(span: Span, messages: unknown, enableTrunca
   span.setAttributes({
     [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: enableTruncation
       ? getTruncatedJsonString(filteredMessages)
-      : getJsonString(filteredMessages),
+      : stringify(filteredMessages),
     [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: filteredLength,
   });
 }

--- a/packages/core/src/tracing/google-genai/index.ts
+++ b/packages/core/src/tracing/google-genai/index.ts
@@ -28,10 +28,10 @@ import {
   GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
 import type { InstrumentedMethodEntry } from '../ai/utils';
+import { stringify } from '../../utils/string';
 import {
   buildMethodPath,
   extractSystemInstructions,
-  getJsonString,
   getTruncatedJsonString,
   resolveAIRecordingOptions,
   shouldEnableTruncation,
@@ -197,7 +197,7 @@ export function addPrivateRequestAttributes(
       [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: filteredLength,
       [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: enableTruncation
         ? getTruncatedJsonString(filteredMessages)
-        : getJsonString(filteredMessages),
+        : stringify(filteredMessages),
     });
   }
 }

--- a/packages/core/src/tracing/langchain/utils.ts
+++ b/packages/core/src/tracing/langchain/utils.ts
@@ -1,5 +1,6 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import type { SpanAttributeValue } from '../../types/span';
+import { stringify } from '../../utils/string';
 import {
   GEN_AI_AGENT_NAME_ATTRIBUTE,
   GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
@@ -27,7 +28,7 @@ import {
   GEN_AI_USAGE_TOTAL_TOKENS_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
 import { isContentMedia, stripInlineMediaFromSingleMessage } from '../ai/mediaStripping';
-import { extractSystemInstructions, getJsonString, getTruncatedJsonString } from '../ai/utils';
+import { extractSystemInstructions, getTruncatedJsonString } from '../ai/utils';
 import { LANGCHAIN_ORIGIN, ROLE_MAP } from './constants';
 import type { LangChainLLMResult, LangChainMessage, LangChainSerialized } from './types';
 
@@ -51,19 +52,6 @@ const setNumberIfDefined = (target: Record<string, SpanAttributeValue>, key: str
 };
 
 /**
- * Converts a value to a string. Avoids double-quoted JSON strings where a plain
- * string is desired, but still handles objects/arrays safely.
- */
-function asString(v: unknown): string {
-  if (typeof v === 'string') return v;
-  try {
-    return JSON.stringify(v);
-  } catch {
-    return String(v);
-  }
-}
-
-/**
  * Converts message content to a string, stripping inline media (base64 images, audio, etc.)
  * from multimodal content before stringification so downstream media stripping can't miss it.
  *
@@ -78,7 +66,7 @@ function asString(v: unknown): string {
  * ])
  * // => '[{"type":"text","text":"What color?"},{"type":"image_url","image_url":{"url":"[Blob substitute]"}}]'
  *
- * // Without this, asString() would JSON.stringify the raw array and the base64 blob
+ * // Without this, stringification would JSON.stringify the raw array and the base64 blob
  * // would end up in span attributes, since downstream stripping only works on objects.
  */
 function normalizeContent(v: unknown): string {
@@ -92,7 +80,7 @@ function normalizeContent(v: unknown): string {
       return String(v);
     }
   }
-  return asString(v);
+  return stringify(v, String);
 }
 
 /**
@@ -264,9 +252,9 @@ function baseRequestAttributes(
   langSmithMetadata?: Record<string, unknown>,
 ): Record<string, SpanAttributeValue> {
   return {
-    [GEN_AI_SYSTEM_ATTRIBUTE]: asString(system ?? 'langchain'),
+    [GEN_AI_SYSTEM_ATTRIBUTE]: stringify(system ?? 'langchain', String),
     [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
-    [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: asString(modelName),
+    [GEN_AI_REQUEST_MODEL_ATTRIBUTE]: stringify(modelName, String),
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: LANGCHAIN_ORIGIN,
     ...extractCommonRequestAttributes(serialized, invocationParams, langSmithMetadata),
   };
@@ -299,7 +287,7 @@ export function extractLLMRequestAttributes(
     setIfDefined(
       attrs,
       GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
-      enableTruncation ? getTruncatedJsonString(messages) : getJsonString(messages),
+      enableTruncation ? getTruncatedJsonString(messages) : stringify(messages),
     );
   }
 
@@ -343,7 +331,7 @@ export function extractChatModelRequestAttributes(
     setIfDefined(
       attrs,
       GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
-      enableTruncation ? getTruncatedJsonString(filteredMessages) : getJsonString(filteredMessages),
+      enableTruncation ? getTruncatedJsonString(filteredMessages) : stringify(filteredMessages),
     );
   }
 
@@ -378,7 +366,7 @@ function addToolCallsAttributes(generations: LangChainMessage[][], attrs: Record
   }
 
   if (toolCalls.length > 0) {
-    setIfDefined(attrs, GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE, asString(toolCalls));
+    setIfDefined(attrs, GEN_AI_RESPONSE_TOOL_CALLS_ATTRIBUTE, stringify(toolCalls, String));
   }
 }
 
@@ -466,7 +454,7 @@ export function extractLlmResponseAttributes(
       .filter((r): r is string => typeof r === 'string');
 
     if (finishReasons.length > 0) {
-      setIfDefined(attrs, GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE, asString(finishReasons));
+      setIfDefined(attrs, GEN_AI_RESPONSE_FINISH_REASONS_ATTRIBUTE, stringify(finishReasons, String));
     }
 
     // Tool calls metadata (names, IDs) are not PII, so capture them regardless of recordOutputs
@@ -479,7 +467,7 @@ export function extractLlmResponseAttributes(
         .filter(t => typeof t === 'string');
 
       if (texts.length > 0) {
-        setIfDefined(attrs, GEN_AI_RESPONSE_TEXT_ATTRIBUTE, asString(texts));
+        setIfDefined(attrs, GEN_AI_RESPONSE_TEXT_ATTRIBUTE, stringify(texts, String));
       }
     }
   }
@@ -506,7 +494,7 @@ export function extractLlmResponseAttributes(
   // Stop reason: v1 stores this in message.response_metadata.finish_reason
   const stopReason = llmOutput?.stop_reason ?? v1Message?.response_metadata?.finish_reason;
   if (stopReason) {
-    setIfDefined(attrs, GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE, asString(stopReason));
+    setIfDefined(attrs, GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE, stringify(stopReason, String));
   }
 
   return attrs;

--- a/packages/core/src/tracing/langchain/utils.ts
+++ b/packages/core/src/tracing/langchain/utils.ts
@@ -38,7 +38,7 @@ import type { LangChainLLMResult, LangChainMessage, LangChainSerialized } from '
  * We keep this tiny helper because call sites are repetitive and easy to miswrite.
  * It also preserves falsy-but-valid values like `0` and `""`.
  */
-const setIfDefined = (target: Record<string, SpanAttributeValue>, key: string, value: unknown): void => {
+const setIfDefined = (target: Record<string, SpanAttributeValue | undefined>, key: string, value: unknown): void => {
   if (value != null) target[key] = value as SpanAttributeValue;
 };
 
@@ -46,7 +46,11 @@ const setIfDefined = (target: Record<string, SpanAttributeValue>, key: string, v
  * Like `setIfDefined`, but converts the value with `Number()` and skips only when the
  * result is `NaN`. This ensures numeric 0 makes it through (unlike truthy checks).
  */
-const setNumberIfDefined = (target: Record<string, SpanAttributeValue>, key: string, value: unknown): void => {
+const setNumberIfDefined = (
+  target: Record<string, SpanAttributeValue | undefined>,
+  key: string,
+  value: unknown,
+): void => {
   const n = Number(value);
   if (!Number.isNaN(n)) target[key] = n;
 };
@@ -69,7 +73,7 @@ const setNumberIfDefined = (target: Record<string, SpanAttributeValue>, key: str
  * // Without this, stringification would JSON.stringify the raw array and the base64 blob
  * // would end up in span attributes, since downstream stripping only works on objects.
  */
-function normalizeContent(v: unknown): string {
+function normalizeContent(v: unknown): string | undefined {
   if (Array.isArray(v)) {
     try {
       const stripped = v.map(part =>
@@ -136,7 +140,9 @@ export function getInvocationParams(tags?: string[] | Record<string, unknown>): 
  * @param messages Mixed LangChain messages
  * @returns Array of normalized `{ role, content }`
  */
-export function normalizeLangChainMessages(messages: LangChainMessage[]): Array<{ role: string; content: string }> {
+export function normalizeLangChainMessages(
+  messages: LangChainMessage[],
+): Array<{ role: string; content: string | undefined }> {
   return messages.map(message => {
     // 1) Prefer _getType() when present
     const maybeGetType = (message as { _getType?: () => string })._getType;
@@ -250,7 +256,7 @@ function baseRequestAttributes(
   serialized: LangChainSerialized,
   invocationParams?: Record<string, unknown>,
   langSmithMetadata?: Record<string, unknown>,
-): Record<string, SpanAttributeValue> {
+): Record<string, SpanAttributeValue | undefined> {
   return {
     [GEN_AI_SYSTEM_ATTRIBUTE]: stringify(system ?? 'langchain', String),
     [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'chat',
@@ -275,7 +281,7 @@ export function extractLLMRequestAttributes(
   enableTruncation: boolean,
   invocationParams?: Record<string, unknown>,
   langSmithMetadata?: Record<string, unknown>,
-): Record<string, SpanAttributeValue> {
+): Record<string, SpanAttributeValue | undefined> {
   const system = langSmithMetadata?.ls_provider;
   const modelName = invocationParams?.model ?? langSmithMetadata?.ls_model_name ?? 'unknown';
 
@@ -310,7 +316,7 @@ export function extractChatModelRequestAttributes(
   enableTruncation: boolean,
   invocationParams?: Record<string, unknown>,
   langSmithMetadata?: Record<string, unknown>,
-): Record<string, SpanAttributeValue> {
+): Record<string, SpanAttributeValue | undefined> {
   const system = langSmithMetadata?.ls_provider ?? llm.id?.[2];
   const modelName = invocationParams?.model ?? langSmithMetadata?.ls_model_name ?? 'unknown';
 

--- a/packages/core/src/tracing/langgraph/index.ts
+++ b/packages/core/src/tracing/langgraph/index.ts
@@ -15,11 +15,11 @@ import {
 } from '../ai/gen-ai-attributes';
 import {
   extractSystemInstructions,
-  getJsonString,
   getTruncatedJsonString,
   resolveAIRecordingOptions,
   shouldEnableTruncation,
 } from '../ai/utils';
+import { stringify } from '../../utils/string';
 import { createLangChainCallbackHandler } from '../langchain';
 import type { BaseChatModel, LangChainMessage } from '../langchain/types';
 import { normalizeLangChainMessages } from '../langchain/utils';
@@ -210,7 +210,7 @@ function instrumentCompiledGraphInvoke(
               span.setAttributes({
                 [GEN_AI_INPUT_MESSAGES_ATTRIBUTE]: enableTruncation
                   ? getTruncatedJsonString(filteredMessages)
-                  : getJsonString(filteredMessages),
+                  : stringify(filteredMessages),
                 [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: filteredLength,
               });
             }

--- a/packages/core/src/tracing/openai/index.ts
+++ b/packages/core/src/tracing/openai/index.ts
@@ -16,10 +16,10 @@ import {
   GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
 import type { InstrumentedMethodEntry } from '../ai/utils';
+import { stringify } from '../../utils/string';
 import {
   buildMethodPath,
   extractSystemInstructions,
-  getJsonString,
   getTruncatedJsonString,
   resolveAIRecordingOptions,
   shouldEnableTruncation,
@@ -128,7 +128,7 @@ export function addRequestAttributes(
 
   span.setAttribute(
     GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
-    enableTruncation ? getTruncatedJsonString(filteredMessages) : getJsonString(filteredMessages),
+    enableTruncation ? getTruncatedJsonString(filteredMessages) : stringify(filteredMessages),
   );
 
   if (Array.isArray(filteredMessages)) {

--- a/packages/core/src/tracing/vercel-ai/utils.ts
+++ b/packages/core/src/tracing/vercel-ai/utils.ts
@@ -10,7 +10,8 @@ import {
   GEN_AI_USAGE_INPUT_TOKENS_ATTRIBUTE,
   GEN_AI_USAGE_OUTPUT_TOKENS_ATTRIBUTE,
 } from '../ai/gen-ai-attributes';
-import { extractSystemInstructions, getJsonString, getTruncatedJsonString } from '../ai/utils';
+import { extractSystemInstructions, getTruncatedJsonString } from '../ai/utils';
+import { stringify } from '../../utils/string';
 import { toolCallSpanContextMap } from './constants';
 import type { TokenSummary, ToolCallSpanContext } from './types';
 import { AI_PROMPT_ATTRIBUTE, AI_PROMPT_MESSAGES_ATTRIBUTE } from './vercel-ai-attributes';
@@ -241,9 +242,7 @@ export function requestMessagesFromPrompt(span: Span, attributes: SpanAttributes
       }
 
       const filteredLength = Array.isArray(filteredMessages) ? filteredMessages.length : 0;
-      const messagesJson = enableTruncation
-        ? getTruncatedJsonString(filteredMessages)
-        : getJsonString(filteredMessages);
+      const messagesJson = enableTruncation ? getTruncatedJsonString(filteredMessages) : stringify(filteredMessages);
 
       span.setAttributes({
         [AI_PROMPT_ATTRIBUTE]: messagesJson,
@@ -275,7 +274,7 @@ export function requestMessagesFromPrompt(span: Span, attributes: SpanAttributes
             ? originalMessagesJson
             : enableTruncation
               ? getTruncatedJsonString(filteredMessages)
-              : getJsonString(filteredMessages);
+              : stringify(filteredMessages);
 
         span.setAttributes({
           [AI_PROMPT_MESSAGES_ATTRIBUTE]: messagesJson,

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -4,6 +4,30 @@ import { stringifyValue } from './normalize';
 export { escapeStringForRegex } from '../vendor/escapeStringForRegex';
 
 /**
+ * Coerce a value to a string without ever throwing. Strings pass through unchanged (so an
+ * already-serialized value isn't double-encoded and a plain string isn't wrapped in quotes);
+ * anything else is `JSON.stringify`-ed, falling back to `fallback` if that throws (e.g. on
+ * circular references or `BigInt`).
+ *
+ * @param value the value to stringify
+ * @param fallback returned when serialization throws, or, if a function, called with `value` to
+ *   produce the fallback. Defaults to `'[unserializable]'`.
+ */
+export function stringify(
+  value: unknown,
+  fallback: string | ((value: unknown) => string) = '[unserializable]',
+): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return typeof fallback === 'function' ? fallback(value) : fallback;
+  }
+}
+
+/**
  * Truncates given string to the maximum characters count
  *
  * @param str An object that contains serializable values

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -7,7 +7,8 @@ export { escapeStringForRegex } from '../vendor/escapeStringForRegex';
  * Coerce a value to a string without ever throwing. Strings pass through unchanged (so an
  * already-serialized value isn't double-encoded and a plain string isn't wrapped in quotes);
  * anything else is `JSON.stringify`-ed, falling back to `fallback` if that throws (e.g. on
- * circular references or `BigInt`).
+ * circular references or `BigInt`). Returns `undefined` for values `JSON.stringify` itself drops
+ * (top-level `undefined`, functions, symbols), matching `JSON.stringify`'s own runtime behavior.
  *
  * @param value the value to stringify
  * @param fallback returned when serialization throws, or, if a function, called with `value` to
@@ -16,7 +17,7 @@ export { escapeStringForRegex } from '../vendor/escapeStringForRegex';
 export function stringify(
   value: unknown,
   fallback: string | ((value: unknown) => string) = '[unserializable]',
-): string {
+): string | undefined {
   if (typeof value === 'string') {
     return value;
   }

--- a/packages/core/test/lib/tracing/ai-message-truncation.test.ts
+++ b/packages/core/test/lib/tracing/ai-message-truncation.test.ts
@@ -618,7 +618,7 @@ describe('getTruncatedJsonString', () => {
     circular.self = circular;
 
     expect(getTruncatedJsonString(circular)).toBe('[unserializable]');
-    expect(() => getTruncatedJsonString([circular])).not.toThrow();
+    expect(getTruncatedJsonString([circular])).toBe('[unserializable]');
   });
 
   it('serializes normal values as before', () => {

--- a/packages/core/test/lib/tracing/ai-message-truncation.test.ts
+++ b/packages/core/test/lib/tracing/ai-message-truncation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { truncateGenAiMessages, truncateGenAiStringInput } from '../../../src/tracing/ai/messageTruncation';
+import { getTruncatedJsonString } from '../../../src/tracing/ai/utils';
 
 describe('message truncation utilities', () => {
   describe('truncateGenAiMessages', () => {
@@ -608,5 +609,20 @@ describe('message truncation utilities', () => {
       ];
       expect(truncateGenAiMessages(messages)).toStrictEqual([]);
     });
+  });
+});
+
+describe('getTruncatedJsonString', () => {
+  it('returns a fallback instead of throwing on circular references', () => {
+    const circular: Record<string, unknown> = { role: 'user', content: 'hi' };
+    circular.self = circular;
+
+    expect(getTruncatedJsonString(circular)).toBe('[unserializable]');
+    expect(() => getTruncatedJsonString([circular])).not.toThrow();
+  });
+
+  it('serializes normal values as before', () => {
+    expect(getTruncatedJsonString('hello')).toBe('hello');
+    expect(getTruncatedJsonString({ a: 1 })).toBe('{"a":1}');
   });
 });

--- a/packages/core/test/lib/tracing/vercel-ai-request-messages.test.ts
+++ b/packages/core/test/lib/tracing/vercel-ai-request-messages.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { getJsonString, getTruncatedJsonString } from '../../../src/tracing/ai/utils';
+import { getTruncatedJsonString } from '../../../src/tracing/ai/utils';
+import { stringify } from '../../../src/utils/string';
 import {
   GEN_AI_INPUT_MESSAGES_ATTRIBUTE,
   GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE,
@@ -56,7 +57,7 @@ describe('requestMessagesFromPrompt (ai.prompt.messages string branch)', () => {
 
     expect(recorded[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE]).toBe(JSON.stringify([{ type: 'text', content: 'be nice' }]));
     // System message removed; output is the SDK's own serialization of just the remainder.
-    expect(recorded[AI_PROMPT_MESSAGES_ATTRIBUTE]).toBe(getJsonString([{ role: 'user', content: 'hello' }]));
+    expect(recorded[AI_PROMPT_MESSAGES_ATTRIBUTE]).toBe(stringify([{ role: 'user', content: 'hello' }]));
     expect(recorded[AI_PROMPT_MESSAGES_ATTRIBUTE]).not.toBe(original);
     expect(recorded[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]).toBe(1);
   });

--- a/packages/core/test/lib/utils/string.test.ts
+++ b/packages/core/test/lib/utils/string.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { setNormalizeStringifier } from '../../../src';
-import { isMatchingPattern, safeJoin, stringMatchesSomePattern, truncate } from '../../../src/utils/string';
+import { isMatchingPattern, safeJoin, stringify, stringMatchesSomePattern, truncate } from '../../../src/utils/string';
 
 describe('truncate()', () => {
   test('it works as expected', () => {
@@ -193,5 +193,37 @@ describe('safeJoin()', () => {
 
   test('supports an empty delimiter', () => {
     expect(safeJoin(['a', 'b', 'c'], '')).toEqual('abc');
+  });
+});
+
+describe('stringify()', () => {
+  test('passes strings through unchanged (no JSON quoting)', () => {
+    expect(stringify('hello')).toBe('hello');
+  });
+
+  test('JSON-stringifies non-string values', () => {
+    expect(stringify({ a: 1 })).toBe('{"a":1}');
+    expect(stringify([1, 2])).toBe('[1,2]');
+    expect(stringify(42)).toBe('42');
+    expect(stringify(null)).toBe('null');
+  });
+
+  test('returns the default fallback on circular references', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(stringify(circular)).toBe('[unserializable]');
+  });
+
+  test('returns a custom string fallback on failure', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(stringify(circular, '[oops]')).toBe('[oops]');
+  });
+
+  test('calls a function fallback with the value on failure', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(stringify(circular, () => 'from-fn')).toBe('from-fn');
+    expect(stringify(circular, String)).toBe('[object Object]');
   });
 });

--- a/packages/server-utils/src/vercel-ai/util.ts
+++ b/packages/server-utils/src/vercel-ai/util.ts
@@ -17,18 +17,6 @@ export function sum(a: number | undefined, b: number | undefined): number | unde
   return a === undefined && b === undefined ? undefined : (a ?? 0) + (b ?? 0);
 }
 
-/** Stringify a value, passing strings through and falling back to a placeholder on circular/unserializable input. */
-export function safeStringify(value: unknown): string {
-  if (typeof value === 'string') {
-    return value;
-  }
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return '[unserializable]';
-  }
-}
-
 /*
  * Streaming support for the `ai:telemetry` tracing channel.
  *

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -42,6 +42,7 @@ import {
   spanToJSON,
   spanToTraceContext,
   startInactiveSpan,
+  stringify,
   withScope,
 } from '@sentry/core';
 import type { TracingChannel } from 'node:diagnostics_channel';
@@ -50,7 +51,6 @@ import {
   asNumber,
   asString,
   isReadableStream,
-  safeStringify,
   type StreamedModelCallResult,
   sum,
   tapModelCallStream,
@@ -411,7 +411,7 @@ export function createSpanFromMessage(
       const input = type === 'embedMany' ? event.values : event.value;
       return startGenAiSpan(GEN_AI_EMBEDDINGS_OPERATION, modelId, {
         ...baseAttributes,
-        ...(recordInputs && input !== undefined ? { [GEN_AI_EMBEDDINGS_INPUT]: safeStringify(input) } : {}),
+        ...(recordInputs && input !== undefined ? { [GEN_AI_EMBEDDINGS_INPUT]: stringify(input) } : {}),
       });
     }
     case 'rerank':
@@ -477,7 +477,7 @@ function buildModelCallSpan(
     [VERCEL_AI_OPERATION_ID_ATTRIBUTE]: operationId,
     ...(recordInputs ? buildInputMessageAttributes(event, enableTruncation) : {}),
     ...(recordInputs && Array.isArray(event.tools)
-      ? { [GEN_AI_REQUEST_AVAILABLE_TOOLS]: safeStringify(event.tools) }
+      ? { [GEN_AI_REQUEST_AVAILABLE_TOOLS]: stringify(event.tools) }
       : {}),
   });
 }
@@ -497,7 +497,7 @@ function buildToolSpan(event: Record<string, unknown>, recordInputs: boolean): S
     ...(toolName ? { [GEN_AI_TOOL_NAME]: toolName } : {}),
     ...(toolCallId ? { [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: toolCallId } : {}),
     ...(description ? { [GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE]: description } : {}),
-    ...(recordInputs && toolInput !== undefined ? { [GEN_AI_TOOL_INPUT]: safeStringify(toolInput) } : {}),
+    ...(recordInputs && toolInput !== undefined ? { [GEN_AI_TOOL_INPUT]: stringify(toolInput) } : {}),
   });
 }
 
@@ -520,7 +520,7 @@ export function enrichSpanOnEnd(
 
   if (type === 'executeTool') {
     if (recordOutputs) {
-      span.setAttribute(GEN_AI_TOOL_OUTPUT, safeStringify(result.output ?? result));
+      span.setAttribute(GEN_AI_TOOL_OUTPUT, stringify(result.output ?? result));
     }
     // From V5 on, tool errors are not rejected (so the `error` channel verb never fires) — they
     // surface as `tool-error` content on the resolved result. Mirror the OTel path by marking the
@@ -555,7 +555,7 @@ export function enrichSpanOnEnd(
   // on the top-level `invoke_agent` span.
   const finishReason = getFinishReason(result);
   if (finishReason && type === 'languageModelCall') {
-    span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, safeStringify([finishReason]));
+    span.setAttribute(GEN_AI_RESPONSE_FINISH_REASONS, stringify([finishReason]));
   }
 
   const response = isObjectLike(result.response) ? result.response : undefined;
@@ -624,7 +624,7 @@ function buildOutputMessages(
   if (!parts.length) {
     return undefined;
   }
-  return safeStringify([{ role: 'assistant', parts, finish_reason: normalizeFinishReason(finishReason) }]);
+  return stringify([{ role: 'assistant', parts, finish_reason: normalizeFinishReason(finishReason) }]);
 }
 
 function toolCallPart(toolCall: Record<string, unknown>): Record<string, unknown> {
@@ -633,7 +633,7 @@ function toolCallPart(toolCall: Record<string, unknown>): Record<string, unknown
     type: 'tool_call',
     id: asString(toolCall.toolCallId),
     name: asString(toolCall.toolName),
-    arguments: typeof args === 'string' ? args : safeStringify(args ?? {}),
+    arguments: typeof args === 'string' ? args : stringify(args ?? {}),
   };
 }
 
@@ -743,14 +743,14 @@ function buildInputMessageAttributes(
   // `gen_ai.system_instructions` as `[{ type: 'text', content }]`; mirror that shape here.
   const instructions = asString(event.instructions);
   if (instructions) {
-    attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE] = safeStringify([{ type: 'text', content: instructions }]);
+    attributes[GEN_AI_SYSTEM_INSTRUCTIONS_ATTRIBUTE] = stringify([{ type: 'text', content: instructions }]);
   }
 
   // The AI SDK start events extend `StandardizedPrompt`; messages live on `messages`, otherwise the
   // simpler `prompt` field is used.
   const messages = event.messages ?? event.prompt;
   if (messages !== undefined) {
-    attributes[GEN_AI_INPUT_MESSAGES] = enableTruncation ? getTruncatedJsonString(messages) : safeStringify(messages);
+    attributes[GEN_AI_INPUT_MESSAGES] = enableTruncation ? getTruncatedJsonString(messages) : stringify(messages);
     // The original (pre-truncation) message count, so the product can show how many were dropped.
     attributes[GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE] = Array.isArray(messages) ? messages.length : 1;
   }

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -26,7 +26,7 @@ import {
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
 import { GEN_AI_EXECUTE_TOOL_SPAN_OP, GEN_AI_INVOKE_AGENT_SPAN_OP } from '@sentry/conventions/op';
-import type { Span } from '@sentry/core';
+import type { Span, SpanAttributes } from '@sentry/core';
 import {
   captureException,
   GEN_AI_CONVERSATION_ID_ATTRIBUTE,
@@ -415,10 +415,8 @@ export function createSpanFromMessage(
   }
 }
 
-type Attributes = Record<string, string | number | boolean>;
-
 /** Start a `gen_ai.<operation>` span named `<operation> <suffix>` (or just `<operation>` when no suffix). */
-function startGenAiSpan(operation: string, suffix: string | undefined, attributes: Attributes): Span {
+function startGenAiSpan(operation: string, suffix: string | undefined, attributes: SpanAttributes): Span {
   return startInactiveSpan({
     name: suffix ? `${operation} ${suffix}` : operation,
     op: `gen_ai.${operation}`,
@@ -428,7 +426,7 @@ function startGenAiSpan(operation: string, suffix: string | undefined, attribute
 
 function buildInvokeAgentSpan(
   event: Record<string, unknown>,
-  baseAttributes: Attributes,
+  baseAttributes: SpanAttributes,
   recordInputs: boolean,
   enableTruncation: boolean,
   callId: string | undefined,
@@ -455,7 +453,7 @@ function buildInvokeAgentSpan(
 
 function buildModelCallSpan(
   event: Record<string, unknown>,
-  baseAttributes: Attributes,
+  baseAttributes: SpanAttributes,
   recordInputs: boolean,
   enableTruncation: boolean,
   callId: string | undefined,
@@ -726,8 +724,8 @@ function resolveRecording(integrationOption: unknown, perCallOption: unknown, gl
 function buildInputMessageAttributes(
   event: Record<string, unknown>,
   enableTruncation: boolean,
-): Record<string, string | number> {
-  const attributes: Record<string, string | number> = {};
+): Record<string, string | number | undefined> {
+  const attributes: Record<string, string | number | undefined> = {};
 
   // `ai` >= 7 forbids system messages in `messages`/`prompt` and exposes the system prompt as a
   // separate `instructions` field. The OTel path lifts the system message out of the prompt into

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -47,14 +47,7 @@ import {
 } from '@sentry/core';
 import type { TracingChannel } from 'node:diagnostics_channel';
 import { bindTracingChannelToSpan } from '../tracing-channel';
-import {
-  asNumber,
-  asString,
-  isReadableStream,
-  type StreamedModelCallResult,
-  sum,
-  tapModelCallStream,
-} from './util';
+import { asNumber, asString, isReadableStream, type StreamedModelCallResult, sum, tapModelCallStream } from './util';
 
 /**
  * The single tracing channel the `ai` package (>= 7) publishes all telemetry lifecycle events to
@@ -476,9 +469,7 @@ function buildModelCallSpan(
     ...baseAttributes,
     [VERCEL_AI_OPERATION_ID_ATTRIBUTE]: operationId,
     ...(recordInputs ? buildInputMessageAttributes(event, enableTruncation) : {}),
-    ...(recordInputs && Array.isArray(event.tools)
-      ? { [GEN_AI_REQUEST_AVAILABLE_TOOLS]: stringify(event.tools) }
-      : {}),
+    ...(recordInputs && Array.isArray(event.tools) ? { [GEN_AI_REQUEST_AVAILABLE_TOOLS]: stringify(event.tools) } : {}),
   });
 }
 


### PR DESCRIPTION
Adds an exported `stringify` to `@sentry/core` and routes the SDK's "serialize a value for a span attribute" helpers through it.

We had a few possible gaps in `getJsonString` and `getTruncatedJsonString` where they throw on circular refs / `BigInt`, and every call site feeds their result straight into `span.setAttribute` with no `try/catch`. So a non-serializable value in an LLM message could throw out of the instrumentation and disrupt the wrapped call.

Regarding the naming, I decided to name it `stringify` because it neither JUST casts to strings nor it just string JSONfies. naming it as either will be confusing. I dropped the `safe` prefix because I don't think we ever want an unsafe option.

One change that needed to propagate is type accuracy. The old functions did return `undefined` but never typed it, it mostly was safe to do so because it often ended up in attributes but type accuracy here is safer.