### PR TITLE
chore: stub modules for orchestrion configs, channels

### DIFF
--- a/packages/server-utils/src/orchestrion/channels.ts
+++ b/packages/server-utils/src/orchestrion/channels.ts
@@ -1,18 +1,31 @@
-import { mysqlChannels } from './config/mysql';
-import { lruMemoizerChannels } from './config/lru-memoizer';
+import { amqplibChannels } from './config/amqplib';
+import { anthropicAiChannels } from './config/anthropic-ai';
+import { dataloaderChannels } from './config/dataloader';
+import { expressChannels } from './config/express';
+import { firebaseChannels } from './config/firebase';
+import { genericPoolChannels } from './config/generic-pool';
+import { googleGenAiChannels } from './config/google-genai';
+import { graphqlChannels } from './config/graphql';
+import { hapiChannels } from './config/hapi';
 import { ioredisChannels } from './config/ioredis';
+import { kafkajsChannels } from './config/kafkajs';
+import { knexChannels } from './config/knex';
+import { langchainChannels } from './config/langchain';
+import { langgraphChannels } from './config/langgraph';
+import { lruMemoizerChannels } from './config/lru-memoizer';
+import { mongodbChannels } from './config/mongodb';
+import { mongooseChannels } from './config/mongoose';
+import { mysqlChannels } from './config/mysql';
+import { mysql2Channels } from './config/mysql2';
+import { openaiChannels } from './config/openai';
 import { pgChannels } from './config/pg';
 import { postgresJsChannels } from './config/postgres';
-import { openaiChannels } from './config/openai';
-import { anthropicAiChannels } from './config/anthropic-ai';
-import { googleGenAiChannels } from './config/google-genai';
-import { vercelAiChannels } from './config/vercel-ai';
-import { amqplibChannels } from './config/amqplib';
-import { hapiChannels } from './config/hapi';
+import { prismaChannels } from './config/prisma';
+import { reactRouterChannels } from './config/react-router';
 import { redisChannels } from './config/redis';
-import { expressChannels } from './config/express';
-import { graphqlChannels } from './config/graphql';
-import { kafkajsChannels } from './config/kafkajs';
+import { remixChannels } from './config/remix';
+import { tediousChannels } from './config/tedious';
+import { vercelAiChannels } from './config/vercel-ai';
 
 /**
  * Fully-qualified `diagnostics_channel` names that orchestrion publishes to.
@@ -26,23 +39,39 @@ import { kafkajsChannels } from './config/kafkajs';
  * prefixed string from this map; the config files set only the unprefixed
  * suffix in `channelName`. Keeping both pieces in one file is what guarantees
  * they don't drift apart and silently stop firing.
+ *
+ * Kept sorted alphabetically by module so concurrent additions insert at different
+ * points rather than all appending to the end (fewer merge conflicts).
  */
 export const CHANNELS = {
-  ...mysqlChannels,
-  ...lruMemoizerChannels,
+  ...amqplibChannels,
+  ...anthropicAiChannels,
+  ...dataloaderChannels,
+  ...expressChannels,
+  ...firebaseChannels,
+  ...genericPoolChannels,
+  ...googleGenAiChannels,
+  ...graphqlChannels,
+  ...hapiChannels,
   ...ioredisChannels,
+  ...kafkajsChannels,
+  ...knexChannels,
+  ...langchainChannels,
+  ...langgraphChannels,
+  ...lruMemoizerChannels,
+  ...mongodbChannels,
+  ...mongooseChannels,
+  ...mysqlChannels,
+  ...mysql2Channels,
+  ...openaiChannels,
   ...pgChannels,
   ...postgresJsChannels,
-  ...openaiChannels,
-  ...anthropicAiChannels,
-  ...googleGenAiChannels,
-  ...vercelAiChannels,
-  ...amqplibChannels,
-  ...hapiChannels,
+  ...prismaChannels,
+  ...reactRouterChannels,
   ...redisChannels,
-  ...expressChannels,
-  ...graphqlChannels,
-  ...kafkajsChannels,
+  ...remixChannels,
+  ...tediousChannels,
+  ...vercelAiChannels,
 } as const;
 
 export type ChannelName = (typeof CHANNELS)[keyof typeof CHANNELS];

