### PR TITLE
ref: Use base keys from conventions for dynamic suffix attribute keys

### DIFF
--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -12,7 +12,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core/browser';
 import type { VendoredTanstackRouter, VendoredTanstackRouterRouteMatch } from './vendor/tanstackrouter-types';
-import { PARAMS_KEY, URL_FULL, URL_PATH, URL_PATH_PARAMETER_KEY, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import {
+  PARAMS_KEY_BASE,
+  URL_FULL,
+  URL_PATH,
+  URL_PATH_PARAMETER_KEY_BASE,
+  URL_TEMPLATE,
+} from '@sentry/conventions/attributes';
 
 interface TanstackRouterLocation {
   pathname: string;
@@ -188,8 +194,8 @@ function routeMatchToParamSpanAttributes(match: VendoredTanstackRouterRouteMatch
   const paramAttributes: Record<string, string> = {};
   Object.entries(match.params).forEach(([key, value]) => {
     paramAttributes[`url.path.params.${key}`] = value; // TODO(v11): remove attribute which does not adhere to Sentry's semantic convention
-    paramAttributes[URL_PATH_PARAMETER_KEY.replace('<key>', key)] = value;
-    paramAttributes[PARAMS_KEY.replace('<key>', key)] = value; // params.[key] is an alias
+    paramAttributes[`${URL_PATH_PARAMETER_KEY_BASE}.${key}`] = value;
+    paramAttributes[`${PARAMS_KEY_BASE}.${key}`] = value; // params.[key] is an alias
   });
 
   return paramAttributes;

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -6,7 +6,13 @@ import {
   spanToJSON,
   startBrowserTracingNavigationSpan,
 } from '@sentry/browser';
-import { PARAMS_KEY, URL_FULL, URL_PATH, URL_PATH_PARAMETER_KEY, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import {
+  PARAMS_KEY_BASE,
+  URL_FULL,
+  URL_PATH,
+  URL_PATH_PARAMETER_KEY_BASE,
+  URL_TEMPLATE,
+} from '@sentry/conventions/attributes';
 import type { Client, Integration, Span } from '@sentry/core';
 import {
   getClient,
@@ -132,8 +138,8 @@ function withSentryRouterRoot(Root: Component<RouteSectionProps>): Component<Rou
         const params = lastMatch.params;
         for (const [key, value] of Object.entries(params)) {
           if (value !== undefined) {
-            rootSpan.setAttribute(URL_PATH_PARAMETER_KEY.replace('<key>', key), value);
-            rootSpan.setAttribute(PARAMS_KEY.replace('<key>', key), value);
+            rootSpan.setAttribute(`${URL_PATH_PARAMETER_KEY_BASE}.${key}`, value);
+            rootSpan.setAttribute(`${PARAMS_KEY_BASE}.${key}`, value);
           }
         }
       } else {

--- a/packages/solid/src/tanstackrouter.ts
+++ b/packages/solid/src/tanstackrouter.ts
@@ -5,7 +5,13 @@ import {
   startBrowserTracingPageLoadSpan,
   WINDOW,
 } from '@sentry/browser';
-import { PARAMS_KEY, URL_FULL, URL_PATH, URL_PATH_PARAMETER_KEY, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import {
+  PARAMS_KEY_BASE,
+  URL_FULL,
+  URL_PATH,
+  URL_PATH_PARAMETER_KEY_BASE,
+  URL_TEMPLATE,
+} from '@sentry/conventions/attributes';
 import type { Integration } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -182,8 +188,8 @@ function routeMatchToParamSpanAttributes(match: RouteMatch | undefined): Record<
 
   const paramAttributes: Record<string, string> = {};
   Object.entries(match.params as Record<string, string>).forEach(([key, value]) => {
-    paramAttributes[URL_PATH_PARAMETER_KEY.replace('<key>', key)] = value;
-    paramAttributes[PARAMS_KEY.replace('<key>', key)] = value; // params.[key] is an alias
+    paramAttributes[`${URL_PATH_PARAMETER_KEY_BASE}.${key}`] = value;
+    paramAttributes[`${PARAMS_KEY_BASE}.${key}`] = value; // params.[key] is an alias
   });
 
   return paramAttributes;

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -1,5 +1,5 @@
 import { captureException, getAbsoluteUrl } from '@sentry/browser';
-import { PARAMS_KEY, URL_PATH_PARAMETER_KEY, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { PARAMS_KEY_BASE, URL_PATH_PARAMETER_KEY_BASE, URL_TEMPLATE } from '@sentry/conventions/attributes';
 import type { Span, SpanAttributes, StartSpanOptions, TransactionSource } from '@sentry/core';
 import {
   getActiveSpan,
@@ -74,8 +74,8 @@ export function instrumentVueRouter(
     const attributes: SpanAttributes = {};
 
     for (const key of Object.keys(to.params)) {
-      attributes[URL_PATH_PARAMETER_KEY.replace('<key>', key)] = to.params[key];
-      attributes[PARAMS_KEY.replace('<key>', key)] = to.params[key]; // params.[key] is an alias
+      attributes[`${URL_PATH_PARAMETER_KEY_BASE}.${key}`] = to.params[key];
+      attributes[`${PARAMS_KEY_BASE}.${key}`] = to.params[key]; // params.[key] is an alias
     }
     for (const key of Object.keys(to.query)) {
       const value = to.query[key];

--- a/packages/vue/src/tanstackrouter.ts
+++ b/packages/vue/src/tanstackrouter.ts
@@ -5,7 +5,13 @@ import {
   startBrowserTracingPageLoadSpan,
   WINDOW,
 } from '@sentry/browser';
-import { PARAMS_KEY, URL_FULL, URL_PATH, URL_PATH_PARAMETER_KEY, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import {
+  PARAMS_KEY_BASE,
+  URL_FULL,
+  URL_PATH,
+  URL_PATH_PARAMETER_KEY_BASE,
+  URL_TEMPLATE,
+} from '@sentry/conventions/attributes';
 import type { Integration } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -191,8 +197,8 @@ function routeMatchToParamSpanAttributes(match: RouteMatch | undefined): Record<
 
   const paramAttributes: Record<string, string> = {};
   Object.entries(match.params as Record<string, string>).forEach(([key, value]) => {
-    paramAttributes[URL_PATH_PARAMETER_KEY.replace('<key>', key)] = value;
-    paramAttributes[PARAMS_KEY.replace('<key>', key)] = value; // params.[key] is an alias
+    paramAttributes[`${URL_PATH_PARAMETER_KEY_BASE}.${key}`] = value;
+    paramAttributes[`${PARAMS_KEY_BASE}.${key}`] = value; // params.[key] is an alias
   });
 
   return paramAttributes;


### PR DESCRIPTION
Sentry conventions now exports `_BASE` keys for attribute keys that have a dynamic suffix. We can now use these keys rather than the full key to avoid the `.replace` call. 