### PR TITLE
fix(nextjs): Mark internal chunk frames as not `in_app`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-13/tests/client/click-error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-13/tests/client/click-error.test.ts
@@ -39,7 +39,7 @@ test('should send error for faulty click handlers', async ({ page }) => {
       expect(frames).toContainEqual(
         expect.objectContaining({
           filename: expect.stringMatching(
-            /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
+            /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js(:\d+)*$/,
           ),
           in_app: false,
         }),
@@ -48,7 +48,7 @@ test('should send error for faulty click handlers', async ({ page }) => {
       expect(frames).not.toContainEqual(
         expect.objectContaining({
           filename: expect.stringMatching(
-            /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
+            /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js(:\d+)*$/,
           ),
           in_app: true,
         }),

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/pages/[locale]/click-error.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/pages/[locale]/click-error.tsx
@@ -1,0 +1,12 @@
+export default function ClickErrorPage() {
+  return (
+    <button
+      id="error-button"
+      onClick={() => {
+        throw new Error('click error');
+      }}
+    >
+      click to throw error
+    </button>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/tests/click-error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/tests/click-error.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test('should mark nextjs internal frames as not in_app for faulty click handlers', async ({ page }) => {
+  // The internal-chunk detection matches webpack chunk names (e.g. `webpack-<hash>.js`), which only exist in
+  // production webpack builds. Turbopack and dev builds emit differently-named chunks, so this is only relevant there.
+  test.skip(process.env.TEST_ENV !== 'production', 'Only relevant for production webpack builds');
+
+  const errorPromise = waitForError('nextjs-15', async errorEvent => {
+    return errorEvent.exception?.values?.[0].value === 'click error';
+  });
+
+  await page.goto('/42/click-error');
+  await page.click('#error-button');
+
+  const errorEvent = await errorPromise;
+
+  expect(errorEvent).toBeDefined();
+
+  const frames = errorEvent?.exception?.values?.[0]?.stacktrace?.frames;
+
+  const internalChunkRegex =
+    /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js(:\d+)*$/;
+
+  const internalFrames = frames?.filter(frame => frame.filename && internalChunkRegex.test(frame.filename)) ?? [];
+
+  expect(internalFrames.length).toBeGreaterThan(0);
+  expect(internalFrames.filter(frame => frame.in_app !== false)).toEqual([]);
+});

--- a/packages/nextjs/src/client/clientNormalizationIntegration.ts
+++ b/packages/nextjs/src/client/clientNormalizationIntegration.ts
@@ -1,6 +1,9 @@
 import { defineIntegration } from '@sentry/core';
 import { rewriteFramesIntegration } from '@sentry/react';
 
+const NEXTJS_INTERNAL_CHUNK_REGEX =
+  /\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js(:\d+)*$/;
+
 export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
   ({
     assetPrefix,
@@ -58,28 +61,13 @@ export const nextjsClientStackFrameNormalizationIntegration = defineIntegration(
           if (frame.filename?.includes('/_next')) {
             frame.filename = decodeURI(frame.filename);
           }
+        } else if (frame.filename?.startsWith('app:///_next')) {
+          frame.filename = decodeURI(frame.filename);
+        }
 
-          if (
-            frame.filename?.match(
-              /\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
-            )
-          ) {
-            // We don't care about these frames. It's Next.js internal code.
-            frame.in_app = false;
-          }
-        } else {
-          if (frame.filename?.startsWith('app:///_next')) {
-            frame.filename = decodeURI(frame.filename);
-          }
-
-          if (
-            frame.filename?.match(
-              /^app:\/\/\/_next\/static\/chunks\/(main-|main-app-|polyfills-|webpack-|framework-|framework\.)[0-9a-f]+\.js$/,
-            )
-          ) {
-            // We don't care about these frames. It's Next.js internal code.
-            frame.in_app = false;
-          }
+        if (frame.filename?.match(NEXTJS_INTERNAL_CHUNK_REGEX)) {
+          // We don't care about these frames. It's Next.js internal code.
+          frame.in_app = false;
         }
 
         return frame;

--- a/packages/nextjs/test/clientNormalizationIntegration.test.ts
+++ b/packages/nextjs/test/clientNormalizationIntegration.test.ts
@@ -1,0 +1,79 @@
+import type { StackFrame } from '@sentry/core';
+import * as SentryReact from '@sentry/react';
+import { JSDOM } from 'jsdom';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { nextjsClientStackFrameNormalizationIntegration } from '../src/client/clientNormalizationIntegration';
+
+const dom = new JSDOM(undefined, { url: 'https://example.com/' });
+const originalWindow = (global as { window?: unknown }).window;
+Object.defineProperty(global, 'window', { value: dom.window, writable: true, configurable: true });
+
+afterAll(() => {
+  Object.defineProperty(global, 'window', { value: originalWindow, writable: true, configurable: true });
+});
+
+type Iteratee = (frame: StackFrame) => StackFrame;
+
+function captureIteratee(options: Parameters<typeof nextjsClientStackFrameNormalizationIntegration>[0]): Iteratee {
+  let iteratee: Iteratee | undefined;
+  const spy = vi.spyOn(SentryReact, 'rewriteFramesIntegration').mockImplementation(rewriteFramesOptions => {
+    iteratee = rewriteFramesOptions?.iteratee as Iteratee;
+    return { name: 'RewriteFrames', processEvent: e => e };
+  });
+
+  nextjsClientStackFrameNormalizationIntegration(options);
+  spy.mockRestore();
+
+  if (!iteratee) {
+    throw new Error('rewriteFramesIntegration was not called with an iteratee');
+  }
+  return iteratee;
+}
+
+describe('nextjsClientStackFrameNormalizationIntegration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('marks Next.js internal chunks as not in_app', () => {
+    const iteratee = () =>
+      captureIteratee({
+        rewriteFramesAssetPrefixPath: '',
+        experimentalThirdPartyOriginStackFrames: false,
+      });
+
+    it.each([
+      'app:///_next/static/chunks/webpack-e0a29dd514f2abf8.js',
+      'app:///_next/static/chunks/webpack-e0a29dd514f2abf8.js:1',
+      'app:///_next/static/chunks/webpack-e0a29dd514f2abf8.js:1:234',
+      'app:///_next/static/chunks/main-app-abc123.js:10:5',
+      'app:///_next/static/chunks/framework.deadbeef.js:2',
+    ])('sets in_app=false for %s', filename => {
+      const frame = iteratee()({ filename });
+      expect(frame.in_app).toBe(false);
+    });
+
+    it('leaves app chunks as in_app', () => {
+      const frame = iteratee()({ filename: 'app:///_next/static/chunks/pages/index-deadbeef.js:1:2' });
+      expect(frame.in_app).toBeUndefined();
+    });
+  });
+
+  describe('experimentalThirdPartyOriginStackFrames', () => {
+    const iteratee = () =>
+      captureIteratee({
+        rewriteFramesAssetPrefixPath: '',
+        experimentalThirdPartyOriginStackFrames: true,
+        assetPrefix: 'https://cdn.example.com',
+      });
+
+    it.each([
+      'https://cdn.example.com/_next/static/chunks/webpack-e0a29dd514f2abf8.js',
+      'https://cdn.example.com/_next/static/chunks/webpack-e0a29dd514f2abf8.js:1',
+      'https://cdn.example.com/_next/static/chunks/webpack-e0a29dd514f2abf8.js:1:234',
+    ])('sets in_app=false for %s', filename => {
+      const frame = iteratee()({ filename });
+      expect(frame.in_app).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
The client stack frame normalization anchored its internal-chunk regex with `.js$`, so frames carrying a trailing `:line` or `:line:col` suffix (e.g. `app:///_next/static/chunks/webpack-<hash>.js:1`) never matched and stayed marked as `in_app`. The regex now tolerates the optional suffix, and the duplicated pattern is collapsed into a single shared constant.

Adds a unit test for the normalization iteratee and an e2e test in the nextjs-15 app verifying internal frames are marked `in_app: false`. Unfortunately this only targets pages router as app router moves this code into regular hashed chunks.