### PR TITLE
chore(node-core): Deprecate `@sentry/node-core` package

### DIFF
--- a/packages/node-core/README.md
+++ b/packages/node-core/README.md
@@ -7,8 +7,7 @@
 # Official Sentry SDK for Node-Core (DEPRECATED)
 
 > DEPRECATION NOTICE: The `@sentry/node-core` package is deprecated and will be removed in the next major version.
-> Its functionality is being merged back into the `@sentry/node` SDK.
-> Use [`@sentry/node`](https://www.npmjs.com/package/@sentry/node) instead.
+> Its functionality will be merged back into the `@sentry/node` SDK.
 
 [![npm version](https://img.shields.io/npm/v/@sentry/node-core.svg)](https://www.npmjs.com/package/@sentry/node-core)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/node-core.svg)](https://www.npmjs.com/package/@sentry/node-core)

--- a/packages/node-core/README.md
+++ b/packages/node-core/README.md
@@ -4,7 +4,11 @@
   </a>
 </p>
 
-# Official Sentry SDK for Node-Core
+# Official Sentry SDK for Node-Core (DEPRECATED)
+
+> DEPRECATION NOTICE: The `@sentry/node-core` package is deprecated and will be removed in the next major version.
+> Its functionality is being merged back into the `@sentry/node` SDK.
+> Use [`@sentry/node`](https://www.npmjs.com/package/@sentry/node) instead.
 
 [![npm version](https://img.shields.io/npm/v/@sentry/node-core.svg)](https://www.npmjs.com/package/@sentry/node-core)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/node-core.svg)](https://www.npmjs.com/package/@sentry/node-core)


### PR DESCRIPTION
The `@sentry/node-core` SDK is being merged back into `@sentry/node` in the next major version. Add a deprecation notice to the README ahead of removal, pointing users to `@sentry/node`.

Closes https://linear.app/getsentry/issue/SDK-1345/add-deprecation-notice-in-sentrynode-core
