### PR TITLE
fix(cloudflare): Import prismaIntegration from server-utils

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/core": "10.67.0",
-    "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "magic-string": "~0.30.21"
   },

--- a/packages/cloudflare/src/nodejs_compat/index.ts
+++ b/packages/cloudflare/src/nodejs_compat/index.ts
@@ -1,3 +1,3 @@
 export * from '../index';
-export { prismaIntegration } from '@sentry/node';
+export { prismaIntegration } from '@sentry/server-utils';
 export { vercelAIIntegration } from './integrations/tracing/vercelai';


### PR DESCRIPTION
closes #22519
closes JS-3123

It appears that when running `@cloudflare/vitest-pool-workers` is obviously not tree-shaking and pulls in `import-in-the-middle` which is not working on `workerd` for good reasons. This makes the entire pool crash. Since the `prismaIntegration` already got refactored into our server utils it is safe to import from there and remove the node dependency (for now).