### PR TITLE
ref(server-utils): Remove unneeded orchestrion config

### DIFF
--- a/packages/server-utils/src/orchestrion/channels.ts
+++ b/packages/server-utils/src/orchestrion/channels.ts
@@ -23,8 +23,6 @@ import { nestjsChannels } from './config/nestjs';
 import { openaiChannels } from './config/openai';
 import { pgChannels } from './config/pg';
 import { postgresJsChannels } from './config/postgres';
-import { prismaChannels } from './config/prisma';
-import { reactRouterChannels } from './config/react-router';
 import { redisChannels } from './config/redis';
 import { remixChannels } from './config/remix';
 import { tediousChannels } from './config/tedious';
@@ -72,8 +70,6 @@ export const CHANNELS = {
   ...openaiChannels,
   ...pgChannels,
   ...postgresJsChannels,
-  ...prismaChannels,
-  ...reactRouterChannels,
   ...redisChannels,
   ...remixChannels,
   ...tediousChannels,

--- a/packages/server-utils/src/orchestrion/config/index.ts
+++ b/packages/server-utils/src/orchestrion/config/index.ts
@@ -26,8 +26,6 @@ import { nestjsConfig } from './nestjs';
 import { openaiConfig } from './openai';
 import { pgConfig } from './pg';
 import { postgresJsConfig } from './postgres';
-import { prismaConfig } from './prisma';
-import { reactRouterConfig } from './react-router';
 import { redisConfig } from './redis';
 import { remixConfig } from './remix';
 import { tediousConfig } from './tedious';
@@ -68,8 +66,6 @@ export const SENTRY_INSTRUMENTATIONS: InstrumentationConfig[] = [
   ...openaiConfig,
   ...pgConfig,
   ...postgresJsConfig,
-  ...prismaConfig,
-  ...reactRouterConfig,
   ...redisConfig,
   ...remixConfig,
   ...tediousConfig,

--- a/packages/server-utils/src/orchestrion/config/prisma.ts
+++ b/packages/server-utils/src/orchestrion/config/prisma.ts
@@ -1,6 +1,0 @@
-import type { InstrumentationConfig } from '..';
-
-// TODO: Stub for the `prisma` orchestrion integration (ports `@prisma/instrumentation`).
-export const prismaConfig: InstrumentationConfig[] = [];
-
-export const prismaChannels = {} as const;

--- a/packages/server-utils/src/orchestrion/config/react-router.ts
+++ b/packages/server-utils/src/orchestrion/config/react-router.ts
@@ -1,6 +1,0 @@
-import type { InstrumentationConfig } from '..';
-
-// TODO: Stub for the `react-router` orchestrion integration (ports `ReactRouterInstrumentation`).
-export const reactRouterConfig: InstrumentationConfig[] = [];
-
-export const reactRouterChannels = {} as const;


### PR DESCRIPTION
Removes the empty `prisma` and `react-router` orchestrion config stubs and their references from `channels.ts`.

They were placeholder stubs, but turns out for these we did not need any orchestrion work, so no stubs are needed anymore.
