### PR TITLE
fix(replay): Set text/javascript MIME type on compression worker Blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Work in this release was contributed by @PeterWadie and @akshitsinha. Thank you 
 
   The SvelteKit SDK now supports SvelteKit 3, including client-side pageload and navigation tracing and server-side native tracing, alongside continued SvelteKit 2 support. No Sentry-specific setup changes are required. The SDK detects your SvelteKit version and picks the right implementation automatically.
 
+### Other Changes
+
+- fix(replay): Set `text/javascript` MIME type on the compression worker Blob ([#22377](https://github.com/getsentry/sentry-javascript/pull/22377))
+
 ## 10.66.0
 
 - chore(node-core): Deprecate `@sentry/node-core` package ([#22285](https://github.com/getsentry/sentry-javascript/pull/22285))

--- a/packages/replay-worker/src/index.ts
+++ b/packages/replay-worker/src/index.ts
@@ -4,6 +4,12 @@ import workerString from './worker';
  * Get the URL for a web worker.
  */
 export function getWorkerURL(): string {
-  const workerBlob = new Blob([workerString]);
+  // Safari (particularly on iOS) validates the MIME type of a Blob before it
+  // will execute it as a classic Worker script. A Blob created without an
+  // explicit `type` defaults to an empty string, which WebKit may reject,
+  // firing a bare `error` event with no message. Blink/Gecko are lenient here,
+  // so this only manifests on Safari. Set an explicit JavaScript MIME type so
+  // the worker loads across browsers.
+  const workerBlob = new Blob([workerString], { type: 'text/javascript' });
   return URL.createObjectURL(workerBlob);
 }

--- a/packages/replay-worker/test/unit/getWorkerURL.test.ts
+++ b/packages/replay-worker/test/unit/getWorkerURL.test.ts
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { getWorkerURL } from '../../src';
+
+describe('getWorkerURL', () => {
+  // Safari (esp. iOS) rejects executing a Blob worker without a JavaScript MIME
+  // type, firing a bare `error` event. The Blob must be tagged `text/javascript`
+  // so the worker loads across browsers.
+  it('creates the worker Blob with a JavaScript MIME type', () => {
+    // jsdom does not implement `URL.createObjectURL`, so stub it and capture the Blob.
+    const createObjectURL = vi.fn<(blob: Blob) => string>().mockReturnValue('blob:mock');
+    URL.createObjectURL = createObjectURL as unknown as typeof URL.createObjectURL;
+
+    const url = getWorkerURL();
+
+    expect(url).toBe('blob:mock');
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    const blob = createObjectURL.mock.calls[0]![0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe('text/javascript');
+  });
+});


### PR DESCRIPTION
tbh I can't find a URL that says safari is more prone to not load a worker blob if it doesn't have a MIME type, but seems reasonable to add one.

## Slop

`getWorkerURL()` builds the Replay compression worker from a `Blob` URL, but the `Blob` was created without a MIME type, so it defaulted to an empty type. Safari (especially on iOS) validates the MIME type before executing a `Blob` as a classic `Worker` and silently rejects a non-JS type — firing a bare `error` event with **no message**, which the SDK surfaces as:

> Failed to load Replay compression worker: Unknown error. This can happen due to CSP policy restrictions, network issues, or the worker script failing to load.

Blink/Gecko are lenient about the blob MIME type, so this particular failure mode is Safari-specific. Tagging the blob `text/javascript` is the standard cross-browser fix.

```ts
const workerBlob = new Blob([workerString], { type: 'text/javascript' });
```

This is a handled error — recording already falls back to the uncompressed buffer — so there is no user-facing behavior change beyond the worker actually loading on Safari.

## Testing

- New `packages/replay-worker/test/unit/getWorkerURL.test.ts` asserts the blob is created with the `text/javascript` MIME type.
- `oxlint` + `oxfmt` clean; `replay-worker` suite passes.

## Notes

This is the low-risk half of a split. A separate follow-up PR handles the cross-browser (Chrome/Edge/Firefox) occurrences of the same captured error, which come from the worker fetch being aborted during page navigation/teardown rather than from the MIME type. Follow-up to #19008, which introduced the descriptive error message but did not address the load failure itself.