### PR TITLE
fix(repo): fix tsconfig diagnostics surfaced by tsgolint 7

### DIFF
--- a/packages/effect/tsconfig.json
+++ b/packages/effect/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "build"
+    "outDir": "build",
+    "rootDir": "./src"
   },
   "include": ["src/**/*"]
 }

--- a/packages/ember/tsconfig.json
+++ b/packages/ember/tsconfig.json
@@ -10,16 +10,15 @@
     "strictPropertyInitialization": true,
     "noEmitOnError": false,
     "noEmit": true,
-    "baseUrl": ".",
     "experimentalDecorators": true,
     "paths": {
-      "dummy/tests/*": ["tests/*"],
-      "dummy/*": ["tests/dummy/app/*", "app/*"],
-      "@sentry/ember": ["addon"],
-      "@sentry/ember/*": ["addon/*"],
-      "@sentry/ember/test-support": ["addon-test-support"],
-      "@sentry/ember/test-support/*": ["addon-test-support/*"],
-      "*": ["types/*"]
+      "dummy/tests/*": ["./tests/*"],
+      "dummy/*": ["./tests/dummy/app/*", "./app/*"],
+      "@sentry/ember": ["./addon"],
+      "@sentry/ember/*": ["./addon/*"],
+      "@sentry/ember/test-support": ["./addon-test-support"],
+      "@sentry/ember/test-support/*": ["./addon-test-support/*"],
+      "*": ["./types/*"]
     }
   },
   "include": ["app/**/*", "addon/**/*", "tests/**/*", "types/**/*", "test-support/**/*", "addon-test-support/**/*"]

--- a/packages/profiling-node/tsconfig.test.json
+++ b/packages/profiling-node/tsconfig.test.json
@@ -5,7 +5,11 @@
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node"]
+    "types": ["node"],
+
+    // The base config sets `rootDir` to `./src`, but the test program also pulls in `test/**/*` and
+    // `vite.config.ts`, so widen it to the package root to keep them under `rootDir`.
+    "rootDir": "."
 
     // other package-specific, test-specific options
   }


### PR DESCRIPTION
Fixes the per-package tsconfig problems tsgolint 7 surfaces once program diagnostics are no longer suppressed.

Those weren't caught because the build process doesn't use TS 7 for these projects. This allows them to be linted with unsuppressed tslint in a later PR.