### PR TITLE
fix(cloudflare,deno,node): Align types of vercelai

### DIFF
--- a/packages/cloudflare/src/integrations/tracing/vercelai.ts
+++ b/packages/cloudflare/src/integrations/tracing/vercelai.ts
@@ -19,6 +19,11 @@ interface VercelAiOptions {
    * Defaults to `true`.
    */
   enableTruncation?: boolean;
+
+  // `recordInputs`/`recordOutputs` are intentionally omitted: this entrypoint only post-processes
+  // spans the AI SDK already emitted, so it cannot decide whether inputs/outputs are recorded.
+  // Control this per call via `experimental_telemetry.recordInputs`/`recordOutputs`, or use the
+  // `@sentry/cloudflare/nodejs_compat` entrypoint for integration-level control on ai >= 7.
 }
 
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {

--- a/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
+++ b/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
@@ -7,16 +7,8 @@
 
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
-import { vercelAiIntegration as serverUtilsVercelAiIntegration } from '@sentry/server-utils';
+import { vercelAiIntegration as serverUtilsVercelAiIntegration, type VercelAiOptions } from '@sentry/server-utils';
 import { vercelAIIntegration as cloudflareVercelAIIntegration } from '../../../integrations/tracing/vercelai';
-
-interface VercelAiOptions {
-  /**
-   * Enable or disable truncation of recorded input messages.
-   * Defaults to `true`.
-   */
-  enableTruncation?: boolean;
-}
 
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   const inner = serverUtilsVercelAiIntegration(options);

--- a/packages/deno/src/integrations/tracing/vercelai.ts
+++ b/packages/deno/src/integrations/tracing/vercelai.ts
@@ -4,15 +4,7 @@
 
 import type { IntegrationFn } from '@sentry/core';
 import { addVercelAiProcessors, defineIntegration, extendIntegration } from '@sentry/core';
-import { vercelAiIntegration as serverUtilsVercelAiIntegration } from '@sentry/server-utils';
-
-interface VercelAiOptions {
-  /**
-   * Enable or disable truncation of recorded input messages.
-   * Defaults to `true`.
-   */
-  enableTruncation?: boolean;
-}
+import { vercelAiIntegration as serverUtilsVercelAiIntegration, type VercelAiOptions } from '@sentry/server-utils';
 
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   const inner = serverUtilsVercelAiIntegration(options);

--- a/packages/node/src/integrations/tracing/vercelai/types.ts
+++ b/packages/node/src/integrations/tracing/vercelai/types.ts
@@ -1,4 +1,5 @@
 import type { Integration } from '@sentry/core';
+import type { VercelAiOptions as VercelAiBaseOptions } from '@sentry/server-utils';
 
 /**
  * Telemetry configuration.
@@ -45,31 +46,12 @@ export declare type AttributeValue =
   | Array<null | undefined | number>
   | Array<null | undefined | boolean>;
 
-export interface VercelAiOptions {
-  /**
-   * Enable or disable input recording. Enabled if `dataCollection.genAI.inputs` (or the deprecated `sendDefaultPii` option) is `true`
-   * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
-   * Integration-level options take precedence over global `dataCollection` config.
-   */
-  recordInputs?: boolean;
-  /**
-   * Enable or disable output recording. Enabled if `dataCollection.genAI.outputs` (or the deprecated `sendDefaultPii` option) is `true`
-   * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
-   * Integration-level options take precedence over global `dataCollection` config.
-   */
-  recordOutputs?: boolean;
-
+export interface VercelAiOptions extends VercelAiBaseOptions {
   /**
    * By default, the instrumentation will register span processors only when the ai package is used.
    * If you want to register the span processors even when the ai package usage cannot be detected, you can set `force` to `true`.
    */
   force?: boolean;
-
-  /**
-   * Enable or disable truncation of recorded input messages.
-   * Defaults to `true`.
-   */
-  enableTruncation?: boolean;
 }
 
 export interface VercelAiIntegration extends Integration {

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -20,9 +20,8 @@ export type {
   TracingChannelBindingHandle,
   TracingChannelPayloadWithSpan,
 } from './tracing-channel';
-export { vercelAiIntegration } from './vercel-ai';
 export type { InstrumentationConfig } from './orchestrion';
-export type { VercelAiOptions } from './vercel-ai';
+export { vercelAiIntegration, type VercelAiOptions } from './vercel-ai';
 export {
   fastifyIntegration,
   // oxlint-disable-next-line typescript/no-deprecated

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -22,6 +22,7 @@ export type {
 } from './tracing-channel';
 export { vercelAiIntegration } from './vercel-ai';
 export type { InstrumentationConfig } from './orchestrion';
+export type { VercelAiOptions } from './vercel-ai';
 export {
   fastifyIntegration,
   // oxlint-disable-next-line typescript/no-deprecated

--- a/packages/server-utils/src/vercel-ai/index.ts
+++ b/packages/server-utils/src/vercel-ai/index.ts
@@ -2,7 +2,7 @@ import { defineIntegration, waitForTracingChannelBinding, type IntegrationFn } f
 import { subscribeVercelAiTracingChannel } from './vercel-ai-dc-subscriber';
 import * as dc from 'node:diagnostics_channel';
 
-type VercelAiOptions = {
+export interface VercelAiOptions {
   /**
    * Enable or disable input recording. Enabled if `dataCollection.genAI.inputs` (or the deprecated `sendDefaultPii` option) is `true`
    * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
@@ -22,7 +22,7 @@ type VercelAiOptions = {
    * Defaults to `true`.
    */
   enableTruncation?: boolean;
-};
+}
 
 const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {
   return {

--- a/packages/vercel-edge/src/integrations/tracing/vercelai.ts
+++ b/packages/vercel-edge/src/integrations/tracing/vercelai.ts
@@ -19,6 +19,11 @@ interface VercelAiOptions {
    * Defaults to `true`.
    */
   enableTruncation?: boolean;
+
+  // `recordInputs`/`recordOutputs` are intentionally omitted: this entrypoint only post-processes
+  // spans the AI SDK already emitted (no OTel patch or tracing channel in the edge runtime), so it
+  // cannot decide whether inputs/outputs are recorded. Control this per call via
+  // `experimental_telemetry.recordInputs`/`recordOutputs`.
 }
 
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {


### PR DESCRIPTION
`recordInput` and `recordOuput` types were missing for integrations that were using the `vercelAiIntegration` from the `server-utils` package. By exporting them this is now aligned.

Only `node` had also `force` in it, so it is only extended there. 

Cloudflare (the older entrypoint) and Vercel Edge only have `enableTrucation`