### PR TITLE
fix(core): Prevent functionToStringIntegration from throwing on cross-origin realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+- fix(core): Prevent `functionToStringIntegration` from throwing on cross-origin `WindowProxy` realms
 
 Work in this release was contributed by @dobladov. Thank you for your contribution!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
-- fix(core): Prevent `functionToStringIntegration` from throwing on cross-origin `WindowProxy` realms
 
 Work in this release was contributed by @dobladov. Thank you for your contribution!
 

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -22,10 +22,17 @@ const _functionToStringIntegration = (() => {
       // e.g. Node with --frozen-intrinsics, XS (an embedded JavaScript engine) or SES (a JavaScript proposal)
       try {
         Function.prototype.toString = function (this: WrappedFunction, ...args: unknown[]): string {
-          const originalFunction = getOriginalFunction(this);
-          const context =
-            SETUP_CLIENTS.has(getClient() as Client) && originalFunction !== undefined ? originalFunction : this;
-          return originalFunctionToString.apply(context, args);
+          try {
+            const originalFunction = getOriginalFunction(this);
+            const context =
+              SETUP_CLIENTS.has(getClient() as Client) && originalFunction !== undefined ? originalFunction : this;
+            return originalFunctionToString.apply(context, args);
+          } catch {
+            // Reading the Sentry carrier off `getClient()` can throw a `SecurityError` when `this` (or the global
+            // object) is a `WindowProxy` whose browsing context was navigated cross-origin. The native
+            // `toString` never throws here, so fall back to it to avoid turning harmless introspection into noise.
+            return originalFunctionToString.apply(this, args);
+          }
         };
       } catch {
         // ignore errors here, just don't patch this

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -4,8 +4,6 @@ import { defineIntegration } from '../integration';
 import type { IntegrationFn } from '../types/integration';
 import { getOriginalFunction } from '../utils/object';
 
-let originalFunctionToString: () => string;
-
 const INTEGRATION_NAME = 'FunctionToString' as const;
 
 const SETUP_CLIENTS = new WeakMap<Client, boolean>();
@@ -15,7 +13,7 @@ const _functionToStringIntegration = (() => {
     name: INTEGRATION_NAME,
     setupOnce() {
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      originalFunctionToString = Function.prototype.toString;
+      const originalFunctionToString = Function.prototype.toString;
 
       // intrinsics (like Function.prototype) might be immutable in some environments
       // e.g. Node with --frozen-intrinsics, XS (an embedded JavaScript engine) or SES (a JavaScript proposal)

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -2,10 +2,9 @@ import type { Client } from '../client';
 import { getClient } from '../currentScopes';
 import { defineIntegration } from '../integration';
 import type { IntegrationFn } from '../types/integration';
-import type { WrappedFunction } from '../types/wrappedfunction';
 import { getOriginalFunction } from '../utils/object';
 
-let originalFunctionToString: () => void;
+let originalFunctionToString: () => string;
 
 const INTEGRATION_NAME = 'FunctionToString' as const;
 
@@ -21,19 +20,24 @@ const _functionToStringIntegration = (() => {
       // intrinsics (like Function.prototype) might be immutable in some environments
       // e.g. Node with --frozen-intrinsics, XS (an embedded JavaScript engine) or SES (a JavaScript proposal)
       try {
-        Function.prototype.toString = function (this: WrappedFunction, ...args: unknown[]): string {
-          try {
-            const originalFunction = getOriginalFunction(this);
-            const context =
-              SETUP_CLIENTS.has(getClient() as Client) && originalFunction !== undefined ? originalFunction : this;
-            return originalFunctionToString.apply(context, args);
-          } catch {
-            // Reading the Sentry carrier off `getClient()` can throw a `SecurityError` when `this` (or the global
-            // object) is a `WindowProxy` whose browsing context was navigated cross-origin. The native
-            // `toString` never throws here, so fall back to it to avoid turning harmless introspection into noise.
-            return originalFunctionToString.apply(this, args);
-          }
-        };
+        Function.prototype.toString = new Proxy(originalFunctionToString, {
+          apply(target, thisArg, args) {
+            const originalFunction = getOriginalFunction(thisArg);
+            let context = thisArg;
+
+            try {
+              if (SETUP_CLIENTS.has(getClient()!) && originalFunction) {
+                context = originalFunction;
+              }
+            } catch {
+              // Reading the Sentry carrier off `getClient()` can throw a `SecurityError` when `this` (or the global
+              // object) is a `WindowProxy` whose browsing context was navigated cross-origin. The native
+              // `toString` never throws here, so fall back to it to avoid turning harmless introspection into noise.
+            }
+
+            return Reflect.apply(target, context, args);
+          },
+        });
       } catch {
         // ignore errors here, just don't patch this
       }

--- a/packages/core/test/lib/integrations/functiontostring.test.ts
+++ b/packages/core/test/lib/integrations/functiontostring.test.ts
@@ -1,7 +1,13 @@
-import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as currentScopes from '../../../src/currentScopes';
 import { fill, getClient, getCurrentScope, setCurrentClient } from '../../../src';
 import { functionToStringIntegration } from '../../../src/integrations/functiontostring';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
+
+vi.mock('../../../src/currentScopes', async importOriginal => {
+  const actual = await importOriginal<typeof currentScopes>();
+  return { ...actual, getClient: vi.fn(actual.getClient) };
+});
 
 describe('FunctionToString', () => {
   beforeEach(() => {
@@ -9,8 +15,13 @@ describe('FunctionToString', () => {
     setCurrentClient(testClient);
   });
 
+  afterEach(() => {
+    vi.mocked(currentScopes.getClient).mockClear();
+  });
+
   afterAll(() => {
     getCurrentScope().setClient(undefined);
+    vi.restoreAllMocks();
   });
 
   it('it works as expected', () => {
@@ -54,5 +65,25 @@ describe('FunctionToString', () => {
     testClient.addIntegration(fts);
 
     expect(foo.bar.toString()).not.toBe(originalFunction);
+  });
+
+  it('falls back to native toString and does not throw when the carrier read throws', () => {
+    const foo = {
+      bar(wat: boolean): boolean {
+        return wat;
+      },
+    };
+    const nativeString = foo.bar.toString();
+
+    const fts = functionToStringIntegration();
+    getClient()?.addIntegration(fts);
+
+    // Simulate a `SecurityError` thrown while reading the Sentry carrier off a cross-origin `WindowProxy`.
+    vi.mocked(currentScopes.getClient).mockImplementation(() => {
+      throw new Error('SecurityError: Blocked a frame from accessing a cross-origin frame.');
+    });
+
+    expect(() => foo.bar.toString()).not.toThrow();
+    expect(foo.bar.toString()).toBe(nativeString);
   });
 });


### PR DESCRIPTION
The default `functionToStringIntegration` patches `Function.prototype.toString`. The patched function reads the Sentry carrier off `getClient()` (→ `getMainCarrier()` → `getSentryCarrier(GLOBAL_OBJ)` → `GLOBAL_OBJ.__SENTRY__`) on **every** `.toString()` invocation.

`GLOBAL_OBJ` is a `WindowProxy` in browser realms. When its browsing context is later navigated cross-origin while code from the old realm can still be invoked (e.g. a parent window holding a reference into a same-origin child iframe whose `src` changed to a cross-origin URL), the `__SENTRY__` read throws a `SecurityError`.

Because the patch lives on `Function.prototype`, the throw is triggered by *any* third-party `.toString()` call, converting harmless introspection into uncatchable `SecurityError` noise that Sentry then reports as unhandled-rejection events.

## Root cause

The native `Function.prototype.toString` never throws for these calls — the throw is introduced solely by the integration's internal carrier access. The fix wraps the patch body in a `try/catch` and falls back to `originalFunctionToString.apply(this, args)`, mirroring the defensive style already used around the patch installation. This keeps the unwrap behavior intact for live realms and degrades to exact native semantics when the carrier read throws.

Fixes getsentry/sentry-javascript#21965

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)