### PR TITLE
fix(v10): Pin `@apm-js-collab/code-transformer-bundler-plugins` to 0.7.1

### DIFF
--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+    "@apm-js-collab/code-transformer-bundler-plugins": "0.7.1",
     "@sentry/core": "10.67.0",
     "@sentry/conventions": "^0.16.0",
     "@sentry/node": "10.67.0",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -116,7 +116,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+    "@apm-js-collab/code-transformer-bundler-plugins": "0.7.1",
     "@apm-js-collab/tracing-hooks": "^0.13.0",
     "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.67.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,7 +404,7 @@
   dependencies:
     json-schema-to-ts "^3.1.1"
 
-"@apm-js-collab/code-transformer-bundler-plugins@^0.7.1":
+"@apm-js-collab/code-transformer-bundler-plugins@0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.1.tgz#f9e7128b87cdabb50e91f2ce3a5c48505b511c41"
   integrity sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==


### PR DESCRIPTION
Attempt to fix the generic-ts3.8 E2E test by pinning `@apm-js-collab/code-transformer-bundler-plugins` to 0.7.1, since 0.7.2 ships a `.d.ts` that TypeScript 3.8 cannot parse.