### PR TITLE
feat(core)!: Remove deprecated `instrumentLangGraph`

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -155,8 +155,6 @@ export {
   instrumentGoogleGenAIClient,
   instrumentLangChainEmbeddings,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,
   profiler,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -137,8 +137,6 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,
   profiler,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -155,8 +155,6 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,
   profiler,

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -113,8 +113,6 @@ export {
   withStreamedSpan,
   spanStreamingIntegration,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentCreateReactAgent,
 } from '@sentry/core';
 

--- a/packages/core/src/server-exports.ts
+++ b/packages/core/src/server-exports.ts
@@ -102,8 +102,6 @@ export {
   instrumentStateGraphCompile,
   instrumentCreateReactAgent,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentCompiledGraphInvoke,
   _INTERNAL_getLangGraphCreateAgentSpanOptions,
 } from './tracing/langgraph';

--- a/packages/core/src/tracing/langgraph/index.ts
+++ b/packages/core/src/tracing/langgraph/index.ts
@@ -349,11 +349,3 @@ export function instrumentStateGraph<T extends { compile: (...args: any[]) => an
 
   return stateGraph;
 }
-
-/**
- * Directly instruments a StateGraph instance to add tracing spans.
- *
- * @deprecated This function was renamed and will be removed in a future major version.
- * Use `instrumentStateGraph` instead.
- */
-export const instrumentLangGraph = instrumentStateGraph;

--- a/packages/core/test/lib/tracing/langgraph.test.ts
+++ b/packages/core/test/lib/tracing/langgraph.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
   instrumentCreateReactAgent,
-  instrumentLangGraph,
   instrumentStateGraph,
   instrumentStateGraphCompile,
 } from '../../../src/tracing/langgraph';
@@ -31,9 +30,5 @@ describe('instrumentStateGraph', () => {
 
     expect(result).toBe(stateGraph);
     expect(stateGraph.compile).not.toBe(originalCompile);
-  });
-
-  it('exposes instrumentLangGraph as a deprecated alias for instrumentStateGraph', () => {
-    expect(instrumentLangGraph).toBe(instrumentStateGraph);
   });
 });

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -133,8 +133,6 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,
   profiler,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -135,8 +135,6 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,
   profiler,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -150,8 +150,6 @@ export {
   createLangChainCallbackHandler,
   instrumentLangChainEmbeddings,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
 } from '@sentry/core';
 

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -126,8 +126,6 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,
   logger,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -128,8 +128,6 @@ export {
   instrumentAnthropicAiClient,
   instrumentGoogleGenAIClient,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentStateGraphCompile,
   zodErrorsIntegration,
   logger,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -75,8 +75,6 @@ export {
   inboundFiltersIntegration,
   instrumentOpenAiClient,
   instrumentStateGraph,
-  // eslint-disable-next-line typescript/no-deprecated
-  instrumentLangGraph,
   instrumentGoogleGenAIClient,
   instrumentAnthropicAiClient,
   eventFiltersIntegration,


### PR DESCRIPTION
Removes the `instrumentLangGraph` alias that getsentry/sentry-javascript#22483 deprecated in favor of `instrumentStateGraph`, completing the rename from getsentry/sentry-javascript#20584.

Fixes getsentry/sentry-javascript#20584