### PR TITLE
feat(core): Add `instrumentStateGraph` API

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
@@ -53,7 +53,7 @@ export default Sentry.withSentry(
         .addEdge(START, 'agent')
         .addEdge('agent', END);
 
-      Sentry.instrumentLangGraph(graph, { recordInputs: true, recordOutputs: true });
+      Sentry.instrumentStateGraph(graph, { recordInputs: true, recordOutputs: true });
 
       const compiled = graph.compile({ name: 'weather_assistant' });
 

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -158,6 +158,8 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   instrumentLangChainEmbeddings,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -140,6 +140,8 @@ export {
   instrumentOpenAiClient,
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -158,6 +158,8 @@ export {
   instrumentOpenAiClient,
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -112,6 +112,8 @@ export {
   metrics,
   withStreamedSpan,
   spanStreamingIntegration,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentCreateReactAgent,
 } from '@sentry/core';

--- a/packages/core/src/server-exports.ts
+++ b/packages/core/src/server-exports.ts
@@ -101,6 +101,8 @@ export type { LangChainOptions, LangChainIntegration } from './tracing/langchain
 export {
   instrumentStateGraphCompile,
   instrumentCreateReactAgent,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentCompiledGraphInvoke,
   _INTERNAL_getLangGraphCreateAgentSpanOptions,

--- a/packages/core/src/tracing/langgraph/index.ts
+++ b/packages/core/src/tracing/langgraph/index.ts
@@ -328,7 +328,7 @@ export function instrumentCreateReactAgent(
  *
  * @example
  * ```typescript
- * import { instrumentLangGraph } from '@sentry/cloudflare';
+ * import { instrumentStateGraph } from '@sentry/cloudflare';
  * import { StateGraph } from '@langchain/langgraph';
  *
  * const graph = new StateGraph(MessagesAnnotation)
@@ -336,12 +336,12 @@ export function instrumentCreateReactAgent(
  *   .addEdge(START, 'agent')
  *   .addEdge('agent', END);
  *
- * instrumentLangGraph(graph, { recordInputs: true, recordOutputs: true });
+ * instrumentStateGraph(graph, { recordInputs: true, recordOutputs: true });
  * const compiled = graph.compile({ name: 'my_agent' });
  * ```
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function instrumentLangGraph<T extends { compile: (...args: any[]) => any }>(
+export function instrumentStateGraph<T extends { compile: (...args: any[]) => any }>(
   stateGraph: T,
   options?: LangGraphOptions,
 ): T {
@@ -349,3 +349,11 @@ export function instrumentLangGraph<T extends { compile: (...args: any[]) => any
 
   return stateGraph;
 }
+
+/**
+ * Directly instruments a StateGraph instance to add tracing spans.
+ *
+ * @deprecated This function was renamed and will be removed in a future major version.
+ * Use `instrumentStateGraph` instead.
+ */
+export const instrumentLangGraph = instrumentStateGraph;

--- a/packages/core/test/lib/tracing/langgraph.test.ts
+++ b/packages/core/test/lib/tracing/langgraph.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { instrumentCreateReactAgent, instrumentStateGraphCompile } from '../../../src/tracing/langgraph';
+import {
+  instrumentCreateReactAgent,
+  instrumentLangGraph,
+  instrumentStateGraph,
+  instrumentStateGraphCompile,
+} from '../../../src/tracing/langgraph';
 
 describe('langgraph double-patch guard', () => {
   it('instrumentStateGraphCompile returns the same wrapper when applied twice', () => {
@@ -14,5 +19,21 @@ describe('langgraph double-patch guard', () => {
     const first = instrumentCreateReactAgent(original);
     const second = instrumentCreateReactAgent(first);
     expect(second).toBe(first);
+  });
+});
+
+describe('instrumentStateGraph', () => {
+  it('wraps the compile method of a StateGraph instance and returns the same instance', () => {
+    const originalCompile = () => ({});
+    const stateGraph = { compile: originalCompile };
+
+    const result = instrumentStateGraph(stateGraph);
+
+    expect(result).toBe(stateGraph);
+    expect(stateGraph.compile).not.toBe(originalCompile);
+  });
+
+  it('exposes instrumentLangGraph as a deprecated alias for instrumentStateGraph', () => {
+    expect(instrumentLangGraph).toBe(instrumentStateGraph);
   });
 });

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -136,6 +136,8 @@ export {
   instrumentOpenAiClient,
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -138,6 +138,8 @@ export {
   instrumentOpenAiClient,
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -151,6 +151,8 @@ export {
   spanStreamingIntegration,
   createLangChainCallbackHandler,
   instrumentLangChainEmbeddings,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
 } from '@sentry/core';

--- a/packages/node/src/integrations/tracing/langgraph/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/langgraph/instrumentation.ts
@@ -6,7 +6,7 @@ import {
 } from '@opentelemetry/instrumentation';
 import { InstrumentationNodeModuleFile } from '../InstrumentationNodeModuleFile';
 import type { CompiledGraph, LangGraphOptions } from '@sentry/core';
-import { getClient, instrumentCreateReactAgent, instrumentLangGraph, SDK_VERSION } from '@sentry/core';
+import { getClient, instrumentCreateReactAgent, instrumentStateGraph, SDK_VERSION } from '@sentry/core';
 
 const supportedVersions = ['>=0.0.0 <2.0.0'];
 
@@ -100,7 +100,7 @@ export class SentryLangGraphInstrumentation extends InstrumentationBase<LangGrap
 
     // Patch StateGraph.compile to instrument both compile() and invoke()
     if (exports.StateGraph && typeof exports.StateGraph === 'function') {
-      instrumentLangGraph(exports.StateGraph.prototype as { compile: (...args: unknown[]) => unknown }, options);
+      instrumentStateGraph(exports.StateGraph.prototype as { compile: (...args: unknown[]) => unknown }, options);
     }
 
     // Patch createReactAgent to instrument agent creation and invocation

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -125,6 +125,8 @@ export {
   instrumentOpenAiClient,
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -127,6 +127,8 @@ export {
   instrumentOpenAiClient,
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -74,6 +74,8 @@ export {
   // eslint-disable-next-line typescript/no-deprecated
   inboundFiltersIntegration,
   instrumentOpenAiClient,
+  instrumentStateGraph,
+  // eslint-disable-next-line typescript/no-deprecated
   instrumentLangGraph,
   instrumentGoogleGenAIClient,
   instrumentAnthropicAiClient,


### PR DESCRIPTION
Adds `instrumentStateGraph` as the new name for the public LangGraph manual-instrumentation function, since the old `instrumentLangGraph` only instruments the `StateGraph` class and is confusing now that a separate `instrumentCreateReactAgent` API exists.  Deprecates `instrumentLangGraph` but does not remove yet so this commit can be backported as is to v10. Removal will be done in a follow-up.