### PR TITLE
test: Remove unnecessary test waits

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/scenario-ioredis-5-11.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/scenario-ioredis-5-11.mjs
@@ -1,10 +1,6 @@
 import * as Sentry from '@sentry/node';
 
 async function run() {
-  // Yield a microtick so the DC subscriber (deferred via Promise.resolve().then)
-  // is registered before ioredis creates its native TracingChannels on import.
-  await Promise.resolve();
-
   const { default: Redis } = await import('ioredis-5');
   const redisClient = new Redis({ host: '127.0.0.1', port: 6382, lazyConnect: true });
 

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/scenario.mjs
@@ -10,10 +10,6 @@ const CONNECT_CONFIG = {
 };
 
 async function run() {
-  // Yield a microtick so the DC subscriber (deferred via Promise.resolve().then)
-  // is registered before mysql2 publishes on its native TracingChannels.
-  await Promise.resolve();
-
   // Gate on the DB actually accepting a connection before opening the span (see `waitForConnection`).
   // MySQL keeps finalizing for a short window after the healthcheck passes and drops early handshakes,
   // so this retries a real connect. It runs outside an active span, so the connect stays uninstrumented.

--- a/dev-packages/node-integration-tests/suites/tracing/redis-dc/scenario-redis-5-tracing.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-dc/scenario-redis-5-tracing.mjs
@@ -1,10 +1,6 @@
 import * as Sentry from '@sentry/node';
 
 async function run() {
-  // Yield a microtick so the DC subscriber (deferred via Promise.resolve().then)
-  // is registered before node-redis eagerly creates its native TracingChannels on require().
-  await Promise.resolve();
-
   const { createClient } = await import('redis-5-tracing');
   const redisClient = await createClient({ socket: { host: '127.0.0.1', port: 6381 } }).connect();
 


### PR DESCRIPTION
Removes the `await Promise.resolve()` microtick yields at the start of the ioredis, mysql2 and redis diagnostics-channel tracing scenarios.

These were added to give the DC subscriber a chance to register before the driver created/published on its native `TracingChannel`s. With the orchestrion instrumentation now reliably wiring up channel subscribers before the instrumented module publishes, the manual yield is no longer needed and the scenarios are simpler without it.
