### PR TITLE
feat(cloudflare): Read wrangler config and resolve the Sentry options module

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -68,10 +68,14 @@
     "@sentry/server-utils": "10.67.0"
   },
   "peerDependencies": {
-    "@cloudflare/workers-types": "^4.x || ^5.x"
+    "@cloudflare/workers-types": "^4.x || ^5.x",
+    "wrangler": "^4.x"
   },
   "peerDependenciesMeta": {
     "@cloudflare/workers-types": {
+      "optional": true
+    },
+    "wrangler": {
       "optional": true
     }
   },

--- a/packages/cloudflare/src/defineCloudflareOptions.ts
+++ b/packages/cloudflare/src/defineCloudflareOptions.ts
@@ -1,0 +1,46 @@
+import type { env as cloudflareEnv } from 'cloudflare:workers';
+import type { CloudflareOptions } from './client';
+
+/**
+ * Define the Sentry options for a Cloudflare Worker in a dedicated module.
+ *
+ * This is the recommended way to configure the SDK when using the Vite plugin's
+ * auto-instrumentation: place an `instrument.server.{ts,js,mjs}` file next to
+ * the worker entry whose **default export** is the result of this function. The
+ * plugin picks it up automatically and hands it to `withSentry`.
+ *
+ * Unlike Node's `Sentry.init(...)`, the options cannot be applied at module
+ * load time on Cloudflare: the DSN and other settings typically come from the
+ * per-request `env`, which only exists inside the handler. Pass a callback to
+ * read from `env`, or a static object when no `env` access is needed — either
+ * way you get full type-checking and autocomplete on {@link CloudflareOptions}.
+ *
+ * At runtime this is a thin pass-through; it only normalizes a static object
+ * into a callback so the plugin always imports a `(env) => options` function.
+ *
+ * @example
+ * ```ts
+ * // src/instrument.server.ts
+ * import { defineCloudflareOptions } from '@sentry/cloudflare';
+ *
+ * export default defineCloudflareOptions((env) => ({
+ *   dsn: env.SENTRY_DSN,
+ *   tracesSampleRate: 1.0,
+ * }));
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Static options — no `env` access needed
+ * export default defineCloudflareOptions({ tracesSampleRate: 1.0 });
+ * ```
+ */
+export function defineCloudflareOptions<Env = typeof cloudflareEnv>(
+  optionsOrCallback: CloudflareOptions | ((env: Env) => CloudflareOptions | undefined),
+): (env: Env) => CloudflareOptions | undefined {
+  if (typeof optionsOrCallback === 'function') {
+    return optionsOrCallback as (env: Env) => CloudflareOptions | undefined;
+  }
+
+  return () => optionsOrCallback;
+}

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -117,6 +117,7 @@ export {
 } from '@sentry/core';
 
 export { withSentry } from './withSentry';
+export { defineCloudflareOptions } from './defineCloudflareOptions';
 export { instrumentDurableObjectWithSentry } from './durableobject';
 export { sentryPagesPlugin } from './pages-plugin';
 

