### PR TITLE
test(sveltekit-3): Fix import `defineEnvVars` from `@sveltejs/kit/env`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/src/env.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/src/env.ts
@@ -1,4 +1,4 @@
-import { defineEnvVars } from '@sveltejs/kit/hooks';
+import { defineEnvVars } from '@sveltejs/kit/env';
 
 // SvelteKit 3 makes "explicit environment variables" the default and removes the
 // legacy `$env/*` virtual modules. Declared vars are imported from `$app/env/private`


### PR DESCRIPTION
SvelteKit `3.0.0-next.11` moved `defineEnvVars` out of `@sveltejs/kit/hooks` into a dedicated `@sveltejs/kit/env` entry, and the old path now throws at build time.