### PR TITLE
fix(ci): Unblock external-contributors checkout on fork PR merges

### DIFF
--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: develop
-          allow-unsafe-pr-checkout: true
       - name: Set up Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/external-contributors.yml
+++ b/.github/workflows/external-contributors.yml
@@ -21,6 +21,9 @@ jobs:
       && endsWith(github.event.pull_request.user.login, '[bot]') == false
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: develop
+          allow-unsafe-pr-checkout: true
       - name: Set up Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
The external-contributors workflow started failing after #21898 bumped `actions/checkout` to v7. That release blocks checkout in `pull_request_target` workflows when the triggering PR came from a fork, even when only checking out the base branch.

This PR ensures we explicitly check out `develop`.

Broken run: https://github.com/getsentry/sentry-javascript/actions/runs/29263604917