--- a/packages/cloudflare/src/vite/instrumentFile.ts
+++ b/packages/cloudflare/src/vite/instrumentFile.ts
@@ -1,0 +1,53 @@
+import { existsSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+
+// Fallback options callback used when no instrument file is present. Returning
+// `undefined` makes the SDK read all configuration (DSN, release, environment,
+// sample rate, …) from the worker's `env` at runtime.
+export const ENV_FALLBACK_OPTIONS_FN = '() => undefined';
+
+// Identifier the generated import binds the user's options module to.
+const OPTIONS_IMPORT_IDENTIFIER = '__SENTRY_OPTIONS_CALLBACK__';
+
+// Conventional, non-configurable name of the Sentry options module. It is
+// looked up next to the worker entry file; its default export is the options
+// callback `(env) => CloudflareOptions`.
+const INSTRUMENT_FILE_BASENAME = 'instrument.server';
+const INSTRUMENT_FILE_EXTENSIONS = ['ts', 'mts', 'js', 'mjs', 'cjs'];
+
+/**
+ * Locate the conventional `instrument.server.*` module sitting next to the
+ * worker entry file. Returns its absolute path, or `undefined` when absent.
+ */
+export function resolveInstrumentFile(entryFilePath: string): string | undefined {
+  const dir = dirname(entryFilePath);
+  for (const ext of INSTRUMENT_FILE_EXTENSIONS) {
+    const candidate = resolve(dir, `${INSTRUMENT_FILE_BASENAME}.${ext}`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Build the `optionsFn` reference and `import` statement for the instrument
+ * module whose **default export** is the options callback
+ * `(env) => CloudflareOptions`.
+ *
+ * The import is emitted relative to `entryFilePath` because it is injected into
+ * the entry file's source. The file extension is kept: extensionless specifiers
+ * only resolve for extensions in Vite's default `resolve.extensions` (which
+ * excludes `.cjs`), and keeping it makes our probe order authoritative when
+ * several `instrument.server.*` files coexist.
+ */
+export function buildOptionsImport(
+  entryFilePath: string,
+  instrumentFilePath: string,
+): { optionsFn: string; importStmt: string } {
+  let relativePath = relative(dirname(entryFilePath), instrumentFilePath).replace(/\\/g, '/');
+  if (!relativePath.startsWith('.')) relativePath = `./${relativePath}`;
+
+  return {
+    optionsFn: OPTIONS_IMPORT_IDENTIFIER,
+    importStmt: `import ${OPTIONS_IMPORT_IDENTIFIER} from '${relativePath}';\n`,
+  };
+}

--- a/packages/cloudflare/src/vite/wranglerConfig.ts
+++ b/packages/cloudflare/src/vite/wranglerConfig.ts
@@ -1,0 +1,67 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { type Unstable_Config, unstable_readConfig } from 'wrangler';
+
+/**
+ * The slice of the wrangler configuration the auto-instrument plugin cares
+ * about. `main` is an absolute path (wrangler resolves it against the config
+ * file's directory).
+ */
+export interface WranglerConfig {
+  main?: string;
+  durableObjects: Array<{ name: string; className: string }>;
+}
+
+/**
+ * Locate and resolve the wrangler configuration via wrangler's own
+ * `unstable_readConfig` — the API `@cloudflare/vite-plugin` uses.
+ *
+ * We only locate the file (probing `wrangler.json`, `.jsonc`, `.toml` inside
+ * `root` with wrangler's own precedence, since it discovers from `cwd` rather
+ * than an arbitrary root); wrangler then parses it, flattens the active
+ * environment (honoring `CLOUDFLARE_ENV`), and resolves `main` to an absolute
+ * path. Durable Object bindings are the active environment's, matching what the
+ * deployed Worker actually binds.
+ *
+ * Returns `undefined` when no config file is found or it can't be read/parsed
+ * (the caller warns and disables auto-instrumentation rather than failing the
+ * whole build).
+ */
+export function resolveWranglerConfig(
+  root: string,
+  explicitPath?: string,
+): { config: WranglerConfig; configDir: string } | undefined {
+  const configPath = explicitPath
+    ? resolve(root, explicitPath)
+    : ['wrangler.json', 'wrangler.jsonc', 'wrangler.toml'].map(name => resolve(root, name)).find(existsSync);
+
+  if (!configPath || !existsSync(configPath)) {
+    return undefined;
+  }
+
+  let raw: Unstable_Config;
+  try {
+    // `hideWarnings` keeps wrangler's config diagnostics (e.g. missing DO
+    // migrations) out of the Vite build output.
+    raw = unstable_readConfig({ config: configPath }, { hideWarnings: true });
+  } catch {
+    return undefined;
+  }
+
+  const durableObjects: WranglerConfig['durableObjects'] = [];
+  const seenClassNames = new Set<string>();
+  for (const binding of raw.durable_objects?.bindings ?? []) {
+    // `script_name` bindings reference a class exported by a *different* worker
+    // — there is nothing to wrap in this worker's entry file.
+    if (typeof binding?.class_name !== 'string' || binding.script_name || seenClassNames.has(binding.class_name)) {
+      continue;
+    }
+    seenClassNames.add(binding.class_name);
+    durableObjects.push({ name: binding.name, className: binding.class_name });
+  }
+
+  return {
+    config: { main: raw.main, durableObjects },
+    configDir: dirname(raw.configPath ?? configPath),
+  };
+}

--- a/packages/cloudflare/test/defineCloudflareOptions.test.ts
+++ b/packages/cloudflare/test/defineCloudflareOptions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { defineCloudflareOptions } from '../src/defineCloudflareOptions';
+
+describe('defineCloudflareOptions', () => {
+  it('returns the callback unchanged', () => {
+    const callback = (env: { SENTRY_DSN: string }) => ({ dsn: env.SENTRY_DSN });
+    expect(defineCloudflareOptions(callback)).toBe(callback);
+  });
+
+  it('passes env through to the callback', () => {
+    const callback = defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
+      dsn: env.SENTRY_DSN,
+      tracesSampleRate: 1.0,
+    }));
+
+    expect(callback({ SENTRY_DSN: 'https://example' })).toEqual({
+      dsn: 'https://example',
+      tracesSampleRate: 1.0,
+    });
+  });
+
+  it('normalizes a static options object into a callback', () => {
+    const callback = defineCloudflareOptions({ tracesSampleRate: 0.5 });
+
+    expect(typeof callback).toBe('function');
+    expect(callback({} as never)).toEqual({ tracesSampleRate: 0.5 });
+  });
+});

