### PR TITLE
ci: Add `v10` to build and license-compliance branch filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - master
+      - v10
       - v9
       - v8
       - release/**

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - v10
       - v9
       - v8
       - release/**
@@ -12,6 +13,7 @@ on:
     branches:
       - develop
       - master
+      - v10
       - v9
       - v8
 


### PR DESCRIPTION
I missed these when creating the v10 branch, which is blocking backports because the license compliance step never gets kicked off. Backport to the v10 branch is here: https://github.com/getsentry/sentry-javascript/pull/22499