### PR TITLE
feat(nestjs): Support WebSocket errors in SentryGlobalFilter

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/app.gateway.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/app.gateway.ts
@@ -1,4 +1,4 @@
-import { SubscribeMessage, WebSocketGateway, MessageBody } from '@nestjs/websockets';
+import { MessageBody, SubscribeMessage, WebSocketGateway, WsException } from '@nestjs/websockets';
 import * as Sentry from '@sentry/nestjs';
 
 @WebSocketGateway()
@@ -6,6 +6,11 @@ export class AppGateway {
   @SubscribeMessage('test-exception')
   handleTestException() {
     throw new Error('This is an exception in a WebSocket handler');
+  }
+
+  @SubscribeMessage('test-ws-exception')
+  handleWsException() {
+    throw new WsException('Expected WebSocket exception');
   }
 
   @SubscribeMessage('test-manual-capture')

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/app.gateway.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/app.gateway.ts
@@ -1,6 +1,9 @@
+import { UseFilters } from '@nestjs/common';
 import { MessageBody, SubscribeMessage, WebSocketGateway, WsException } from '@nestjs/websockets';
 import * as Sentry from '@sentry/nestjs';
+import { SentryGlobalFilter } from '@sentry/nestjs/setup';
 
+@UseFilters(new SentryGlobalFilter())
 @WebSocketGateway()
 export class AppGateway {
   @SubscribeMessage('test-exception')

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/tests/errors.test.ts
@@ -22,16 +22,36 @@ test('Captures manually reported error in WebSocket gateway handler', async ({ b
   socket.disconnect();
 });
 
+test('Automatically captures unexpected errors in WebSocket gateway handlers', async ({ baseURL }) => {
+  const errorPromise = waitForError('nestjs-websockets', event => {
+    return event.exception?.values?.[0]?.value === 'This is an exception in a WebSocket handler';
+  });
+
+  const socket = io(baseURL!);
+  await new Promise<void>(resolve => socket.on('connect', resolve));
+
+  socket.emit('test-exception', {});
+
+  const error = await errorPromise;
+
+  expect(error.exception?.values?.[0]).toMatchObject({
+    type: 'Error',
+    value: 'This is an exception in a WebSocket handler',
+  });
+
+  socket.disconnect();
+});
+
 // There is no good mechanism to verify that an event was NOT sent to Sentry.
-// The idea here is that we first send a message that triggers an exception which won't be auto-captured,
+// The idea here is that we first send a message that triggers an expected exception which won't be auto-captured,
 // and then send a message that triggers a manually captured error which will be sent to Sentry.
 // If the manually captured error arrives, we can deduce that the first exception was not sent,
 // because Socket.IO guarantees message ordering: https://socket.io/docs/v4/delivery-guarantees
-test('Does not automatically capture exceptions in WebSocket gateway handler', async ({ baseURL }) => {
+test('Does not automatically capture expected WebSocket exceptions', async ({ baseURL }) => {
   let errorEventOccurred = false;
 
   waitForError('nestjs-websockets', event => {
-    if (!event.type && event.exception?.values?.[0]?.value === 'This is an exception in a WebSocket handler') {
+    if (!event.type && event.exception?.values?.[0]?.value === 'Expected WebSocket exception') {
       errorEventOccurred = true;
     }
 
@@ -45,7 +65,7 @@ test('Does not automatically capture exceptions in WebSocket gateway handler', a
   const socket = io(baseURL!);
   await new Promise<void>(resolve => socket.on('connect', resolve));
 
-  socket.emit('test-exception', {});
+  socket.emit('test-ws-exception', {});
   socket.emit('test-manual-capture', {});
   await manualCapturePromise;
 

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/tests/errors.test.ts
@@ -34,9 +34,12 @@ test('Automatically captures unexpected errors in WebSocket gateway handlers', a
 
   const error = await errorPromise;
 
-  expect(error.exception?.values?.[0]).toMatchObject({
-    type: 'Error',
-    value: 'This is an exception in a WebSocket handler',
+  expect(error.exception?.values).toHaveLength(1);
+  expect(error.exception?.values?.[0]?.type).toBe('Error');
+  expect(error.exception?.values?.[0]?.value).toBe('This is an exception in a WebSocket handler');
+  expect(error.exception?.values?.[0]?.mechanism).toEqual({
+    handled: false,
+    type: 'auto.ws.nestjs.global_filter',
   });
 
   socket.disconnect();

--- a/packages/nestjs/src/helpers.ts
+++ b/packages/nestjs/src/helpers.ts
@@ -25,10 +25,25 @@ export function isExpectedError(exception: unknown): boolean {
     return true;
   }
 
-  // RpcException
-  if (typeof ex.getError === 'function' && typeof ex.initMessage === 'function') {
+  // RpcException / WsException (same duck-type shape)
+  if (isWsException(exception)) {
     return true;
   }
 
   return false;
+}
+
+/**
+ * Determines if the exception is a WsException (or RpcException, which has the same shape).
+ * Both have `getError()` and `initMessage()` methods.
+ *
+ * We use duck-typing to avoid importing from `@nestjs/websockets` or `@nestjs/microservices`.
+ */
+export function isWsException(exception: unknown): boolean {
+  if (typeof exception !== 'object' || exception === null) {
+    return false;
+  }
+
+  const ex = exception as Record<string, unknown>;
+  return typeof ex.getError === 'function' && typeof ex.initMessage === 'function';
 }

--- a/packages/nestjs/src/helpers.ts
+++ b/packages/nestjs/src/helpers.ts
@@ -25,8 +25,7 @@ export function isExpectedError(exception: unknown): boolean {
     return true;
   }
 
-  // RpcException / WsException (same duck-type shape)
-  if (isWsException(exception)) {
+  if (isWsOrRpcException(exception)) {
     return true;
   }
 
@@ -34,12 +33,12 @@ export function isExpectedError(exception: unknown): boolean {
 }
 
 /**
- * Determines if the exception is a WsException (or RpcException, which has the same shape).
+ * Determines if the exception is a WsException or RpcException, which have the same shape.
  * Both have `getError()` and `initMessage()` methods.
  *
  * We use duck-typing to avoid importing from `@nestjs/websockets` or `@nestjs/microservices`.
  */
-export function isWsException(exception: unknown): boolean {
+export function isWsOrRpcException(exception: unknown): boolean {
   if (typeof exception !== 'object' || exception === null) {
     return false;
   }

--- a/packages/nestjs/src/setup.ts
+++ b/packages/nestjs/src/setup.ts
@@ -153,10 +153,6 @@ class SentryGlobalFilter extends BaseExceptionFilter {
     }
 
     if (contextType === 'ws') {
-      if (exception instanceof HttpException) {
-        throw exception;
-      }
-
       if (!isExpectedError(exception)) {
         captureException(exception, {
           mechanism: {

--- a/packages/nestjs/src/setup.ts
+++ b/packages/nestjs/src/setup.ts
@@ -10,7 +10,7 @@ import { Catch, Global, HttpException, Injectable, Logger, Module } from '@nestj
 import { APP_INTERCEPTOR, BaseExceptionFilter } from '@nestjs/core';
 import { captureException, debug, getDefaultIsolationScope, getIsolationScope } from '@sentry/core';
 import type { Observable } from 'rxjs';
-import { isExpectedError } from './helpers';
+import { isExpectedError, isWsException } from './helpers';
 
 // Partial extract of FastifyRequest interface
 // https://github.com/fastify/fastify/blob/87f9f20687c938828f1138f91682d568d2a31e53/types/request.d.ts#L41
@@ -149,6 +149,37 @@ class SentryGlobalFilter extends BaseExceptionFilter {
 
       // Log the error and return, otherwise we may crash the user's app by handling rpc errors in a http context
       this._logger.error(exception.message, exception.stack);
+      return;
+    }
+
+    if (contextType === 'ws') {
+      if (exception instanceof HttpException) {
+        throw exception;
+      }
+
+      if (!isExpectedError(exception)) {
+        captureException(exception, {
+          mechanism: {
+            handled: false,
+            type: 'auto.ws.nestjs.global_filter',
+          },
+        });
+      }
+
+      const client = host.switchToWs().getClient<{ emit: (event: string, data: unknown) => void }>();
+
+      if (isWsException(exception)) {
+        const result = (exception as { getError: () => unknown }).getError();
+        const response = typeof result === 'object' && result !== null ? result : { status: 'error', message: result };
+        client.emit('exception', response);
+        return;
+      }
+
+      if (exception instanceof Error) {
+        this._logger.error(exception.message, exception.stack);
+      }
+
+      client.emit('exception', { status: 'error', message: 'Internal server error' });
       return;
     }
 

--- a/packages/nestjs/src/setup.ts
+++ b/packages/nestjs/src/setup.ts
@@ -10,7 +10,7 @@ import { Catch, Global, HttpException, Injectable, Logger, Module } from '@nestj
 import { APP_INTERCEPTOR, BaseExceptionFilter } from '@nestjs/core';
 import { captureException, debug, getDefaultIsolationScope, getIsolationScope } from '@sentry/core';
 import type { Observable } from 'rxjs';
-import { isExpectedError, isWsException } from './helpers';
+import { isExpectedError, isWsOrRpcException } from './helpers';
 
 // Partial extract of FastifyRequest interface
 // https://github.com/fastify/fastify/blob/87f9f20687c938828f1138f91682d568d2a31e53/types/request.d.ts#L41
@@ -164,7 +164,7 @@ class SentryGlobalFilter extends BaseExceptionFilter {
 
       const client = host.switchToWs().getClient<{ emit?: (event: string, data: unknown) => void }>();
 
-      if (isWsException(exception)) {
+      if (isWsOrRpcException(exception)) {
         const result = (exception as { getError: () => unknown }).getError();
         const response = typeof result === 'object' && result !== null ? result : { status: 'error', message: result };
         client.emit?.('exception', response);

--- a/packages/nestjs/src/setup.ts
+++ b/packages/nestjs/src/setup.ts
@@ -162,12 +162,12 @@ class SentryGlobalFilter extends BaseExceptionFilter {
         });
       }
 
-      const client = host.switchToWs().getClient<{ emit: (event: string, data: unknown) => void }>();
+      const client = host.switchToWs().getClient<{ emit?: (event: string, data: unknown) => void }>();
 
       if (isWsException(exception)) {
         const result = (exception as { getError: () => unknown }).getError();
         const response = typeof result === 'object' && result !== null ? result : { status: 'error', message: result };
-        client.emit('exception', response);
+        client.emit?.('exception', response);
         return;
       }
 
@@ -175,7 +175,7 @@ class SentryGlobalFilter extends BaseExceptionFilter {
         this._logger.error(exception.message, exception.stack);
       }
 
-      client.emit('exception', { status: 'error', message: 'Internal server error' });
+      client.emit?.('exception', { status: 'error', message: 'Internal server error' });
       return;
     }
 

--- a/packages/nestjs/test/sentry-global-filter.test.ts
+++ b/packages/nestjs/test/sentry-global-filter.test.ts
@@ -8,6 +8,7 @@ import { SentryGlobalFilter } from '../src/setup';
 
 vi.mock('../src/helpers', () => ({
   isExpectedError: vi.fn(),
+  isWsException: vi.fn(),
 }));
 
 vi.mock('@sentry/core', () => ({
@@ -27,6 +28,7 @@ describe('SentryGlobalFilter', () => {
   let mockLoggerError: any;
   let mockLoggerWarn: any;
   let isExpectedErrorMock: any;
+  let isWsExceptionMock: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -57,6 +59,7 @@ describe('SentryGlobalFilter', () => {
     mockCaptureException = vi.spyOn(SentryCore, 'captureException').mockReturnValue('mock-event-id');
 
     isExpectedErrorMock = vi.mocked(Helpers.isExpectedError).mockImplementation(() => false);
+    isWsExceptionMock = vi.mocked(Helpers.isWsException).mockImplementation(() => false);
   });
 
   describe('HTTP context', () => {
@@ -271,6 +274,7 @@ describe('SentryGlobalFilter', () => {
 
     it('does not capture expected WebSocket exceptions and emits their response', () => {
       isExpectedErrorMock.mockReturnValueOnce(true);
+      isWsExceptionMock.mockReturnValueOnce(true);
       const exception = {
         getError: () => 'Expected WebSocket exception',
         initMessage: vi.fn(),

--- a/packages/nestjs/test/sentry-global-filter.test.ts
+++ b/packages/nestjs/test/sentry-global-filter.test.ts
@@ -302,5 +302,24 @@ describe('SentryGlobalFilter', () => {
         message: 'Internal server error',
       });
     });
+
+    it('captures unexpected errors when the WebSocket client cannot emit', () => {
+      vi.mocked(mockArgumentsHost.switchToWs).mockReturnValue({
+        getClient: () => ({}),
+        getData: vi.fn(),
+        getPattern: vi.fn(),
+      });
+      const error = new Error('WebSocket adapter without emit');
+
+      filter.catch(error, mockArgumentsHost);
+
+      expect(mockCaptureException).toHaveBeenCalledWith(error, {
+        mechanism: {
+          handled: false,
+          type: 'auto.ws.nestjs.global_filter',
+        },
+      });
+      expect(mockLoggerError).toHaveBeenCalledWith(error.message, error.stack);
+    });
   });
 });

--- a/packages/nestjs/test/sentry-global-filter.test.ts
+++ b/packages/nestjs/test/sentry-global-filter.test.ts
@@ -8,7 +8,7 @@ import { SentryGlobalFilter } from '../src/setup';
 
 vi.mock('../src/helpers', () => ({
   isExpectedError: vi.fn(),
-  isWsException: vi.fn(),
+  isWsOrRpcException: vi.fn(),
 }));
 
 vi.mock('@sentry/core', () => ({
@@ -28,7 +28,7 @@ describe('SentryGlobalFilter', () => {
   let mockLoggerError: any;
   let mockLoggerWarn: any;
   let isExpectedErrorMock: any;
-  let isWsExceptionMock: any;
+  let isWsOrRpcExceptionMock: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,7 +59,7 @@ describe('SentryGlobalFilter', () => {
     mockCaptureException = vi.spyOn(SentryCore, 'captureException').mockReturnValue('mock-event-id');
 
     isExpectedErrorMock = vi.mocked(Helpers.isExpectedError).mockImplementation(() => false);
-    isWsExceptionMock = vi.mocked(Helpers.isWsException).mockImplementation(() => false);
+    isWsOrRpcExceptionMock = vi.mocked(Helpers.isWsOrRpcException).mockImplementation(() => false);
   });
 
   describe('HTTP context', () => {
@@ -274,7 +274,7 @@ describe('SentryGlobalFilter', () => {
 
     it('does not capture expected WebSocket exceptions and emits their response', () => {
       isExpectedErrorMock.mockReturnValueOnce(true);
-      isWsExceptionMock.mockReturnValueOnce(true);
+      isWsOrRpcExceptionMock.mockReturnValueOnce(true);
       const exception = {
         getError: () => 'Expected WebSocket exception',
         initMessage: vi.fn(),

--- a/packages/nestjs/test/sentry-global-filter.test.ts
+++ b/packages/nestjs/test/sentry-global-filter.test.ts
@@ -237,4 +237,52 @@ describe('SentryGlobalFilter', () => {
       expect(mockCaptureException).not.toHaveBeenCalled();
     });
   });
+
+  describe('WebSocket context', () => {
+    let mockEmit: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockEmit = vi.fn();
+      vi.mocked(mockArgumentsHost.getType).mockReturnValue('ws');
+      vi.mocked(mockArgumentsHost.switchToWs).mockReturnValue({
+        getClient: () => ({ emit: mockEmit }),
+        getData: vi.fn(),
+        getPattern: vi.fn(),
+      });
+    });
+
+    it('captures unexpected errors and emits a generic error response', () => {
+      const error = new Error('Test WebSocket error');
+
+      filter.catch(error, mockArgumentsHost);
+
+      expect(mockCaptureException).toHaveBeenCalledWith(error, {
+        mechanism: {
+          handled: false,
+          type: 'auto.ws.nestjs.global_filter',
+        },
+      });
+      expect(mockLoggerError).toHaveBeenCalledWith(error.message, error.stack);
+      expect(mockEmit).toHaveBeenCalledWith('exception', {
+        status: 'error',
+        message: 'Internal server error',
+      });
+    });
+
+    it('does not capture expected WebSocket exceptions and emits their response', () => {
+      isExpectedErrorMock.mockReturnValueOnce(true);
+      const exception = {
+        getError: () => 'Expected WebSocket exception',
+        initMessage: vi.fn(),
+      };
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      expect(mockEmit).toHaveBeenCalledWith('exception', {
+        status: 'error',
+        message: 'Expected WebSocket exception',
+      });
+    });
+  });
 });

--- a/packages/nestjs/test/sentry-global-filter.test.ts
+++ b/packages/nestjs/test/sentry-global-filter.test.ts
@@ -288,5 +288,19 @@ describe('SentryGlobalFilter', () => {
         message: 'Expected WebSocket exception',
       });
     });
+
+    it('does not capture HTTP exceptions and emits a generic error response', () => {
+      isExpectedErrorMock.mockReturnValueOnce(true);
+      const exception = new HttpException('Bad request', HttpStatus.BAD_REQUEST);
+
+      filter.catch(exception, mockArgumentsHost);
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+      expect(mockLoggerError).toHaveBeenCalledWith(exception.message, exception.stack);
+      expect(mockEmit).toHaveBeenCalledWith('exception', {
+        status: 'error',
+        message: 'Internal server error',
+      });
+    });
   });
 });


### PR DESCRIPTION
Before submitting a pull request, please take a look at our  <br>[Contributing](<https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md>) guidelines and verify:

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [X] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

Fixes getsentry/sentry-javascript#16067

`SentryGlobalFilter` now handles WebSocket exceptions without delegating them to Nest's HTTP `BaseExceptionFilter`.

Unexpected gateway errors are captured with the `auto.ws.nestjs.global_filter` mechanism and emit a generic error response. Expected `WsException` responses are preserved without being reported to Sentry. `WsException` is detected by shape so `@nestjs/websockets` does not become a required dependency.

Unit and NestJS WebSocket E2E coverage was added for unexpected errors, expected `WsException` values, and HTTP exceptions raised in a WebSocket context.

*Root cause*: WebSocket exceptions were delegated to an HTTP exception filter which expects an HTTP adapter and cannot correctly respond through a WebSocket client.