### PR TITLE
feat(skills): Add backport-pr skill

### DIFF
--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -31,10 +31,9 @@ If the PR number is missing, ask for it. Do not guess.
     `fix(cloudflare,deno,node): ...` -> `fix(v10/cloudflare,deno,node): ...`.
 - **PR body** is a single line: `Backport of: #<original-pr-number>`.
 - **PR is opened as a draft.**
-- **Branch name**: `backport/<major>-<short-slug>`, where `<short-slug>` comes from the
-  original PR title, e.g. `backport/v10-fix-log-flush-starvation`. If you already use a
-  personal branch prefix (some contributors do, e.g. `<initials>/...`), keep using it — only
-  the base branch and commit/PR title conventions below are load-bearing.
+- **Working branch**: any local branch off the target major works — the name isn't
+  load-bearing (GitHub ignores it and contributors use varied prefixes). Just pick something
+  descriptive. What matters is the base branch and the commit/PR title conventions.
 - The changes come from the PR's **squash-merge commit** on `develop` (one commit per PR),
   so a single `git cherry-pick` normally covers the whole PR.
 
@@ -76,7 +75,7 @@ producing an empty commit.
 ### 2. Create the backport branch off the target major
 
 ```bash
-git checkout -b backport/<major>-<slug> origin/<major>
+git checkout -b <branch> origin/<major>
 ```
 
 ### 3. Cherry-pick the merge commit
@@ -137,7 +136,7 @@ git status --porcelain   # expect no output
 ### 6. Push and open the draft PR
 
 ```bash
-git push -u origin backport/<major>-<slug>
+git push -u origin <branch>
 
 gh pr create \
   --draft \
@@ -156,8 +155,8 @@ gh pr comment <PR> --body "<major> backport: #<new-backport-pr>"
 
 ## Notes
 
-- Never push directly to `develop`, `master`, or the major branch. Work only on the
-  `backport/<major>-...` branch and open a PR.
+- Never push directly to `develop`, `master`, or the major branch. Work only on your
+  backport branch and open a PR.
 - One PR per backport. If asked to backport several PRs, repeat the whole flow per PR (each
   gets its own branch and draft PR).
 - If asked to backport to multiple majors at once (e.g. v10 and v9), do them as separate

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -147,27 +147,17 @@ git status --porcelain   # expect no output
 
 ### 6. Push and open the draft PR
 
-`gh pr create` prints the new PR's URL — capture it, since step 7 needs its number.
+The `Backport of: #<PR>` body references the original PR, so GitHub cross-links the two
+automatically — no separate comment needed.
 
 ```bash
 git push -u origin <branch>
 
-backport_url=$(gh pr create \
+gh pr create \
   --draft \
   --base <major> \
   --title "<namespaced-title>" \
-  --body "Backport of: #<PR>")
-echo "$backport_url"
-```
-
-### 7. Cross-link on the original PR
-
-Comment on the original PR with a link to the backport (e.g. `v10 backport: #NNNN`). Pass the
-URL captured above — `gh pr comment` accepts it directly, so you don't have to parse the number
-out:
-
-```bash
-gh pr comment <PR> --body "<major> backport: $backport_url"
+  --body "Backport of: #<PR>"
 ```
 
 ## Notes

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -128,6 +128,10 @@ rather than being new authored work.
 Build the namespaced title as in the convention above: `<prefix>(<major>/<scope>):` when the
 original had a scope, or `<prefix>(<major>):` when it didn't (never emit an empty `<major>/`).
 
