### PR TITLE
test(cloudflare): Add tests for `ignoreSpans` with continued traces

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/index.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+  SERVER_URL: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 0,
+    traceLifecycle: 'stream',
+    ignoreSpans: ['ignored-child'],
+    tracePropagationTargets: [env.SERVER_URL],
+  }),
+  {
+    async fetch(_request, env, _ctx) {
+      await Sentry.startSpan({ name: 'ignored-child' }, async () => {
+        await fetch(`${env.SERVER_URL}/outgoing`);
+      });
+
+      return Response.json({ status: 'ok' });
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/test.ts
@@ -1,0 +1,51 @@
+import type { Envelope, SerializedStreamedSpanContainer } from '@sentry/core';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { createTestServer } from '@sentry-internal/test-utils';
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../../runner';
+
+it('preserves a positive sampling decision across an ignored child span', async ({ signal }) => {
+  const [serverUrl, closeTestServer] = await createTestServer()
+    .get('/outgoing', headers => {
+      expect(headers['sentry-trace']).toMatch(/^12345678901234567890123456789012-[\da-f]{16}-1$/);
+      expect(headers['baggage']).toBe(
+        'sentry-trace_id=12345678901234567890123456789012,sentry-sample_rate=1,sentry-sampled=true,sentry-public_key=public,sentry-sample_rand=0.5',
+      );
+    })
+    .start();
+
+  const runner = createRunner(__dirname)
+    .withServerUrl(serverUrl)
+    .expect(envelope => {
+      const container = getSpanContainer(envelope);
+      const serverSpan = container.items.find(item => item.attributes[SENTRY_OP]?.value === 'http.server');
+      const fetchSpan = container.items.find(item => item.attributes[SENTRY_OP]?.value === 'http.client');
+
+      expect(serverSpan?.is_segment).toBe(true);
+      expect(serverSpan?.trace_id).toBe('12345678901234567890123456789012');
+      expect(fetchSpan?.parent_span_id).toBe(serverSpan?.span_id);
+      expect(container.items.some(item => item.name === 'ignored-child')).toBe(false);
+    })
+    .start(signal);
+
+  try {
+    const response = await runner.makeRequest<{ status: string }>('get', '/', {
+      headers: {
+        'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
+        baggage:
+          'sentry-trace_id=12345678901234567890123456789012,sentry-sample_rate=1,sentry-sampled=true,sentry-public_key=public,sentry-sample_rand=0.5',
+      },
+    });
+
+    expect(response?.status).toBe('ok');
+    await runner.completed();
+  } finally {
+    closeTestServer();
+  }
+});
+
+function getSpanContainer(envelope: Envelope): SerializedStreamedSpanContainer {
+  const spanItem = envelope[1].find(item => item[0].type === 'span');
+  expect(spanItem).toBeDefined();
+  return spanItem![1] as SerializedStreamedSpanContainer;
+}

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "ignore-spans-streamed-continued-trace-child",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_als"],
+}

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/index.ts
@@ -1,0 +1,22 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+  SERVER_URL: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 0,
+    traceLifecycle: 'stream',
+    ignoreSpans: [{ attributes: { 'sentry.op': 'http.client' } }],
+    tracePropagationTargets: [env.SERVER_URL],
+  }),
+  {
+    async fetch(_request, env, _ctx) {
+      await fetch(`${env.SERVER_URL}/outgoing`);
+      return Response.json({ status: 'ok' });
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/test.ts
@@ -1,0 +1,52 @@
+import type { Envelope, SerializedStreamedSpanContainer } from '@sentry/core';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { createTestServer } from '@sentry-internal/test-utils';
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../../runner';
+
+it('preserves a positive sampling decision when the outgoing fetch span is ignored', async ({ signal }) => {
+  let outgoingSentryTrace: string | string[] | undefined;
+
+  const [serverUrl, closeTestServer] = await createTestServer()
+    .get('/outgoing', headers => {
+      outgoingSentryTrace = headers['sentry-trace'];
+      expect(headers['baggage']).toBe(
+        'sentry-trace_id=12345678901234567890123456789012,sentry-sample_rate=1,sentry-sampled=true,sentry-public_key=public,sentry-sample_rand=0.5',
+      );
+    })
+    .start();
+
+  const runner = createRunner(__dirname)
+    .withServerUrl(serverUrl)
+    .expect(envelope => {
+      const container = getSpanContainer(envelope);
+      const serverSpan = container.items.find(item => item.attributes[SENTRY_OP]?.value === 'http.server');
+
+      expect(serverSpan?.is_segment).toBe(true);
+      expect(serverSpan?.trace_id).toBe('12345678901234567890123456789012');
+      expect(outgoingSentryTrace).toBe(`12345678901234567890123456789012-${serverSpan?.span_id}-1`);
+      expect(container.items.some(item => item.attributes[SENTRY_OP]?.value === 'http.client')).toBe(false);
+    })
+    .start(signal);
+
+  try {
+    const response = await runner.makeRequest<{ status: string }>('get', '/', {
+      headers: {
+        'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
+        baggage:
+          'sentry-trace_id=12345678901234567890123456789012,sentry-sample_rate=1,sentry-sampled=true,sentry-public_key=public,sentry-sample_rand=0.5',
+      },
+    });
+
+    expect(response?.status).toBe('ok');
+    await runner.completed();
+  } finally {
+    closeTestServer();
+  }
+});
+
+function getSpanContainer(envelope: Envelope): SerializedStreamedSpanContainer {
+  const spanItem = envelope[1].find(item => item[0].type === 'span');
+  expect(spanItem).toBeDefined();
+  return spanItem![1] as SerializedStreamedSpanContainer;
+}

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "ignore-spans-streamed-continued-trace-http-client",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_als"],
+}

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/index.ts
@@ -1,0 +1,22 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+  SERVER_URL: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 0,
+    traceLifecycle: 'stream',
+    ignoreSpans: [{ op: 'http.server' }],
+    tracePropagationTargets: [env.SERVER_URL],
+  }),
+  {
+    async fetch(_request, env, _ctx) {
+      await fetch(`${env.SERVER_URL}/outgoing`);
+      return Response.json({ status: 'ok' });
+    },
+  },
+);

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/test.ts
@@ -1,0 +1,32 @@
+import { createTestServer } from '@sentry-internal/test-utils';
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../../runner';
+
+it('propagates a negative sampling decision when the continued server segment is ignored', async ({ signal }) => {
+  expect.assertions(3);
+
+  const [serverUrl, closeTestServer] = await createTestServer()
+    .get('/outgoing', headers => {
+      expect(headers['sentry-trace']).toMatch(/^12345678901234567890123456789012-[\da-f]{16}-0$/);
+      expect(headers['baggage']).toBe(
+        'sentry-trace_id=12345678901234567890123456789012,sentry-sample_rate=1,sentry-sampled=false,sentry-public_key=public,sentry-sample_rand=0.5',
+      );
+    })
+    .start();
+
+  const runner = createRunner(__dirname).withServerUrl(serverUrl).start(signal);
+
+  try {
+    const response = await runner.makeRequest<{ status: string }>('get', '/', {
+      headers: {
+        'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
+        baggage:
+          'sentry-trace_id=12345678901234567890123456789012,sentry-sample_rate=1,sentry-sampled=true,sentry-public_key=public,sentry-sample_rand=0.5',
+      },
+    });
+
+    expect(response?.status).toBe('ok');
+  } finally {
+    closeTestServer();
+  }
+});

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "ignore-spans-streamed-continued-trace-segment",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_als"],
+}


### PR DESCRIPTION
Node and browser required some fixes that also trickled down to clouflare. But luckily no further fixes, so this PR only adds tests.

closes getsentry/sentry-javascript#22262