### PR TITLE
feat(deps): Bump `@sentry/conventions` to 0.16.0

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -63,7 +63,7 @@
     "@sentry/browser": "10.65.0",
     "@sentry/replay": "10.65.0",
     "@sentry/opentelemetry": "10.65.0",
-    "@sentry/conventions": "0.15.1",
+    "@sentry/conventions": "0.16.0",
     "@supabase/supabase-js": "2.49.3",
     "axios": "1.16.0",
     "babel-loader": "^10.1.1",

--- a/dev-packages/cloudflare-integration-tests/package.json
+++ b/dev-packages/cloudflare-integration-tests/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260426.0",
     "@sentry-internal/test-utils": "10.65.0",
-    "@sentry/conventions": "0.15.1",
+    "@sentry/conventions": "0.16.0",
     "eslint-plugin-regexp": "^3.1.0",
     "prisma": "6.15.0",
     "vitest": "^3.2.6",

--- a/dev-packages/node-core-integration-tests/package.json
+++ b/dev-packages/node-core-integration-tests/package.json
@@ -50,7 +50,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@sentry/conventions": "0.15.1",
+    "@sentry/conventions": "0.16.0",
     "@types/node-cron": "^3.0.11",
     "@types/node-schedule": "^2.1.7",
     "eslint-plugin-regexp": "^3.1.0",

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -102,7 +102,7 @@
     "yargs": "^16.2.0"
   },
   "devDependencies": {
-    "@sentry/conventions": "0.15.1",
+    "@sentry/conventions": "0.16.0",
     "@sentry-internal/test-utils": "10.65.0",
     "@types/amqplib": "^0.10.5",
     "@types/node-cron": "^3.0.11",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@sentry/browser": "10.65.0",
     "@sentry/core": "10.65.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@sentry/browser": "10.65.0",
     "@sentry/core": "10.65.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/node": "10.65.0",
     "@sentry/vite-plugin": "^5.3.0"
   },

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.220.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/node": "10.65.0",
     "@sentry/node-core": "10.65.0",

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@sentry/core": "10.65.0",
-    "@sentry/conventions": "^0.15.1"
+    "@sentry/conventions": "^0.16.0"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@sentry/browser-utils": "10.65.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/feedback": "10.65.0",
     "@sentry/replay": "10.65.0",
     "@sentry/replay-canvas": "10.65.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,6 +108,6 @@
     "zod": "^3.24.1"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.15.1"
+    "@sentry/conventions": "^0.16.0"
   }
 }

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.220.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/node": "10.65.0",
     "@sentry/server-utils": "10.65.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -80,7 +80,7 @@
     "@rollup/plugin-commonjs": "28.0.1",
     "@sentry/browser-utils": "10.65.0",
     "@sentry/bundler-plugin-core": "^5.3.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/node": "10.65.0",
     "@sentry/opentelemetry": "10.65.0",

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -101,7 +101,7 @@
     }
   },
   "dependencies": {
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/opentelemetry": "10.65.0",
     "import-in-the-middle": "^3.0.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -68,7 +68,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/instrumentation": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/node-core": "10.65.0",
     "@sentry/opentelemetry": "10.65.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -48,7 +48,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0"
   },
   "peerDependencies": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -49,7 +49,7 @@
     "@opentelemetry/instrumentation": "^0.220.0",
     "@sentry/browser": "10.65.0",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/node": "10.65.0",
     "@sentry/react": "10.65.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@sentry/browser": "10.65.0",
     "@sentry/core": "10.65.0",
-    "@sentry/conventions": "^0.15.1"
+    "@sentry/conventions": "^0.16.0"
   },
   "peerDependencies": {
     "react": "^16.14.0 || 17.x || 18.x || 19.x"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -68,7 +68,7 @@
     "@opentelemetry/instrumentation": "^0.220.0",
     "@remix-run/router": "^1.23.3",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/node": "10.65.0",
     "@sentry/react": "10.65.0",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -96,7 +96,7 @@
     "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
     "@apm-js-collab/code-transformer": "^0.18.0",
     "@apm-js-collab/tracing-hooks": "^0.11.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "magic-string": "~0.30.0"
   },

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@sentry/browser": "10.65.0",
     "@sentry/core": "10.65.0",
-    "@sentry/conventions": "^0.15.1"
+    "@sentry/conventions": "^0.16.0"
   },
   "peerDependencies": {
     "@solidjs/router": "^0.13.4 || ^0.14.0 || ^0.15.0",

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@sentry/cloudflare": "10.65.0",
     "@sentry/core": "10.65.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/node": "10.65.0",
     "@sentry/svelte": "10.65.0",
     "@sentry/vite-plugin": "^5.3.0",

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser-utils": "10.65.0",
-    "@sentry/conventions": "^0.15.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0",
     "@sentry/node": "10.65.0",
     "@sentry/react": "10.65.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@sentry/browser": "10.65.0",
     "@sentry/core": "10.65.0",
-    "@sentry/conventions": "^0.15.1"
+    "@sentry/conventions": "^0.16.0"
   },
   "peerDependencies": {
     "@tanstack/vue-router": "^1.64.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7439,10 +7439,10 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
-"@sentry/conventions@0.15.1", "@sentry/conventions@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.15.1.tgz#5b8888862d1e444678938f5afdd7842bca42f7cc"
-  integrity sha512-ZLP8bRdMON3prWE2tJyImuYscCxdcJeIPIhrOs/rgyFm3C1nCh1B6gdvPj3AZ5zW08oSFFCsq7T+tYEW3h8MNA==
+"@sentry/conventions@0.16.0", "@sentry/conventions@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
+  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
 
 "@sentry/node-cpu-profiler@^2.4.2":
   version "2.4.2"


### PR DESCRIPTION
## What

Bump `@sentry/conventions` from `0.15.1` to `0.16.0` across every workspace.

- Runtime packages (`packages/*`) keep the caret range `^0.16.0`.
- Dev-package test suites (`dev-packages/*`) keep the exact pin `0.16.0`.
- Refresh `yarn.lock`.

## Why

Pull the latest `@sentry/conventions` release into all packages and keep versions aligned across the monorepo.