### PR TITLE
test(e2e): Add E2E test app for orchestrion instrumentations on Remix

### DIFF
--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+
+/.cache
+/build
+/public/build
+.env
+
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/entry.client.tsx
@@ -1,0 +1,27 @@
+import { RemixBrowser, useLocation, useMatches } from '@remix-run/react';
+import * as Sentry from '@sentry/remix';
+import { StrictMode, startTransition, useEffect } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+
+Sentry.init({
+  dsn: 'https://username@domain/123',
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  integrations: [
+    Sentry.browserTracingIntegration({
+      useEffect,
+      useLocation,
+      useMatches,
+    }),
+  ],
+  tracesSampleRate: 1.0,
+  tunnel: 'http://localhost:3031/', // proxy server
+});
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>,
+  );
+});

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/entry.server.tsx
@@ -1,0 +1,110 @@
+import { PassThrough } from 'node:stream';
+
+import type { AppLoadContext, EntryContext } from '@remix-run/node';
+import { createReadableStreamFromReadable } from '@remix-run/node';
+import { RemixServer } from '@remix-run/react';
+import * as Sentry from '@sentry/remix';
+import isbot from 'isbot';
+import { renderToPipeableStream } from 'react-dom/server';
+
+const ABORT_DELAY = 5_000;
+
+export const handleError = Sentry.wrapHandleErrorWithSentry(() => {});
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext,
+  _loadContext: AppLoadContext,
+) {
+  return isbot(request.headers.get('user-agent'))
+    ? handleBotRequest(request, responseStatusCode, responseHeaders, remixContext)
+    : handleBrowserRequest(request, responseStatusCode, responseHeaders, remixContext);
+}
+
+function handleBotRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext,
+) {
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer context={remixContext} url={request.url} abortDelay={ABORT_DELAY} />,
+      {
+        onAllReady() {
+          shellRendered = true;
+          const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set('Content-Type', 'text/html');
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            }),
+          );
+
+          pipe(body);
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      },
+    );
+
+    setTimeout(abort, ABORT_DELAY);
+  });
+}
+
+function handleBrowserRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext,
+) {
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer context={remixContext} url={request.url} abortDelay={ABORT_DELAY} />,
+      {
+        onShellReady() {
+          shellRendered = true;
+          const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set('Content-Type', 'text/html');
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            }),
+          );
+
+          pipe(body);
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      },
+    );
+
+    setTimeout(abort, ABORT_DELAY);
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/root.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/root.tsx
@@ -1,0 +1,34 @@
+import { Links, Meta, Outlet, Scripts, ScrollRestoration, useRouteError } from '@remix-run/react';
+import { captureRemixErrorBoundaryError, withSentry } from '@sentry/remix';
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const eventId = captureRemixErrorBoundaryError(error);
+
+  return (
+    <div>
+      <span>ErrorBoundary Error</span>
+      <span id="event-id">{eventId}</span>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}
+
+export default withSentry(App);

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/_index.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/_index.tsx
@@ -1,0 +1,3 @@
+export default function Index() {
+  return <div>home</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/db-ioredis.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/db-ioredis.tsx
@@ -1,0 +1,24 @@
+import Redis from 'ioredis';
+
+// Page route (not a loader-only resource route): so the http.server
+// transaction is renamed to the matched route (`GET db-ioredis`) and the
+// orchestrion-injected ioredis spans land on a per-route transaction.
+export async function loader() {
+  const redis = new Redis({
+    // Don't keep retrying forever if Redis goes away (e.g. on test teardown)
+    maxRetriesPerRequest: 1,
+    retryStrategy: () => null,
+  });
+
+  try {
+    await redis.set('test-key', 'test-value');
+    const value = await redis.get('test-key');
+    return { value };
+  } finally {
+    redis.disconnect();
+  }
+}
+
+export default function DbIoredis() {
+  return <div>db-ioredis</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/db-mysql.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/db-mysql.tsx
@@ -1,0 +1,20 @@
+import mysql from 'mysql';
+
+const connection = mysql.createConnection({
+  user: 'root',
+  password: 'docker',
+});
+
+export function loader() {
+  return new Promise<{ status: string }>(resolve => {
+    connection.query('SELECT 1 + 1 AS solution', () => {
+      connection.query('SELECT NOW()', ['1', '2'], () => {
+        resolve({ status: 'ok' });
+      });
+    });
+  });
+}
+
+export default function DbMysql() {
+  return <div>db-mysql</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/db-mysql.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/app/routes/db-mysql.tsx
@@ -1,18 +1,22 @@
 import mysql from 'mysql';
 
-const connection = mysql.createConnection({
-  user: 'root',
-  password: 'docker',
-});
-
-export function loader() {
-  return new Promise<{ status: string }>(resolve => {
-    connection.query('SELECT 1 + 1 AS solution', () => {
-      connection.query('SELECT NOW()', ['1', '2'], () => {
-        resolve({ status: 'ok' });
-      });
-    });
+export async function loader() {
+  const connection = mysql.createConnection({
+    user: 'root',
+    password: 'docker',
   });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      connection.query('SELECT 1 + 1 AS solution', err => (err ? reject(err) : resolve()));
+    });
+    await new Promise<void>((resolve, reject) => {
+      connection.query('SELECT NOW()', ['1', '2'], err => (err ? reject(err) : resolve()));
+    });
+    return { status: 'ok' };
+  } finally {
+    connection.end();
+  }
 }
 
 export default function DbMysql() {

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/docker-compose.yml
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  db:
+    image: mysql:8.0
+    restart: always
+    container_name: e2e-tests-remix-orchestrion-mysql
+    # The `mysql` 2.x driver doesn't speak MySQL 8's default
+    # `caching_sha2_password` auth, so force the legacy plugin.
+    command: ['--default-authentication-plugin=mysql_native_password']
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: docker
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -uroot -pdocker']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  redis:
+    image: redis:7
+    restart: always
+    container_name: e2e-tests-remix-orchestrion-redis
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/global-setup.mjs
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/global-setup.mjs
@@ -1,0 +1,24 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Boot MySQL and Redis here (rather than in the `start` script) so the cold
+// image pulls happen outside Playwright's webServer startup-timeout window.
+// `--wait` blocks until the healthchecks in docker-compose.yml pass, so the app
+// can connect immediately.
+export default async function globalSetup() {
+  // Each run copies this app to a fresh temp dir, so `docker compose` doesn't
+  // recognize a leftover container from a previous (e.g. interrupted) run as
+  // part of the same project - but the container names are fixed, so the daemon
+  // still refuses to create new ones. Force-remove any stale leftovers first.
+  for (const container of ['e2e-tests-remix-orchestrion-mysql', 'e2e-tests-remix-orchestrion-redis']) {
+    try {
+      execSync(`docker rm -f ${container}`, { stdio: 'ignore' });
+    } catch {
+      // no stale container to remove
+    }
+  }
+  execSync('docker compose up -d --wait', { cwd: __dirname, stdio: 'inherit' });
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/global-teardown.mjs
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/global-teardown.mjs
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function globalTeardown() {
+  execSync('docker compose down --volumes', {
+    cwd: __dirname,
+    stdio: 'inherit',
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/instrument.server.cjs
@@ -1,0 +1,14 @@
+const Sentry = require('@sentry/remix');
+
+// Opt into diagnostics-channel-based auto-instrumentation. This registers the
+// channel subscribers (e.g. for mysql and ioredis) that turn the
+// diagnostics-channel events - injected at build time by the orchestrion Vite
+// plugin (see vite.config.ts) - into Sentry spans. Must run before Sentry.init().
+Sentry.experimentalUseDiagnosticsChannelInjection();
+
+Sentry.init({
+  dsn: 'https://username@domain/123',
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  tracesSampleRate: 1.0,
+  tunnel: 'http://localhost:3031/', // proxy server
+});

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/package.json
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/package.json
@@ -2,6 +2,7 @@
   "name": "remix-orchestrion",
   "private": true,
   "sideEffects": false,
+  "type": "module",
   "//": "Need to use ioredis 5.10.1 because that's the last version before they support tracing channels",
   "scripts": {
     "build": "remix vite:build",

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/package.json
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "remix-orchestrion",
+  "private": true,
+  "sideEffects": false,
+  "//": "Need to use ioredis 5.10.1 because that's the last version before they support tracing channels",
+  "scripts": {
+    "build": "remix vite:build",
+    "dev": "remix vite:dev",
+    "start": "NODE_OPTIONS='--require=./instrument.server.cjs' remix-serve ./build/server/index.js",
+    "proxy": "node start-event-proxy.mjs",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm test",
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "@remix-run/node": "2.17.4",
+    "@remix-run/react": "2.17.4",
+    "@remix-run/serve": "2.17.4",
+    "@sentry/remix": "file:../../packed/sentry-remix-packed.tgz",
+    "@sentry/server-utils": "file:../../packed/sentry-server-utils-packed.tgz",
+    "ioredis": "5.10.1",
+    "isbot": "^3.6.8",
+    "mysql": "^2.18.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.58.0",
+    "@remix-run/dev": "2.17.4",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.34",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.11",
+    "vite-tsconfig-paths": "^4.2.1"
+  },
+  "resolutions": {
+    "@types/react": "18.2.22"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/playwright.config.mjs
@@ -1,0 +1,15 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+import { fileURLToPath } from 'url';
+
+const config = getPlaywrightConfig(
+  {
+    startCommand: `pnpm start`,
+  },
+  // Boot MySQL and Redis before the tests run, outside the webServer startup-timeout window.
+  {
+    globalSetup: fileURLToPath(new URL('./global-setup.mjs', import.meta.url)),
+    globalTeardown: fileURLToPath(new URL('./global-teardown.mjs', import.meta.url)),
+  },
+);
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/remix.env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/remix.env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="@remix-run/dev" />
+/// <reference types="@remix-run/node" />

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'remix-orchestrion',
+});

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/tests/build-injection.test.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/tests/build-injection.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+
+// The `db.test.ts` runtime assertions prove orchestrion spans appear, but spans alone
+// don't prove they came from the BUILD-time transform: if the Vite plugin silently
+// failed to load, the deps would stay external and the runtime `--import` hook would
+// inject the channels at runtime instead - the span tests would still pass. These
+// assertions inspect the built server bundle directly so a broken plugin can't hide
+// behind that runtime fallback.
+test.describe('orchestrion build-time injection', () => {
+  const serverBundle = readFileSync(path.join(process.cwd(), 'build/server/index.js'), 'utf8');
+
+  test('force-bundles the instrumented deps instead of externalizing them', () => {
+    // The plugin adds mysql/ioredis to `ssr.noExternal` so the transform sees their
+    // source. Without it they'd be left as bare imports (this is an ESM server build)
+    // or `require(...)` calls resolved from node_modules at runtime - untouched, with
+    // no channels injected.
+    expect(serverBundle).not.toMatch(/(from\s*["']mysql["']|require\(["']mysql["']\))/);
+    expect(serverBundle).not.toMatch(/(from\s*["']ioredis["']|require\(["']ioredis["']\))/);
+  });
+
+  test('injects the diagnostics-channel publishers into the bundled deps', () => {
+    // The transform wraps each instrumented function with a `tracingChannel("<name>")`
+    // publisher whose channel name is a string literal. The subscriber side passes the
+    // channel name as a variable, so a literal-arg match is unique to the injected
+    // publisher and proves the build-time transform ran.
+    expect(serverBundle).toMatch(/tracingChannel\(["']orchestrion:mysql:query["']\)/);
+    expect(serverBundle).toMatch(/tracingChannel\(["']orchestrion:ioredis:command["']\)/);
+    expect(serverBundle).toMatch(/tracingChannel\(["']orchestrion:ioredis:connect["']\)/);
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/tests/db.test.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/tests/db.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Instruments ioredis automatically via orchestrion', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('remix-orchestrion', transactionEvent => {
+    return (
+      transactionEvent.contexts?.trace?.op === 'http.server' && !!transactionEvent.transaction?.includes('db-ioredis')
+    );
+  });
+
+  await fetch(`${baseURL}/db-ioredis`);
+
+  const transactionEvent = await transactionEventPromise;
+
+  const spans = transactionEvent.spans || [];
+
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.redis',
+      description: 'set test-key [1 other arguments]',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'redis',
+        'db.statement': 'set test-key [1 other arguments]',
+      }),
+    }),
+  );
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.redis',
+      description: 'get test-key',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'redis',
+        'db.statement': 'get test-key',
+      }),
+    }),
+  );
+});
+
+test('Instruments mysql automatically via orchestrion', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('remix-orchestrion', transactionEvent => {
+    return (
+      transactionEvent.contexts?.trace?.op === 'http.server' && !!transactionEvent.transaction?.includes('db-mysql')
+    );
+  });
+
+  await fetch(`${baseURL}/db-mysql`);
+
+  const transactionEvent = await transactionEventPromise;
+
+  const spans = transactionEvent.spans || [];
+
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.mysql',
+      description: 'SELECT 1 + 1 AS solution',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'mysql',
+        'db.statement': 'SELECT 1 + 1 AS solution',
+        'db.user': 'root',
+        'db.connection_string': expect.any(String),
+        'net.peer.name': expect.any(String),
+        'net.peer.port': 3306,
+      }),
+    }),
+  );
+  expect(spans).toContainEqual(
+    expect.objectContaining({
+      op: 'db',
+      origin: 'auto.db.orchestrion.mysql',
+      description: 'SELECT NOW()',
+      status: 'ok',
+      data: expect.objectContaining({
+        'db.system': 'mysql',
+        'db.statement': 'SELECT NOW()',
+        'db.user': 'root',
+        'db.connection_string': expect.any(String),
+        'net.peer.name': expect.any(String),
+        'net.peer.port': 3306,
+      }),
+    }),
+  );
+});

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "include": ["remix.env.d.ts", "./app/**/*.ts", "./app/**/*.tsx"],
+  "exclude": ["node_modules", "build"],
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "target": "ES2019",
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./app/*"]
+    },
+    "types": ["@remix-run/node", "vite/client"],
+
+    // Remix takes care of building everything in `remix vite:build`.
+    "noEmit": true
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/vite.config.ts
@@ -1,0 +1,20 @@
+import { vitePlugin as remix } from '@remix-run/dev';
+import { sentryRemixVitePlugin } from '@sentry/remix';
+import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [
+    remix({
+      ignoredRouteFiles: ['**/.*'],
+      serverModuleFormat: 'cjs',
+    }),
+    sentryRemixVitePlugin(),
+    // Runs the orchestrion code transform over the SSR server bundle and
+    // force-bundles the instrumented deps (mysql, ioredis, …) so the
+    // diagnostics-channel calls are actually injected at build time.
+    sentryOrchestrionPlugin(),
+    tsconfigPaths(),
+  ],
+});

--- a/dev-packages/e2e-tests/test-applications/remix-orchestrion/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-orchestrion/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   plugins: [
     remix({
       ignoredRouteFiles: ['**/.*'],
-      serverModuleFormat: 'cjs',
     }),
     sentryRemixVitePlugin(),
     // Runs the orchestrion code transform over the SSR server bundle and


### PR DESCRIPTION
## What

Adds a Remix (v2, Vite) E2E test app that exercises orchestrion-based auto-instrumentation for `mysql` and `ioredis`.

- `vite.config.ts` wires `sentryRemixVitePlugin()` + `sentryOrchestrionPlugin()` to inject `diagnostics_channel` calls into the bundled DB drivers at build time.
- `instrument.server.cjs` opts in via `experimentalUseDiagnosticsChannelInjection()` before `Sentry.init()`, loaded through `--require`.
- Page routes `/db-mysql` and `/db-ioredis` run each driver in a loader; `tests/db.test.ts` asserts the `auto.db.orchestrion.{mysql,redis}` spans.
- `docker-compose.yml` + global setup/teardown boot MySQL 8 and Redis 7 outside the Playwright startup window.

## Why

Extends the orchestrion E2E coverage (already landed for Next.js, TanStack Start, React Router, SvelteKit, Nuxt, Astro) to Remix.

Closes: #21998