### PR TITLE
chore(ci): Temporarily assign orchestrion reviews to whole JS SDK team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,8 @@
 # Node/server runtimes and related packages
 /packages/node/                     @getsentry/team-javascript-sdks-server
 /packages/node-core/                @getsentry/team-javascript-sdks-server
-/packages/server-utils/             @getsentry/team-javascript-sdks-server
+# TEMP: whole JS SDK team reviews orchestrion work; revert to team-javascript-sdks-server after
+/packages/server-utils/             @getsentry/team-javascript-sdks
 /packages/node-native/              @getsentry/team-javascript-sdks-server
 /packages/profiling-node/           @getsentry/team-javascript-sdks-server
 /packages/opentelemetry/            @getsentry/team-javascript-sdks-server


### PR DESCRIPTION
## What

Point `/packages/server-utils/` (where orchestrion work lives) at `@getsentry/team-javascript-sdks` instead of the server team.

- Adds a TEMP comment marking the change for revert.

## Why

The whole JS SDK team is currently working on orchestrion, so reviews shouldn't be gated on the server team alone. This is temporary and should be reverted once the work lands.