### PR TITLE
ref: Omit redundant `captureError: false` from tracing-channel callsites

### DIFF
--- a/packages/nestjs/src/integrations/orchestrion-subscriber.ts
+++ b/packages/nestjs/src/integrations/orchestrion-subscriber.ts
@@ -128,9 +128,6 @@ export function subscribeToNestChannels(): void {
   // `start`, makes it the active context for the bootstrap, and ends it
   // on `asyncEnd` (or `end` if `create` throws synchronously).
   //
-  // `captureError: false`: a failed bootstrap surfaces to the caller.
-  // We just annotate the span.
-  //
   // `bindTracingChannelToSpan` uses `bindStore`, which needs the
   // async-context binding registered after integration `setupOnce`; defer
   // until it's available. Only this bind is deferred (it fires at
@@ -138,14 +135,10 @@ export function subscribeToNestChannels(): void {
   // calls below stay synchronous because the decorator channels fire at
   // module-load time, which a deferred subscription could miss.
   waitForTracingChannelBinding(() => {
-    bindTracingChannelToSpan(
-      diagnosticsChannel.tracingChannel<ChannelContext>(CHANNELS.NESTJS_APP_CREATION),
-      data => {
-        const moduleCls = data.arguments?.[0] as { name?: string } | undefined;
-        return startInactiveSpan(getAppCreationSpanOptions(data.moduleVersion, moduleCls?.name));
-      },
-      { captureError: false },
-    );
+    bindTracingChannelToSpan(diagnosticsChannel.tracingChannel<ChannelContext>(CHANNELS.NESTJS_APP_CREATION), data => {
+      const moduleCls = data.arguments?.[0] as { name?: string } | undefined;
+      return startInactiveSpan(getAppCreationSpanOptions(data.moduleVersion, moduleCls?.name));
+    });
   });
 
   // request_context + request_handler. `RouterExecutionContext.create`

--- a/packages/server-utils/src/integrations/tracing-channel/redis.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/redis.ts
@@ -232,7 +232,6 @@ function bindNodeRedisCommandChannel(
       return startCommandSpan(commandName, wireArgs.slice(1), nodeRedisAttributes(options));
     },
     {
-      captureError: false,
       beforeSpanEnd(span, data) {
         if ('error' in data || !responseHook) {
           return;
@@ -269,18 +268,14 @@ function getExecutorArgs(data: CommandContext): Array<string | Buffer> | undefin
 
 function bindNodeRedisConnectChannel(): void {
   const channel = diagnosticsChannel.tracingChannel<CommandContext, CommandContext>(CHANNELS.NODE_REDIS_CONNECT);
-  bindTracingChannelToSpan(
-    channel,
-    data => {
-      const options = (data.self as NodeRedisClient | undefined)?.options;
-      return startInactiveSpan({
-        name: 'redis-connect',
-        kind: SPAN_KIND.CLIENT,
-        attributes: { ...nodeRedisAttributes(options), [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db' },
-      });
-    },
-    { captureError: false },
-  );
+  bindTracingChannelToSpan(channel, data => {
+    const options = (data.self as NodeRedisClient | undefined)?.options;
+    return startInactiveSpan({
+      name: 'redis-connect',
+      kind: SPAN_KIND.CLIENT,
+      attributes: { ...nodeRedisAttributes(options), [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db' },
+    });
+  });
 }
 
 // Batch (multi/pipeline): one span per `exec`. Batched commands bypass `sendCommand`, so
@@ -288,27 +283,23 @@ function bindNodeRedisConnectChannel(): void {
 // mirrors the native `node-redis:batch` span (see `redis-dc-subscriber.ts`).
 function bindNodeRedisBatchChannel(channelName: string, getOperation: (data: CommandContext) => string): void {
   const channel = diagnosticsChannel.tracingChannel<CommandContext, CommandContext>(channelName);
-  bindTracingChannelToSpan(
-    channel,
-    data => {
-      const commands = data.arguments?.[0];
-      const size = Array.isArray(commands) ? commands.length : undefined;
-      const socket = (data.self as NodeRedisClient | undefined)?.options?.socket;
-      return startInactiveSpan({
-        name: getOperation(data),
-        kind: SPAN_KIND.CLIENT,
-        attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis',
-          [DB_SYSTEM_NAME]: DB_SYSTEM_VALUE_REDIS,
-          ...(size && size > 1 ? { [DB_OPERATION_BATCH_SIZE]: size } : {}),
-          ...(socket?.host != null ? { [SERVER_ADDRESS]: socket.host } : {}),
-          ...(socket?.port != null ? { [SERVER_PORT]: socket.port } : {}),
-        },
-      });
-    },
-    { captureError: false },
-  );
+  bindTracingChannelToSpan(channel, data => {
+    const commands = data.arguments?.[0];
+    const size = Array.isArray(commands) ? commands.length : undefined;
+    const socket = (data.self as NodeRedisClient | undefined)?.options?.socket;
+    return startInactiveSpan({
+      name: getOperation(data),
+      kind: SPAN_KIND.CLIENT,
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis',
+        [DB_SYSTEM_NAME]: DB_SYSTEM_VALUE_REDIS,
+        ...(size && size > 1 ? { [DB_OPERATION_BATCH_SIZE]: size } : {}),
+        ...(socket?.host != null ? { [SERVER_ADDRESS]: socket.host } : {}),
+        ...(socket?.port != null ? { [SERVER_PORT]: socket.port } : {}),
+      },
+    });
+  });
 }
 
 const _redisChannelIntegration = ((options: RedisChannelIntegrationOptions = {}) => {

--- a/packages/server-utils/src/redis/redis-dc-subscriber.ts
+++ b/packages/server-utils/src/redis/redis-dc-subscriber.ts
@@ -164,9 +164,6 @@ function setupCommandChannel<T extends RedisCommandData | IORedisCommandData>(
       });
     },
     {
-      // Command failures are surfaced to (and usually handled by) the caller; only annotate the
-      // span so we don't emit a duplicate error event for every failed command.
-      captureError: false,
       beforeSpanEnd(span, data) {
         if ('error' in data) return;
         runResponseHook(responseHook, span, data.command, getCommandArgs(data), data.result);
@@ -180,44 +177,36 @@ function setupBatchChannel(
   channelName: string,
   getOperationName: (data: RedisBatchData) => string,
 ): void {
-  bindTracingChannelToSpan(
-    tracingChannel<RedisBatchData>(channelName),
-    data => {
-      return startInactiveSpan({
-        name: getOperationName(data),
-        attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis',
-          [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
-          // should only include batch size greater than 1,
-          // or else it isn't properly considered a "batch"
-          ...(Number(data.batchSize) > 1 ? { [DB_OPERATION_BATCH_SIZE]: data.batchSize } : {}),
-          ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
-          ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
-        },
-      });
-    },
-    { captureError: false },
-  );
+  bindTracingChannelToSpan(tracingChannel<RedisBatchData>(channelName), data => {
+    return startInactiveSpan({
+      name: getOperationName(data),
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis',
+        [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
+        // should only include batch size greater than 1,
+        // or else it isn't properly considered a "batch"
+        ...(Number(data.batchSize) > 1 ? { [DB_OPERATION_BATCH_SIZE]: data.batchSize } : {}),
+        ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
+        ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
+      },
+    });
+  });
 }
 
 function setupConnectChannel(tracingChannel: RedisTracingChannelFactory, channelName: string): void {
-  bindTracingChannelToSpan(
-    tracingChannel<RedisConnectData>(channelName),
-    data => {
-      return startInactiveSpan({
-        name: 'redis-connect',
-        attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis.connect',
-          [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
-          ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
-          ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
-        },
-      });
-    },
-    { captureError: false },
-  );
+  bindTracingChannelToSpan(tracingChannel<RedisConnectData>(channelName), data => {
+    return startInactiveSpan({
+      name: 'redis-connect',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.redis.connect',
+        [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
+        ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
+        ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),
+      },
+    });
+  });
 }
 
 function runResponseHook(


### PR DESCRIPTION
`captureError` defaults to `false` in `bindTracingChannelToSpan`, so passing it explicitly at the redis and nestjs subscriber callsites is redundant.