### PR TITLE
feat(replay): Allow skipping the final flush on stop() via { flush: false }

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- feat(replay): Allow skipping the final flush when stopping recording via `stop({ flush: false })` ([#PR_NUMBER](https://github.com/getsentry/sentry-javascript/pull/PR_NUMBER))
+- feat(replay): Allow skipping the final flush when stopping recording via `stop({ flush: false })` ([#22300](https://github.com/getsentry/sentry-javascript/pull/22300))
 
 ## 10.66.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- feat(replay): Allow skipping the final flush when stopping recording via `stop({ flush: false })` ([#PR_NUMBER](https://github.com/getsentry/sentry-javascript/pull/PR_NUMBER))
+
 ## 10.66.0
 
 - chore(node-core): Deprecate `@sentry/node-core` package ([#22285](https://github.com/getsentry/sentry-javascript/pull/22285))

--- a/packages/replay-internal/src/integration.ts
+++ b/packages/replay-internal/src/integration.ts
@@ -298,13 +298,25 @@ export class Replay implements Integration {
   /**
    * Currently, this needs to be manually called (e.g. for tests). Sentry SDK
    * does not support a teardown
+   *
+   * @param options.flush - Whether to flush the pending replay segment when stopping.
+   * When recording in `session` mode, `stop()` flushes the buffered-but-unsent segment by
+   * default (`flush: true`), matching the previous behavior. Pass `flush: false` to stop
+   * recording without sending that pending segment — useful when a user withdraws consent
+   * and no further data should leave the browser.
+   *
+   * Note: `flush: false` only prevents the *pending* (final) segment from being sent. It does
+   * **not** retract segments that were already sent earlier during `session` recording.
    */
-  public stop(): Promise<void> {
+  public stop(options?: { flush?: boolean }): Promise<void> {
     if (!this._replay) {
       return Promise.resolve();
     }
 
-    return this._replay.stop({ forceFlush: this._replay.recordingMode === 'session', reason: 'manual' });
+    return this._replay.stop({
+      forceFlush: options?.flush ?? this._replay.recordingMode === 'session',
+      reason: 'manual',
+    });
   }
 
   /**

--- a/packages/replay-internal/test/integration/stop.test.ts
+++ b/packages/replay-internal/test/integration/stop.test.ts
@@ -153,6 +153,45 @@ describe('Integration | stop', () => {
     });
   });
 
+  it('does not flush the pending segment when stopped with `{ flush: false }` in session mode', async function () {
+    // Default mock SDK records in `session` mode (replaysSessionSampleRate: 1.0)
+    expect(replay.recordingMode).toBe('session');
+
+    const TEST_EVENT = getTestEventIncremental({ timestamp: BASE_TIMESTAMP });
+    addEvent(replay, TEST_EVENT, true);
+    expect(replay.eventBuffer?.hasEvents).toBe(true);
+    expect(mockRunFlush).toHaveBeenCalledTimes(0);
+
+    // stop without force-flushing the pending segment (e.g. on consent withdrawal)
+    await integration.stop({ flush: false });
+
+    // the buffered segment must not have been flushed/sent
+    expect(mockRunFlush).toHaveBeenCalledTimes(0);
+    expect(replay).not.toHaveLastSentReplay();
+
+    // recording is still torn down as usual
+    expect(replay.eventBuffer).toBe(null);
+    expect(replay.session).toEqual(undefined);
+  });
+
+  it('flushes the pending segment when stopped with `{ flush: true }` in session mode', async function () {
+    expect(replay.recordingMode).toBe('session');
+
+    const TEST_EVENT = getTestEventIncremental({ timestamp: BASE_TIMESTAMP });
+    addEvent(replay, TEST_EVENT, true);
+    expect(replay.eventBuffer?.hasEvents).toBe(true);
+    expect(mockRunFlush).toHaveBeenCalledTimes(0);
+
+    // explicitly force-flush the pending segment
+    await integration.stop({ flush: true });
+
+    expect(mockRunFlush).toHaveBeenCalledTimes(1);
+    expect(replay.eventBuffer).toBe(null);
+    expect(replay).toHaveLastSentReplay({
+      recordingData: JSON.stringify([TEST_EVENT]),
+    });
+  });
+
   it('does not call core SDK `addClickKeypressInstrumentationHandler` after initial setup', async function () {
     // NOTE: We clear mockAddDomInstrumentationHandler after every test
     await integration.stop();


### PR DESCRIPTION
Closes getsentry/sentry-javascript#22220

## Summary

`ReplayIntegration.stop()` always force-flushes the pending segment when `recordingMode === 'session'`, with no public way to opt out. Because Replay envelopes bypass `beforeSend`, consent-gated setups (CookieYes / OneTrust / Usercentrics / custom CMPs) that call `stop()` on consent withdrawal end up sending the buffered segment **after** the user revoked consent. The only workaround today is reaching into the private `_replay` field to call the internal `stop({ forceFlush: false })`, which isn't something we want to depend on in production code.

This exposes the already-existing internal `forceFlush` control on the public integration API.

## Changes

* `stop()` now accepts an optional `{ flush?: boolean }`:

  ```ts
  public stop(options?: { flush?: boolean }): Promise<void> {
    if (!this._replay) {
      return Promise.resolve();
    }
    return this._replay.stop({
      forceFlush: options?.flush ?? this._replay.recordingMode === 'session',
      reason: 'manual',
    });
  }
  ```
* **Defaults to the current behavior** (`flush` unset → flush when `recordingMode === 'session'`), so it's fully backwards compatible and safe to land in v10.
* `flush: false` stops recording without sending the pending segment.
* Added a doc comment noting the caveat (per @isaacs' comment on the issue): `flush: false` only suppresses the *pending/final* segment — it does **not** retract segments already sent earlier during `session` recording.
* Added tests for both `flush: false` (does not send) and `flush: true` (sends) in `session` mode.

## API naming

The issue proposed matching the internal `forceFlush` name, and @isaacs flagged that `forceFlush` leaks an internal term into the public surface. I went with the public-facing `flush` (`stop({ flush: false })`) since it reads better as public API, while mapping to the internal `forceFlush`. Happy to switch to `forceFlush` (matching the internal name, least surprising for anyone who already knows it) or a dedicated `discard`-style option instead — whichever the team prefers.

## Verification

* `packages/replay-internal` test suite: **476 passed** (incl. 2 new `stop` tests).
* Changed files are `oxfmt`-clean and typecheck cleanly.

- [X] Added tests for the new behavior.
- [X] Test suite passes for the affected package.
- [X] Linked the related issue (getsentry/sentry-javascript#22220).