### PR TITLE
chore(ci): Temporarily assign node/node-core reviews to whole JS SDK team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,9 @@
 /dev-packages/browser-integration-tests/ @getsentry/team-javascript-sdks-browser
 
 # Node/server runtimes and related packages
-/packages/node/                     @getsentry/team-javascript-sdks-server
-/packages/node-core/                @getsentry/team-javascript-sdks-server
 # TEMP: whole JS SDK team reviews orchestrion work; revert to team-javascript-sdks-server after
+/packages/node/                     @getsentry/team-javascript-sdks
+/packages/node-core/                @getsentry/team-javascript-sdks
 /packages/server-utils/             @getsentry/team-javascript-sdks
 /packages/node-native/              @getsentry/team-javascript-sdks-server
 /packages/profiling-node/           @getsentry/team-javascript-sdks-server


### PR DESCRIPTION
## What

Point `/packages/node/` and `/packages/node-core/` at `@getsentry/team-javascript-sdks` instead of the server team, matching #22215 for server-utils.

- Groups node, node-core, and server-utils under the shared TEMP comment.

## Why

Orchestrion work moves between these packages and server-utils, so the whole JS SDK team should review them. Temporary; revert to team-javascript-sdks-server once the work lands.