### PR TITLE
chore: Do not treat flaky test issues as bug

### DIFF
--- a/.github/FLAKY_CI_FAILURE_TEMPLATE.md
+++ b/.github/FLAKY_CI_FAILURE_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 title: '[Flaky CI]: {{ env.JOB_NAME }} - {{ env.TEST_NAME }}'
-labels: Tests, Bug, "Flaky Test"
+labels: Tests, "Flaky Test"
 ---
 
 ### Flakiness Type


### PR DESCRIPTION
This kind of messes up our repo health stats - IMHO these are not bugs in this sense of the word (although things that should be fixed), so I'd rather not capture them as such.

I _think_ this field is not used anyhow anymore, we use the explicit labels defined, but to be consistent...