### PR TITLE
fix(nextjs): Remove orchestrion webpack plugin lazy loading

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -433,7 +433,7 @@ export function constructWebpackConfigFunction({
 
     // Orchestrion code-transform loader — Node server runtime only, never the edge compilation
     if (runtime === 'server' && userSentryOptions._experimental?.useDiagnosticsChannelInjection) {
-      newConfig.plugins.push(sentryOrchestrionWebpackPlugin() as WebpackPluginInstance);
+      newConfig.plugins.push(sentryOrchestrionWebpackPlugin() as unknown as WebpackPluginInstance);
     }
 
     return newConfig;

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -39,12 +39,11 @@
     },
     "./orchestrion/vite": {
       "types": "./build/types/orchestrion/bundler/vite.d.ts",
-      "import": "./build/esm/orchestrion/bundler/vite.js"
+      "default": "./build/esm/orchestrion/bundler/vite.js"
     },
     "./orchestrion/webpack": {
       "types": "./build/types/orchestrion/bundler/webpack.d.ts",
-      "import": "./build/esm/orchestrion/bundler/webpack.js",
-      "require": "./build/cjs/orchestrion/bundler/webpack.js"
+      "default": "./build/esm/orchestrion/bundler/webpack.js"
     },
     "./orchestrion/import-hook": {
       "import": "./build/orchestrion/import-hook.mjs"

--- a/packages/server-utils/src/orchestrion/bundler/webpack.ts
+++ b/packages/server-utils/src/orchestrion/bundler/webpack.ts
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
 import { SENTRY_INSTRUMENTATIONS } from '../config';
+import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/vite';
 
 // Both branches use `createRequire` (never alias the CJS `require`) so bundlers consuming this
 // module don't emit a "Critical dependency" warning.
@@ -46,10 +47,6 @@ export function getSentryInstrumentations(): InstrumentationConfig[] {
  * does NOT inject the `__SENTRY_ORCHESTRION__.bundler` marker — that would disable the runtime
  * module hook, which externalized packages still need (hybrid setup).
  */
-export function sentryOrchestrionWebpackPlugin(): unknown {
-  const mod = getOrchestrionRequire()('@apm-js-collab/code-transformer-bundler-plugins/webpack') as {
-    default?: (options: { instrumentations: InstrumentationConfig[] }) => unknown;
-  };
-  const codeTransformerWebpack = mod.default ?? (mod as unknown as NonNullable<typeof mod.default>);
-  return codeTransformerWebpack({ instrumentations: SENTRY_INSTRUMENTATIONS });
+export function sentryOrchestrionWebpackPlugin(): ReturnType<typeof codeTransformer> {
+  return codeTransformer({ instrumentations: SENTRY_INSTRUMENTATIONS });
 }

--- a/packages/server-utils/src/orchestrion/bundler/webpack.ts
+++ b/packages/server-utils/src/orchestrion/bundler/webpack.ts
@@ -5,7 +5,7 @@ import { createRequire } from 'node:module';
 import { dirname } from 'node:path';
 import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
 import { SENTRY_INSTRUMENTATIONS } from '../config';
-import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/vite';
+import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/webpack';
 
 // Both branches use `createRequire` (never alias the CJS `require`) so bundlers consuming this
 // module don't emit a "Critical dependency" warning.


### PR DESCRIPTION
Since the orchestrion feature is tergetting v11, our minimum supported Node version will be v20.19 and therefore all supported versions will support `require(esm)`. For that reason I've changed the default export to be ESM. This works around the ESM interop issues and we no longer need to load the library lazily.