### PR TITLE
docs(agents): Prefer reusing existing utils before adding new ones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ Uses **Git Flow** (see `docs/gitflow.md`).
 ## Coding Standards
 
 - Follow existing conventions — check neighboring files
+- Reach for existing utils before writing a new one. Most shared helpers live in `@sentry/core` (`packages/core/src/utils/`), with browser helpers in `packages/browser-utils/`. Search first (LSP `workspaceSymbol` or grep) for common needs (type guards in `is.ts`, object/array helpers, `normalize`, `dsn`, `merge`, string/url helpers). Reuse or extend the existing util rather than adding a near-duplicate; only introduce a new util when nothing fits.
 - Only use libraries already in the codebase
 - Never expose secrets or keys
 - When modifying files, cover all occurrences (including `src/` and `test/`)


### PR DESCRIPTION
Adds a item to `AGENTS.md` (`CLAUDE.md` symlinks to it) telling agents to search for an existing util before writing a new one, pointing at where shared helpers actually live (`packages/core/src/utils/`, `packages/browser-utils/`).

Motivation: LLM-assisted changes have a habit of introducing near-duplicate helpers instead of reusing what's already there. This is a passive nudge rather than an enforced check.

I did a quick check spawned a couple of agents on bogus tasks that needed a couple of utils, and watched its reasoning and it picked up on this, so while it doesn't enforce it, it may help us curb the util soup we get.

This is a follow up to my previous util cleanup PRs #22155 #22163 #22154 