### PR TITLE
feat(core)!: Default `attachStacktrace` to true

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -208,11 +208,16 @@ Sentry.init({
 });
 ```
 
-### `attachStacktrace` defaults to `true` for `captureMessage`
+### `attachStacktrace` defaults to `true`
 
 Affected SDKs: All SDKs.
 
-`captureMessage` now attaches a stack trace by default. Pass `attachStacktrace: false` in `Sentry.init` if you do not want stack traces attached to messages. Note that grouping in Sentry differs for events with and without stack traces, so you may see new issue groups after upgrading.
+`attachStacktrace` now defaults to `true`. Events captured with `Sentry.captureMessage`, and non-`Error` values passed to `Sentry.captureException`, now attach a synthetic stack trace pointing to the call site. Pass `attachStacktrace: false` in `Sentry.init` to restore the previous behavior.
+
+Two consequences to be aware of when upgrading:
+
+- **Issue grouping:** Grouping in Sentry differs for events with and without stack traces, so you may see new issue groups after upgrading.
+- **Release health:** Events with a stack trace are counted as errors, so a `captureMessage` call (including messages emitted by `captureConsoleIntegration`) now marks the current session as _errored_. This affects errored-session counts but does **not** mark sessions as crashed, so crash-free session rate is unaffected. If you use `captureMessage` for purely informational output, consider using Sentry Logs instead, which is better suited and does not affect release health.
 
 ### `tracePropagationTargets` matching is now case-insensitive
 

--- a/dev-packages/browser-integration-tests/suites/integrations/captureConsole/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/captureConsole/init.js
@@ -6,4 +6,5 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [captureConsoleIntegration()],
+  attachStacktrace: false,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -10,4 +10,15 @@ sentryTest('should capture a simple message string', async ({ getLocalTestUrl, p
 
   expect(eventData.message).toBe('foo');
   expect(eventData.level).toBe('info');
+  expect(eventData.exception?.values?.[0]).toEqual({
+    mechanism: {
+      handled: true,
+      type: 'generic',
+      synthetic: true,
+    },
+    stacktrace: {
+      frames: expect.arrayContaining([expect.any(Object), expect.any(Object)]),
+    },
+    value: 'foo',
+  });
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/init.js
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  attachStacktrace: false,
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/subject.js
@@ -1,0 +1,1 @@
+Sentry.captureMessage('foo');

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/test.ts
@@ -1,0 +1,14 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/core';
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
+
+sentryTest('does not capture a stack trace if `attachStackTrace` is `false`', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(eventData.message).toBe('foo');
+  expect(eventData.level).toBe('info');
+  expect(eventData.exception).toBeUndefined();
+});

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    attachStacktrace: false,
   }),
   {
     async fetch(request, _env, _ctx) {

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -1,4 +1,4 @@
-import { afterAll, test } from 'vitest';
+import { afterAll, expect, test } from 'vitest';
 import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
 afterAll(() => {
@@ -11,6 +11,15 @@ test('should capture a simple message string', async () => {
       event: {
         message: 'Message',
         level: 'info',
+        exception: {
+          values: [
+            {
+              mechanism: { synthetic: true, type: 'generic', handled: true },
+              value: 'Message',
+              stacktrace: { frames: expect.any(Array) },
+            },
+          ],
+        },
       },
     })
     .start()

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/scenario.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  transport: loggingTransport,
+  attachStacktrace: false,
+});
+
+Sentry.captureMessage('Message');

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_no_stacktrace/test.ts
@@ -1,0 +1,19 @@
+import { afterAll, expect, test } from 'vitest';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
+
+test('does not capture a stack trace if `attachStackTrace` is `false`', async () => {
+  await createRunner(__dirname, 'scenario.ts')
+    .expect({
+      event: event => {
+        expect(event.message).toBe('Message');
+        expect(event.level).toBe('info');
+        expect(event.exception).toBeUndefined();
+      },
+    })
+    .start()
+    .completed();
+});

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
@@ -5,6 +5,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,
+  attachStacktrace: false,
 });
 
 Sentry.captureMessage('debug_message', 'debug');

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
@@ -5,6 +5,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,
+  attachStacktrace: false,
 });
 
 const globalScope = Sentry.getGlobalScope();

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
@@ -5,6 +5,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,
+  attachStacktrace: false,
 });
 
 const globalScope = Sentry.getGlobalScope();

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/scenario.ts
@@ -5,6 +5,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,
+  attachStacktrace: false,
 });
 
 Sentry.captureMessage('no_user');

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/scenario.ts
@@ -5,6 +5,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,
+  attachStacktrace: false,
 });
 
 Sentry.setUser({

--- a/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
@@ -5,6 +5,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,
+  attachStacktrace: false,
 });
 
 Sentry.setUser({ id: 'qux' });

--- a/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-events.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-events.ts
@@ -6,6 +6,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
+  attachStacktrace: false,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -334,8 +334,9 @@ export function eventFromUnknownInput(
   // - a plain Object
   //
   // So bail out and capture it as a simple message:
-  event = eventFromString(stackParser, `${exception}`, syntheticException, attachStacktrace);
-  addExceptionTypeValue(event, `${exception}`, undefined);
+  const stringifiedException = String(exception);
+  event = eventFromString(stackParser, stringifiedException, syntheticException, attachStacktrace);
+  addExceptionTypeValue(event, stringifiedException, undefined);
   addExceptionMechanism(event, {
     synthetic: true,
   });

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -289,7 +289,7 @@ export function eventFromUnknownInput(
       event = eventFromError(stackParser, exception as Error);
 
       const firstException = event.exception?.values?.[0];
-      if (attachStacktrace !== false && syntheticException && firstException && !firstException.stacktrace) {
+      if (attachStacktrace && syntheticException && firstException && !firstException.stacktrace) {
         const frames = parseStackFrames(stackParser, syntheticException);
         if (frames.length) {
           firstException.stacktrace = { frames };
@@ -351,7 +351,7 @@ function eventFromString(
 ): Event {
   const event: Event = {};
 
-  if (attachStacktrace !== false && syntheticException) {
+  if (attachStacktrace && syntheticException) {
     const frames = parseStackFrames(stackParser, syntheticException);
     if (frames.length) {
       event.exception = {

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -289,7 +289,7 @@ export function eventFromUnknownInput(
       event = eventFromError(stackParser, exception as Error);
 
       const firstException = event.exception?.values?.[0];
-      if (attachStacktrace && syntheticException && firstException && !firstException.stacktrace) {
+      if (attachStacktrace !== false && syntheticException && firstException && !firstException.stacktrace) {
         const frames = parseStackFrames(stackParser, syntheticException);
         if (frames.length) {
           firstException.stacktrace = { frames };
@@ -351,7 +351,7 @@ function eventFromString(
 ): Event {
   const event: Event = {};
 
-  if (attachStacktrace && syntheticException) {
+  if (attachStacktrace !== false && syntheticException) {
     const frames = parseStackFrames(stackParser, syntheticException);
     if (frames.length) {
       event.exception = {

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -334,7 +334,7 @@ export function eventFromUnknownInput(
   // - a plain Object
   //
   // So bail out and capture it as a simple message:
-  event = eventFromString(stackParser, exception as string, syntheticException, attachStacktrace);
+  event = eventFromString(stackParser, `${exception}`, syntheticException, attachStacktrace);
   addExceptionTypeValue(event, `${exception}`, undefined);
   addExceptionMechanism(event, {
     synthetic: true,

--- a/packages/browser/test/eventbuilder.test.ts
+++ b/packages/browser/test/eventbuilder.test.ts
@@ -326,6 +326,20 @@ describe('eventFromMessage ', () => {
     });
   });
 
+  it('adds a synthetic stack trace by default when attachStacktrace is not set', async () => {
+    const syntheticException = new Error('Test message');
+    const event = await eventFromMessage(defaultStackParser, 'Test message', 'info', { syntheticException });
+    expect(event.exception?.values?.[0]).toEqual(
+      expect.objectContaining({
+        mechanism: { handled: true, synthetic: true, type: 'generic' },
+        stacktrace: {
+          frames: expect.arrayContaining([expect.any(Object), expect.any(Object)]),
+        },
+        value: 'Test message',
+      }),
+    );
+  });
+
   it('creates an event with a synthetic stack trace if attachStacktrace is true', async () => {
     const syntheticException = new Error('Test message');
     const event = await eventFromMessage(defaultStackParser, 'Test message', 'info', { syntheticException }, true);

--- a/packages/browser/test/eventbuilder.test.ts
+++ b/packages/browser/test/eventbuilder.test.ts
@@ -169,6 +169,19 @@ describe('eventFromUnknownInput', () => {
     });
   });
 
+  it('uses the stringified value for a non-Error input when attachStacktrace is true', async () => {
+    const syntheticException = new Error('Test message');
+    const event = await eventFromUnknownInput(defaultStackParser, new Response('test body'), syntheticException, true);
+
+    expect(event.exception?.values?.[0]).toEqual(
+      expect.objectContaining({
+        mechanism: { handled: true, synthetic: true, type: 'generic' },
+        type: 'Error',
+        value: '[object Response]',
+      }),
+    );
+  });
+
   it('add a synthetic stack trace to DOMException with empty stack traces if attachStacktrace is true', async () => {
     const exception = new DOMException('The string did not match the expected pattern.', 'SyntaxError');
     exception.stack = '';

--- a/packages/browser/test/eventbuilder.test.ts
+++ b/packages/browser/test/eventbuilder.test.ts
@@ -339,20 +339,6 @@ describe('eventFromMessage ', () => {
     });
   });
 
-  it('adds a synthetic stack trace by default when attachStacktrace is not set', async () => {
-    const syntheticException = new Error('Test message');
-    const event = await eventFromMessage(defaultStackParser, 'Test message', 'info', { syntheticException });
-    expect(event.exception?.values?.[0]).toEqual(
-      expect.objectContaining({
-        mechanism: { handled: true, synthetic: true, type: 'generic' },
-        stacktrace: {
-          frames: expect.arrayContaining([expect.any(Object), expect.any(Object)]),
-        },
-        value: 'Test message',
-      }),
-    );
-  });
-
   it('creates an event with a synthetic stack trace if attachStacktrace is true', async () => {
     const syntheticException = new Error('Test message');
     const event = await eventFromMessage(defaultStackParser, 'Test message', 'info', { syntheticException }, true);

--- a/packages/browser/test/eventbuilder.test.ts
+++ b/packages/browser/test/eventbuilder.test.ts
@@ -182,6 +182,17 @@ describe('eventFromUnknownInput', () => {
     );
   });
 
+  it('does not throw and stringifies the value for a Symbol input', async () => {
+    const event = await eventFromUnknownInput(defaultStackParser, Symbol('foo'));
+
+    expect(event.exception?.values?.[0]).toEqual(
+      expect.objectContaining({
+        type: 'Error',
+        value: 'Symbol(foo)',
+      }),
+    );
+  });
+
   it('add a synthetic stack trace to DOMException with empty stack traces if attachStacktrace is true', async () => {
     const exception = new DOMException('The string did not match the expected pattern.', 'SyntaxError');
     exception.stack = '';

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -19,6 +19,7 @@ import {
   captureEvent,
   captureException,
   captureMessage,
+  defaultStackParser,
   flush,
   getClient,
   getCurrentScope,
@@ -249,6 +250,23 @@ describe('SentryBrowser', () => {
             expect(event.level).toBe('info');
             expect(event.message).toBe('test');
             expect(event.exception).toBeUndefined();
+            resolve();
+            return event;
+          },
+          dsn,
+        });
+        setCurrentClient(new BrowserClient(options));
+        captureMessage('test');
+      }));
+
+    it('attaches a synthetic stacktrace to messages by default', () =>
+      new Promise<void>(resolve => {
+        const options = getDefaultBrowserClientOptions({
+          stackParser: defaultStackParser,
+          beforeSend: event => {
+            expect(event.message).toBe('test');
+            expect(event.exception?.values?.[0]?.stacktrace?.frames?.length).toBeGreaterThan(0);
+            expect(event.exception?.values?.[0]?.mechanism?.synthetic).toBe(true);
             resolve();
             return event;
           },

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -246,6 +246,7 @@ describe('SentryBrowser', () => {
     it('should capture an message', () =>
       new Promise<void>(resolve => {
         const options = getDefaultBrowserClientOptions({
+          attachStacktrace: false,
           beforeSend: event => {
             expect(event.level).toBe('info');
             expect(event.message).toBe('test');

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -234,7 +234,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
    * @param options Options for the client.
    */
   protected constructor(options: O) {
-    this._options = options;
+    this._options = { attachStacktrace: true, ...options };
     this._integrations = {};
     this._numProcessing = 0;
     this._outcomes = {};

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -182,8 +182,9 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   enabled?: boolean;
 
   /**
-   * Stack traces are automatically attached to all events captured with `Sentry.captureMessage`.
-   * Set this to `false` to disable attaching stack traces to these events.
+   * Stack traces are automatically attached to events that don't otherwise have one. This applies
+   * to events captured with `Sentry.captureMessage` and to non-Error values passed to
+   * `Sentry.captureException`. Set this to `false` to disable attaching these stack traces.
    *
    * Grouping in Sentry is different for events with stack traces and without. As a result, you will get
    * new groups as you enable or disable this flag for certain events.

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -182,12 +182,13 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   enabled?: boolean;
 
   /**
-   * When enabled, stack traces are automatically attached to all events captured with `Sentry.captureMessage`.
+   * Stack traces are automatically attached to all events captured with `Sentry.captureMessage`.
+   * Set this to `false` to disable attaching stack traces to these events.
    *
    * Grouping in Sentry is different for events with stack traces and without. As a result, you will get
    * new groups as you enable or disable this flag for certain events.
    *
-   * @default false
+   * @default true
    */
   attachStacktrace?: boolean;
 

--- a/packages/core/src/utils/eventbuilder.ts
+++ b/packages/core/src/utils/eventbuilder.ts
@@ -199,7 +199,7 @@ export function eventFromMessage(
     level,
   };
 
-  if (attachStacktrace && hint?.syntheticException) {
+  if (attachStacktrace !== false && hint?.syntheticException) {
     const frames = parseStackFrames(stackParser, hint.syntheticException);
     if (frames.length) {
       event.exception = {

--- a/packages/core/src/utils/eventbuilder.ts
+++ b/packages/core/src/utils/eventbuilder.ts
@@ -199,7 +199,7 @@ export function eventFromMessage(
     level,
   };
 
-  if (attachStacktrace !== false && hint?.syntheticException) {
+  if (attachStacktrace && hint?.syntheticException) {
     const frames = parseStackFrames(stackParser, hint.syntheticException);
     if (frames.length) {
       event.exception = {

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -103,7 +103,7 @@ describe('Client', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, test: true });
       const client = new TestClient(options);
 
-      expect(client.getOptions()).toEqual(options);
+      expect(client.getOptions()).toEqual({ attachStacktrace: true, ...options });
     });
   });
 

--- a/packages/core/test/lib/utils/eventbuilder.test.ts
+++ b/packages/core/test/lib/utils/eventbuilder.test.ts
@@ -167,6 +167,32 @@ describe('eventFromMessage', () => {
     });
   });
 
+  it('attaches a synthetic exception by default when `attachStackTrace` is not set', () => {
+    const syntheticException = new Error('Test Message');
+    const event = eventFromMessage(stackParser, 'Test Message', 'info', { syntheticException, event_id: '123abc' });
+
+    expect(event).toEqual({
+      event_id: '123abc',
+      exception: {
+        values: [
+          {
+            mechanism: {
+              handled: true,
+              synthetic: true,
+              type: 'generic',
+            },
+            stacktrace: {
+              frames: expect.any(Array),
+            },
+            value: 'Test Message',
+          },
+        ],
+      },
+      level: 'info',
+      message: 'Test Message',
+    });
+  });
+
   it('attaches a synthetic exception if passed and `attachStackTrace` is true', () => {
     const syntheticException = new Error('Test Message');
     const event = eventFromMessage(

--- a/packages/core/test/lib/utils/eventbuilder.test.ts
+++ b/packages/core/test/lib/utils/eventbuilder.test.ts
@@ -167,32 +167,6 @@ describe('eventFromMessage', () => {
     });
   });
 
-  it('attaches a synthetic exception by default when `attachStackTrace` is not set', () => {
-    const syntheticException = new Error('Test Message');
-    const event = eventFromMessage(stackParser, 'Test Message', 'info', { syntheticException, event_id: '123abc' });
-
-    expect(event).toEqual({
-      event_id: '123abc',
-      exception: {
-        values: [
-          {
-            mechanism: {
-              handled: true,
-              synthetic: true,
-              type: 'generic',
-            },
-            stacktrace: {
-              frames: expect.any(Array),
-            },
-            value: 'Test Message',
-          },
-        ],
-      },
-      level: 'info',
-      message: 'Test Message',
-    });
-  });
-
   it('attaches a synthetic exception if passed and `attachStackTrace` is true', () => {
     const syntheticException = new Error('Test Message');
     const event = eventFromMessage(

--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -48,7 +48,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "?",
               in_app: true,
-              lineno: 42,
+              lineno: 43,
               post_context: [
                 "",
                 "  await delay(200);",
@@ -74,7 +74,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "something",
               in_app: true,
-              lineno: 39,
+              lineno: 40,
               post_context: [
                 "  }",
                 "",

--- a/packages/deno/test/mod.test.ts
+++ b/packages/deno/test/mod.test.ts
@@ -12,6 +12,7 @@ function getTestClient(callback: (event?: Event) => void): DenoClient {
     debug: true,
     integrations: getDefaultIntegrations({}),
     stackParser: createStackParser(nodeStackLineParser()),
+    attachStacktrace: false,
     transport: makeTestTransport(envelope => {
       callback(getNormalizedEvent(envelope));
     }),

--- a/packages/node/test/sdk/client.test.ts
+++ b/packages/node/test/sdk/client.test.ts
@@ -29,6 +29,7 @@ describe('NodeClient', () => {
     const client = new NodeClient(options);
 
     expect(client.getOptions()).toEqual({
+      attachStacktrace: true,
       dsn: expect.any(String),
       integrations: [],
       transport: options.transport,


### PR DESCRIPTION
`attachStacktrace: true` is now the default. Stack traces are attached to message/string-derived events unless a user explicitly sets `attachStacktrace: false`.

This by default attaches a synthetic stack trace in three cases going forward:

1. `captureMessage(...)`: always (browser + server).
2. `captureException(<non-Error primitive, e.g. a string>)`: browser only (server already attached one unconditionally).
3. `captureException(<DOMException/DOMError with a .stack>)`: browser only.

Closes https://github.com/getsentry/sentry-javascript/issues/21188