### PR TITLE
fix(replay): Skip client reports for replay failures after stop

### DIFF
--- a/packages/replay-internal/src/util/addEvent.ts
+++ b/packages/replay-internal/src/util/addEvent.ts
@@ -81,6 +81,15 @@ async function _addEvent(
 
     return await eventBuffer.addEvent(eventAfterPossibleCallback);
   } catch (error) {
+    // If replay is no longer enabled, the buffer was torn down by `stop()`
+    // (session refresh, mutation limit, etc.), which rejects any in-flight
+    // `addEvent` with "Worker destroyed". Any error that is thrown after stopping
+    // should not result in a client report
+    if (!replay.isEnabled()) {
+      replay.handleException(error);
+      return null;
+    }
+
     const isExceeded = error && error instanceof EventBufferSizeExceededError;
     const reason = isExceeded ? 'eventBufferOverflow' : 'eventBufferError';
     const client = getClient();

--- a/packages/replay-internal/test/unit/util/addEvent.test.ts
+++ b/packages/replay-internal/test/unit/util/addEvent.test.ts
@@ -11,14 +11,26 @@ import { addEvent, shouldAddEvent } from '../../../src/util/addEvent';
 import { BASE_TIMESTAMP } from '../..';
 import { getTestEventIncremental } from '../../utils/getTestEvent';
 import { setupReplayContainer } from '../../utils/setupReplayContainer';
+import { getDefaultClientOptions, init } from '../../utils/TestClient';
+import { getCurrentScope } from '@sentry/core';
 
 describe('Unit | util | addEvent', () => {
   beforeAll(() => {
     vi.useFakeTimers();
   });
 
+  beforeEach(() => {
+    getCurrentScope().setClient(undefined);
+  });
+
   it('stops when encountering a compression error', async function () {
     vi.setSystemTime(BASE_TIMESTAMP);
+
+    const client = init(
+      getDefaultClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+      }),
+    );
 
     const replay = setupReplayContainer({
       options: {
@@ -29,6 +41,9 @@ describe('Unit | util | addEvent', () => {
     await vi.runAllTimersAsync();
     await (replay.eventBuffer as EventBufferProxy).ensureWorkerIsLoaded();
 
+    const handleExceptionSpy = vi.spyOn(replay, 'handleException');
+    const recordDroppedEventSpy = vi.spyOn(client, 'recordDroppedEvent');
+
     // @ts-expect-error Mock this private so it triggers an error
     vi.spyOn(replay.eventBuffer._compression._worker, 'postMessage').mockImplementationOnce(() => {
       return Promise.reject('test worker error');
@@ -37,6 +52,49 @@ describe('Unit | util | addEvent', () => {
     await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 10, type: 2 });
 
     expect(replay.isEnabled()).toEqual(false);
+    expect(handleExceptionSpy).toHaveBeenCalledWith('test worker error');
+    expect(recordDroppedEventSpy).toHaveBeenCalledWith('internal_sdk_error', 'replay');
+  });
+
+  it('does not surface an error when the buffer is torn down mid-add', async function () {
+    vi.setSystemTime(BASE_TIMESTAMP);
+
+    const client = init(
+      getDefaultClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+      }),
+    );
+
+    const replay = setupReplayContainer({
+      options: {
+        useCompression: true,
+      },
+    });
+
+    await vi.runAllTimersAsync();
+    await (replay.eventBuffer as EventBufferProxy).ensureWorkerIsLoaded();
+
+    const handleExceptionSpy = vi.spyOn(replay, 'handleException');
+    const recordDroppedEventSpy = vi.spyOn(client, 'recordDroppedEvent');
+
+    // Simulate the teardown race: while an `addEvent` is in-flight, a concurrent
+    // `stop()` (e.g. session refresh) disables replay and destroys the worker,
+    // rejecting the pending request with "Worker destroyed". This must be treated
+    // as benign - no dropped-event outcome, no exception, no redundant stop.
+    vi.spyOn(
+      // @ts-expect-error Access private worker to simulate the teardown race
+      replay.eventBuffer._compression._worker,
+      'postMessage',
+    ).mockImplementationOnce(async () => {
+      await replay.stop({ reason: 'sessionExpired' });
+      throw new Error('Worker destroyed');
+    });
+
+    await addEvent(replay, getTestEventIncremental({ timestamp: BASE_TIMESTAMP + 10 }));
+
+    expect(replay.isEnabled()).toEqual(false);
+    expect(handleExceptionSpy).toHaveBeenCalledWith(new Error('Worker destroyed'));
+    expect(recordDroppedEventSpy).not.toHaveBeenCalled();
   });
 
   it('stops when exceeding buffer size limit', async function () {


### PR DESCRIPTION
While looking into https://github.com/getsentry/sentry-javascript/issues/22169, I noticed a problem with when/how we capture `internal_sdk_error` client reports for replays:

When a replay stops naturally for whatever reason (e.g. session expired, ...), the buffer worker is destroyed.
If any pending things happen to be in the buffer at this point, when they flush to the main process they will trigger `_addEvent` with an error (e.g. `Worker destroyed`). This would be recorded as a client report with `internal_sdk_error`. However, at this point replay was already stopped naturally and no client reports should be recorded for it. To make matters worse, this could lead to multiple client reports being sent at the same time (e.g. if many events are pending at the same time). This can lead to highly skewed replay outcomes.

This PR fixes this by skipping outcome generation if the replay is already stopped at this time. I am not 100% sure if this is the only problem in the linked issue but it likely is. There may be other problems with how they start/handle sessions, but that may or may not be an actual problem and is likely separate from this.

Closes https://github.com/getsentry/sentry-javascript/issues/22169