### PR TITLE
feat(server-utils): Rewrite `@opentelemetry/instrumentation-generic-pool` to orchestrion

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
@@ -1,10 +1,14 @@
 import { afterAll, describe, expect } from 'vitest';
+import { isOrchestrionEnabled } from '../../../utils';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
 describe('genericPool v2 auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
+
+  // The orchestrion channel integration replaces the OTel one 1:1 but tags spans with its own origin.
+  const ORIGIN = isOrchestrionEnabled() ? 'auto.db.orchestrion.generic_pool' : 'auto.db.otel.generic_pool';
 
   createEsmAndCjsTests(
     __dirname,
@@ -17,18 +21,18 @@ describe('genericPool v2 auto instrumentation', () => {
           spans: expect.arrayContaining([
             expect.objectContaining({
               description: 'generic-pool.acquire',
-              origin: 'auto.db.otel.generic_pool',
+              origin: ORIGIN,
               data: {
-                'sentry.origin': 'auto.db.otel.generic_pool',
+                'sentry.origin': ORIGIN,
               },
               status: 'ok',
             }),
 
             expect.objectContaining({
               description: 'generic-pool.acquire',
-              origin: 'auto.db.otel.generic_pool',
+              origin: ORIGIN,
               data: {
-                'sentry.origin': 'auto.db.otel.generic_pool',
+                'sentry.origin': ORIGIN,
               },
               status: 'ok',
             }),
@@ -47,15 +51,18 @@ describe('genericPool v2 auto instrumentation', () => {
     'instrument.mjs',
     (createRunner, test) => {
       test('marks the `generic-pool.acquire` span as errored when acquiring fails', async () => {
+        // The orchestrion path also records the rejection's `error.type` on the span.
+        const errorData = isOrchestrionEnabled()
+          ? { 'sentry.origin': ORIGIN, 'error.type': 'Error' }
+          : { 'sentry.origin': ORIGIN };
+
         const EXPECTED_TRANSACTION = {
           transaction: 'Test Transaction',
           spans: expect.arrayContaining([
             expect.objectContaining({
               description: 'generic-pool.acquire',
-              origin: 'auto.db.otel.generic_pool',
-              data: {
-                'sentry.origin': 'auto.db.otel.generic_pool',
-              },
+              origin: ORIGIN,
+              data: errorData,
               status: 'internal_error',
             }),
           ]),

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
@@ -1,10 +1,14 @@
 import { afterAll, describe, expect } from 'vitest';
+import { isOrchestrionEnabled } from '../../../utils';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
 describe('genericPool auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
+
+  // The orchestrion channel integration replaces the OTel one 1:1 but tags spans with its own origin.
+  const ORIGIN = isOrchestrionEnabled() ? 'auto.db.orchestrion.generic_pool' : 'auto.db.otel.generic_pool';
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('should auto-instrument `genericPool` package when calling pool.require()', async () => {
@@ -13,18 +17,18 @@ describe('genericPool auto instrumentation', () => {
         spans: expect.arrayContaining([
           expect.objectContaining({
             description: 'generic-pool.acquire',
-            origin: 'auto.db.otel.generic_pool',
+            origin: ORIGIN,
             data: {
-              'sentry.origin': 'auto.db.otel.generic_pool',
+              'sentry.origin': ORIGIN,
             },
             status: 'ok',
           }),
 
           expect.objectContaining({
             description: 'generic-pool.acquire',
-            origin: 'auto.db.otel.generic_pool',
+            origin: ORIGIN,
             data: {
-              'sentry.origin': 'auto.db.otel.generic_pool',
+              'sentry.origin': ORIGIN,
             },
             status: 'ok',
           }),
@@ -37,15 +41,18 @@ describe('genericPool auto instrumentation', () => {
 
   createEsmAndCjsTests(__dirname, 'scenario-error.mjs', 'instrument.mjs', (createRunner, test) => {
     test('marks the `generic-pool.acquire` span as errored when acquiring fails', async () => {
+      // The orchestrion path also records the rejection's `error.type` on the span.
+      const errorData = isOrchestrionEnabled()
+        ? { 'sentry.origin': ORIGIN, 'error.type': 'TimeoutError' }
+        : { 'sentry.origin': ORIGIN };
+
       const EXPECTED_TRANSACTION = {
         transaction: 'Test Transaction',
         spans: expect.arrayContaining([
           expect.objectContaining({
             description: 'generic-pool.acquire',
-            origin: 'auto.db.otel.generic_pool',
-            data: {
-              'sentry.origin': 'auto.db.otel.generic_pool',
-            },
+            origin: ORIGIN,
+            data: errorData,
             status: 'internal_error',
           }),
         ]),

--- a/packages/server-utils/src/integrations/tracing-channel/generic-pool.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/generic-pool.ts
@@ -1,0 +1,55 @@
+import * as diagnosticsChannel from 'node:diagnostics_channel';
+import type { IntegrationFn } from '@sentry/core';
+import {
+  debug,
+  defineIntegration,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  startInactiveSpan,
+  waitForTracingChannelBinding,
+} from '@sentry/core';
+import { DEBUG_BUILD } from '../../debug-build';
+import { CHANNELS } from '../../orchestrion/channels';
+import { bindTracingChannelToSpan } from '../../tracing-channel';
+
+// Same name as the OTel integration by design — when enabled, the OTel
+// 'GenericPool' integration is omitted from the default set.
+const INTEGRATION_NAME = 'GenericPool' as const;
+
+interface GenericPoolAcquireContext {
+  arguments: unknown[];
+}
+
+const _genericPoolChannelIntegration = (() => {
+  return {
+    name: INTEGRATION_NAME,
+    setupOnce() {
+      // `tracingChannel` is unavailable before Node 18.19 so do nothing in that case.
+      if (!diagnosticsChannel.tracingChannel) {
+        return;
+      }
+
+      DEBUG_BUILD && debug.log(`[orchestrion:generic-pool] subscribing to channel "${CHANNELS.GENERIC_POOL_ACQUIRE}"`);
+
+      waitForTracingChannelBinding(() => {
+        bindTracingChannelToSpan(
+          diagnosticsChannel.tracingChannel<GenericPoolAcquireContext>(CHANNELS.GENERIC_POOL_ACQUIRE),
+          () =>
+            startInactiveSpan({
+              name: 'generic-pool.acquire',
+              attributes: {
+                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.orchestrion.generic_pool',
+              },
+            }),
+        );
+      });
+    },
+  };
+}) satisfies IntegrationFn;
+
+/**
+ * EXPERIMENTAL — orchestrion-driven generic-pool integration. Subscribes to
+ * `orchestrion:generic-pool:acquire` (injected into `generic-pool/lib/Pool.js`'s
+ * `Pool.prototype.acquire`). Creates a `generic-pool.acquire` span for each
+ * acquisition. Requires the orchestrion runtime hook or bundler plugin.
+ */
+export const genericPoolChannelIntegration = defineIntegration(_genericPoolChannelIntegration);

--- a/packages/server-utils/src/integrations/tracing-channel/generic-pool.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/generic-pool.ts
@@ -1,13 +1,11 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn } from '@sentry/core';
 import {
-  debug,
   defineIntegration,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startInactiveSpan,
   waitForTracingChannelBinding,
 } from '@sentry/core';
-import { DEBUG_BUILD } from '../../debug-build';
 import { CHANNELS } from '../../orchestrion/channels';
 import { bindTracingChannelToSpan } from '../../tracing-channel';
 
@@ -28,20 +26,7 @@ const _genericPoolChannelIntegration = (() => {
         return;
       }
 
-      DEBUG_BUILD && debug.log(`[orchestrion:generic-pool] subscribing to channel "${CHANNELS.GENERIC_POOL_ACQUIRE}"`);
-
-      waitForTracingChannelBinding(() => {
-        bindTracingChannelToSpan(
-          diagnosticsChannel.tracingChannel<GenericPoolAcquireContext>(CHANNELS.GENERIC_POOL_ACQUIRE),
-          () =>
-            startInactiveSpan({
-              name: 'generic-pool.acquire',
-              attributes: {
-                [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.orchestrion.generic_pool',
-              },
-            }),
-        );
-      });
+      waitForTracingChannelBinding(() => instrumentGenericPool());
     },
   };
 }) satisfies IntegrationFn;
@@ -53,3 +38,16 @@ const _genericPoolChannelIntegration = (() => {
  * acquisition. Requires the orchestrion runtime hook or bundler plugin.
  */
 export const genericPoolChannelIntegration = defineIntegration(_genericPoolChannelIntegration);
+
+function instrumentGenericPool(): void {
+  bindTracingChannelToSpan(
+    diagnosticsChannel.tracingChannel<GenericPoolAcquireContext>(CHANNELS.GENERIC_POOL_ACQUIRE),
+    () =>
+      startInactiveSpan({
+        name: 'generic-pool.acquire',
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.orchestrion.generic_pool',
+        },
+      }),
+  );
+}

--- a/packages/server-utils/src/orchestrion/config/generic-pool.ts
+++ b/packages/server-utils/src/orchestrion/config/generic-pool.ts
@@ -1,6 +1,23 @@
 import type { InstrumentationConfig } from '@apm-js-collab/code-transformer';
 
-// TODO: Stub for the `generic-pool` orchestrion integration (ports `@opentelemetry/instrumentation-generic-pool`).
-export const genericPoolConfig: InstrumentationConfig[] = [];
+// Two shapes of `acquire`, both publishing to the same `orchestrion:generic-pool:acquire` channel:
+// - v3+: `class Pool { acquire(priority) }` returns a promise, so `kind: 'Auto'` resolves to `wrapPromise`.
+// - v2.4–v3: `Pool.prototype.acquire = function acquire(callback, priority)` is callback-based.
+// Versions before 2.4 assigned an anonymous `acquire` per pool instance (a factory), which a static
+// transform can't target, so they're out of scope (matching how the OTel instrumentation split them).
+export const genericPoolConfig = [
+  {
+    channelName: 'acquire',
+    module: { name: 'generic-pool', versionRange: '>=3.0.0 <4', filePath: 'lib/Pool.js' },
+    functionQuery: { className: 'Pool', methodName: 'acquire', kind: 'Auto' },
+  },
+  {
+    channelName: 'acquire',
+    module: { name: 'generic-pool', versionRange: '>=2.4.0 <3', filePath: 'lib/generic-pool.js' },
+    functionQuery: { expressionName: 'acquire', kind: 'Callback' },
+  },
+] satisfies InstrumentationConfig[];
 
-export const genericPoolChannels = {} as const;
+export const genericPoolChannels = {
+  GENERIC_POOL_ACQUIRE: 'orchestrion:generic-pool:acquire',
+} as const;

--- a/packages/server-utils/src/orchestrion/index.ts
+++ b/packages/server-utils/src/orchestrion/index.ts
@@ -1,5 +1,6 @@
 import { amqplibChannelIntegration } from '../integrations/tracing-channel/amqplib';
 import { anthropicChannelIntegration } from '../integrations/tracing-channel/anthropic';
+import { genericPoolChannelIntegration } from '../integrations/tracing-channel/generic-pool';
 import { googleGenAIChannelIntegration } from '../integrations/tracing-channel/google-genai';
 import {
   graphqlChannelIntegration,
@@ -23,6 +24,7 @@ export { nestjsChannels } from './config/nestjs';
 export {
   amqplibChannelIntegration,
   anthropicChannelIntegration,
+  genericPoolChannelIntegration,
   googleGenAIChannelIntegration,
   graphqlChannelIntegration,
   hapiChannelIntegration,
@@ -66,6 +68,7 @@ export const channelIntegrations = {
   postgresIntegration: postgresChannelIntegration,
   postgresJsIntegration: postgresJsChannelIntegration,
   mysqlIntegration: mysqlChannelIntegration,
+  genericPoolIntegration: genericPoolChannelIntegration,
   lruMemoizerIntegration: lruMemoizerChannelIntegration,
   openaiIntegration: openaiChannelIntegration,
   anthropicIntegration: anthropicChannelIntegration,


### PR DESCRIPTION
Ports the `generic-pool` instrumentation from OTel's `InstrumentationBase` to an orchestrion diagnostics-channel listener.

- **Transform config** (`config/generic-pool.ts`): injects the `orchestrion:generic-pool:acquire` channel into `acquire` for two shapes — v3+ `class Pool { acquire(priority) }` (promise, `kind: 'Auto'`) and v2.4–v3 `Pool.prototype.acquire = function acquire(callback, priority)` (callback, `kind: 'Callback'`). Both publish to the same channel.

_Version scope_: v2.4+ and v3 are supported. v2.0–2.4 assigned an anonymous `acquire` per pool instance inside the `Pool` factory, which a static code transform has no named target to hook — the same boundary the original OTel instrumentation drew (it needed runtime factory-wrapping there). Under orchestrion those versions are not instrumented; the OTel integration still covers them when orchestrion is off.

So this only covers 2.4+ which seems acceptable, the vast majority of usage according to npm is 3+ anyhow.

Fixes #20751

🤖 Generated with [Claude Code](https://claude.com/claude-code)