### PR TITLE
chore(skills): Add libraries to framework update watcher

### DIFF
--- a/.agents/skills/track-framework-updates/assets/digest-schema.json
+++ b/.agents/skills/track-framework-updates/assets/digest-schema.json
@@ -14,7 +14,7 @@
     {
       "name": "React",
       "sentryPackages": ["@sentry/react"],
-      "category": "client",
+      "category": "client|server|meta-framework|platform|library",
       "releases": [
         {
           "tag": "v19.0.0",

--- a/.agents/skills/track-framework-updates/assets/digest-template.md
+++ b/.agents/skills/track-framework-updates/assets/digest-template.md
@@ -39,6 +39,10 @@ _Window: last <SINCE_DAYS> days · generated <GENERATED_AT>_
 
 <!-- Same per-framework structure as Client-Side. Covers Node.js, Bun, Deno, Cloudflare Workers, AWS Lambda, Google Cloud. -->
 
+## Libraries
+
+<!-- Same per-framework structure as Client-Side. Covers state management (e.g. Pinia), loggers (e.g. Pino, Winston, Consola), validators (e.g. Zod), and other utility libraries the SDK instruments. -->
+
 ## Source coverage
 
 ⚠ The following SDK packages are **not tracked** in `sources.json`. Add an upstream framework entry or exclude them in `scripts/check_sources.py`:

--- a/.agents/skills/track-framework-updates/sources.json
+++ b/.agents/skills/track-framework-updates/sources.json
@@ -101,6 +101,17 @@
       "rss": []
     },
     {
+      "name": "Express",
+      "sentryPackages": ["@sentry/node"],
+      "category": "server",
+      "github": {
+        "repo": "expressjs/express",
+        "discussions": false,
+        "rfcsRepo": null
+      },
+      "rss": ["https://expressjs.com/feed.xml"]
+    },
+    {
       "name": "Elysia",
       "sentryPackages": ["@sentry/elysia"],
       "category": "server",
@@ -271,6 +282,61 @@
       "category": "platform",
       "github": {
         "repo": "googleapis/google-cloud-node",
+        "discussions": false,
+        "rfcsRepo": null
+      },
+      "rss": []
+    },
+    {
+      "name": "Pinia",
+      "sentryPackages": ["@sentry/vue", "@sentry/nuxt"],
+      "category": "library",
+      "github": {
+        "repo": "vuejs/pinia",
+        "discussions": false,
+        "rfcsRepo": null
+      },
+      "rss": []
+    },
+    {
+      "name": "Pino",
+      "sentryPackages": ["@sentry/node"],
+      "category": "library",
+      "github": {
+        "repo": "pinojs/pino",
+        "discussions": false,
+        "rfcsRepo": null
+      },
+      "rss": []
+    },
+    {
+      "name": "Winston",
+      "sentryPackages": ["@sentry/node"],
+      "category": "library",
+      "github": {
+        "repo": "winstonjs/winston",
+        "discussions": false,
+        "rfcsRepo": null
+      },
+      "rss": []
+    },
+    {
+      "name": "Consola",
+      "sentryPackages": ["@sentry/core"],
+      "category": "library",
+      "github": {
+        "repo": "unjs/consola",
+        "discussions": false,
+        "rfcsRepo": null
+      },
+      "rss": []
+    },
+    {
+      "name": "Zod",
+      "sentryPackages": ["@sentry/core"],
+      "category": "library",
+      "github": {
+        "repo": "colinhacks/zod",
         "discussions": false,
         "rfcsRepo": null
       },


### PR DESCRIPTION
Since we missed the Pinia major version (see issue https://github.com/getsentry/sentry-javascript/issues/22320), I added some libraries to our framework update watcher.
