### PR TITLE
ref(server-utils): Collapse express route/use into one orchestrion channel

### DIFF
--- a/packages/server-utils/src/integrations/tracing-channel/express/instrumentation.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/express/instrumentation.ts
@@ -60,12 +60,7 @@ export function instrumentExpress(
   // matched route can be reconstructed with its parameters intact at request
   // time. Only the `end` event matters (the layer is on the router's stack by
   // then); the others are required by the subscriber type, so no-op them.
-  for (const channelName of [
-    CHANNELS.EXPRESS_ROUTE,
-    CHANNELS.EXPRESS_USE,
-    CHANNELS.ROUTER_ROUTE,
-    CHANNELS.ROUTER_USE,
-  ]) {
+  for (const channelName of [CHANNELS.EXPRESS_REGISTER, CHANNELS.ROUTER_REGISTER]) {
     tracingChannel<RegistrationChannelContext>(channelName).subscribe({
       start: NOOP,
       asyncStart: NOOP,

--- a/packages/server-utils/src/orchestrion/config/express.ts
+++ b/packages/server-utils/src/orchestrion/config/express.ts
@@ -32,25 +32,29 @@ export const expressConfig = [
   // handler, `use`'s trailing function argument is a registration payload, not a
   // callback — so `Callback` would misclassify it and never fire `end`.
   //
+  // `route` and `use` share a single `register` channel: the subscriber handles
+  // both identically (record the freshly-registered layer's path) and they live
+  // in the same file, so one channel per module covers both.
+  //
   // Express v4 ships its own router in `express/lib/router/index.js`.
   {
-    channelName: 'route',
+    channelName: 'register',
     module: { name: 'express', versionRange: '>=4.0.0 <5', filePath: 'lib/router/index.js' },
     functionQuery: { expressionName: 'route', kind: 'Sync' },
   },
   {
-    channelName: 'use',
+    channelName: 'register',
     module: { name: 'express', versionRange: '>=4.0.0 <5', filePath: 'lib/router/index.js' },
     functionQuery: { expressionName: 'use', kind: 'Sync' },
   },
   // Express v5 delegates routing to the standalone `router` package.
   {
-    channelName: 'route',
+    channelName: 'register',
     module: { name: 'router', versionRange: '>=2.0.0 <3', filePath: 'index.js' },
     functionQuery: { expressionName: 'route', kind: 'Sync' },
   },
   {
-    channelName: 'use',
+    channelName: 'register',
     module: { name: 'router', versionRange: '>=2.0.0 <3', filePath: 'index.js' },
     functionQuery: { expressionName: 'use', kind: 'Sync' },
   },
@@ -66,8 +70,8 @@ export const expressChannels = {
   // Layer *registration* (`Router.prototype.route`/`.use`), used to capture each
   // layer's registered path pattern so the matched route can be reconstructed
   // with its parameters intact (`req.baseUrl` only exposes the resolved prefix).
-  EXPRESS_ROUTE: 'orchestrion:express:route',
-  EXPRESS_USE: 'orchestrion:express:use',
-  ROUTER_ROUTE: 'orchestrion:router:route',
-  ROUTER_USE: 'orchestrion:router:use',
+  // `route` and `use` share one channel per module — the subscriber treats both
+  // the same.
+  EXPRESS_REGISTER: 'orchestrion:express:register',
+  ROUTER_REGISTER: 'orchestrion:router:register',
 } as const;

--- a/packages/server-utils/src/orchestrion/config/express.ts
+++ b/packages/server-utils/src/orchestrion/config/express.ts
@@ -32,9 +32,8 @@ export const expressConfig = [
   // handler, `use`'s trailing function argument is a registration payload, not a
   // callback — so `Callback` would misclassify it and never fire `end`.
   //
-  // `route` and `use` share a single `register` channel: the subscriber handles
-  // both identically (record the freshly-registered layer's path) and they live
-  // in the same file, so one channel per module covers both.
+  // `route` and `use` share one `register` channel because the subscriber handles
+  // them identically, saving a channel per module.
   //
   // Express v4 ships its own router in `express/lib/router/index.js`.
   {
@@ -70,8 +69,6 @@ export const expressChannels = {
   // Layer *registration* (`Router.prototype.route`/`.use`), used to capture each
   // layer's registered path pattern so the matched route can be reconstructed
   // with its parameters intact (`req.baseUrl` only exposes the resolved prefix).
-  // `route` and `use` share one channel per module — the subscriber treats both
-  // the same.
   EXPRESS_REGISTER: 'orchestrion:express:register',
   ROUTER_REGISTER: 'orchestrion:router:register',
 } as const;


### PR DESCRIPTION
Merges the express `route`/`use` registration channels into a single per-module `register` channel to reduce the number of tracing channels — the subscriber treats both identically, so there's no behavior change.