### PR TITLE
ref(react-router): Decouple ServerBuild capture from the OTel patch

### DIFF
--- a/packages/react-router/src/server/integration/reactRouterServer.ts
+++ b/packages/react-router/src/server/integration/reactRouterServer.ts
@@ -14,8 +14,6 @@ const instrumentReactRouter = generateInstrumentOnce(INTEGRATION_NAME, () => {
 export const instrumentReactRouterServer = Object.assign(
   (): void => {
     instrumentReactRouter();
-    // Register global for Vite plugin ServerBuild capture
-    registerServerBuildGlobal();
   },
   { id: INTEGRATION_NAME },
 );
@@ -27,6 +25,10 @@ export const reactRouterServerIntegration = defineIntegration(() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
+      // Register global for Vite plugin ServerBuild capture. Registered independently of the OTEL
+      // patch so this capture path keeps working once the OTEL instrumentation is removed.
+      registerServerBuildGlobal();
+
       // Enable OTEL data-loader spans only on Node versions without the diagnostics_channel-based instrumentation API.
       if (
         (NODE_VERSION.major === 20 && NODE_VERSION.minor < 19) ||

--- a/packages/react-router/test/server/integration/reactRouterServer.test.ts
+++ b/packages/react-router/test/server/integration/reactRouterServer.test.ts
@@ -2,7 +2,10 @@ import { HTTP_ROUTE } from '@sentry/conventions/attributes';
 import type { Client, Event, EventType, StreamedSpanJSON } from '@sentry/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReactRouterInstrumentation } from '../../../src/server/instrumentation/reactRouter';
-import { reactRouterServerIntegration } from '../../../src/server/integration/reactRouterServer';
+import {
+  instrumentReactRouterServer,
+  reactRouterServerIntegration,
+} from '../../../src/server/integration/reactRouterServer';
 import * as serverBuild from '../../../src/server/serverBuild';
 import * as serverGlobals from '../../../src/server/serverGlobals';
 
@@ -51,6 +54,14 @@ describe('reactRouterServerIntegration', () => {
     integration.setupOnce!();
 
     expect(registerServerBuildGlobalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not register the server build global from the OTEL instrumentation setup', () => {
+    // Guards against re-coupling: the Vite-plugin capture registration must not depend on the
+    // OTEL patch being installed, so it survives once the OTEL instrumentation is removed.
+    instrumentReactRouterServer();
+
+    expect(registerServerBuildGlobalSpy).not.toHaveBeenCalled();
   });
 
   it('enables OTEL data-loader span creation on Node 20.18', () => {


### PR DESCRIPTION
Moves `registerServerBuildGlobal()` out of the OTel instrumentation setup and registers the Vite-plugin ServerBuild capture independently in the integration's `setupOnce()`. This keeps the capture path working once the OTel instrumentation is removed in a follow-up.

No behavior change — both ServerBuild capture paths (OTel proxy and Vite plugin) remain active.

Fixes getsentry/sentry-javascript#22411  <br>Ref getsentry/sentry-javascript#22290