### PR TITLE
feat(core)!: Remove `streamGenAiSpans` flag

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/index.ts
@@ -28,7 +28,6 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
-    streamGenAiSpans: true,
   }),
   {
     async fetch(_request, _env, _ctx) {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/index.ts
@@ -46,7 +46,6 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
-    streamGenAiSpans: true,
   }),
   {
     async fetch(_request, _env, _ctx) {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/index.ts
@@ -31,7 +31,6 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
-    streamGenAiSpans: true,
   }),
   {
     async fetch(_request, _env, _ctx) {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
@@ -11,7 +11,6 @@ export default Sentry.withSentry(
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     dataCollection: { genAI: { inputs: true, outputs: true } },
-    streamGenAiSpans: true,
   }),
   {
     async fetch(_request, _env, _ctx) {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/openai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/openai/index.ts
@@ -33,7 +33,6 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
-    streamGenAiSpans: true,
   }),
   {
     async fetch(_request, _env, _ctx) {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
@@ -13,9 +13,6 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
-    // Keep gen_ai spans embedded in the transaction (instead of streamed as a
-    // separate envelope container) so they can be asserted on `transaction.spans`.
-    streamGenAiSpans: false,
   }),
   {
     async fetch(request) {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/test.ts
@@ -22,40 +22,29 @@ it('traces a basic Workers AI text generation request', async ({ signal }) => {
     .ignore('event')
     .expect(envelope => {
       const transactionEvent = envelope[1]?.[0]?.[1] as any;
+      expect(transactionEvent.transaction).toBe('GET /');
 
-      // The transaction event is framework-generated and carries non-deterministic fields
-      // (random ports, ids, timestamps, sdk version), so we assert the stable subset.
-      expect(transactionEvent).toEqual(
+      const container = envelope[1]?.[1]?.[1] as any;
+      expect(container).toBeDefined();
+      expect(container.items).toHaveLength(1);
+
+      expect(container.items[0]).toEqual(
         expect.objectContaining({
-          type: 'transaction',
-          transaction: 'GET /',
-          transaction_info: { source: 'route' },
-          contexts: expect.objectContaining({
-            trace: expect.objectContaining({
-              op: 'http.server',
-              origin: 'auto.http.cloudflare',
-              status: 'ok',
-            }),
-          }),
-          spans: [
-            expect.objectContaining({
-              description: 'chat @cf/meta/llama-3.1-8b-instruct',
-              op: 'gen_ai.chat',
-              origin: 'auto.ai.cloudflare.workers_ai',
-              data: {
-                'sentry.origin': 'auto.ai.cloudflare.workers_ai',
-                'sentry.op': 'gen_ai.chat',
-                [GEN_AI_PROVIDER_NAME]: 'cloudflare.workers_ai',
-                [GEN_AI_OPERATION_NAME]: 'chat',
-                [GEN_AI_REQUEST_MODEL]: '@cf/meta/llama-3.1-8b-instruct',
-                [GEN_AI_REQUEST_TEMPERATURE]: 0.7,
-                [GEN_AI_REQUEST_MAX_TOKENS]: 100,
-                [GEN_AI_USAGE_INPUT_TOKENS]: 12,
-                [GEN_AI_USAGE_OUTPUT_TOKENS]: 7,
-                [GEN_AI_USAGE_TOTAL_TOKENS]: 19,
-              },
-            }),
-          ],
+          name: 'chat @cf/meta/llama-3.1-8b-instruct',
+          status: 'ok',
+          is_segment: false,
+          attributes: {
+            'sentry.origin': { value: 'auto.ai.cloudflare.workers_ai', type: 'string' },
+            'sentry.op': { value: 'gen_ai.chat', type: 'string' },
+            [GEN_AI_PROVIDER_NAME]: { value: 'cloudflare.workers_ai', type: 'string' },
+            [GEN_AI_OPERATION_NAME]: { value: 'chat', type: 'string' },
+            [GEN_AI_REQUEST_MODEL]: { value: '@cf/meta/llama-3.1-8b-instruct', type: 'string' },
+            [GEN_AI_REQUEST_TEMPERATURE]: { value: 0.7, type: 'double' },
+            [GEN_AI_REQUEST_MAX_TOKENS]: { value: 100, type: 'integer' },
+            [GEN_AI_USAGE_INPUT_TOKENS]: { value: 12, type: 'integer' },
+            [GEN_AI_USAGE_OUTPUT_TOKENS]: { value: 7, type: 'integer' },
+            [GEN_AI_USAGE_TOTAL_TOKENS]: { value: 19, type: 'integer' },
+          },
         }),
       );
     })
@@ -69,38 +58,29 @@ it('traces a streaming Workers AI text generation request', async ({ signal }) =
     .ignore('event')
     .expect(envelope => {
       const transactionEvent = envelope[1]?.[0]?.[1] as any;
+      expect(transactionEvent.transaction).toBe('GET /stream');
 
-      expect(transactionEvent).toEqual(
+      const container = envelope[1]?.[1]?.[1] as any;
+      expect(container).toBeDefined();
+      expect(container.items).toHaveLength(1);
+
+      expect(container.items[0]).toEqual(
         expect.objectContaining({
-          type: 'transaction',
-          transaction: 'GET /stream',
-          transaction_info: { source: 'url' },
-          contexts: expect.objectContaining({
-            trace: expect.objectContaining({
-              op: 'http.server',
-              origin: 'auto.http.cloudflare',
-              status: 'ok',
-            }),
-          }),
-          spans: [
-            expect.objectContaining({
-              description: 'chat @cf/meta/llama-3.1-8b-instruct',
-              op: 'gen_ai.chat',
-              origin: 'auto.ai.cloudflare.workers_ai',
-              data: {
-                'sentry.origin': 'auto.ai.cloudflare.workers_ai',
-                'sentry.op': 'gen_ai.chat',
-                [GEN_AI_PROVIDER_NAME]: 'cloudflare.workers_ai',
-                [GEN_AI_OPERATION_NAME]: 'chat',
-                [GEN_AI_REQUEST_MODEL]: '@cf/meta/llama-3.1-8b-instruct',
-                [GEN_AI_REQUEST_STREAM_ATTRIBUTE]: true,
-                [GEN_AI_RESPONSE_STREAMING]: true,
-                [GEN_AI_USAGE_INPUT_TOKENS]: 12,
-                [GEN_AI_USAGE_OUTPUT_TOKENS]: 7,
-                [GEN_AI_USAGE_TOTAL_TOKENS]: 19,
-              },
-            }),
-          ],
+          name: 'chat @cf/meta/llama-3.1-8b-instruct',
+          status: 'ok',
+          is_segment: false,
+          attributes: {
+            'sentry.origin': { value: 'auto.ai.cloudflare.workers_ai', type: 'string' },
+            'sentry.op': { value: 'gen_ai.chat', type: 'string' },
+            [GEN_AI_PROVIDER_NAME]: { value: 'cloudflare.workers_ai', type: 'string' },
+            [GEN_AI_OPERATION_NAME]: { value: 'chat', type: 'string' },
+            [GEN_AI_REQUEST_MODEL]: { value: '@cf/meta/llama-3.1-8b-instruct', type: 'string' },
+            [GEN_AI_REQUEST_STREAM_ATTRIBUTE]: { value: true, type: 'boolean' },
+            [GEN_AI_RESPONSE_STREAMING]: { value: true, type: 'boolean' },
+            [GEN_AI_USAGE_INPUT_TOKENS]: { value: 12, type: 'integer' },
+            [GEN_AI_USAGE_OUTPUT_TOKENS]: { value: 7, type: 'integer' },
+            [GEN_AI_USAGE_TOTAL_TOKENS]: { value: 19, type: 'integer' },
+          },
         }),
       );
     })

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/ai-streaming.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/ai-streaming.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan, waitForTransaction } from '@sentry-internal/test-utils';
+import type { SerializedStreamedSpan } from '@sentry/core';
 
 // Drives Workers AI through the real Cloudflare Agents SDK + Vercel AI SDK + `workers-ai-provider`
 // stack (the OpenAI-compatible SSE shape, `choices[].delta.content`) from an Agent's `onRequest`.
@@ -7,54 +8,47 @@ import { waitForTransaction } from '@sentry-internal/test-utils';
 // production where only input + usage survived. The model output is read from
 // `gen_ai.output.messages`, so the streaming instrumentation must emit it alongside the
 // deprecated `gen_ai.response.text`.
-function assertGenAiStreamingSpan(spans: Array<Record<string, any>> | undefined): void {
-  const genAiSpan = (spans ?? []).find(span => span.op === 'gen_ai.chat');
-
-  expect(genAiSpan).toBeDefined();
-  expect(genAiSpan.origin).toBe('auto.ai.cloudflare.workers_ai');
-  expect(genAiSpan.data).toEqual(
-    expect.objectContaining({
-      'sentry.origin': 'auto.ai.cloudflare.workers_ai',
-      'gen_ai.operation.name': 'chat',
-      'gen_ai.request.model': '@cf/meta/llama-3.1-8b-instruct',
-      'gen_ai.response.streaming': true,
-      'gen_ai.response.text': 'The capital of France is Paris.',
-      'gen_ai.output.messages': JSON.stringify([
-        { role: 'assistant', parts: [{ type: 'text', content: 'The capital of France is Paris.' }] },
-      ]),
-      'gen_ai.usage.input_tokens': 15,
-      'gen_ai.usage.output_tokens': 8,
-      'gen_ai.usage.total_tokens': 23,
-    }),
+function assertGenAiStreamingSpan(span: SerializedStreamedSpan): void {
+  expect(getSpanOp(span)).toBe('gen_ai.chat');
+  expect(span.attributes['sentry.origin']?.value).toBe('auto.ai.cloudflare.workers_ai');
+  expect(span.attributes['gen_ai.operation.name']?.value).toBe('chat');
+  expect(span.attributes['gen_ai.request.model']?.value).toBe('@cf/meta/llama-3.1-8b-instruct');
+  expect(span.attributes['gen_ai.response.streaming']?.value).toBe(true);
+  expect(span.attributes['gen_ai.response.text']?.value).toBe('The capital of France is Paris.');
+  expect(span.attributes['gen_ai.output.messages']?.value).toBe(
+    JSON.stringify([{ role: 'assistant', parts: [{ type: 'text', content: 'The capital of France is Paris.' }] }]),
   );
+  expect(span.attributes['gen_ai.usage.input_tokens']?.value).toBe(15);
+  expect(span.attributes['gen_ai.usage.output_tokens']?.value).toBe(8);
+  expect(span.attributes['gen_ai.usage.total_tokens']?.value).toBe(23);
 }
 
 test('captures Workers AI streaming output when driven via an Agent', async ({ request, baseURL }) => {
-  const transactionPromise = waitForTransaction('cloudflare-agent', transactionEvent => {
-    return (
-      transactionEvent.transaction === 'GET /agents/my-agent/test' &&
-      (transactionEvent.spans ?? []).some(span => span.op === 'gen_ai.chat')
-    );
-  });
+  const spanPromise = waitForStreamedSpan('cloudflare-agent', span => getSpanOp(span) === 'gen_ai.chat');
+  const transactionPromise = waitForTransaction(
+    'cloudflare-agent',
+    transactionEvent => transactionEvent.transaction === 'GET /agents/my-agent/test',
+  );
 
   const response = await request.get(`${baseURL}/agents/my-agent/test`);
   expect(response.ok()).toBe(true);
 
-  const transaction = await transactionPromise;
-  assertGenAiStreamingSpan(transaction.spans);
+  const [span, transaction] = await Promise.all([spanPromise, transactionPromise]);
+  expect(span.trace_id).toBe(transaction.contexts?.trace?.trace_id);
+  assertGenAiStreamingSpan(span);
 });
 
 test('captures Workers AI streaming output when driven via an AIChatAgent', async ({ request, baseURL }) => {
-  const transactionPromise = waitForTransaction('cloudflare-agent', transactionEvent => {
-    return (
-      transactionEvent.transaction === 'GET /agents/my-chat-agent/test' &&
-      (transactionEvent.spans ?? []).some(span => span.op === 'gen_ai.chat')
-    );
-  });
+  const spanPromise = waitForStreamedSpan('cloudflare-agent', span => getSpanOp(span) === 'gen_ai.chat');
+  const transactionPromise = waitForTransaction(
+    'cloudflare-agent',
+    transactionEvent => transactionEvent.transaction === 'GET /agents/my-chat-agent/test',
+  );
 
   const response = await request.get(`${baseURL}/agents/my-chat-agent/test`);
   expect(response.ok()).toBe(true);
 
-  const transaction = await transactionPromise;
-  assertGenAiStreamingSpan(transaction.spans);
+  const [span, transaction] = await Promise.all([spanPromise, transactionPromise]);
+  expect(span.trace_id).toBe(transaction.contexts?.trace?.trace_id);
+  assertGenAiStreamingSpan(span);
 });

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/chat-conversation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/chat-conversation.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan, waitForTransaction } from '@sentry-internal/test-utils';
 import { sendChatMessage } from './agent-socket';
 
 // In the Agents model one agent instance is one conversation, so the instance name is the
@@ -7,12 +7,11 @@ import { sendChatMessage } from './agent-socket';
 const CONVERSATION_ID = 'chat-conv-instance';
 
 test('stamps the conversation id on gen_ai spans created inside a chat turn', async ({ baseURL }) => {
-  const transactionPromise = waitForTransaction('cloudflare-agent', transactionEvent => {
-    return (
-      transactionEvent.transaction === 'webSocketMessage' &&
-      (transactionEvent.spans ?? []).some(span => span.op === 'gen_ai.chat')
-    );
-  });
+  const spanPromise = waitForStreamedSpan('cloudflare-agent', span => getSpanOp(span) === 'gen_ai.chat');
+  const transactionPromise = waitForTransaction(
+    'cloudflare-agent',
+    transactionEvent => transactionEvent.transaction === 'webSocketMessage',
+  );
 
   await sendChatMessage(baseURL!, {
     binding: 'my-chat-agent',
@@ -20,13 +19,7 @@ test('stamps the conversation id on gen_ai spans created inside a chat turn', as
     prompt: 'What is the capital of France?',
   });
 
-  const transaction = await transactionPromise;
-
-  const genAiSpan = (transaction.spans ?? []).find(span => span.op === 'gen_ai.chat');
-  expect(genAiSpan).toBeDefined();
-  expect(genAiSpan?.data).toEqual(
-    expect.objectContaining({
-      'gen_ai.conversation.id': CONVERSATION_ID,
-    }),
-  );
+  const [genAiSpan, transaction] = await Promise.all([spanPromise, transactionPromise]);
+  expect(genAiSpan.trace_id).toBe(transaction.contexts?.trace?.trace_id);
+  expect(genAiSpan.attributes['gen_ai.conversation.id']?.value).toBe(CONVERSATION_ID);
 });

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker/index.ts
@@ -15,9 +15,6 @@ const sentryOptions = (env: Env) => ({
   tracesSampleRate: 1,
   enableRpcTracePropagation: true,
   durableObjectStorageSpanAllowlist: ['cf_user_key'],
-  // Keep gen_ai spans embedded in the transaction (instead of streamed as a separate envelope
-  // container) so they can be asserted on `transaction.spans`.
-  streamGenAiSpans: false,
 });
 
 /**

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/index.ts
@@ -8,7 +8,6 @@ export default Sentry.withSentry(
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tunnel: 'http://localhost:3031/',
-    streamGenAiSpans: false,
     tracesSampleRate: 1.0,
     integrations: [Sentry.vercelAIIntegration()],
   }),

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/tests/index.test.ts
@@ -1,23 +1,33 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForRequest } from '@sentry-internal/test-utils';
 
 test('does not capture Vercel AI v7 spans without nodejs_compat', async ({ baseURL }) => {
-  const transactionPromise = waitForTransaction('cloudflare-vercelai-v7-als', txn => {
-    return txn.transaction === 'GET /generate';
+  // The transaction envelope also carries any extracted gen_ai spans as a span v2 container item,
+  // so we wait for the whole envelope and assert neither place contains AI spans.
+  const envelopePromise = waitForRequest('cloudflare-vercelai-v7-als', ({ envelope }) => {
+    const transactionItem = envelope[1].find(([header]) => header.type === 'transaction');
+    return (transactionItem?.[1] as any)?.transaction === 'GET /generate';
   });
 
   const response = await fetch(`${baseURL}/generate`);
   expect(response.status).toBe(200);
 
-  const transaction = await transactionPromise;
+  const { envelope } = await envelopePromise;
 
+  const transaction = envelope[1].find(([header]) => header.type === 'transaction')?.[1] as any;
   expect(transaction.transaction).toBe('GET /generate');
   expect(transaction.contexts?.trace?.op).toBe('http.server');
 
-  // v7 uses diagnostics_channel which is not available with nodejs_als,
-  // so no AI spans should be present.
-  const aiSpans = (transaction.spans || []).filter(
+  // v7 uses diagnostics_channel which is not available with nodejs_als, so no AI spans should be
+  // present — neither embedded in the transaction nor streamed as a span v2 container item.
+  const embeddedAiSpans = (transaction.spans || []).filter(
     (span: any) => span.op?.startsWith('gen_ai.') || span.description?.includes('generateText'),
   );
-  expect(aiSpans).toHaveLength(0);
+  expect(embeddedAiSpans).toHaveLength(0);
+
+  const streamedGenAiSpans = envelope[1]
+    .filter(([header]) => header.type === 'span')
+    .flatMap(([, payload]) => (payload as any).items ?? [])
+    .filter((span: any) => getSpanOp(span)?.startsWith('gen_ai.'));
+  expect(streamedGenAiSpans).toHaveLength(0);
 });

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/index.ts
@@ -9,7 +9,6 @@ export default Sentry.withSentry(
     environment: 'qa',
     tunnel: 'http://localhost:3031/',
     tracesSampleRate: 1.0,
-    streamGenAiSpans: false,
     integrations: [Sentry.vercelAIIntegration()],
   }),
   {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/tests/index.test.ts
@@ -1,57 +1,40 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpans } from '@sentry-internal/test-utils';
 
 test('captures Vercel AI v7 spans with nodejs_compat using tracing channels', async ({ baseURL }) => {
-  const transactionPromise = waitForTransaction('cloudflare-vercelai-v7-compat', txn => {
-    return txn.transaction === 'GET /generate';
-  });
+  // gen_ai spans are extracted into a separate span v2 envelope item
+  const genAiSpansPromise = waitForStreamedSpans('cloudflare-vercelai-v7-compat', spans =>
+    spans.some(span => getSpanOp(span) === 'gen_ai.invoke_agent'),
+  );
 
   const response = await fetch(`${baseURL}/generate`);
 
   expect(response.status).toBe(200);
 
-  const transaction = await transactionPromise;
+  const genAiSpans = await genAiSpansPromise;
 
-  expect(transaction.transaction).toBe('GET /generate');
-  expect(transaction.contexts?.trace?.op).toBe('http.server');
-  expect(transaction.spans).toHaveLength(2);
-
-  expect(transaction.spans).toEqual(
+  expect(genAiSpans).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        description: 'invoke_agent',
-        op: 'gen_ai.invoke_agent',
-        origin: 'auto.vercelai.channel',
-        parent_span_id: expect.any(String),
-        span_id: expect.any(String),
-        start_timestamp: expect.any(Number),
-        timestamp: expect.any(Number),
-        trace_id: expect.any(String),
-        data: expect.objectContaining({
-          'gen_ai.operation.name': 'invoke_agent',
-          'gen_ai.usage.input_tokens': 10,
-          'gen_ai.usage.output_tokens': 20,
-          'gen_ai.usage.total_tokens': 30,
-          'sentry.op': 'gen_ai.invoke_agent',
-          'sentry.origin': 'auto.vercelai.channel',
+        name: 'invoke_agent',
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': { value: 'invoke_agent', type: 'string' },
+          'gen_ai.usage.input_tokens': { value: 10, type: 'integer' },
+          'gen_ai.usage.output_tokens': { value: 20, type: 'integer' },
+          'gen_ai.usage.total_tokens': { value: 30, type: 'integer' },
+          'sentry.op': { value: 'gen_ai.invoke_agent', type: 'string' },
+          'sentry.origin': { value: 'auto.vercelai.channel', type: 'string' },
         }),
       }),
       expect.objectContaining({
-        description: 'generate_content mock-model-id',
-        op: 'gen_ai.generate_content',
-        origin: 'auto.vercelai.channel',
-        parent_span_id: expect.any(String),
-        span_id: expect.any(String),
-        start_timestamp: expect.any(Number),
-        timestamp: expect.any(Number),
-        trace_id: expect.any(String),
-        data: expect.objectContaining({
-          'gen_ai.operation.name': 'generate_content',
-          'gen_ai.usage.input_tokens': 10,
-          'gen_ai.usage.output_tokens': 20,
-          'gen_ai.usage.total_tokens': 30,
-          'sentry.op': 'gen_ai.generate_content',
-          'sentry.origin': 'auto.vercelai.channel',
+        name: 'generate_content mock-model-id',
+        attributes: expect.objectContaining({
+          'gen_ai.operation.name': { value: 'generate_content', type: 'string' },
+          'gen_ai.usage.input_tokens': { value: 10, type: 'integer' },
+          'gen_ai.usage.output_tokens': { value: 20, type: 'integer' },
+          'gen_ai.usage.total_tokens': { value: 30, type: 'integer' },
+          'sentry.op': { value: 'gen_ai.generate_content', type: 'string' },
+          'sentry.origin': { value: 'auto.vercelai.channel', type: 'string' },
         }),
       }),
     ]),

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.server.config.ts
@@ -12,5 +12,4 @@ Sentry.init({
     bufferSize: 1000,
   },
   integrations: [Sentry.vercelAIIntegration()],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.server.config.ts
@@ -10,7 +10,6 @@ Sentry.init({
   dataCollection: { userInfo: true },
   // debug: true,
   integrations: [Sentry.vercelAIIntegration(), Sentry.nodeRuntimeMetricsIntegration({ collectionIntervalMs: 1_000 })],
-  streamGenAiSpans: true,
   // Verify Log type is available
   beforeSendLog(log: Log) {
     return log;

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-no-truncation.mjs
@@ -22,5 +22,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-streaming-with-truncation.mjs
@@ -13,5 +13,4 @@ Sentry.init({
       enableTruncation: true,
     }),
   ],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-streaming.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
   traceLifecycle: 'stream',
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-options.mjs
@@ -21,5 +21,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-truncation.mjs
@@ -16,5 +16,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-no-truncation.mjs
@@ -22,5 +22,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-streaming-with-truncation.mjs
@@ -13,5 +13,4 @@ Sentry.init({
       enableTruncation: true,
     }),
   ],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-streaming.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
   traceLifecycle: 'stream',
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-options.mjs
@@ -21,5 +21,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-pii.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-truncation.mjs
@@ -16,5 +16,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-no-truncation.mjs
@@ -22,5 +22,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming-with-truncation.mjs
@@ -13,5 +13,4 @@ Sentry.init({
       enableTruncation: true,
     }),
   ],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-streaming.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
   traceLifecycle: 'stream',
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-pii.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-truncation.mjs
@@ -16,5 +16,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-pii.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-truncation.mjs
@@ -16,5 +16,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-agent.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-agent.mjs
@@ -7,8 +7,6 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: true, outputs: true } },
-  // This suite asserts on gen_ai spans embedded in the transaction, so opt out of span streaming.
-  streamGenAiSpans: false,
   transport: loggingTransport,
   beforeSendTransaction: event => {
     // Filter out mock express server transactions

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-no-truncation.mjs
@@ -15,5 +15,4 @@ Sentry.init({
       enableTruncation: false,
     }),
   ],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-streaming-with-truncation.mjs
@@ -13,5 +13,4 @@ Sentry.init({
       enableTruncation: true,
     }),
   ],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-streaming.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
   traceLifecycle: 'stream',
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-with-pii.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: false, outputs: false } },
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
@@ -368,27 +368,31 @@ describe('LangGraph integration', () => {
           transaction: event => {
             const spans = event.spans ?? [];
             expect(event.transaction).toBe('main');
-            expect(spans).toHaveLength(3);
+            expect(spans).toContainEqual(expect.objectContaining({ op: 'http.client' }));
+          },
+        })
+        .expect({
+          span: container => {
+            const spans = container.items;
             expect(spans).toContainEqual(
               expect.objectContaining({
-                data: expect.objectContaining({
-                  [GEN_AI_OPERATION_NAME]: 'invoke_agent',
-                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.invoke_agent',
-                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ai.langgraph',
-                  [GEN_AI_AGENT_NAME]: 'helpful_assistant',
-                  [GEN_AI_PIPELINE_NAME]: 'helpful_assistant',
-                }),
-                description: 'invoke_agent helpful_assistant',
-                op: 'gen_ai.invoke_agent',
-                origin: 'auto.ai.langgraph',
+                name: 'invoke_agent helpful_assistant',
                 status: 'ok',
+                attributes: expect.objectContaining({
+                  [GEN_AI_OPERATION_NAME]: expect.objectContaining({ value: 'invoke_agent' }),
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: expect.objectContaining({ value: 'gen_ai.invoke_agent' }),
+                  [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: expect.objectContaining({ value: 'auto.ai.langgraph' }),
+                  [GEN_AI_AGENT_NAME]: expect.objectContaining({ value: 'helpful_assistant' }),
+                  [GEN_AI_PIPELINE_NAME]: expect.objectContaining({ value: 'helpful_assistant' }),
+                }),
               }),
             );
-            expect(spans).toContainEqual(expect.objectContaining({ op: 'http.client' }));
             expect(spans).toContainEqual(
               expect.objectContaining({
-                data: expect.objectContaining({ [GEN_AI_AGENT_NAME]: 'helpful_assistant' }),
-                op: 'gen_ai.chat',
+                attributes: expect.objectContaining({
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: expect.objectContaining({ value: 'gen_ai.chat' }),
+                  [GEN_AI_AGENT_NAME]: expect.objectContaining({ value: 'helpful_assistant' }),
+                }),
               }),
             );
           },
@@ -407,43 +411,49 @@ describe('LangGraph integration', () => {
           transaction: event => {
             const spans = event.spans ?? [];
             expect(event.transaction).toBe('main');
-            expect(spans).toHaveLength(9);
-            expect(spans).toContainEqual(
-              expect.objectContaining({
-                data: expect.objectContaining({
-                  [GEN_AI_OPERATION_NAME]: 'invoke_agent',
-                  [GEN_AI_AGENT_NAME]: 'math_assistant',
-                }),
-                op: 'gen_ai.invoke_agent',
-                status: 'ok',
-              }),
-            );
-            expect(spans).toContainEqual(
-              expect.objectContaining({
-                data: expect.objectContaining({
-                  [GEN_AI_OPERATION_NAME]: 'execute_tool',
-                  [GEN_AI_TOOL_NAME]: 'add',
-                  'gen_ai.tool.type': 'function',
-                }),
-                description: 'execute_tool add',
-                op: 'gen_ai.execute_tool',
-                status: 'ok',
-              }),
-            );
-            expect(spans).toContainEqual(
-              expect.objectContaining({
-                data: expect.objectContaining({
-                  [GEN_AI_OPERATION_NAME]: 'execute_tool',
-                  [GEN_AI_TOOL_NAME]: 'multiply',
-                  'gen_ai.tool.type': 'function',
-                }),
-                description: 'execute_tool multiply',
-                op: 'gen_ai.execute_tool',
-                status: 'ok',
-              }),
-            );
             expect(spans.filter(span => span.op === 'http.client')).toHaveLength(3);
-            expect(spans.filter(span => span.op === 'gen_ai.chat')).toHaveLength(3);
+          },
+        })
+        .expect({
+          span: container => {
+            const spans = container.items;
+            expect(spans).toContainEqual(
+              expect.objectContaining({
+                status: 'ok',
+                attributes: expect.objectContaining({
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: expect.objectContaining({ value: 'gen_ai.invoke_agent' }),
+                  [GEN_AI_OPERATION_NAME]: expect.objectContaining({ value: 'invoke_agent' }),
+                  [GEN_AI_AGENT_NAME]: expect.objectContaining({ value: 'math_assistant' }),
+                }),
+              }),
+            );
+            expect(spans).toContainEqual(
+              expect.objectContaining({
+                name: 'execute_tool add',
+                status: 'ok',
+                attributes: expect.objectContaining({
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: expect.objectContaining({ value: 'gen_ai.execute_tool' }),
+                  [GEN_AI_OPERATION_NAME]: expect.objectContaining({ value: 'execute_tool' }),
+                  [GEN_AI_TOOL_NAME]: expect.objectContaining({ value: 'add' }),
+                  'gen_ai.tool.type': expect.objectContaining({ value: 'function' }),
+                }),
+              }),
+            );
+            expect(spans).toContainEqual(
+              expect.objectContaining({
+                name: 'execute_tool multiply',
+                status: 'ok',
+                attributes: expect.objectContaining({
+                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: expect.objectContaining({ value: 'gen_ai.execute_tool' }),
+                  [GEN_AI_OPERATION_NAME]: expect.objectContaining({ value: 'execute_tool' }),
+                  [GEN_AI_TOOL_NAME]: expect.objectContaining({ value: 'multiply' }),
+                  'gen_ai.tool.type': expect.objectContaining({ value: 'function' }),
+                }),
+              }),
+            );
+            expect(
+              spans.filter(span => span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]?.value === 'gen_ai.chat'),
+            ).toHaveLength(3);
           },
         })
         .start()
@@ -457,12 +467,16 @@ describe('LangGraph integration', () => {
         .ignore('event')
         .expect({
           transaction: event => {
-            const spans = event.spans ?? [];
-            const chatSpans = spans.filter(s => s.op === 'gen_ai.chat');
+            expect(event.transaction).toBe('main');
+          },
+        })
+        .expect({
+          span: container => {
+            const chatSpans = container.items.filter(
+              s => s.attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]?.value === 'gen_ai.chat',
+            );
             expect(chatSpans).toHaveLength(1);
-            expect(chatSpans[0]?.data).toMatchObject({
-              [GEN_AI_AGENT_NAME]: 'plain_assistant',
-            });
+            expect(chatSpans[0]?.attributes[GEN_AI_AGENT_NAME]?.value).toBe('plain_assistant');
           },
         })
         .start()

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-no-truncation.mjs
@@ -21,5 +21,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-root-span.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-root-span.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: false, outputs: false } },
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming-with-truncation.mjs
@@ -13,5 +13,4 @@ Sentry.init({
       enableTruncation: true,
     }),
   ],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-streaming.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
   traceLifecycle: 'stream',
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-options.mjs
@@ -20,5 +20,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-pii.mjs
@@ -14,5 +14,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-truncation.mjs
@@ -15,5 +15,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument.mjs
@@ -14,5 +14,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument-with-pii.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: false, outputs: false } },
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-root-span.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-root-span.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: false, outputs: false } },
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-options.mjs
@@ -21,5 +21,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-pii.mjs
@@ -14,5 +14,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument.mjs
@@ -14,5 +14,4 @@ Sentry.init({
     }
     return event;
   },
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
@@ -15,5 +15,4 @@ Sentry.init({
       enableTruncation: false,
     }),
   ],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
@@ -8,5 +8,4 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-truncation.mjs
@@ -9,5 +9,4 @@ Sentry.init({
   dataCollection: { genAI: { inputs: true, outputs: true } },
   transport: loggingTransport,
   integrations: [Sentry.vercelAIIntegration({ enableTruncation: true })],
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
@@ -7,5 +7,4 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument-with-pii.mjs
@@ -9,5 +9,4 @@ Sentry.init({
   // inputs and outputs are enabeld by default when opting into dataCollection
   dataCollection: {},
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument.mjs
@@ -7,5 +7,4 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  streamGenAiSpans: true,
 });

--- a/packages/core/src/tracing/ai/utils.ts
+++ b/packages/core/src/tracing/ai/utils.ts
@@ -4,7 +4,6 @@
  */
 import { captureException } from '../../exports';
 import { getClient } from '../../currentScopes';
-import { hasSpanStreamingEnabled } from '../spans/hasSpanStreamingEnabled';
 import type { Span } from '../../types/span';
 import { isThenable } from '../../utils/is';
 import {
@@ -61,22 +60,17 @@ export function resolveAIRecordingOptions<T extends AIRecordingOptions>(options?
 /**
  * Resolves whether truncation should be enabled.
  * If the user explicitly set `enableTruncation`, that value is used.
- * Otherwise, truncation is disabled whenever gen_ai spans are sent through the span streaming / v2
- * span path, i.e. full span streaming (`traceLifecycle: 'stream'`) or `streamGenAiSpans`. That path
- * is not subject to the transaction payload-size limits that truncation works around, so the full
- * message data can be retained. `streamGenAiSpans` is opt-out (on unless explicitly set to `false`).
+ * Otherwise, truncation is disabled because gen_ai spans are always sent through the v2 span path
+ * (full span streaming via `traceLifecycle: 'stream'`, or extraction into a v2 span envelope for
+ * static transactions). That path is not subject to the transaction payload-size limits that
+ * truncation works around, so the full message data can be retained.
  */
 export function shouldEnableTruncation(enableTruncation: boolean | undefined): boolean {
   if (enableTruncation !== undefined) {
     return enableTruncation;
   }
 
-  const client = getClient();
-  if (!client) {
-    return true;
-  }
-
-  return !hasSpanStreamingEnabled(client) && client.getOptions().streamGenAiSpans === false;
+  return !getClient();
 }
 
 /**

--- a/packages/core/src/tracing/spans/extractGenAiSpans.ts
+++ b/packages/core/src/tracing/spans/extractGenAiSpans.ts
@@ -20,7 +20,6 @@ export function extractGenAiSpansFromEvent(event: Event, client: Client): SpanCo
     event.type !== 'transaction' ||
     !event.spans?.length ||
     !event.sdkProcessingMetadata?.hasGenAiSpans ||
-    client.getOptions().streamGenAiSpans === false ||
     hasSpanStreamingEnabled(client)
   ) {
     return undefined;

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -556,20 +556,6 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   orgId?: `${number}` | number;
 
   /**
-   * Unless set to `false`, gen_ai spans will be extracted from transactions and sent as v2 span envelope items.
-   *
-   * This enables streaming gen_ai spans, avoiding payload size limits of usual transactions.
-   *
-   * Because the v2 span format is not subject to the transaction payload-size limits that gen_ai message
-   * truncation exists to work around, this also disables gen_ai input truncation by default. Set
-   * `enableTruncation: true` on the respective AI integration to opt back into truncation, or set this
-   * option to `false` to send gen_ai spans as part of the transaction (which re-enables truncation by default).
-   *
-   * @default true
-   */
-  streamGenAiSpans?: boolean;
-
-  /**
    * If logs support should be enabled.
    *
    * @default false

--- a/packages/core/test/lib/tracing/ai/utils.test.ts
+++ b/packages/core/test/lib/tracing/ai/utils.test.ts
@@ -111,18 +111,8 @@ describe('shouldEnableTruncation', () => {
     expect(shouldEnableTruncation(undefined)).toBe(true);
   });
 
-  it('defaults to false with a default client (streamGenAiSpans is opt-out)', () => {
+  it('defaults to false with a default client', () => {
     setupClient();
-    expect(shouldEnableTruncation(undefined)).toBe(false);
-  });
-
-  it('defaults to true when streamGenAiSpans is explicitly disabled', () => {
-    setupClient({ streamGenAiSpans: false });
-    expect(shouldEnableTruncation(undefined)).toBe(true);
-  });
-
-  it('defaults to false when streamGenAiSpans is enabled', () => {
-    setupClient({ streamGenAiSpans: true });
     expect(shouldEnableTruncation(undefined)).toBe(false);
   });
 
@@ -131,8 +121,8 @@ describe('shouldEnableTruncation', () => {
     expect(shouldEnableTruncation(undefined)).toBe(false);
   });
 
-  it('explicit enableTruncation: true overrides streamGenAiSpans', () => {
-    setupClient({ streamGenAiSpans: true });
+  it('explicit enableTruncation: true overrides the default', () => {
+    setupClient();
     expect(shouldEnableTruncation(true)).toBe(true);
   });
 

--- a/packages/core/test/lib/tracing/spans/extractGenAiSpans.test.ts
+++ b/packages/core/test/lib/tracing/spans/extractGenAiSpans.test.ts
@@ -120,7 +120,7 @@ describe('extractGenAiSpansFromEvent', () => {
     expect(extractGenAiSpansFromEvent(event, makeClient())).toBeUndefined();
   });
 
-  it('extracts gen_ai spans by default when streamGenAiSpans is unset', () => {
+  it('extracts gen_ai spans by default', () => {
     const event = makeTransactionEvent([makeSpanJSON({ op: 'gen_ai.chat', span_id: 'genai001' })], true);
 
     const result = extractGenAiSpansFromEvent(event, makeClient());
@@ -128,14 +128,6 @@ describe('extractGenAiSpansFromEvent', () => {
     expect(result).toBeDefined();
     expect(result![0].item_count).toBe(1);
     expect(event.spans).toHaveLength(0);
-  });
-
-  it('returns undefined when streamGenAiSpans is explicitly disabled', () => {
-    const event = makeTransactionEvent([makeSpanJSON({ op: 'gen_ai.chat' })]);
-    const client = makeClient({ streamGenAiSpans: false });
-
-    expect(extractGenAiSpansFromEvent(event, client)).toBeUndefined();
-    expect(event.spans).toHaveLength(1);
   });
 
   it('returns undefined when span streaming is enabled', () => {


### PR DESCRIPTION
Removes the `streamGenAiSpans` client option, making the extraction of gen_ai spans into a v2 span envelope container the unconditional default (it was already the default via `@default true`). Truncation logic will be removed in a follow up.

Related to https://github.com/getsentry/sentry-javascript/issues/21129