+`--amend` only rewrites HEAD, which is exactly right for the usual single squash commit. If
+step 3 cherry-picked multiple commits, leave their individual messages as-is — the namespaced
+title lives on the PR (step 6), not on each commit.
+
 Stage only the files the cherry-pick and verification touched — `git add -u` restages tracked
 files without sweeping in unrelated local edits. Sanity-check the staged set with
 `git status` first if `yarn format` may have reformatted files outside the backport.

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backport-pr
-description: Backport a merged PR to a maintenance major branch (v10 by default) in getsentry/sentry-javascript. Cherry-picks the PR's squash-merge commit onto the target branch, namespaces the commit/PR title scope (e.g. fix(core) -> fix(v10/core)), and opens a draft backport PR. Use when asked to backport a PR, port a fix to v10 (or an older major like v9), or cut a maintenance release change. Trigger phrases include "backport", "port to v10", "cherry-pick to the maintenance branch", "release this on v10".
+description: Backport a merged PR to a maintenance major branch (v10 by default) in getsentry/sentry-javascript. Cherry-picks the PR's squash-merge commit onto the target branch, namespaces the commit/PR title scope (e.g. fix(core) -> fix(v10/core)), and opens a draft backport PR. Use when asked to backport a PR, or port a fix to v10 (or an older major like v9). Trigger phrases include "backport", "port to v10", "cherry-pick to the maintenance branch", "release this on v10".
 argument-hint: '<pr-number> [target-major]  # e.g. 18211 v10; target defaults to v10'
 ---
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backport-pr
 description: Backport a merged PR to a maintenance major branch (v10 by default) in getsentry/sentry-javascript. Cherry-picks the PR's squash-merge commit onto the target branch, namespaces the commit/PR title scope (e.g. fix(core) -> fix(v10/core)), and opens a draft backport PR. Use when asked to backport a PR, or port a fix to v10 (or an older major like v9). Trigger phrases include "backport", "port to v10", "release this on v10".
-argument-hint: '<pr-number> [target-major]  # e.g. 18211 v10; target defaults to v10'
+argument-hint: '<pr-url-or-number> [target-major]  # e.g. https://github.com/getsentry/sentry-javascript/pull/18211 v10; target defaults to v10'
 ---
 
 # Backport a PR to a maintenance major branch
@@ -13,11 +13,13 @@ backports.
 
 ## Inputs
 
-- **PR number** (required): the already-merged PR on `develop` to backport.
+- **PR** (required): the already-merged PR on `develop` to backport, given as either a full
+  GitHub URL or a bare number. `gh pr view` accepts both, so pass whichever the user gave
+  through unchanged; `<PR>` in the commands below is that value.
 - **Target major** (optional, default `v10`): the maintenance branch to backport onto.
   Accept `v10`, `10`, `v9`, etc. Normalize to a branch name like `v10`.
 
-If the PR number is missing, ask for it. Do not guess.
+If no PR is given, ask for it. Do not guess.
 
 ## Convention (learned from the v9 backports)
 
@@ -51,7 +53,9 @@ Verify:
 - Its `baseRefName` is `develop` (or the expected parent major). If it targeted something
   else, confirm with the user before continuing.
 
-Grab `mergeCommit.oid` — this is the squash commit to cherry-pick.
+Grab `mergeCommit.oid` — this is the squash commit to cherry-pick. Also grab `number`: use
+that bare number (not the raw input) wherever `#<PR>` appears below, so `Backport of:` reads
+`Backport of: #18211` even when the user passed a URL.
 
 Make sure the target branch exists and is up to date:
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -6,10 +6,10 @@ argument-hint: '<pr-number-or-url> [target-major]  # e.g. 18211 v10; target defa
 
 # Backport a PR to a maintenance major branch
 
-`develop` is the current major (v11). Released changes now go onto the previous major's
-maintenance branch (`v10` by default). This skill cherry-picks a merged PR's changes onto
-that branch and opens a draft backport PR, following the same convention used for the v9
-backports.
+`develop` is the current major (v11). A change that also needs to ship on a still-maintained
+older major has to land on that major's branch too (`v10` by default). This skill cherry-picks
+a merged `develop` PR onto that branch and opens a draft backport PR, following the same
+convention used for the v9 backports.
 
 ## Inputs
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: backport-pr
 description: Backport a merged PR to a maintenance major branch (v10 by default) in getsentry/sentry-javascript. Cherry-picks the PR's squash-merge commit onto the target branch, namespaces the commit/PR title scope (e.g. fix(core) -> fix(v10/core)), and opens a draft backport PR. Use when asked to backport a PR, or port a fix to v10 (or an older major like v9). Trigger phrases include "backport", "port to v10", "release this on v10".
