### PR TITLE
ref(server-utils): Small fastify cleanup

### DIFF
--- a/packages/server-utils/src/integrations/tracing-channel/fastify/index.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/fastify/index.ts
@@ -40,7 +40,7 @@ interface FastifyIntegrationOptions {
   shouldHandleError: (error: Error, request: FastifyRequest, reply: FastifyReply) => boolean;
 }
 
-const _fastifyIntegration = (({ shouldHandleError }: Partial<FastifyIntegrationOptions>) => {
+const _fastifyIntegration = (({ shouldHandleError }: Partial<FastifyIntegrationOptions> = {}) => {
   let _shouldHandleError: (error: Error, request: FastifyRequest, reply: FastifyReply) => boolean;
 
   return {

--- a/packages/server-utils/src/integrations/tracing-channel/fastify/index.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/fastify/index.ts
@@ -1,7 +1,6 @@
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
 import type { FastifyIntegration, FastifyReply, FastifyRequest } from './types';
-
 import { instrumentFastify as _instrumentFastify } from './instrumentation';
 import { defaultShouldHandleError, INTEGRATION_NAME } from './utils';
 import { subscribeToFastifyErrorChannel, handleFastifyError as _handleFastifyError } from './errors';
@@ -76,9 +75,7 @@ const _fastifyIntegration = (({ shouldHandleError }: Partial<FastifyIntegrationO
  * })
  * ```
  */
-export const fastifyIntegration = defineIntegration((options: Partial<FastifyIntegrationOptions> = {}) =>
-  _fastifyIntegration(options),
-);
+export const fastifyIntegration = defineIntegration(_fastifyIntegration);
 
 /**
  * @deprecated This export is deprecated and will not longer be exposed in the next major version.

--- a/packages/server-utils/src/integrations/tracing-channel/fastify/utils.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/fastify/utils.ts
@@ -1,6 +1,6 @@
 import type { FastifyReply, FastifyRequest } from './types';
 
-export const INTEGRATION_NAME = 'Fastify';
+export const INTEGRATION_NAME = 'Fastify' as const;
 
 /**
  * Default function to determine if an error should be sent to Sentry


### PR DESCRIPTION
Small cleanup in the fastify tracing-channel integration:

- Pass `_fastifyIntegration` directly to `defineIntegration` instead of wrapping it in an extra arrow function that only forwards its options.
- Mark `INTEGRATION_NAME` as `const` for a narrower type.
