### PR TITLE
deps(server-utils): bump @apm-js-collab/code-transformer and tracing-hooks

### DIFF
--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -94,8 +94,8 @@
   },
   "dependencies": {
     "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
-    "@apm-js-collab/code-transformer": "^0.15.0",
-    "@apm-js-collab/tracing-hooks": "^0.10.1",
+    "@apm-js-collab/code-transformer": "^0.18.0",
+    "@apm-js-collab/tracing-hooks": "^0.11.0",
     "@sentry/conventions": "^0.15.1",
     "@sentry/core": "10.65.0",
     "magic-string": "~0.30.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -426,12 +426,36 @@
     semifies "^1.0.0"
     source-map "^0.6.0"
 
-"@apm-js-collab/tracing-hooks@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.10.1.tgz#52a463f6dd03e99582a7dde9816257efabdf63b9"
-  integrity sha512-w2OWXR7FWrKqSziuE9+QclaZrStxO/8+OwbXM635s/zs0Eez1Qo3ivSPdB2WsaPY/iznKTytONPx/PitD7IXcA==
+"@apm-js-collab/code-transformer@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer/-/code-transformer-0.16.0.tgz#f49f3f88839907aea86a23c0a8102ad5038b8273"
+  integrity sha512-J3YRXRsxr/d48E7iDOAyVLrqQMCGU1iHWxXPKq7EeXQTRDDJ50piOfQNqxsM7u4XogJlirXvLHIznr0T33HTKw==
   dependencies:
-    "@apm-js-collab/code-transformer" "^0.15.0"
+    "@types/estree" "^1.0.8"
+    astring "^1.9.0"
+    esquery "^1.7.0"
+    meriyah "^6.1.4"
+    semifies "^1.0.0"
+    source-map "^0.6.0"
+
+"@apm-js-collab/code-transformer@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer/-/code-transformer-0.18.0.tgz#722972c05f04bc37f4bbd5067f42ffd7a990eee9"
+  integrity sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==
+  dependencies:
+    "@types/estree" "^1.0.8"
+    astring "^1.9.0"
+    esquery "^1.7.0"
+    meriyah "^6.1.4"
+    semifies "^1.0.0"
+    source-map "^0.6.0"
+
+"@apm-js-collab/tracing-hooks@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.11.0.tgz#4c9c378695d65e90574893c1faba3c13b5bdbd14"
+  integrity sha512-5hWEcCGF4hcNh9lyB70p58pXn4HyUAVCad44wK6j110Ky+ivG19TfKHLB2aIDgItabCj6VPZm0DMAMNRnJDNBw==
+  dependencies:
+    "@apm-js-collab/code-transformer" "^0.16.0"
     debug "^4.4.1"
     module-details-from-path "^1.0.4"
 


### PR DESCRIPTION
Bump `@apm-js-collab/code-transformer` to ^0.18.0 and `@apm-js-collab/tracing-hooks` to ^0.11.0.
