### PR TITLE
ref(server-utils): Share one orchestrion channel across OpenAI chat/responses/conversations

### DIFF
--- a/packages/server-utils/src/integrations/tracing-channel/openai.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/openai.ts
@@ -26,12 +26,11 @@ const INTEGRATION_NAME = 'OpenAI' as const;
 // are attributable separately from the OTel/proxy one.
 const ORIGIN = 'auto.ai.orchestrion.openai';
 
-// Each instrumented `create` method maps to the gen_ai operation its span reports.
+// Each instrumented `create` method maps to the gen_ai operation its span reports. Chat completions,
+// the responses API, and the conversations API all share the `chat` channel and operation.
 const INSTRUMENTED_CHANNELS = [
   { channel: CHANNELS.OPENAI_CHAT, operation: 'chat' },
-  { channel: CHANNELS.OPENAI_RESPONSES, operation: 'chat' },
   { channel: CHANNELS.OPENAI_EMBEDDINGS, operation: 'embeddings' },
-  { channel: CHANNELS.OPENAI_CONVERSATIONS, operation: 'chat' },
 ] as const;
 
 /**

--- a/packages/server-utils/src/integrations/tracing-channel/openai.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/openai.ts
@@ -26,8 +26,7 @@ const INTEGRATION_NAME = 'OpenAI' as const;
 // are attributable separately from the OTel/proxy one.
 const ORIGIN = 'auto.ai.orchestrion.openai';
 
-// Each instrumented `create` method maps to the gen_ai operation its span reports. Chat completions,
-// the responses API, and the conversations API all share the `chat` channel and operation.
+// Each instrumented `create` method maps to the gen_ai operation its span reports.
 const INSTRUMENTED_CHANNELS = [
   { channel: CHANNELS.OPENAI_CHAT, operation: 'chat' },
   { channel: CHANNELS.OPENAI_EMBEDDINGS, operation: 'embeddings' },

--- a/packages/server-utils/src/orchestrion/config/openai.ts
+++ b/packages/server-utils/src/orchestrion/config/openai.ts
@@ -9,8 +9,7 @@ export const openaiConfig = [
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },
     functionQuery: { className: 'Completions', methodName: 'create', kind: 'Auto' as const },
   })),
-  // OpenAI responses API — same `create(body, options)` shape as chat completions, and the subscriber
-  // reports it as the same `chat` operation, so it shares the `chat` channel.
+  // OpenAI responses API — same `create(body, options)` shape as chat completions.
   ...['resources/responses/responses.js', 'resources/responses/responses.mjs'].map(filePath => ({
     channelName: 'chat',
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },
@@ -22,8 +21,7 @@ export const openaiConfig = [
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },
     functionQuery: { className: 'Embeddings', methodName: 'create', kind: 'Auto' as const },
   })),
-  // OpenAI conversations API — same `create(body, options)` shape as chat completions, reported as the
-  // same `chat` operation, so it shares the `chat` channel.
+  // OpenAI conversations API — same `create(body, options)` shape as chat completions.
   ...['resources/conversations/conversations.js', 'resources/conversations/conversations.mjs'].map(filePath => ({
     channelName: 'chat',
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },

--- a/packages/server-utils/src/orchestrion/config/openai.ts
+++ b/packages/server-utils/src/orchestrion/config/openai.ts
@@ -9,9 +9,10 @@ export const openaiConfig = [
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },
     functionQuery: { className: 'Completions', methodName: 'create', kind: 'Auto' as const },
   })),
-  // OpenAI responses API — same `create(body, options)` shape as chat completions.
+  // OpenAI responses API — same `create(body, options)` shape as chat completions, and the subscriber
+  // reports it as the same `chat` operation, so it shares the `chat` channel.
   ...['resources/responses/responses.js', 'resources/responses/responses.mjs'].map(filePath => ({
-    channelName: 'responses',
+    channelName: 'chat',
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },
     functionQuery: { className: 'Responses', methodName: 'create', kind: 'Auto' as const },
   })),
@@ -21,17 +22,18 @@ export const openaiConfig = [
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },
     functionQuery: { className: 'Embeddings', methodName: 'create', kind: 'Auto' as const },
   })),
-  // OpenAI conversations API — same `create(body, options)` shape as chat completions.
+  // OpenAI conversations API — same `create(body, options)` shape as chat completions, reported as the
+  // same `chat` operation, so it shares the `chat` channel.
   ...['resources/conversations/conversations.js', 'resources/conversations/conversations.mjs'].map(filePath => ({
-    channelName: 'conversations',
+    channelName: 'chat',
     module: { name: 'openai', versionRange: '>=4.0.0 <7', filePath },
     functionQuery: { className: 'Conversations', methodName: 'create', kind: 'Auto' as const },
   })),
 ] satisfies InstrumentationConfig[];
 
 export const openaiChannels = {
+  // Chat completions, the responses API, and the conversations API all report a `chat` operation with
+  // identical span handling, so they share one channel.
   OPENAI_CHAT: 'orchestrion:openai:chat',
-  OPENAI_RESPONSES: 'orchestrion:openai:responses',
   OPENAI_EMBEDDINGS: 'orchestrion:openai:embeddings',
-  OPENAI_CONVERSATIONS: 'orchestrion:openai:conversations',
 } as const;


### PR DESCRIPTION
Points the OpenAI `responses` and `conversations` APIs at the existing `chat` channel to reduce the number of tracing channels — all three already report the same `chat` operation with identical span handling, so there's no behavior change.