--- a/packages/server-utils/src/orchestrion/config/dataloader.ts
+++ b/packages/server-utils/src/orchestrion/config/dataloader.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `dataloader` orchestrion integration (ports `@opentelemetry/instrumentation-dataloader`).
+export const dataloaderConfig: InstrumentationConfig[] = [];
+
+export const dataloaderChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/firebase.ts
+++ b/packages/server-utils/src/orchestrion/config/firebase.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `firebase` orchestrion integration (ports `FirebaseInstrumentation`).
+export const firebaseConfig: InstrumentationConfig[] = [];
+
+export const firebaseChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/generic-pool.ts
+++ b/packages/server-utils/src/orchestrion/config/generic-pool.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `generic-pool` orchestrion integration (ports `@opentelemetry/instrumentation-generic-pool`).
+export const genericPoolConfig: InstrumentationConfig[] = [];
+
+export const genericPoolChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/index.ts
+++ b/packages/server-utils/src/orchestrion/config/index.ts
@@ -1,37 +1,65 @@
 import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
 import { uniq } from '@sentry/core';
-import { mysqlConfig } from './mysql';
-import { lruMemoizerConfig } from './lru-memoizer';
+import { amqplibConfig } from './amqplib';
+import { anthropicAiConfig } from './anthropic-ai';
+import { dataloaderConfig } from './dataloader';
+import { expressConfig } from './express';
+import { firebaseConfig } from './firebase';
+import { genericPoolConfig } from './generic-pool';
+import { googleGenAiConfig } from './google-genai';
+import { graphqlConfig } from './graphql';
+import { hapiConfig } from './hapi';
 import { ioredisConfig } from './ioredis';
+import { kafkajsConfig } from './kafkajs';
+import { knexConfig } from './knex';
+import { langchainConfig } from './langchain';
+import { langgraphConfig } from './langgraph';
+import { lruMemoizerConfig } from './lru-memoizer';
+import { mongodbConfig } from './mongodb';
+import { mongooseConfig } from './mongoose';
+import { mysqlConfig } from './mysql';
+import { mysql2Config } from './mysql2';
 import { openaiConfig } from './openai';
 import { pgConfig } from './pg';
 import { postgresJsConfig } from './postgres';
-import { anthropicAiConfig } from './anthropic-ai';
-import { googleGenAiConfig } from './google-genai';
-import { vercelAiConfig } from './vercel-ai';
-import { amqplibConfig } from './amqplib';
-import { hapiConfig } from './hapi';
+import { prismaConfig } from './prisma';
+import { reactRouterConfig } from './react-router';
 import { redisConfig } from './redis';
-import { expressConfig } from './express';
-import { graphqlConfig } from './graphql';
-import { kafkajsConfig } from './kafkajs';
+import { remixConfig } from './remix';
+import { tediousConfig } from './tedious';
+import { vercelAiConfig } from './vercel-ai';
 
