### PR TITLE
ci(v10): Add `v10` to build and license-compliance branch filters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - develop
       - master
+      - v10
       - v9
       - v8
       - release/**

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - master
+      - v10
       - v9
       - v8
       - release/**
@@ -12,6 +13,7 @@ on:
     branches:
       - develop
       - master
+      - v10
       - v9
       - v8
 


### PR DESCRIPTION
Backport of: #22498