### PR TITLE
fix(bundler-plugins): do not warn on known sourcemap-less chunks

### DIFF
--- a/dev-packages/bundler-plugin-integration-tests/fixtures/esbuild/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/esbuild/basic-cjs.test.ts
@@ -35,7 +35,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/esbuild/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/esbuild/basic.test.ts
@@ -35,7 +35,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/esbuild/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/esbuild/release-disabled.test.ts
@@ -34,7 +34,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rolldown/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rolldown/basic-cjs.test.ts
@@ -20,7 +20,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rolldown/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rolldown/basic.test.ts
@@ -20,7 +20,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rolldown/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rolldown/release-disabled.test.ts
@@ -19,7 +19,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rollup3/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rollup3/basic-cjs.test.ts
@@ -11,7 +11,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rollup3/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rollup3/basic.test.ts
@@ -11,7 +11,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rollup3/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rollup3/release-disabled.test.ts
@@ -10,7 +10,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rollup4/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rollup4/basic-cjs.test.ts
@@ -11,7 +11,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rollup4/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rollup4/basic.test.ts
@@ -11,7 +11,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/rollup4/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/rollup4/release-disabled.test.ts
@@ -10,7 +10,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite4/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite4/basic-cjs.test.ts
@@ -19,7 +19,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite4/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite4/basic.test.ts
@@ -19,7 +19,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite4/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite4/release-disabled.test.ts
@@ -18,7 +18,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite7/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite7/basic-cjs.test.ts
@@ -19,7 +19,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite7/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite7/basic.test.ts
@@ -19,7 +19,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite7/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite7/release-disabled.test.ts
@@ -18,7 +18,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite8/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite8/basic-cjs.test.ts
@@ -20,7 +20,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite8/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite8/basic.test.ts
@@ -20,7 +20,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/vite8/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/vite8/release-disabled.test.ts
@@ -19,7 +19,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     ",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/webpack5/basic-cjs.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/webpack5/basic-cjs.test.ts
@@ -16,7 +16,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/webpack5/basic.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/webpack5/basic.test.ts
@@ -16,7 +16,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles, runFileInNode }) => {
       "sentry-cli-mock.json": "["releases","new","CURRENT_SHA"],
     ["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/dev-packages/bundler-plugin-integration-tests/fixtures/webpack5/release-disabled.test.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/webpack5/release-disabled.test.ts
@@ -15,7 +15,6 @@ test(import.meta.url, ({ runBundler, readOutputFiles }) => {
     ;",
       "sentry-cli-mock.json": "["releases","set-commits","CURRENT_SHA","--auto","--ignore-missing"],
     ["releases","finalize","CURRENT_SHA"],
-    ["sourcemaps","upload","-p","fake-project","--release","CURRENT_SHA","sentry-bundler-plugin-upload-path","--ignore","node_modules","--no-rewrite"],
     ",
     }
   `);

--- a/packages/bundler-plugins/src/core/build-plugin-manager.ts
+++ b/packages/bundler-plugins/src/core/build-plugin-manager.ts
@@ -703,6 +703,19 @@ export function createSentryBuildPluginManager(
                   setMeasurement('files', files.length, 'none', prepBundlesSpan);
                   setMeasurement('upload_size', uploadSize, 'byte', prepBundlesSpan);
 
+                  // Preparation produced no artifacts, meaning none of the
+                  // matched bundles had an associated source map. This almost
+                  // always means source map generation is turned off in the
+                  // bundler, so warn instead of silently reporting success.
+                  if (files.length === 0) {
+                    logger.warn(
+                      `No source maps found for any of the ${debugIdChunkFilePaths.length} matched build ` +
+                        'artifacts, so no source maps were uploaded to Sentry. This usually means source map ' +
+                        'generation is not enabled in your bundler. Enable it so Sentry can un-minify your stack traces.',
+                    );
+                    return;
+                  }
+
                   await startSpan({ name: 'upload', scope: sentryScope }, async () => {
                     const cliInstance = createCliInstance(options);
                     await cliInstance.releases.uploadSourceMaps(options.release.name ?? 'undefined', {
@@ -717,9 +730,11 @@ export function createSentryBuildPluginManager(
                       live: 'rejectOnError',
                     });
                   });
-                });
 
-                logger.info('Successfully uploaded source maps to Sentry');
+                  // this must be in the method so that the "no sourcemaps"
+                  // early return doesn't also log success.
+                  logger.info('Successfully uploaded source maps to Sentry');
+                });
               }
             }
           } catch (e) {

--- a/packages/bundler-plugins/src/core/debug-id-upload.ts
+++ b/packages/bundler-plugins/src/core/debug-id-upload.ts
@@ -48,28 +48,40 @@ export async function prepareBundleForDebugIdUpload(
   const uniqueUploadName = `${debugId}-${chunkIndex}`;
 
   bundleContent = addDebugIdToBundleSource(bundleContent, debugId);
+
+  const sourceMapPath = await determineSourceMapPathFromBundle(
+    bundleFilePath,
+    bundleContent,
+    logger,
+    resolveSourceMapHook,
+  );
+
+  // A chunk with a debug ID but no resolvable source map
+  // (e.g. framework-generated stub chunks that never emit one) can't be
+  // symbolicated, so uploading its minified source alone accomplishes
+  // nothing and only makes the uploader warn about a missing source map ref.
+  // Skip it, unless the source map is inlined into the bundle, in which case
+  // the source file carries the map itself and must still be uploaded.
+  if (!sourceMapPath && !bundleHasInlineSourceMap(bundleContent)) {
+    logger.debug(`Not uploading bundle without a source map: ${bundleFilePath}`);
+    return;
+  }
+
   const writeSourceFilePromise = fs.promises.writeFile(
     path.join(uploadFolder, `${uniqueUploadName}.js`),
     bundleContent,
     'utf-8',
   );
 
-  const writeSourceMapFilePromise = determineSourceMapPathFromBundle(
-    bundleFilePath,
-    bundleContent,
-    logger,
-    resolveSourceMapHook,
-  ).then(async sourceMapPath => {
-    if (sourceMapPath) {
-      await prepareSourceMapForDebugIdUpload(
+  const writeSourceMapFilePromise = sourceMapPath
+    ? prepareSourceMapForDebugIdUpload(
         sourceMapPath,
         path.join(uploadFolder, `${uniqueUploadName}.js.map`),
         debugId,
         rewriteSourcesHook,
         logger,
-      );
-    }
-  });
+      )
+    : Promise.resolve();
 
   await writeSourceFilePromise;
   await writeSourceMapFilePromise;
@@ -105,6 +117,16 @@ function addDebugIdToBundleSource(bundleSource: string, debugId: string): string
   } else {
     return `${bundleSource}\n//# debugId=${debugId}`;
   }
+}
+
+/**
+ * Whether the bundle carries its source map inlined as `sourceMappingURL=data:`
+ * URI, rather than referencing a separate `.map` file. Such bundles must still
+ * be uploaded even when no `.map` file is found, because the source file itself
+ * contains the map.
+ */
+function bundleHasInlineSourceMap(bundleSource: string): boolean {
+  return /^\s*\/\/# sourceMappingURL=data:/m.test(bundleSource);
 }
 
 /**

--- a/packages/bundler-plugins/test/core/build-plugin-manager.test.ts
+++ b/packages/bundler-plugins/test/core/build-plugin-manager.test.ts
@@ -417,6 +417,44 @@ describe('createSentryBuildPluginManager', () => {
         live: 'rejectOnError',
       });
     });
+
+    // Skipping mapless chunks (so the CLI stops warning per stub chunk) must
+    // not swallow the signal that source map generation is disabled.
+    it('warns and skips upload when none of the matched bundles have a source map', async () => {
+      mockCliUploadSourceMaps.mockResolvedValue(undefined);
+
+      // Bundles were found, but preparation produced no artifacts
+      mockGlobFiles.mockResolvedValue(['/app/dist/a.js', '/app/dist/b.js']);
+
+      vi.spyOn(fs.promises, 'mkdtemp').mockResolvedValue('/tmp/sentry-upload-empty');
+      vi.spyOn(fs.promises, 'readdir').mockResolvedValue([] as never);
+      vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 0 } as fs.Stats);
+      vi.spyOn(fs.promises, 'rm').mockResolvedValue(undefined as never);
+
+      mockPrepareBundleForDebugIdUpload.mockResolvedValue(undefined);
+
+      const manager = createSentryBuildPluginManager(
+        {
+          authToken: 't',
+          org: 'o',
+          project: 'p',
+          release: { name: 'some-release-name', dist: '1' },
+          sourcemaps: { assets: ['/app/dist/**/*'] },
+        },
+        { buildTool: 'webpack', loggerPrefix: '[sentry-webpack-plugin]' },
+      );
+
+      const warnSpy = vi.spyOn(manager.logger, 'warn');
+
+      await manager.uploadSourcemaps(['/unused']);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/source map generation is not enabled/);
+      // Nothing to upload, so the CLI upload must be skipped entirely.
+      expect(mockCliUploadSourceMaps).not.toHaveBeenCalled();
+
+      vi.restoreAllMocks();
+    });
   });
 
   describe('injectDebugIds', () => {
@@ -477,9 +515,10 @@ describe('createSentryBuildPluginManager', () => {
       mockPrepareBundleForDebugIdUpload.mockResolvedValue(undefined);
       mockCliUploadSourceMaps.mockResolvedValue(undefined);
 
-      // Mock fs operations needed for temp folder upload path
+      // Mock fs operations needed for temp folder upload path. `readdir` returns a prepared artifact
+      // so the upload path runs (an empty temp folder warns and skips the upload instead).
       vi.spyOn(fs.promises, 'mkdtemp').mockResolvedValue('/tmp/sentry-test');
-      vi.spyOn(fs.promises, 'readdir').mockResolvedValue([]);
+      vi.spyOn(fs.promises, 'readdir').mockResolvedValue(['bundle.js', 'bundle.js.map'] as never);
       vi.spyOn(fs.promises, 'stat').mockResolvedValue({ size: 1000 } as fs.Stats);
       vi.spyOn(fs.promises, 'rm').mockResolvedValue(undefined);
     });

--- a/packages/bundler-plugins/test/core/debug-id-upload.test.ts
+++ b/packages/bundler-plugins/test/core/debug-id-upload.test.ts
@@ -61,4 +61,48 @@ describe('prepareBundleForDebugIdUpload', () => {
     expect(capturedContexts).toHaveLength(1);
     expect(capturedContexts[0]!.mapDir).toBe(bundleDir);
   });
+
+  const debugIdSnippet = (debugId: string): string =>
+    `;!function(){try{var e="undefined"!=typeof window?window:{},n=(new e.Error).stack;n&&(e._sentryDebugIds=e._sentryDebugIds||{},e._sentryDebugIds[n]="${debugId}",e._sentryDebugIdIdentifier="sentry-dbid-${debugId}")}catch(e){}}();`;
+
+  const noopRewriteHook: RewriteSourcesHook = source => source;
+  const makeLogger = (): Logger =>
+    ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) as unknown as Logger;
+
+  it('does not write an upload artifact for a chunk that has no source map', async () => {
+    const bundleDir = path.join(tmpDir, 'src');
+    const uploadDir = path.join(tmpDir, 'upload');
+    fs.mkdirSync(bundleDir, { recursive: true });
+    fs.mkdirSync(uploadDir, { recursive: true });
+
+    const debugId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const bundlePath = path.join(bundleDir, 'stub.js');
+    // A stub chunk: debug ID snippet but no code and no sourceMappingURL / adjacent `.map`.
+    fs.writeFileSync(bundlePath, `"use strict";\n${debugIdSnippet(debugId)}`);
+
+    await prepareBundleForDebugIdUpload(bundlePath, uploadDir, 0, makeLogger(), noopRewriteHook, undefined);
+
+    expect(fs.readdirSync(uploadDir)).toEqual([]);
+  });
+
+  it('writes an upload artifact for a chunk whose source map is inlined', async () => {
+    const bundleDir = path.join(tmpDir, 'src');
+    const uploadDir = path.join(tmpDir, 'upload');
+    fs.mkdirSync(bundleDir, { recursive: true });
+    fs.mkdirSync(uploadDir, { recursive: true });
+
+    const debugId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const bundlePath = path.join(bundleDir, 'inline.js');
+    const inlineMap = Buffer.from(JSON.stringify({ version: 3, sources: ['a.ts'], mappings: 'AAAA' })).toString(
+      'base64',
+    );
+    fs.writeFileSync(
+      bundlePath,
+      `"use strict";\n// code\n${debugIdSnippet(debugId)}\n//# sourceMappingURL=data:application/json;base64,${inlineMap}`,
+    );
+
+    await prepareBundleForDebugIdUpload(bundlePath, uploadDir, 0, makeLogger(), noopRewriteHook, undefined);
+
+    expect(fs.readdirSync(uploadDir)).toEqual([`${debugId}-0.js`]);
+  });
 });


### PR DESCRIPTION
Prevent potentially large number of noisy warnings that by design never emit sourcemaps.

For example:

```
~/b0f41f6b-e36f-409b-817f-921f7d295a7b-155.js (no sourcemap found, debug id b0f41f6b-...)
  - warning: could not determine a source map reference (Could not auto-detect referenced sourcemap for ~/b0f41f6b-...-155.js)
```

This cannot be safely avoided using the file path glob approach, as seen in getsentry/sentry-javascript#18938, because the file paths in question here (uuids and alphanumeric hashes) can't be guaranteed to *never* hold user code as seen in the cases covered by getsentry/sentry-javascript#18938.

Instead, when no symbolication can be performed because the chunk is a stub without any sourcemap, downgrade the warning to a debug log.

fix: getsentry/sentry-javascript#22199  <br>fix: getsentry/sentry-javascript#22199