### PR TITLE
fix: Include bundler CJS exports to fix Node warning

### DIFF
--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -39,11 +39,13 @@
     },
     "./orchestrion/vite": {
       "types": "./build/types/orchestrion/bundler/vite.d.ts",
-      "import": "./build/esm/orchestrion/bundler/vite.js"
+      "import": "./build/esm/orchestrion/bundler/vite.js",
+      "require": "./build/cjs/orchestrion/bundler/vite.js"
     },
     "./orchestrion/rollup": {
       "types": "./build/types/orchestrion/bundler/rollup.d.ts",
-      "import": "./build/esm/orchestrion/bundler/rollup.js"
+      "import": "./build/esm/orchestrion/bundler/rollup.js",
+      "require": "./build/cjs/orchestrion/bundler/rollup.js"
     },
     "./orchestrion/webpack": {
       "types": "./build/types/orchestrion/bundler/webpack.d.ts",
@@ -52,7 +54,8 @@
     },
     "./orchestrion/esbuild": {
       "types": "./build/types/orchestrion/bundler/esbuild.d.ts",
-      "import": "./build/esm/orchestrion/bundler/esbuild.js"
+      "import": "./build/esm/orchestrion/bundler/esbuild.js",
+      "require": "./build/cjs/orchestrion/bundler/esbuild.js"
     },
     "./orchestrion/import-hook": {
       "import": "./build/orchestrion/import-hook.mjs"


### PR DESCRIPTION
We saw a Node.js warning at runtime:

> `@sentry/server-utils/orchestrion/vite` is ESM-only (its exports map has only import, no require), but vite.config.ts is being loaded as CJS because the app has no "type": "module". 

Adding missing require exports should fix this!