--- a/packages/cloudflare/test/vite/wranglerConfig.test.ts
+++ b/packages/cloudflare/test/vite/wranglerConfig.test.ts
@@ -1,0 +1,250 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveWranglerConfig } from '../../src/vite/wranglerConfig';
+
+function writeTempDir(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sentry-cf-'));
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(dir, name), content);
+  }
+  return dir;
+}
+
+describe('resolveWranglerConfig', () => {
+  it('parses wrangler.toml', () => {
+    const dir = writeTempDir({
+      'wrangler.toml': [
+        'main = "src/index.ts"',
+        '',
+        '[[durable_objects.bindings]]',
+        'name = "MY_DO"',
+        'class_name = "MyDurableObject"',
+      ].join('\n'),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result).toBeDefined();
+    // wrangler resolves `main` to an absolute path against the config dir.
+    expect(result!.config.main).toBe(join(dir, 'src/index.ts'));
+    expect(result!.config.durableObjects).toEqual([{ name: 'MY_DO', className: 'MyDurableObject' }]);
+  });
+
+  it('parses wrangler.json', () => {
+    const dir = writeTempDir({
+      'wrangler.json': JSON.stringify({
+        main: 'src/worker.ts',
+        durable_objects: {
+          bindings: [{ name: 'DO_A', class_name: 'A' }],
+        },
+      }),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result).toBeDefined();
+    expect(result!.config.main).toBe(join(dir, 'src/worker.ts'));
+    expect(result!.config.durableObjects).toEqual([{ name: 'DO_A', className: 'A' }]);
+  });
+
+  it('parses wrangler.jsonc (strips comments)', () => {
+    const dir = writeTempDir({
+      'wrangler.jsonc': [
+        '{',
+        '  // Entry point',
+        '  "main": "src/index.ts",',
+        '  /* DO bindings */',
+        '  "durable_objects": {',
+        '    "bindings": [',
+        '      { "name": "DO", "class_name": "MyDO" }',
+        '    ]',
+        '  }',
+        '}',
+      ].join('\n'),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result).toBeDefined();
+    expect(result!.config.main).toBe(join(dir, 'src/index.ts'));
+    expect(result!.config.durableObjects).toEqual([{ name: 'DO', className: 'MyDO' }]);
+  });
+
+  it('parses JSONC with trailing commas', () => {
+    const dir = writeTempDir({
+      'wrangler.jsonc': [
+        '{',
+        '  "main": "src/index.ts",',
+        '  "durable_objects": {',
+        '    "bindings": [',
+        '      { "name": "DO", "class_name": "MyDO" },',
+        '    ],',
+        '  },',
+        '}',
+      ].join('\n'),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.main).toBe(join(dir, 'src/index.ts'));
+    expect(result!.config.durableObjects).toEqual([{ name: 'DO', className: 'MyDO' }]);
+  });
+
+  it('parses TOML single-quoted (literal) strings', () => {
+    const dir = writeTempDir({ 'wrangler.toml': "main = 'src/index.ts'" });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.main).toBe(join(dir, 'src/index.ts'));
+  });
+
+  it('prefers wrangler.json over wrangler.toml (matching wrangler itself)', () => {
+    const dir = writeTempDir({
+      'wrangler.toml': 'main = "from-toml.ts"',
+      'wrangler.json': '{ "main": "from-json.ts" }',
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.main).toBe(join(dir, 'from-json.ts'));
+  });
+
+  it('prefers wrangler.jsonc over wrangler.toml (matching wrangler itself)', () => {
+    const dir = writeTempDir({
+      'wrangler.toml': 'main = "from-toml.ts"',
+      'wrangler.jsonc': '{ "main": "from-jsonc.ts" }',
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.main).toBe(join(dir, 'from-jsonc.ts'));
+  });
+
+  it('handles TOML with commented-out bindings', () => {
+    const dir = writeTempDir({
+      'wrangler.toml': [
+        'main = "src/index.ts"',
+        '',
+        '# [[durable_objects.bindings]]',
+        '# name = "IGNORED"',
+        '# class_name = "IgnoredDO"',
+        '',
+        '[[durable_objects.bindings]]',
+        'name = "REAL"',
+        'class_name = "RealDO"',
+      ].join('\n'),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.durableObjects).toEqual([{ name: 'REAL', className: 'RealDO' }]);
+  });
+
+  it('handles multiple DO bindings', () => {
+    const dir = writeTempDir({
+      'wrangler.toml': [
+        'main = "src/index.ts"',
+        '',
+        '[[durable_objects.bindings]]',
+        'name = "DO_A"',
+        'class_name = "A"',
+        '',
+        '[[durable_objects.bindings]]',
+        'name = "DO_B"',
+        'class_name = "B"',
+      ].join('\n'),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.durableObjects).toHaveLength(2);
+    expect(result!.config.durableObjects[0]).toEqual({ name: 'DO_A', className: 'A' });
+    expect(result!.config.durableObjects[1]).toEqual({ name: 'DO_B', className: 'B' });
+  });
+
+  it('returns undefined when no config exists', () => {
+    const dir = writeTempDir({});
+    expect(resolveWranglerConfig(dir)).toBeUndefined();
+  });
+
+  it('returns undefined for explicit non-existent path', () => {
+    expect(resolveWranglerConfig('/tmp', '/tmp/nonexistent.toml')).toBeUndefined();
+  });
+
+  it('resolves a relative explicit path against the root', () => {
+    const dir = writeTempDir({ 'custom.toml': 'main = "src/index.ts"' });
+
+    const result = resolveWranglerConfig(dir, 'custom.toml');
+    expect(result).toBeDefined();
+    expect(result!.config.main).toBe(join(dir, 'src/index.ts'));
+    expect(result!.configDir).toBe(dir);
+  });
+
+  it('returns undefined for an empty config file instead of crashing', () => {
+    const dir = writeTempDir({ 'wrangler.json': '' });
+    expect(resolveWranglerConfig(dir)).toBeUndefined();
+  });
+
+  it('returns undefined for invalid TOML instead of crashing', () => {
+    const dir = writeTempDir({ 'wrangler.toml': 'main = [' });
+    expect(resolveWranglerConfig(dir)).toBeUndefined();
+  });
+
+  it('skips DO bindings with a script_name (class lives in another worker)', () => {
+    const dir = writeTempDir({
+      'wrangler.json': JSON.stringify({
+        main: 'src/index.ts',
+        durable_objects: {
+          bindings: [
+            { name: 'LOCAL', class_name: 'LocalDO' },
+            { name: 'EXTERNAL', class_name: 'ExternalDO', script_name: 'other-worker' },
+          ],
+        },
+      }),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.durableObjects).toEqual([{ name: 'LOCAL', className: 'LocalDO' }]);
+  });
+
+  it('uses only the active environment DO bindings (does not union across envs)', () => {
+    // wrangler flattens to the active environment (top level here, since no
+    // CLOUDFLARE_ENV), matching what the deployed Worker actually binds. A
+    // class bound only in a non-active env is intentionally not included.
+    const dir = writeTempDir({
+      'wrangler.json': JSON.stringify({
+        main: 'src/index.ts',
+        durable_objects: { bindings: [{ name: 'TOP', class_name: 'TopDO' }] },
+        env: {
+          production: {
+            durable_objects: {
+              bindings: [{ name: 'PROD_ONLY', class_name: 'ProdDO' }],
+            },
+          },
+        },
+      }),
+    });
+
+    const result = resolveWranglerConfig(dir);
+    expect(result!.config.durableObjects).toEqual([{ name: 'TOP', className: 'TopDO' }]);
+  });
+
+  it('honors CLOUDFLARE_ENV for both main and DO bindings', () => {
+    const dir = writeTempDir({
+      'wrangler.json': JSON.stringify({
+        main: 'src/index.ts',
+        durable_objects: { bindings: [{ name: 'TOP', class_name: 'TopDO' }] },
+        env: {
+          staging: {
+            main: 'src/staging.ts',
+            durable_objects: { bindings: [{ name: 'STAGING_DO', class_name: 'StagingDO' }] },
+          },
+        },
+      }),
+    });
+
+    const previous = process.env.CLOUDFLARE_ENV;
+    process.env.CLOUDFLARE_ENV = 'staging';
+    try {
+      const result = resolveWranglerConfig(dir)!;
+      expect(result.config.main).toBe(join(dir, 'src/staging.ts'));
+      expect(result.config.durableObjects).toEqual([{ name: 'STAGING_DO', className: 'StagingDO' }]);
+    } finally {
+      if (previous === undefined) delete process.env.CLOUDFLARE_ENV;
+      else process.env.CLOUDFLARE_ENV = previous;
+    }
+  });
+});

--- a/scripts/ci-unit-tests.ts
+++ b/scripts/ci-unit-tests.ts
@@ -28,7 +28,7 @@ const BROWSER_TEST_PACKAGES = [
 ];
 
 // Packages that cannot run in Node 18
-const SKIP_NODE_18_PACKAGES = ['@sentry/react-router'];
+const SKIP_NODE_18_PACKAGES = ['@sentry/react-router', '@sentry/cloudflare'];
 
 function getAllPackages(): string[] {
   const { workspaces }: { workspaces: string[] } = JSON.parse(

--- a/scripts/ci-unit-tests.ts
+++ b/scripts/ci-unit-tests.ts
@@ -28,7 +28,7 @@ const BROWSER_TEST_PACKAGES = [
 ];
 
 // Packages that cannot run in Node 18
-const SKIP_NODE_18_PACKAGES = ['@sentry/react-router', '@sentry/cloudflare'];
+const SKIP_NODE_18_PACKAGES = ['@sentry/react-router'];
 
 function getAllPackages(): string[] {
   const { workspaces }: { workspaces: string[] } = JSON.parse(


### PR DESCRIPTION
(replaces #22291)

part of #22066

Add the building blocks the auto-instrument Vite plugin will use, with no wiring into a plugin yet:

- `wranglerConfig`: locate and parse `wrangler.{json,jsonc,toml}` via wrangler's own `unstable_readConfig`, returning the worker entry (`main`) and the configured Durable Object class names.
- `instrumentFile`: find a conventional `instrument.server.{ts,js,mjs,cjs}` next to the entry and build the options import, falling back to an env-based callback when absent.
- `defineCloudflareOptions`: identity helper that gives the options callback its type in that module.

Adds `wrangler` as an optional peer dependency (used to read the config).

The `instrument.server.*` config can and should be written like the following:

```js
import { defineCloudflareOptions } from '@sentry/cloudflare';

export default defineCloudflareOptions((env) => ({
  dsn: env.SENTRY_DSN,
  tracesSampleRate: 1.0,
}));
```

`defineCloudflareOptions` is only adding typings for `env` so it is easier it can also be used like the following:

```js
import { defineCloudflareOptions } from '@sentry/cloudflare';

export default defineCloudflareOptions({
  dsn: env.SENTRY_DSN,
  tracesSampleRate: 1.0,
});
```

or

```js
import type { CloudflareOptions } from '@sentry/cloudflare';

export default {
  dsn: env.SENTRY_DSN,
  tracesSampleRate: 1.0,
} satisfies CloudflareOptions;
```


## Future possibilities

For now there is a shared config for all instrumentations. In the future there would be the possibility to have different exports and map them to the actual bindings. E.g.:

```js
import { defineCloudflareOptions } from '@sentry/cloudflare';

// specifically for the durable object called `MY_DURABLE_OBJECT`. This is defined in the wrangler config
export const MY_DURABLE_OBJECT = defineCloudflareOptions((env) => ({
  dsn: env.OTHER_SENTRY_DSN,
  tracesSampleRate: 0.5,
}));

// for the default worker and all the other bindings
export default defineCloudflareOptions((env) => ({
  dsn: env.SENTRY_DSN,
  tracesSampleRate: 1.0,
}));
```