-argument-hint: '<pr-url-or-number> [target-major]  # e.g. https://github.com/getsentry/sentry-javascript/pull/18211 v10; target defaults to v10'
+argument-hint: '<pr-number-or-url> [target-major]  # e.g. 18211 v10; target defaults to v10'
 ---
 
 # Backport a PR to a maintenance major branch

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -97,9 +97,10 @@ git cherry-pick <mergeCommit-oid>
   in step 1 guards against, caught here for changes that landed via a different commit.
 - On **conflicts**: resolve them by consulting the original diff (`git show <oid>`).
   The target major may lack refactors that landed on `develop`, so adapt the change to the
-  older code rather than force-porting it. After resolving: `git add -A && git cherry-pick --continue`.
-  If the change can't be cleanly adapted, stop and surface the conflict to the user instead
-  of guessing.
+  older code rather than force-porting it. Stage the resolved files with `git add -u` (tracked
+  files only, so stray untracked workspace files don't get baked in), then
+  `git cherry-pick --continue`. If the change can't be cleanly adapted, stop and surface the
+  conflict to the user instead of guessing.
 - If the PR was **not** squash-merged (multiple commits, e.g. a merge commit), cherry-pick
   each relevant commit in order, or use `git cherry-pick -m 1 <merge-oid>` for a merge commit.
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -31,8 +31,10 @@ If the PR number is missing, ask for it. Do not guess.
     `fix(cloudflare,deno,node): ...` -> `fix(v10/cloudflare,deno,node): ...`.
 - **PR body** is a single line: `Backport of: #<original-pr-number>`.
 - **PR is opened as a draft.**
-- **Branch name**: `ab/<major>-<short-slug>` (personal rule is the `ab/` prefix). Derive
-  `<short-slug>` from the original PR title, e.g. `ab/v10-fix-log-flush-starvation`.
+- **Branch name**: `backport/<major>-<short-slug>`, where `<short-slug>` comes from the
+  original PR title, e.g. `backport/v10-fix-log-flush-starvation`. If you already use a
+  personal branch prefix (some contributors do, e.g. `<initials>/...`), keep using it — only
+  the base branch and commit/PR title conventions below are load-bearing.
 - The changes come from the PR's **squash-merge commit** on `develop` (one commit per PR),
   so a single `git cherry-pick` normally covers the whole PR.
 
@@ -74,7 +76,7 @@ producing an empty commit.
 ### 2. Create the backport branch off the target major
 
 ```bash
-git checkout -b ab/<major>-<slug> origin/<major>
+git checkout -b backport/<major>-<slug> origin/<major>
 ```
 
 ### 3. Cherry-pick the merge commit
@@ -95,21 +97,12 @@ git cherry-pick <mergeCommit-oid>
 - If the PR was **not** squash-merged (multiple commits, e.g. a merge commit), cherry-pick
   each relevant commit in order, or use `git cherry-pick -m 1 <merge-oid>` for a merge commit.
 
-### 4. Reword the commit to namespace the scope
+### 4. Build and verify
 
-Rewrite only the subject line's scope to include the major; keep the body. Do **not** add a
-`Co-Authored-By` line or conventional prefix beyond what's described here — the backport
-branch's first commit mirrors an existing commit rather than being new authored work.
-
-```bash
-git commit --amend -m "<prefix>(<major>/<scope>): <original subject>" -m "Backport of: #<PR>"
-```
-
-Example: `fix(v10/core): Fix logs flush timeout starvation with continuous logging`
-
-### 5. Build and verify before pushing
-
-Run the repo's pre-commit checks so the backport branch is green:
+Run the repo's pre-commit checks. Do this **before** finalizing the commit in step 5, because
+`yarn format` writes changes to the working tree — those fixes must end up inside the backport
+commit, not left dangling after it (otherwise you'd push an unformatted tree and CI would fail
+on a commit that doesn't match your local state).
 
 ```bash
 yarn format
@@ -121,10 +114,30 @@ Run tests scoped to the touched packages when possible (full `yarn test` if unsu
 target major's toolchain differs and a check fails for reasons unrelated to the change, note
 it for the user rather than silently skipping.
 
+### 5. Finalize the commit (reword scope + fold in verification changes)
+
+Stage anything `yarn format`/`yarn lint` changed, then amend in one step: this both namespaces
+the subject scope with the major and captures the formatting fixes. Rewrite only the subject's
+scope; keep the body. Do **not** add a `Co-Authored-By` line — the backport commit mirrors an
+existing commit rather than being new authored work.
+
+```bash
+git add -A
+git commit --amend -m "<prefix>(<major>/<scope>): <original subject>" -m "Backport of: #<PR>"
+```
+
+Example subject: `fix(v10/core): Fix logs flush timeout starvation with continuous logging`
+
+Confirm the tree is clean so nothing is left uncommitted before you push:
+
+```bash
+git status --porcelain   # expect no output
+```
+
 ### 6. Push and open the draft PR
 
 ```bash
-git push -u origin ab/<major>-<slug>
+git push -u origin backport/<major>-<slug>
 
 gh pr create \
   --draft \
@@ -144,7 +157,7 @@ gh pr comment <PR> --body "<major> backport: #<new-backport-pr>"
 ## Notes
 
 - Never push directly to `develop`, `master`, or the major branch. Work only on the
-  `ab/<major>-...` branch and open a PR.
+  `backport/<major>-...` branch and open a PR.
 - One PR per backport. If asked to backport several PRs, repeat the whole flow per PR (each
   gets its own branch and draft PR).
 - If asked to backport to multiple majors at once (e.g. v10 and v9), do them as separate

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -46,6 +46,7 @@ gh pr view <PR> --json number,title,baseRefName,mergeCommit,state,url
 ```
 
 Verify:
+
 - The PR is **merged** (`state == "MERGED"`). If not, stop and tell the user.
 - Its `baseRefName` is `develop` (or the expected parent major). If it targeted something
   else, confirm with the user before continuing.

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -116,13 +116,17 @@ it for the user rather than silently skipping.
 ### 5. Finalize the commit (reword scope + fold in verification changes)
 
 Stage anything `yarn format`/`yarn lint` changed, then amend in one step: this both namespaces
-the subject scope with the major and captures the formatting fixes. Rewrite only the subject's
-scope; keep the body. Do **not** add a `Co-Authored-By` line — the backport commit mirrors an
-existing commit rather than being new authored work.
+the subject scope with the major and captures the formatting fixes. The final message is the
+namespaced subject plus the one-line `Backport of:` body (this replaces the squash-merge body,
+matching the convention above). Do **not** add a `Co-Authored-By` line — the backport commit
+mirrors an existing commit rather than being new authored work.
+
+Build the namespaced title as in the convention above: `<prefix>(<major>/<scope>):` when the
+original had a scope, or `<prefix>(<major>):` when it didn't (never emit an empty `<major>/`).
 
 ```bash
 git add -A
-git commit --amend -m "<prefix>(<major>/<scope>): <original subject>" -m "Backport of: #<PR>"
+git commit --amend -m "<namespaced-title>" -m "Backport of: #<PR>"
 ```
 
 Example subject: `fix(v10/core): Fix logs flush timeout starvation with continuous logging`
@@ -141,7 +145,7 @@ git push -u origin <branch>
 gh pr create \
   --draft \
   --base <major> \
-  --title "<prefix>(<major>/<scope>): <original subject>" \
+  --title "<namespaced-title>" \
   --body "Backport of: #<PR>"
 ```
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -117,31 +117,39 @@ Run tests scoped to the touched packages when possible (full `yarn test` if unsu
 target major's toolchain differs and a check fails for reasons unrelated to the change, note
 it for the user rather than silently skipping.
 
-### 5. Finalize the commit (reword scope + fold in verification changes)
+### 5. Finalize the commit (fold in verification changes)
 
-Stage the format/lint fixes, then amend in one step: this both namespaces the subject scope
-with the major and captures those fixes. The final message is the namespaced subject plus the
-one-line `Backport of:` body (this replaces the squash-merge body, matching the convention
-above). Do **not** add a `Co-Authored-By` line — the backport commit mirrors an existing commit
-rather than being new authored work.
-
-Build the namespaced title as in the convention above: `<prefix>(<major>/<scope>):` when the
-original had a scope, or `<prefix>(<major>):` when it didn't (never emit an empty `<major>/`).
-
-`--amend` only rewrites HEAD, which is exactly right for the usual single squash commit. If
-step 3 cherry-picked multiple commits, leave their individual messages as-is — the namespaced
-title lives on the PR (step 6), not on each commit.
-
-Stage only the files the cherry-pick and verification touched — `git add -u` restages tracked
-files without sweeping in unrelated local edits. Sanity-check the staged set with
-`git status` first if `yarn format` may have reformatted files outside the backport.
+First stage the format/lint fixes. Use `git add -u` so only tracked files the cherry-pick and
+verification touched are staged, not unrelated local edits — sanity-check with `git status`
+first if `yarn format` may have reformatted files outside the backport.
 
 ```bash
 git add -u
+```
+
+Then finalize, depending on how step 3 went:
+
+**Single squash commit (the usual case)** — amend HEAD to both namespace the subject scope and
+fold in the staged fixes. The message is the namespaced title plus the one-line `Backport of:`
+body (this replaces the squash-merge body, matching the convention above). Do **not** add a
+`Co-Authored-By` line — the backport commit mirrors an existing commit, not new authored work.
+
+Build the title as in the convention: `<prefix>(<major>/<scope>):` when the original had a
+scope, or `<prefix>(<major>):` when it didn't (never emit an empty `<major>/`).
+
+```bash
 git commit --amend -m "<namespaced-title>" -m "Backport of: #<PR>"
 ```
 
 Example subject: `fix(v10/core): Fix logs flush timeout starvation with continuous logging`
+
+**Multiple commits (non-squash merge)** — leave the individual commit messages as-is; the
+namespaced title lives on the PR (step 6), not on each commit. Just fold the staged fixes into
+HEAD without rewording:
+
+```bash
+git commit --amend --no-edit
+```
 
 Confirm the tree is clean so nothing is left uncommitted before you push:
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -32,9 +32,7 @@ If no PR is given, ask for it. Do not guess.
     `fix(cloudflare,deno,node): ...` -> `fix(v10/cloudflare,deno,node): ...`.
 - **PR body** is a single line: `Backport of: #<original-pr-number>`.
 - **PR is opened as a draft.**
-- **Working branch**: any local branch off the target major works — the name isn't
-  load-bearing (GitHub ignores it and contributors use varied prefixes). Just pick something
-  descriptive. What matters is the base branch and the commit/PR title conventions.
+- **Working branch**: branch off the target major and give it a descriptive name.
 - The changes come from the PR's **squash-merge commit** on `develop` (one commit per PR),
   so a single `git cherry-pick` normally covers the whole PR.
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -63,15 +63,20 @@ git rev-parse --verify origin/<major>   # errors if the branch doesn't exist
 
 If `origin/<major>` doesn't exist, stop: the maintenance branch hasn't been created yet.
 
-Then check the change isn't already on the target. A freshly cut major often still shares
+Then check whether the change is already on the target. A freshly cut major often still shares
 history with `develop`, so a recent PR may already be present:
 
 ```bash
 git merge-base --is-ancestor <mergeCommit-oid> origin/<major> && echo "ALREADY ON <major>"
 ```
 
-If it prints `ALREADY ON`, there's nothing to backport — stop and tell the user rather than
-producing an empty commit.
+If it prints `ALREADY ON`, the commit is in the target's history — usually meaning nothing to
+backport. It's not conclusive on its own, though: a commit that was later reverted on the
+maintenance branch still shows as an ancestor. So treat this as a strong signal to stop and
+tell the user, but if you have reason to think the change was reverted, confirm the fix is
+actually present (e.g. `git log origin/<major> -- <a changed file>`, or grep for the change)
+before deciding. The cherry-pick in step 3 is the real backstop — it comes up empty only when
+the change is genuinely still applied.
 
 ### 2. Create the backport branch off the target major
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backport-pr
-description: Backport a merged PR to a maintenance major branch (v10 by default) in getsentry/sentry-javascript. Cherry-picks the PR's squash-merge commit onto the target branch, namespaces the commit/PR title scope (e.g. fix(core) -> fix(v10/core)), and opens a draft backport PR. Use when asked to backport a PR, or port a fix to v10 (or an older major like v9). Trigger phrases include "backport", "port to v10", "cherry-pick to the maintenance branch", "release this on v10".
+description: Backport a merged PR to a maintenance major branch (v10 by default) in getsentry/sentry-javascript. Cherry-picks the PR's squash-merge commit onto the target branch, namespaces the commit/PR title scope (e.g. fix(core) -> fix(v10/core)), and opens a draft backport PR. Use when asked to backport a PR, or port a fix to v10 (or an older major like v9). Trigger phrases include "backport", "port to v10", "release this on v10".
 argument-hint: '<pr-number> [target-major]  # e.g. 18211 v10; target defaults to v10'
 ---
 

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -106,9 +106,12 @@ on a commit that doesn't match your local state).
 
 ```bash
 yarn format
-yarn lint
+yarn lint:fix
 yarn build:dev
 ```
+
+Use `lint:fix`, not `lint` — plain `yarn lint` only reports, so auto-fixable issues would
+otherwise survive to fail CI.
 
 Run tests scoped to the touched packages when possible (full `yarn test` if unsure). If the
 target major's toolchain differs and a check fails for reasons unrelated to the change, note
@@ -116,17 +119,21 @@ it for the user rather than silently skipping.
 
 ### 5. Finalize the commit (reword scope + fold in verification changes)
 
-Stage anything `yarn format`/`yarn lint` changed, then amend in one step: this both namespaces
-the subject scope with the major and captures the formatting fixes. The final message is the
-namespaced subject plus the one-line `Backport of:` body (this replaces the squash-merge body,
-matching the convention above). Do **not** add a `Co-Authored-By` line — the backport commit
-mirrors an existing commit rather than being new authored work.
+Stage the format/lint fixes, then amend in one step: this both namespaces the subject scope
+with the major and captures those fixes. The final message is the namespaced subject plus the
+one-line `Backport of:` body (this replaces the squash-merge body, matching the convention
+above). Do **not** add a `Co-Authored-By` line — the backport commit mirrors an existing commit
+rather than being new authored work.
 
 Build the namespaced title as in the convention above: `<prefix>(<major>/<scope>):` when the
 original had a scope, or `<prefix>(<major>):` when it didn't (never emit an empty `<major>/`).
 
+Stage only the files the cherry-pick and verification touched — `git add -u` restages tracked
+files without sweeping in unrelated local edits. Sanity-check the staged set with
+`git status` first if `yarn format` may have reformatted files outside the backport.
+
 ```bash
-git add -A
+git add -u
 git commit --amend -m "<namespaced-title>" -m "Backport of: #<PR>"
 ```
 
@@ -140,22 +147,27 @@ git status --porcelain   # expect no output
 
 ### 6. Push and open the draft PR
 
+`gh pr create` prints the new PR's URL — capture it, since step 7 needs its number.
+
 ```bash
 git push -u origin <branch>
 
-gh pr create \
+backport_url=$(gh pr create \
   --draft \
   --base <major> \
   --title "<namespaced-title>" \
-  --body "Backport of: #<PR>"
+  --body "Backport of: #<PR>")
+echo "$backport_url"
 ```
 
 ### 7. Cross-link on the original PR
 
-Add a note to the original PR pointing at the backport (mirrors `v9 backport: #NNNN`):
+Comment on the original PR with a link to the backport (e.g. `v10 backport: #NNNN`). Pass the
+URL captured above — `gh pr comment` accepts it directly, so you don't have to parse the number
+out:
 
 ```bash
-gh pr comment <PR> --body "<major> backport: #<new-backport-pr>"
+gh pr comment <PR> --body "<major> backport: $backport_url"
 ```
 
 ## Notes

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -8,8 +8,7 @@ argument-hint: '<pr-number-or-url> [target-major]  # e.g. 18211 v10; target defa
 
 `develop` is the current major (v11). A change that also needs to ship on a still-maintained
 older major has to land on that major's branch too (`v10` by default). This skill cherry-picks
-a merged `develop` PR onto that branch and opens a draft backport PR, following the same
-convention used for the v9 backports.
+a merged `develop` PR onto that branch and opens a draft backport PR.
 
 ## Inputs
 
@@ -21,7 +20,7 @@ convention used for the v9 backports.
 
 If no PR is given, ask for it. Do not guess.
 
-## Convention (learned from the v9 backports)
+## Convention
 
 - **Base branch** = the target major branch (`v10`), which must already exist on `origin`.
 - **Commit + PR title**: keep the original conventional-commit prefix but namespace the

--- a/.agents/skills/backport-pr/SKILL.md
+++ b/.agents/skills/backport-pr/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: backport-pr
+description: Backport a merged PR to a maintenance major branch (v10 by default) in getsentry/sentry-javascript. Cherry-picks the PR's squash-merge commit onto the target branch, namespaces the commit/PR title scope (e.g. fix(core) -> fix(v10/core)), and opens a draft backport PR. Use when asked to backport a PR, port a fix to v10 (or an older major like v9), or cut a maintenance release change. Trigger phrases include "backport", "port to v10", "cherry-pick to the maintenance branch", "release this on v10".
+argument-hint: '<pr-number> [target-major]  # e.g. 18211 v10; target defaults to v10'
+---
+
+# Backport a PR to a maintenance major branch
+
+`develop` is the current major (v11). Released changes now go onto the previous major's
+maintenance branch (`v10` by default). This skill cherry-picks a merged PR's changes onto
+that branch and opens a draft backport PR, following the same convention used for the v9
+backports.
+
+## Inputs
+
+- **PR number** (required): the already-merged PR on `develop` to backport.
+- **Target major** (optional, default `v10`): the maintenance branch to backport onto.
+  Accept `v10`, `10`, `v9`, etc. Normalize to a branch name like `v10`.
+
+If the PR number is missing, ask for it. Do not guess.
+
+## Convention (learned from the v9 backports)
+
+- **Base branch** = the target major branch (`v10`), which must already exist on `origin`.
+- **Commit + PR title**: keep the original conventional-commit prefix but namespace the
+  scope with the major, e.g.
+  - `fix(core): Fix logs flush starvation` -> `fix(v10/core): Fix logs flush starvation`
+  - `feat(node): Add X` -> `feat(v10/node): Add X`
+  - If the original has no scope (e.g. `fix: ...`), use `fix(v10): ...`.
+  - For a multi-scope title, prefix the whole group once, not each scope:
+    `fix(cloudflare,deno,node): ...` -> `fix(v10/cloudflare,deno,node): ...`.
+- **PR body** is a single line: `Backport of: #<original-pr-number>`.
+- **PR is opened as a draft.**
+- **Branch name**: `ab/<major>-<short-slug>` (personal rule is the `ab/` prefix). Derive
+  `<short-slug>` from the original PR title, e.g. `ab/v10-fix-log-flush-starvation`.
+- The changes come from the PR's **squash-merge commit** on `develop` (one commit per PR),
+  so a single `git cherry-pick` normally covers the whole PR.
+
+## Steps
+
+### 1. Resolve the PR and target branch
+
+```bash
+# Fetch PR metadata (title, merge commit, base branch)
+gh pr view <PR> --json number,title,baseRefName,mergeCommit,state,url
+```
+
+Verify:
+- The PR is **merged** (`state == "MERGED"`). If not, stop and tell the user.
+- Its `baseRefName` is `develop` (or the expected parent major). If it targeted something
+  else, confirm with the user before continuing.
+
+Grab `mergeCommit.oid` — this is the squash commit to cherry-pick.
+
+Make sure the target branch exists and is up to date:
+
+```bash
+git fetch origin <major> develop
+git rev-parse --verify origin/<major>   # errors if the branch doesn't exist
+```
+
+If `origin/<major>` doesn't exist, stop: the maintenance branch hasn't been created yet.
+
+Then check the change isn't already on the target. A freshly cut major often still shares
+history with `develop`, so a recent PR may already be present:
+
+```bash
+git merge-base --is-ancestor <mergeCommit-oid> origin/<major> && echo "ALREADY ON <major>"
+```
+
+If it prints `ALREADY ON`, there's nothing to backport — stop and tell the user rather than
+producing an empty commit.
+
+### 2. Create the backport branch off the target major
+
+```bash
+git checkout -b ab/<major>-<slug> origin/<major>
+```
+
+### 3. Cherry-pick the merge commit
+
+```bash
+git cherry-pick <mergeCommit-oid>
+```
+
+- If git reports the pick is **empty** ("nothing to commit" / "the previous cherry-pick is
+  now empty"), the change is already on the target. Run `git cherry-pick --abort` and stop —
+  do not force it through with `--allow-empty`. This is the same situation the ancestor check
+  in step 1 guards against, caught here for changes that landed via a different commit.
+- On **conflicts**: resolve them by consulting the original diff (`git show <oid>`).
+  The target major may lack refactors that landed on `develop`, so adapt the change to the
+  older code rather than force-porting it. After resolving: `git add -A && git cherry-pick --continue`.
+  If the change can't be cleanly adapted, stop and surface the conflict to the user instead
+  of guessing.
+- If the PR was **not** squash-merged (multiple commits, e.g. a merge commit), cherry-pick
+  each relevant commit in order, or use `git cherry-pick -m 1 <merge-oid>` for a merge commit.
+
+### 4. Reword the commit to namespace the scope
+
+Rewrite only the subject line's scope to include the major; keep the body. Do **not** add a
+`Co-Authored-By` line or conventional prefix beyond what's described here — the backport
+branch's first commit mirrors an existing commit rather than being new authored work.
+
+```bash
+git commit --amend -m "<prefix>(<major>/<scope>): <original subject>" -m "Backport of: #<PR>"
+```
+
+Example: `fix(v10/core): Fix logs flush timeout starvation with continuous logging`
+
+### 5. Build and verify before pushing
+
+Run the repo's pre-commit checks so the backport branch is green:
+
+```bash
+yarn format
+yarn lint
+yarn build:dev
+```
+
+Run tests scoped to the touched packages when possible (full `yarn test` if unsure). If the
+target major's toolchain differs and a check fails for reasons unrelated to the change, note
+it for the user rather than silently skipping.
+
+### 6. Push and open the draft PR
+
+```bash
+git push -u origin ab/<major>-<slug>
+
+gh pr create \
+  --draft \
+  --base <major> \
+  --title "<prefix>(<major>/<scope>): <original subject>" \
+  --body "Backport of: #<PR>"
+```
+
+### 7. Cross-link on the original PR
+
+Add a note to the original PR pointing at the backport (mirrors `v9 backport: #NNNN`):
+
+```bash
+gh pr comment <PR> --body "<major> backport: #<new-backport-pr>"
+```
+
+## Notes
+
+- Never push directly to `develop`, `master`, or the major branch. Work only on the
+  `ab/<major>-...` branch and open a PR.
+- One PR per backport. If asked to backport several PRs, repeat the whole flow per PR (each
+  gets its own branch and draft PR).
+- If asked to backport to multiple majors at once (e.g. v10 and v9), do them as separate
+  branches/PRs, each based off its own `origin/<major>`.

--- a/agents.toml
+++ b/agents.toml
@@ -51,8 +51,8 @@ name = "bump-size-limit"
 source = "path:.agents/skills/bump-size-limit"
 
 [[skills]]
-name = "upgrade-otel"
-source = "path:.agents/skills/upgrade-otel"
+name = "vendor-otel"
+source = "path:.agents/skills/vendor-otel"
 
 [[skills]]
 name = "skill-scanner"
@@ -61,3 +61,27 @@ source = "getsentry/skills"
 [[skills]]
 name = "skill-creator"
 source = "anthropics/skills"
+
+[[skills]]
+name = "backport-pr"
+source = "path:.agents/skills/backport-pr"
+
+[[skills]]
+name = "bump-conventions"
+source = "path:.agents/skills/bump-conventions"
+
+[[skills]]
+name = "linear-project-status"
+source = "path:.agents/skills/linear-project-status"
+
+[[skills]]
+name = "linear-project-update"
+source = "path:.agents/skills/linear-project-update"
+
+[[skills]]
+name = "track-framework-updates"
+source = "path:.agents/skills/track-framework-updates"
+
+[[skills]]
+name = "write-tests"
+source = "path:.agents/skills/write-tests"


### PR DESCRIPTION
## What

Adds a `backport-pr` skill that backports a merged PR to a maintenance major branch.

- Defaults to `v10`, with a target-major parameter for older majors (e.g. `v9`).
- Cherry-picks the PR's squash-merge commit onto the target branch.
- Namespaces the commit/PR title scope, e.g. `fix(core):` becomes `fix(v10/core):`.
- Opens a draft backport PR with a `Backport of: #<pr>` body and cross-links the original.

## Why

`develop` is now v11 and released changes go onto the previous major's maintenance branch. This codifies the manual convention we used for the v9 backports so it's repeatable and consistent.