### PR TITLE
fix(vue): Support pinia 4 in peer dependency range

### DIFF
--- a/dev-packages/e2e-tests/test-applications/vue-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-3/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@sentry/vue": "file:../../packed/sentry-vue-packed.tgz",
-    "pinia": "^3.0.0",
+    "pinia": "^4.0.0",
     "vue": "^3.4.15",
     "vue-router": "^4.2.5"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "@tanstack/vue-router": "^1.64.0",
-    "pinia": "2.x || 3.x",
+    "pinia": "2.x || 3.x || 4.x",
     "vue": "2.x || 3.x"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Pinia 4 has no API-changes, so we only need to update peer-dependency range. Also updates Pinia in the E2E test.

Pinia Release: https://github.com/vuejs/pinia/releases/tag/v4.0.0

Closes https://github.com/getsentry/sentry-javascript/issues/22320