### PR TITLE
chore(deps): Bump orchestrion dependencies to latest

### DIFF
--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
+    "@apm-js-collab/code-transformer-bundler-plugins": "^0.6.0",
     "@sentry/core": "10.65.0",
     "@sentry/node": "10.65.0",
     "@sentry/server-utils": "10.65.0"

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -113,9 +113,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@apm-js-collab/code-transformer-bundler-plugins": "^0.5.0",
+    "@apm-js-collab/code-transformer-bundler-plugins": "^0.6.0",
     "@apm-js-collab/code-transformer": "^0.18.0",
-    "@apm-js-collab/tracing-hooks": "^0.11.0",
+    "@apm-js-collab/tracing-hooks": "^0.12.0",
     "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.65.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,39 +404,15 @@
   dependencies:
     json-schema-to-ts "^3.1.1"
 
-"@apm-js-collab/code-transformer-bundler-plugins@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.5.0.tgz#8a08136e8281f7e8e36ac6810d2b122c5917de93"
-  integrity sha512-YxLBY5nGlurL7QeJLq6e5g0ouBpAp0pwgyA/5rHXEXwhiPLn9ZHbT+Y2LlP90GT872cSocfjWRYu/fnpuBudNQ==
+"@apm-js-collab/code-transformer-bundler-plugins@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.6.0.tgz#ed64bae9e1871366eadc1ef6dabc9ee6ccc53e57"
+  integrity sha512-Hys7LDskIB/BNrd87GAfYWHRE3mWgcPYonK4W9uxjho4N0JnPKk2YQyOLlqmkyVhj2UzwLRpmbJ4D6uR9O7wyw==
   dependencies:
-    "@apm-js-collab/code-transformer" "^0.15.0"
+    "@apm-js-collab/code-transformer" "^0.18.0"
     es-module-lexer "^2.1.0"
     magic-string "^0.30.21"
     module-details-from-path "^1.0.4"
-
-"@apm-js-collab/code-transformer@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz#a3a1b6c7b92db16f8277636b4a72a1626e2fa52a"
-  integrity sha512-XmXYVs8CzJ1Aj79noVbn2weUO/XWtRyURpGqx7aU7DOXlUQhR0WKOQNF0okh7PCeY37vxf7kU3v57OAkEPm3ww==
-  dependencies:
-    "@types/estree" "^1.0.8"
-    astring "^1.9.0"
-    esquery "^1.7.0"
-    meriyah "^6.1.4"
-    semifies "^1.0.0"
-    source-map "^0.6.0"
-
-"@apm-js-collab/code-transformer@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer/-/code-transformer-0.16.0.tgz#f49f3f88839907aea86a23c0a8102ad5038b8273"
-  integrity sha512-J3YRXRsxr/d48E7iDOAyVLrqQMCGU1iHWxXPKq7EeXQTRDDJ50piOfQNqxsM7u4XogJlirXvLHIznr0T33HTKw==
-  dependencies:
-    "@types/estree" "^1.0.8"
-    astring "^1.9.0"
-    esquery "^1.7.0"
-    meriyah "^6.1.4"
-    semifies "^1.0.0"
-    source-map "^0.6.0"
 
 "@apm-js-collab/code-transformer@^0.18.0":
   version "0.18.0"
@@ -450,12 +426,12 @@
     semifies "^1.0.0"
     source-map "^0.6.0"
 
-"@apm-js-collab/tracing-hooks@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.11.0.tgz#4c9c378695d65e90574893c1faba3c13b5bdbd14"
-  integrity sha512-5hWEcCGF4hcNh9lyB70p58pXn4HyUAVCad44wK6j110Ky+ivG19TfKHLB2aIDgItabCj6VPZm0DMAMNRnJDNBw==
+"@apm-js-collab/tracing-hooks@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.12.0.tgz#b65505d1d075fc8d8f4fa1973c37eaa9a9975b3f"
+  integrity sha512-U1cDbHOFbeToq5VWNcroBtQpz3hfH39uLkzJ5lorBFVNhHbTNj5MQvP+jODDwxBkG6A/agbQelG15rEoDgnjWg==
   dependencies:
-    "@apm-js-collab/code-transformer" "^0.16.0"
+    "@apm-js-collab/code-transformer" "^0.18.0"
     debug "^4.4.1"
     module-details-from-path "^1.0.4"
 


### PR DESCRIPTION
This bumps orchestrion dependencies:

* `"@apm-js-collab/code-transformer-bundler-plugins": "^0.6.0"`
* `"@apm-js-collab/tracing-hooks": "^0.12.0"`

which basically just updates those to use `"@apm-js-collab/code-transformer": "^0.18.0"` as deps.


Required for https://github.com/getsentry/sentry-javascript/pull/22141