### PR TITLE
ref(core): Remove redundant log buffer flush

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -467,7 +467,6 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    */
   // @ts-expect-error - PromiseLike is a subset of Promise
   public async close(timeout?: number): PromiseLike<boolean> {
-    _INTERNAL_flushLogsBuffer(this);
     const result = await this.flush(timeout);
     this.getOptions().enabled = false;
     this.emit('close');

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -2220,7 +2220,7 @@ describe('Client', () => {
         .spyOn(logsInternalModule, '_INTERNAL_flushLogsBuffer')
         .mockImplementation(() => undefined);
 
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
       const client = new TestClient(options);
 
       await client.close();


### PR DESCRIPTION
This PR removes the explicit log-buffer flush from `Client.close()`. `Client.flush()` (called by `close`) already emits the flush hook, which we listen to in `setupWeightBasedFlushing` for logs and metrics. So the explicit call flushes enabled log buffers twice.

ref #19347

(just found this while going over our closing logic, so figured I'd remove the line)