### PR TITLE
test(browser-integration): Fix local runs referencing renamed `type-check` command

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "OXLINT_TSGOLINT_DANGEROUSLY_SUPPRESS_PROGRAM_DIAGNOSTICS=true oxlint . --fix --type-aware",
     "lint:types": "tsc --noEmit",
     "postinstall": "yarn install-browsers",
-    "pretest": "yarn clean && yarn type-check",
+    "pretest": "yarn clean && yarn lint:types",
     "test": "yarn test:all --project='chromium'",
     "test:all": "npx playwright test -c playwright.browser.config.ts",
     "test:bundle": "PW_BUNDLE=bundle yarn test",


### PR DESCRIPTION
We renamed the `type-check` package.json script to `lint:types` to leverage repo-wide type checking. Looks like the clanker missed that another script (`pretest`) still called the type checking command by its old name. (this appears to only be an issue in local runs as it worked fine on CI via other test scripts).