### PR TITLE
ref(node-core): Vendor OTel rpc-metadata and drop `@opentelemetry/core` dependency

### DIFF
--- a/packages/node-core/README.md
+++ b/packages/node-core/README.md
@@ -13,17 +13,16 @@
 Unlike the `@sentry/node` SDK, this SDK comes with no OpenTelemetry auto-instrumentation out of the box. It requires the following OpenTelemetry dependencies and supports both v1 and v2 of OpenTelemetry:
 
 - `@opentelemetry/api`
-- `@opentelemetry/core`
 - `@opentelemetry/instrumentation`
 - `@opentelemetry/sdk-trace-base`
 
 ## Installation
 
 ```bash
-npm install @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/core @opentelemetry/instrumentation @opentelemetry/sdk-trace-base
+npm install @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/instrumentation @opentelemetry/sdk-trace-base
 
 # Or yarn
-yarn add @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/core @opentelemetry/instrumentation @opentelemetry/sdk-trace-base
+yarn add @sentry/node-core @sentry/opentelemetry @opentelemetry/api @opentelemetry/instrumentation @opentelemetry/sdk-trace-base
 ```
 
 ## Usage

--- a/packages/node-core/package.json
+++ b/packages/node-core/package.json
@@ -78,16 +78,12 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.30.1 || ^2.1.0",
     "@opentelemetry/instrumentation": ">=0.57.1 <1",
     "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
     "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {
-      "optional": true
-    },
-    "@opentelemetry/core": {
       "optional": true
     },
     "@opentelemetry/instrumentation": {
@@ -108,7 +104,6 @@
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/core": "^2.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.220.0",
     "@opentelemetry/instrumentation": "^0.220.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",

--- a/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node-core/src/integrations/http/httpServerSpansIntegration.ts
@@ -2,8 +2,8 @@
 import { errorMonitor } from 'node:events';
 import type { IncomingHttpHeaders } from 'node:http';
 import { context } from '@opentelemetry/api';
-import type { RPCMetadata } from '@opentelemetry/core';
-import { RPCType, setRPCMetadata } from '@opentelemetry/core';
+import type { RPCMetadata } from './vendored/rpcMetadata';
+import { RPCType, setRPCMetadata } from './vendored/rpcMetadata';
 import {
   HTTP_CLIENT_IP,
   HTTP_FLAVOR,

--- a/packages/node-core/src/integrations/http/vendored/rpcMetadata.ts
+++ b/packages/node-core/src/integrations/http/vendored/rpcMetadata.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NOTICE from the Sentry authors:
+ * - Vendored from: https://github.com/open-telemetry/opentelemetry-js/tree/main/packages/opentelemetry-core/src/trace/rpc-metadata.ts
+ * - Upstream version: @opentelemetry/core@2.9.0
+ * - `getRPCMetadata` and `deleteRPCMetadata` were removed since they're not used
+ */
+
+import type { Context, Span } from '@opentelemetry/api';
+import { createContextKey } from '@opentelemetry/api';
+
+const RPC_METADATA_KEY = createContextKey('OpenTelemetry SDK Context Key RPC_METADATA');
+
+export enum RPCType {
+  HTTP = 'http',
+}
+
+type HTTPMetadata = {
+  type: RPCType.HTTP;
+  route?: string;
+  span: Span;
+};
+
+/**
+ * Allows for future rpc metadata to be used with this mechanism
+ */
+export type RPCMetadata = HTTPMetadata;
+
+/** Set the current RPC metadata on the given context. */
+export function setRPCMetadata(context: Context, meta: RPCMetadata): Context {
+  return context.setValue(RPC_METADATA_KEY, meta);
+}


### PR DESCRIPTION
`@sentry/node-core` only depended on `@opentelemetry/core` for the RPC metadata helpers (`getRPCMetadata`/`setRPCMetadata`/`RPCType`) used by the HTTP server spans integration. This vendors that single small module and drops the dependency entirely.

The vendored file is colocated with its sole consumer under `integrations/http/vendored/rpcMetadata.ts`, matching the pattern already used for the vendored undici instrumentation (colocated with consumer) rather than a top-level `vendored/` directory, since it has exactly one caller.

With the import switched to the vendored copy, `@opentelemetry/core` is no longer referenced anywhere in `src`, so it was removed from `peerDependencies`, `peerDependenciesMeta`, `devDependencies`, and the README's dependency list and install commands.

ref #21674
closes #22280 