+// Kept sorted alphabetically by module so concurrent additions insert at different
+// points rather than all appending to the end (fewer merge conflicts).
 export const SENTRY_INSTRUMENTATIONS: InstrumentationConfig[] = [
-  ...mysqlConfig,
-  ...lruMemoizerConfig,
+  ...amqplibConfig,
+  ...anthropicAiConfig,
+  ...dataloaderConfig,
+  ...expressConfig,
+  ...firebaseConfig,
+  ...genericPoolConfig,
+  ...googleGenAiConfig,
+  ...graphqlConfig,
+  ...hapiConfig,
   ...ioredisConfig,
+  ...kafkajsConfig,
+  ...knexConfig,
+  ...langchainConfig,
+  ...langgraphConfig,
+  ...lruMemoizerConfig,
+  ...mongodbConfig,
+  ...mongooseConfig,
+  ...mysqlConfig,
+  ...mysql2Config,
   ...openaiConfig,
   ...pgConfig,
   ...postgresJsConfig,
-  ...anthropicAiConfig,
-  ...googleGenAiConfig,
-  ...vercelAiConfig,
-  ...hapiConfig,
-  ...amqplibConfig,
+  ...prismaConfig,
+  ...reactRouterConfig,
   ...redisConfig,
-  ...expressConfig,
-  ...graphqlConfig,
-  ...kafkajsConfig,
+  ...remixConfig,
+  ...tediousConfig,
+  ...vercelAiConfig,
 ];
 
 /**

--- a/packages/server-utils/src/orchestrion/config/knex.ts
+++ b/packages/server-utils/src/orchestrion/config/knex.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `knex` orchestrion integration (ports `@opentelemetry/instrumentation-knex`).
+export const knexConfig: InstrumentationConfig[] = [];
+
+export const knexChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/langchain.ts
+++ b/packages/server-utils/src/orchestrion/config/langchain.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `langchain` orchestrion integration (ports `SentryLangChainInstrumentation`).
+export const langchainConfig: InstrumentationConfig[] = [];
+
+export const langchainChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/langgraph.ts
+++ b/packages/server-utils/src/orchestrion/config/langgraph.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `langgraph` orchestrion integration (ports `SentryLangGraphInstrumentation`).
+export const langgraphConfig: InstrumentationConfig[] = [];
+
+export const langgraphChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/mongodb.ts
+++ b/packages/server-utils/src/orchestrion/config/mongodb.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `mongodb` orchestrion integration (ports `@opentelemetry/instrumentation-mongodb`).
+export const mongodbConfig: InstrumentationConfig[] = [];
+
+export const mongodbChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/mongoose.ts
+++ b/packages/server-utils/src/orchestrion/config/mongoose.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `mongoose` orchestrion integration (ports `@opentelemetry/instrumentation-mongoose`).
+export const mongooseConfig: InstrumentationConfig[] = [];
+
+export const mongooseChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/mysql2.ts
+++ b/packages/server-utils/src/orchestrion/config/mysql2.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `mysql2` orchestrion integration (ports `@opentelemetry/instrumentation-mysql2`).
+export const mysql2Config: InstrumentationConfig[] = [];
+
+export const mysql2Channels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/prisma.ts
+++ b/packages/server-utils/src/orchestrion/config/prisma.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `prisma` orchestrion integration (ports `@prisma/instrumentation`).
+export const prismaConfig: InstrumentationConfig[] = [];
+
+export const prismaChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/react-router.ts
+++ b/packages/server-utils/src/orchestrion/config/react-router.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `react-router` orchestrion integration (ports `ReactRouterInstrumentation`).
+export const reactRouterConfig: InstrumentationConfig[] = [];
+
+export const reactRouterChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/remix.ts
+++ b/packages/server-utils/src/orchestrion/config/remix.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `remix` orchestrion integration (ports `RemixInstrumentation`).
+export const remixConfig: InstrumentationConfig[] = [];
+
+export const remixChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/tedious.ts
+++ b/packages/server-utils/src/orchestrion/config/tedious.ts
@@ -1,0 +1,6 @@
+import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
+
+// TODO: Stub for the `tedious` orchestrion integration (ports `@opentelemetry/instrumentation-tedious`).
+export const tediousConfig: InstrumentationConfig[] = [];
+
+export const tediousChannels = {} as const;


### PR DESCRIPTION
As several of us focus on porting integrations to orchestrion, each new addition to the barrel file causes conflicts in all pending PRs.

Stub out the remaining TODO instrumentations, and sort them alphabetically, to reduce the incidence of conflicts and allow us to more swiftly get these all landed.

Koa, NestJS, and AWS are intentionally *not* included, because PRs are already in progress to instrument those, and so they can fit themselves into the list easily enough once this lands (or this patch can be updated if those land first).
