### PR TITLE
test: Disable span streaming in transaction-asserting tests

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/subject.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/subject.js
@@ -6,6 +6,7 @@ setTimeout(() => {
 
   cdnScript.addEventListener('load', () => {
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: 'https://public@dsn.ingest.sentry.io/1337',
       replaysSessionSampleRate: 0.42,
     });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/addBreadcrumb/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/addBreadcrumb/init.js
@@ -1,5 +1,5 @@
 Sentry.onLoad(function () {
-  Sentry.init({});
+  Sentry.init({ traceLifecycle: 'static' });
   Sentry.addBreadcrumb({
     category: 'auth',
     message: 'testing loader',

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/captureExceptionInOnLoad/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/captureExceptionInOnLoad/init.js
@@ -1,5 +1,5 @@
 Sentry.onLoad(function () {
   // You _have_ to call Sentry.init() before calling Sentry.captureException() in Sentry.onLoad()!
-  Sentry.init();
+  Sentry.init({ traceLifecycle: 'static' });
   Sentry.captureException('Test exception');
 });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customBrowserTracing/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customBrowserTracing/init.js
@@ -2,6 +2,7 @@ window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.onLoad(function () {
   Sentry.init({
+    traceLifecycle: 'static',
     integrations: [
       // Without this syntax, this will be re-written by the test framework
       window['Sentry'].browserTracingIntegration(),

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customInit/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customInit/init.js
@@ -5,6 +5,7 @@ setTimeout(() => {
     window.__hadSentry = window.sentryIsLoaded();
 
     Sentry.init({
+      traceLifecycle: 'static',
       sampleRate: 0.5,
     });
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrations/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrations/init.js
@@ -8,6 +8,7 @@ class CustomIntegration {
 
 Sentry.onLoad(function () {
   Sentry.init({
+    traceLifecycle: 'static',
     integrations: [new CustomIntegration()],
   });
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrationsFunction/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrationsFunction/init.js
@@ -8,6 +8,7 @@ class CustomIntegration {
 
 Sentry.onLoad(function () {
   Sentry.init({
+    traceLifecycle: 'static',
     integrations: integrations => [new CustomIntegration()].concat(integrations),
   });
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/init.js
@@ -1,5 +1,6 @@
 Sentry.onLoad(function () {
   Sentry.init({
+    traceLifecycle: 'static',
     integrations: [
       // Without this syntax, this will be re-written by the test framework
       window['Sentry'].replayIntegration({

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/init.js
@@ -1,3 +1,3 @@
 Sentry.onLoad(function () {
-  Sentry.init({});
+  Sentry.init({ traceLifecycle: 'static' });
 });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/keepSentryGlobal/init.js
@@ -1,5 +1,5 @@
 window.sentryOnLoad = function () {
-  Sentry.init({});
+  Sentry.init({ traceLifecycle: 'static' });
 
   window.__sentryLoaded = true;
 };

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/pageloadTransaction/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/pageloadTransaction/init.js
@@ -1,5 +1,5 @@
 window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.onLoad(function () {
-  Sentry.init({});
+  Sentry.init({ traceLifecycle: 'static' });
 });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/replay/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/replay/init.js
@@ -1,5 +1,6 @@
 Sentry.onLoad(function () {
   Sentry.init({
+    traceLifecycle: 'static',
     replaysSessionSampleRate: 1,
   });
 });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoad/template.html
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoad/template.html
@@ -5,6 +5,7 @@
     <script>
       window.sentryOnLoad = function () {
         Sentry.init({
+          traceLifecycle: 'static',
           tracesSampleRate: 0.123,
         });
       };

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadAndOnLoad/template.html
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadAndOnLoad/template.html
@@ -5,6 +5,7 @@
     <script>
       window.sentryOnLoad = function () {
         Sentry.init({
+          traceLifecycle: 'static',
           tracesSampleRate: 0.123,
         });
       };

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadError/template.html
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadError/template.html
@@ -5,6 +5,7 @@
     <script>
       window.sentryOnLoad = function () {
         Sentry.init({
+          traceLifecycle: 'static',
           tracesSampleRate: 0.123,
         });
 

--- a/dev-packages/browser-integration-tests/suites/errors/fetch-enhance-messages-off/init.js
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch-enhance-messages-off/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   enhanceFetchErrorMessages: false,
 });

--- a/dev-packages/browser-integration-tests/suites/errors/fetch-enhance-messages-report-only/init.js
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch-enhance-messages-report-only/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   enhanceFetchErrorMessages: 'report-only',
 });

--- a/dev-packages/browser-integration-tests/suites/errors/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/errors/fetch/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/feedback/attachTo/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/attachTo/init.js
@@ -10,6 +10,7 @@ window.Sentry = Sentry;
 window.feedback = feedback;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [feedback],
 });

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedback/init.js
@@ -5,6 +5,7 @@ import { feedbackIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     feedbackIntegration({

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackAndReplay/hasSampling/init.js
@@ -5,6 +5,7 @@ import { feedbackIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   replaysOnErrorSampleRate: 1.0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackCsp/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackCsp/init.js
@@ -5,6 +5,7 @@ import { feedbackIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     feedbackIntegration({ tags: { from: 'integration init' }, styleNonce: 'foo1234', scriptNonce: 'foo1234' }),

--- a/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackWithProfiling/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/captureFeedbackWithProfiling/init.js
@@ -8,6 +8,7 @@ import { feedbackIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration(),

--- a/dev-packages/browser-integration-tests/suites/feedback/logger/init.js
+++ b/dev-packages/browser-integration-tests/suites/feedback/logger/init.js
@@ -10,6 +10,7 @@ window.Sentry = Sentry;
 window.feedback = feedback;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   debug: true,
   integrations: [feedback],

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/console/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/console/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
   integrations: [Sentry.breadcrumbsIntegration()],

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
   integrations: [Sentry.breadcrumbsIntegration()],

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
   integrations: [Sentry.breadcrumbsIntegration()],

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/history/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/history/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
   integrations: [Sentry.breadcrumbsIntegration()],

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
   integrations: [Sentry.breadcrumbsIntegration()],

--- a/dev-packages/browser-integration-tests/suites/integrations/ContextLines/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/ContextLines/init.js
@@ -4,6 +4,7 @@ import { contextLinesIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [contextLinesIntegration()],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/browserApiErrors/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/browserApiErrors/init.js
@@ -12,6 +12,7 @@ const myClickListener = () => {
 btn.addEventListener('click', myClickListener);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/browser-integration-tests/suites/integrations/browserApiErrors/unregisterOriginalCallbacks/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/browserApiErrors/unregisterOriginalCallbacks/init.js
@@ -12,6 +12,7 @@ const myClickListener = () => {
 btn.addEventListener('click', myClickListener);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserApiErrorsIntegration({

--- a/dev-packages/browser-integration-tests/suites/integrations/captureConsole-attachStackTrace/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/captureConsole-attachStackTrace/init.js
@@ -4,6 +4,7 @@ import { captureConsoleIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [captureConsoleIntegration()],
   attachStacktrace: true,

--- a/dev-packages/browser-integration-tests/suites/integrations/captureConsole/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/captureConsole/init.js
@@ -4,6 +4,7 @@ import { captureConsoleIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [captureConsoleIntegration()],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/featureFlags/onError/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/featureFlags/onError/init.js
@@ -6,6 +6,7 @@ window.Sentry = Sentry;
 // window.sentryFeatureFlagsIntegration = Sentry.featureFlagsIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [Sentry.featureFlagsIntegration()],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/featureFlags/onSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/featureFlags/onSpan/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/growthbook/onError/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/growthbook/onError/init.js
@@ -31,6 +31,7 @@ window.Sentry = Sentry;
 window.sentryGrowthBookIntegration = Sentry.growthbookIntegration({ growthbookClass: window.GrowthBook });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [window.sentryGrowthBookIntegration],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/growthbook/onSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/growthbook/onSpan/init.js
@@ -29,6 +29,7 @@ window.Sentry = Sentry;
 window.sentryGrowthBookIntegration = Sentry.growthbookIntegration({ growthbookClass: window.GrowthBook });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/launchdarkly/onError/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/launchdarkly/onError/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window.sentryLDIntegration = Sentry.launchDarklyIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [window.sentryLDIntegration],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/launchdarkly/onSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/launchdarkly/onSpan/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window.sentryLDIntegration = Sentry.launchDarklyIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/openfeature/onError/errorHook/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/openfeature/onError/errorHook/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window.sentryOpenFeatureIntegration = Sentry.openFeatureIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [window.sentryOpenFeatureIntegration],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/openfeature/onError/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/openfeature/onError/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window.sentryOpenFeatureIntegration = Sentry.openFeatureIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [window.sentryOpenFeatureIntegration],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/openfeature/onSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/openfeature/onSpan/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window.sentryOpenFeatureIntegration = Sentry.openFeatureIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/statsig/onError/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/statsig/onError/init.js
@@ -29,6 +29,7 @@ window.Sentry = Sentry;
 window.sentryStatsigIntegration = Sentry.statsigIntegration({ featureFlagClient: window.statsigClient });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [window.sentryStatsigIntegration],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/statsig/onSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/statsig/onSpan/init.js
@@ -29,6 +29,7 @@ window.Sentry = Sentry;
 window.sentryStatsigIntegration = Sentry.statsigIntegration({ featureFlagClient: window.statsigClient });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/badSignature/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/badSignature/init.js
@@ -10,6 +10,7 @@ window.Sentry = Sentry;
 window.sentryUnleashIntegration = Sentry.unleashIntegration({ featureFlagClientClass: window.UnleashClient });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [window.sentryUnleashIntegration],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/onError/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/onError/init.js
@@ -44,6 +44,7 @@ window.Sentry = Sentry;
 window.sentryUnleashIntegration = Sentry.unleashIntegration({ featureFlagClientClass: window.UnleashClient });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   integrations: [window.sentryUnleashIntegration],

--- a/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/onSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/featureFlags/unleash/onSpan/init.js
@@ -49,6 +49,7 @@ window.Sentry = Sentry;
 window.sentryUnleashIntegration = Sentry.unleashIntegration({ featureFlagClientClass: window.UnleashClient });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/globalHandlers/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/globalHandlers/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/graphqlClient/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/graphqlClient/init.js
@@ -5,6 +5,7 @@ import { graphqlClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration(),

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/init.js
@@ -4,6 +4,7 @@ import { httpClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [httpClientIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withAbortController/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withAbortController/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withDataCollection/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withDataCollection/init.js
@@ -4,6 +4,7 @@ import { httpClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [httpClientIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withDisabledDataCollection/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withDisabledDataCollection/init.js
@@ -4,6 +4,7 @@ import { httpClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [httpClientIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withHeadersOnlyDataCollection/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withHeadersOnlyDataCollection/init.js
@@ -4,6 +4,7 @@ import { httpClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [httpClientIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withoutSendDefaultPii/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/withoutSendDefaultPii/init.js
@@ -4,6 +4,7 @@ import { httpClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [httpClientIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/init.js
@@ -4,6 +4,7 @@ import { httpClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [httpClientIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/withDataCollection/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/xhr/withDataCollection/init.js
@@ -4,6 +4,7 @@ import { httpClientIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [httpClientIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/existingIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/existingIntegration/init.js
@@ -8,6 +8,7 @@ window.Sentry = {
 };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/feedbackIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/feedbackIntegration/init.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/moduleMetadataIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/moduleMetadataIntegration/init.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/validIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/validIntegration/init.js
@@ -7,6 +7,7 @@ window.Sentry = {
 };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/validIntegrationNpm/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/lazyLoad/validIntegrationNpm/init.js
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/browser';
 window._testSentry = { ...Sentry };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadata/init.js
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser';
 import { moduleMetadataIntegration } from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [moduleMetadataIntegration()],
   beforeSend(event) {

--- a/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/moduleMetadata/appliesMetadataWithRewriteFrames/init.js
@@ -6,6 +6,7 @@ import { moduleMetadataIntegration } from '@sentry/browser';
 import { rewriteFramesIntegration } from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     moduleMetadataIntegration(),

--- a/dev-packages/browser-integration-tests/suites/integrations/supabase/auth/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/supabase/auth/init.js
@@ -6,6 +6,7 @@ window.Sentry = Sentry;
 const supabaseClient = createClient('https://test.supabase.co', 'test-key');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration(), Sentry.supabaseIntegration({ supabaseClient })],
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/supabase/db-operations/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/supabase/db-operations/init.js
@@ -6,6 +6,7 @@ window.Sentry = Sentry;
 const supabaseClient = createClient('https://test.supabase.co', 'test-key');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration(), Sentry.supabaseIntegration({ supabaseClient })],
   tracesSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/integrations/thirdPartyErrorsFilter/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/thirdPartyErrorsFilter/init.js
@@ -25,6 +25,7 @@ _sentryModuleMetadataGlobal._sentryModuleMetadata[new Error().stack] = Object.as
 );
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     thirdPartyErrorFilterIntegration({ behaviour: 'apply-tag-if-contains-third-party-frames', filterKeys: ['my-app'] }),

--- a/dev-packages/browser-integration-tests/suites/integrations/viewHierarchy/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/viewHierarchy/init.js
@@ -4,6 +4,7 @@ import { viewHierarchyIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [viewHierarchyIntegration()],
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/webWorker/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/webWorker/init.js
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 // Initialize Sentry with webWorker integration
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/browser-integration-tests/suites/ipv6/init.js
+++ b/dev-packages/browser-integration-tests/suites/ipv6/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@[2001:db8::1]/1337',
   sendClientReports: false,
   defaultIntegrations: false,

--- a/dev-packages/browser-integration-tests/suites/manual-client/force-init-chrome-extension/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/force-init-chrome-extension/init.js
@@ -6,6 +6,7 @@ window.Sentry = Sentry;
 window.chrome = { runtime: { id: 'mock-extension-id' } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   skipBrowserExtensionCheck: true,
 });

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-browser-extension/init.js
@@ -6,5 +6,6 @@ window.Sentry = Sentry;
 window.browser = { runtime: { id: 'mock-extension-id' } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/init.js
+++ b/dev-packages/browser-integration-tests/suites/manual-client/skip-init-chrome-extension/init.js
@@ -6,5 +6,6 @@ window.Sentry = Sentry;
 window.chrome = { runtime: { id: 'mock-extension-id' } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/acs/getCurrentScope/init.js
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/acs/getCurrentScope/init.js
@@ -15,5 +15,6 @@ window.__SENTRY__ = {
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/isOlderThan/init.js
+++ b/dev-packages/browser-integration-tests/suites/old-sdk-interop/hub/isOlderThan/init.js
@@ -15,5 +15,6 @@ window.__SENTRY__ = {
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/opentelemetry/node-exports/init.js
+++ b/dev-packages/browser-integration-tests/suites/opentelemetry/node-exports/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/profiling/legacyMode/subject.js
+++ b/dev-packages/browser-integration-tests/suites/profiling/legacyMode/subject.js
@@ -4,6 +4,7 @@ import { browserProfilingIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [browserProfilingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/profiling/manualMode/subject.js
+++ b/dev-packages/browser-integration-tests/suites/profiling/manualMode/subject.js
@@ -4,6 +4,7 @@ import { browserProfilingIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [browserProfilingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_multiple-chunks/subject.js
+++ b/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_multiple-chunks/subject.js
@@ -4,6 +4,7 @@ import { browserProfilingIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [browserProfilingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_overlapping-spans/subject.js
+++ b/dev-packages/browser-integration-tests/suites/profiling/traceLifecycleMode_overlapping-spans/subject.js
@@ -4,6 +4,7 @@ import { browserProfilingIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 const client = Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [browserProfilingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/addBreadcrumb/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/beforeSendTransaction/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/beforeSendTransaction/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   beforeSendTransaction: transactionEvent => {

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/errorEvent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/captureFeedback/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureFeedback/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/captureFeedback/withCaptureException/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureFeedback/withCaptureException/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   beforeSend(event) {
     Sentry.captureFeedback({

--- a/dev-packages/browser-integration-tests/suites/public-api/captureFeedback/withCaptureMessage/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureFeedback/withCaptureMessage/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   beforeSend(event) {
     Sentry.captureFeedback({

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/multipleMessageAttachStacktrace/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/multipleMessageAttachStacktrace/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   attachStacktrace: true,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   attachStacktrace: true,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/dataCollection/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/dataCollection/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
   dataCollection: { userInfo: true },

--- a/dev-packages/browser-integration-tests/suites/public-api/dataCollection/overrideIp/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/dataCollection/overrideIp/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
   dataCollection: { userInfo: false },

--- a/dev-packages/browser-integration-tests/suites/public-api/dataCollection/replay/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/dataCollection/replay/init.js
@@ -12,6 +12,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/public-api/dataCollection/sessions/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/dataCollection/sessions/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   dataCollection: { userInfo: true },
   release: '1.0',

--- a/dev-packages/browser-integration-tests/suites/public-api/debug/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/debug/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   debug: true,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/denyUrls/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/denyUrls/init.js
@@ -5,6 +5,7 @@ window.Sentry = Sentry;
 window._errorCount = 0;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   denyUrls: ['foo.js'],
   beforeSend: event => {

--- a/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/diagnoseSdkConnectivity/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/public-api/ignoreErrors/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/ignoreErrors/init.js
@@ -5,6 +5,7 @@ window.Sentry = Sentry;
 window._errorCount = 0;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   ignoreErrors: ['ignoreErrorTest'],
   beforeSend: event => {

--- a/dev-packages/browser-integration-tests/suites/public-api/init/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/init/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/init/stringSampleRate/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/init/stringSampleRate/init.js
@@ -5,6 +5,7 @@ window.Sentry = Sentry;
 window._errorCount = 0;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: '0',
   beforeSend() {

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/original-callback/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/original-callback/init.js
@@ -8,5 +8,6 @@ window.originalBuiltIns = {
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onError/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/onUnhandledRejection/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/requestAnimationFrame/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/requestAnimationFrame/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setTimeoutFrozen/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/setTimeoutFrozen/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   // We assert on the debug message, so we need to enable debug mode
   debug: true,

--- a/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/instrumentation/xhr/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/logger/consoleLoggingIntegrationShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/logger/consoleLoggingIntegrationShim/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 
 // consoleLoggingIntegration should not actually work, but still not error out
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   integrations: [Sentry.consoleLoggingIntegration()],

--- a/dev-packages/browser-integration-tests/suites/public-api/logger/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/logger/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   // purposefully testing against the experimental flag here
   _experiments: {

--- a/dev-packages/browser-integration-tests/suites/public-api/logger/integration/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/logger/integration/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   enableLogs: true,
   // Purposefully specifying the experimental flag here

--- a/dev-packages/browser-integration-tests/suites/public-api/logger/loggerShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/logger/loggerShim/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/metrics/afterCaptureMetric/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/metrics/afterCaptureMetric/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/browser-integration-tests/suites/public-api/metrics/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/metrics/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/browser-integration-tests/suites/public-api/setContext/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/setContext/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/setExtra/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/setExtra/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/setExtras/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/setExtras/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/setTag/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/setTag/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/setTags/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/setTags/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/setUser/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/setUser/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   dataCollection: { userInfo: true },
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/showReportDialog/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/showReportDialog/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   normalizeDepth: 10,

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-mixed-transaction/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-mixed-transaction/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone-sdk-disabled/init.js
@@ -12,6 +12,7 @@ window.fetch = (...args) => {
 };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   enabled: false,

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/standalone/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
 });

--- a/dev-packages/browser-integration-tests/suites/public-api/withScope/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/withScope/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   dataCollection: { userInfo: true },
 });

--- a/dev-packages/browser-integration-tests/suites/replay/attachRawBodyFromRequest/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/attachRawBodyFromRequest/init.js
@@ -12,6 +12,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/autoFlushOnFeedback/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/autoFlushOnFeedback/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeManual/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferModeReload/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/bufferStalledRequests/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/bufferStalledRequests/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/manualSnapshot/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/records/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/records/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/captureComponentName/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/captureComponentName/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/init.js
@@ -9,6 +9,7 @@ window.Replay = replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayOffline/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayOffline/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionDisabled/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionEnabled/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/compressionWorkerUrl/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/compressionWorkerUrl/init.js
@@ -10,6 +10,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/customEvents/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/customEvents/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/dsc/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/dsc/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration(), window.Replay],
   tracePropagationTargets: [/.*/],

--- a/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/beforeErrorSampling/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/droppedError/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorModeCustomTransport/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorModeCustomTransport/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorNotSent/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/errors/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/errors/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureTimestamps/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureTimestamps/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   // We ensure to sample for errors, so by default nothing is sent

--- a/dev-packages/browser-integration-tests/suites/replay/fileInput/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/fileInput/init.js
@@ -10,6 +10,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/flushing/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/flushing/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/ignoreMutations/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/ignoreMutations/init.js
@@ -12,6 +12,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/keyboardEvents/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/logger/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/logger/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/maxReplayDuration/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/minReplayDuration/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/minReplayDurationLimit/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/minReplayDurationLimit/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/multiple-pages/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/multiple-pages/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/privacyBlock/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyBlock/init.js
@@ -12,6 +12,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/privacyDefault/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyDefault/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInput/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInput/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/privacyInputMaskAll/init.js
@@ -11,6 +11,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/replayIntegrationShim/init.js
@@ -10,6 +10,7 @@ window.Replay = new Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/replayShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/replayShim/init.js
@@ -10,6 +10,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/requests/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/requests/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/sampling/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sampling/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/sessionInactive/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionInactive/init.js
@@ -8,6 +8,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/disable/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/disable/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/error/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/error/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   replaysSessionSampleRate: 0.0,

--- a/dev-packages/browser-integration-tests/suites/replay/slowClick/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/slowClick/init.js
@@ -10,6 +10,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/throttleBreadcrumbs/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/throttleBreadcrumbs/init.js
@@ -9,6 +9,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/compressed/init.js
@@ -10,6 +10,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/init.js
+++ b/dev-packages/browser-integration-tests/suites/replay/unicode/uncompressed/init.js
@@ -10,6 +10,7 @@ window.Replay = Sentry.replayIntegration({
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,

--- a/dev-packages/browser-integration-tests/suites/sessions/init.js
+++ b/dev-packages/browser-integration-tests/suites/sessions/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '0.1',
 });

--- a/dev-packages/browser-integration-tests/suites/sessions/initial-scope/init.js
+++ b/dev-packages/browser-integration-tests/suites/sessions/initial-scope/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '0.1',
   integrations: [Sentry.browserSessionIntegration({ lifecycle: 'route' })],

--- a/dev-packages/browser-integration-tests/suites/sessions/page-lifecycle/init.js
+++ b/dev-packages/browser-integration-tests/suites/sessions/page-lifecycle/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '0.1',
 });

--- a/dev-packages/browser-integration-tests/suites/sessions/route-lifecycle/init.js
+++ b/dev-packages/browser-integration-tests/suites/sessions/route-lifecycle/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '0.1',
   integrations: [Sentry.browserSessionIntegration({ lifecycle: 'route' })],

--- a/dev-packages/browser-integration-tests/suites/sessions/start-session/init.js
+++ b/dev-packages/browser-integration-tests/suites/sessions/start-session/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '0.1',
   integrations: [Sentry.browserSessionIntegration({ lifecycle: 'route' })],

--- a/dev-packages/browser-integration-tests/suites/sessions/user/init.js
+++ b/dev-packages/browser-integration-tests/suites/sessions/user/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '0.1',
   integrations: [Sentry.browserSessionIntegration({ lifecycle: 'route' })],

--- a/dev-packages/browser-integration-tests/suites/stacktraces/init.js
+++ b/dev-packages/browser-integration-tests/suites/stacktraces/init.js
@@ -3,5 +3,6 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/bindScopeToEmitter/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/bindScopeToEmitter/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/http-timings/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/ignoreMeasureSpans/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-navigation-click/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-navigation-click/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
   integrations: [

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/default/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/default/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-negative/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-negative/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-precedence/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta-precedence/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/meta/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/tracesSampler-precedence/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/tracesSampler-precedence/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/interaction-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/interaction-spans/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
   integrations: [Sentry.browserTracingIntegration({ _experiments: { enableInteractions: true } })],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/negatively-sampled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/negatively-sampled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   // We want to ignore redirects for this test
   integrations: [Sentry.browserTracingIntegration({ detectRedirects: false })],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/session-storage/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/session-storage/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ linkPreviousTrace: 'session-storage' })],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-disabled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-non-chromium/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-disabled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/meta/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/meta/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-aborting-pageload/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/multiple-redirects/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/multiple-redirects/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/navigation-navigation-click/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/navigation-navigation-click/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/navigation-navigation-keypress/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/navigation-navigation-keypress/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/navigation-redirect/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/navigation-redirect/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/opt-out/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/opt-out/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-navigation-click/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-navigation-click/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-navigation-keypress/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-navigation-keypress/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-navigation-time/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-navigation-time/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-redirect/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-redirect/pageload-redirect/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-end/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-end/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-start/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/on-request-span-start/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-update-txn-name/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-updateSpanName/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-updateSpanName/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadDelayed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadDelayed/init.js
@@ -6,6 +6,7 @@ window._testBaseTimestamp = performance.timeOrigin / 1000;
 setTimeout(() => {
   window._testTimeoutTimestamp = (performance.timeOrigin + performance.now()) / 1000;
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     integrations: [Sentry.browserTracingIntegration()],
     tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageloadWithChildSpanTimeout/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded/default/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded/default/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ enableReportPageLoaded: true })],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded/finalTimeout/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded/finalTimeout/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ enableReportPageLoaded: true, finalTimeout: 3000 })],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded/navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/reportPageLoaded/navigation/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window._testBaseTimestamp = performance.timeOrigin / 1000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ enableReportPageLoaded: true, instrumentNavigation: false })],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/resource-spans-ignored/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/resource-spans-ignored/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/spotlight-interaction-filter/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/spotlight-interaction-filter/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/standalone-without-baggage/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/standalone-without-baggage/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['sentry-test-external.io'],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/customTargets/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsMatch/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsMatch/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/tracePropagationTargets/defaultTargetsNoMatch/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/twp-errors-meta/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/twp-errors-meta/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: integrations => {
     integrations.push(Sentry.browserTracingIntegration());

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/twp-errors/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/twp-errors/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: integrations => {
     integrations.push(Sentry.browserTracingIntegration());

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationShim/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/dsc-txn-name-update/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ instrumentNavigation: false, instrumentPageLoad: false })],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/init.js
@@ -4,6 +4,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   environment: 'production',

--- a/dev-packages/browser-integration-tests/suites/tracing/envelope-header/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/envelope-header/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: [/.*/],

--- a/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/ignoreSpans/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/linking-addLink/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/linking-addLink/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/linking-addLinks/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/linking-addLinks/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/linking-spanOptions/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/linking-spanOptions/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/maxSpans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/maxSpans/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/connection-rtt-navigation/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/element-timing/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/element-timing/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration(), Sentry.elementTimingIntegration()],

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans-domexception-details/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans-domexception-details/init.js
@@ -22,6 +22,7 @@ Object.defineProperty(measure, 'detail', {
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({})],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-measure-spans/init.js
@@ -10,6 +10,7 @@ performance.measure('Next.js-before-hydration', {
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-navigate/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-navigate/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.browserTracingIntegration({

--- a/dev-packages/browser-integration-tests/suites/tracing/microfrontend-span-attribution/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/microfrontend-span-attribution/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/no-parent-span-client-report/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ instrumentPageLoad: false, instrumentNavigation: false })],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-data-url/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-data-url/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-immediate/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-immediate/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-no-tracing/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracePropagationTargets: ['http://sentry-test-site.example'],
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-relative-url/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-relative-url/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-strip-query-and-fragment/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-strip-query-and-fragment/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ instrumentPageLoad: false, instrumentNavigation: false })],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-trace-header-merging/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-trace-header-merging/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-unsampled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-tracing-without-performance/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-custom-sentry-headers-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-custom-sentry-headers-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-custom-sentry-headers/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-custom-sentry-headers/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-request/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-data-url/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-data-url/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-no-tracing/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracePropagationTargets: ['http://sentry-test-site.example'],
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-relative-url/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-relative-url/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-strip-query-and-fragment/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-strip-query-and-fragment/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration({ instrumentPageLoad: false, instrumentNavigation: false })],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-unsampled/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-tracing-without-performance/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-custom-sentry-headers-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-custom-sentry-headers-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/setSpanActive/default/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/setSpanActive/default/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/setSpanActive/nested-parentAlwaysRoot/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/setSpanActive/nested-parentAlwaysRoot/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
   parentSpanIsAlwaysRootSpan: false,

--- a/dev-packages/browser-integration-tests/suites/tracing/setSpanActive/nested/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/setSpanActive/nested/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/stringSampleRate/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/stringSampleRate/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: '1',
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/init.js
@@ -5,6 +5,7 @@ import { feedbackIntegration } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration(), feedbackIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTraceSampling/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/startNewTraceSampling/init.js
@@ -15,6 +15,7 @@ crypto.randomUUID = function randomUUID() {
 };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ['http://sentry-test-site.example'],

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-headers/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-headers/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   // in browser TwP means not setting tracesSampleRate but adding browserTracingIntegration,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance-propagateTraceparent/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   // in browser TwP means not setting tracesSampleRate but adding browserTracingIntegration,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/trace-lifetime/tracing-without-performance/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   // in browser TwP means not setting tracesSampleRate but adding browserTracingIntegration,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
+++ b/dev-packages/browser-integration-tests/suites/transport/multiplexed/init.js
@@ -4,6 +4,7 @@ import { makeMultiplexedTransport } from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: makeMultiplexedTransport(Sentry.makeFetchTransport, ({ getEvent }) => {
     const event = getEvent('event');

--- a/dev-packages/browser-integration-tests/suites/transport/offline/init.js
+++ b/dev-packages/browser-integration-tests/suites/transport/offline/init.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: Sentry.makeBrowserOfflineTransport(),
 });

--- a/dev-packages/browser-integration-tests/suites/wasm/init.js
+++ b/dev-packages/browser-integration-tests/suites/wasm/init.js
@@ -4,6 +4,7 @@ import { wasmIntegration } from '@sentry/wasm';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [wasmIntegration()],
   beforeSend: event => {

--- a/dev-packages/browser-integration-tests/suites/wasm/thirdPartyFilter/init.js
+++ b/dev-packages/browser-integration-tests/suites/wasm/thirdPartyFilter/init.js
@@ -25,6 +25,7 @@ _sentryModuleMetadataGlobal._sentryModuleMetadata[new Error().stack] = Object.as
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     wasmIntegration({ applicationKey: 'wasm-test-app' }),

--- a/dev-packages/browser-integration-tests/suites/wasm/webWorker/init.js
+++ b/dev-packages/browser-integration-tests/suites/wasm/webWorker/init.js
@@ -4,6 +4,7 @@ import { wasmIntegration } from '@sentry/wasm';
 window.Sentry = Sentry;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [wasmIntegration({ applicationKey: 'wasm-worker-app' })],
 });

--- a/dev-packages/bun-integration-tests/suites/basic/index.ts
+++ b/dev-packages/bun-integration-tests/suites/basic/index.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/bun';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 });

--- a/dev-packages/bundler-tests/fixtures/basic/index.js
+++ b/dev-packages/bundler-tests/fixtures/basic/index.js
@@ -1,5 +1,6 @@
 import { init } from '@sentry/browser';
 
 init({
+  traceLifecycle: 'static',
   dsn: 'https://00000000000000000000000000000000@o000000.ingest.sentry.io/0000000',
 });

--- a/dev-packages/deno-integration-tests/suites/orchestrion-mysql/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-mysql/test.ts
@@ -56,7 +56,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
 
 Deno.test('mysql instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Mysql'), `Mysql should be in defaults, got ${names.join(', ')}`);
 });
@@ -99,6 +99,7 @@ Deno.test('mysql instrumentation: orchestrion:mysql:query channel produces a nes
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-postgres/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-postgres/test.ts
@@ -56,7 +56,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
 
 Deno.test('pg instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Postgres'), `Postgres should be in defaults, got ${names.join(', ')}`);
 });
@@ -99,6 +99,7 @@ Deno.test('pg instrumentation: orchestrion:pg:query channel produces a nested db
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/e2e-tests/test-applications/angular-17/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-18/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-18/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-19/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-19/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-20/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-20/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-21/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-21/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-22/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-22/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-4/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-4/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-4/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-4/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-6/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-6/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-6/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-6/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.server.config.js
@@ -7,6 +7,7 @@ import { experimentalUseDiagnosticsChannelInjection } from '@sentry/node';
 experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/browser-mfe-vite/apps/shell/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/browser-mfe-vite/apps/shell/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import * as Sentry from '@sentry/react';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: import.meta.env.MODE || 'development',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
@@ -3,6 +3,7 @@ import MyWorker2 from './worker2.ts?worker';
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: import.meta.env.MODE || 'development',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/bun-bytecode/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/bun-bytecode/src/main.ts
@@ -4,6 +4,7 @@
 import * as Sentry from '@sentry/bun';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   tracesSampleRate: 0,
 });

--- a/dev-packages/e2e-tests/test-applications/bun-mysql/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/bun-mysql/src/app.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/bun';
 import mysql from 'mysql';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/create-react-app/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-react-app/src/index.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import './index.css';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/entry.client.tsx
@@ -14,6 +14,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/remix';
 import * as process from 'process';
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/app/entry.client.tsx
@@ -14,6 +14,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/remix';
 import process from 'process';
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.client.tsx
@@ -20,6 +20,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.server.tsx
@@ -19,6 +19,7 @@ installGlobals();
 const ABORT_DELAY = 5_000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/instrument.server.cjs
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/remix');
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
@@ -20,6 +20,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/instrument.server.cjs
@@ -11,6 +11,7 @@ if (injectOrchestrion) {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/src/app.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
 });

--- a/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/__snapshots__/server.test.ts.snap
+++ b/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/__snapshots__/server.test.ts.snap
@@ -4,13 +4,13 @@ exports[`Find symbolicated event on sentry 1`] = `
 {
   "colno": 41,
   "contextLine": "const eventId = Sentry.captureException(new Error('Sentry Debug ID E2E Test Error'));",
-  "lineno": 8,
+  "lineno": 9,
   "postContext": [
     "",
     "process.stdout.write(eventId);",
   ],
   "preContext": [
-    "Sentry.init({",
+    "  traceLifecycle: 'static',",
     "  environment: 'qa', // dynamic sampling bias to keep transactions",
     "  dsn: process.env.E2E_TEST_DSN,",
     "});",

--- a/dev-packages/e2e-tests/test-applications/default-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/default-browser/src/index.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/deno-mysql/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-mysql/src/app.ts
@@ -6,6 +6,7 @@ import '@sentry/deno/import';
 import * as Sentry from '@sentry/deno';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/deno-pg/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-pg/src/app.ts
@@ -7,6 +7,7 @@ import '@sentry/deno/import';
 import * as Sentry from '@sentry/deno';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/deno-redis/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-redis/src/app.ts
@@ -3,6 +3,7 @@ import IORedis from 'ioredis';
 import { createClient } from 'redis';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/deno/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/src/app.ts
@@ -18,6 +18,7 @@ import { MockLanguageModelV1 } from 'ai/test';
 import { z } from 'zod';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/elysia-bun/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/elysia-bun/src/app.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/elysia';
 import { Elysia } from 'elysia';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/elysia-node/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/elysia-node/src/app.ts
@@ -3,6 +3,7 @@ import { Elysia } from 'elysia';
 import { node } from '@elysiajs/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/ember-classic/app/app.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/app/app.ts
@@ -6,6 +6,7 @@ import Resolver from 'ember-resolver';
 import config from './config/environment';
 
 Sentry.init({
+  traceLifecycle: 'static',
   replaysSessionSampleRate: 1,
   replaysOnErrorSampleRate: 1,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/app/app.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/app/app.ts
@@ -5,6 +5,7 @@ import loadInitializers from 'ember-load-initializers';
 import Resolver from 'ember-resolver';
 
 Sentry.init({
+  traceLifecycle: 'static',
   replaysSessionSampleRate: 1,
   replaysOnErrorSampleRate: 1,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/instrument.node.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/instrument.node.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/hono/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { StrictMode, startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Could not find a working way to set the DSN in the browser side from the environment variables
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/instrument.server.mjs
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/instrument.server.mjs
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react-router';
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection

--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
@@ -16,6 +16,7 @@ performance.mark('sentry-sdk-init-start', {
 
 if (import.meta.env.MODE === 'tracing-replay') {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -27,6 +28,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'tracing') {
   // Tracing + errors, but no replay — isolates the replay integration's cost.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -38,6 +40,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // (We don't recommend this setup anywhere and neither will it work well.
   // this is purely for testing if it changes anything about overhead.)
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -50,6 +53,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'errors-only') {
   // Default integrations only — errors are always captured, no tracing or replay.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -57,6 +61,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'minimal-integrations') {
   // Minimal integratoins setup only (everything necessary to automatically get errors)
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -74,6 +79,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // DSN set but every integration disabled. Isolates the cost of the enabled
   // client itself from the default instrumentation that wraps DOM/timer/network APIs.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -85,6 +91,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // removeEventListener on ~32 prototypes plus setTimeout/setInterval/rAF/XHR.
   // Isolates that global monkey-patching cost from the rest of the defaults.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -95,6 +102,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // Default integrations minus Breadcrumbs, which adds a lot of monkey patching to
   // DOM and Network APIs as well as event targets and listeners
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -104,6 +112,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // Default integrations minus Breadcrumbs, which adds a lot of monkey patching to
   // DOM and Network APIs as well as event targets and listeners
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -113,7 +122,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'init-only') {
   // enabled: false makes the SDK a guaranteed no-op (no transport allocation,
   // no DSN warning). We're measuring pure SDK-loading + tree-shaking cost.
-  Sentry.init({ enabled: false });
+  Sentry.init({ traceLifecycle: 'static', enabled: false });
 }
 
 performance.measure('sentry-sdk-init-duration', {

--- a/dev-packages/e2e-tests/test-applications/nestjs-11/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-11/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-8/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-8/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-bullmq/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-bullmq/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-fastify/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-fastify/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-graphql/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-graphql/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-microservices/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-microservices/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nestjs-orchestrion/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-orchestrion/src/instrument.ts
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/nestjs';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init({
+      traceLifecycle: 'static',
       environment: 'qa', // dynamic sampling bias to keep transactions
       dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
       tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.SENTRY_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.client.config.ts
@@ -3,6 +3,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.edge.config.ts
@@ -6,6 +6,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/instrumentation-client.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import type { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.server.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/sentry.server.config.ts
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Use a fake but properly formatted Sentry SaaS DSN for tunnel route testing
   dsn: 'https://public@o12345.ingest.us.sentry.io/67890',

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Use a fake but properly formatted Sentry SaaS DSN for tunnel route testing
   dsn: 'https://public@o12345.ingest.us.sentry.io/67890',

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Use a fake but properly formatted Sentry SaaS DSN for tunnel route testing
   dsn: 'https://public@o12345.ingest.us.sentry.io/67890',

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/instrumentation-client.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import type { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.server.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init({
+      traceLifecycle: 'static',
       environment: 'qa', // dynamic sampling bias to keep transactions
       dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
       tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.edge.config.ts
@@ -6,6 +6,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/src/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/src/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init({
+      traceLifecycle: 'static',
       environment: 'qa', // dynamic sampling bias to keep transactions
       dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
       tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nitro-3/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nitro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nitro-3/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/src/main.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 // Let's us test trace propagation
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/src/app.js
@@ -38,6 +38,7 @@ async function run() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   Sentry.init({
+    traceLifecycle: 'static',
     environment: 'qa', // dynamic sampling bias to keep transactions
     dsn: process.env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
@@ -53,6 +53,7 @@ async function run() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   Sentry.init({
+    traceLifecycle: 'static',
     environment: 'qa', // dynamic sampling bias to keep transactions
     dsn: process.env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/src/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-incorrect-instrumentation/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-incorrect-instrumentation/src/app.ts
@@ -12,6 +12,7 @@ const port = 3030;
 // import and init sentry last for missing instrumentation
 import * as Sentry from '@sentry/node';
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/node-express-orchestrion-cjs/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-express-orchestrion-cjs/src/app.js
@@ -6,6 +6,7 @@ const Sentry = require('@sentry/node');
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/node-express-orchestrion/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-orchestrion/src/instrument.mjs
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/node';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/src/app.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 let lastTransactionId: string | undefined;
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-express-v5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/src/app.ts
@@ -7,6 +7,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
@@ -7,6 +7,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app-handle-error-override.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app-handle-error-override.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app-handle-error-override.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-firebase/firestore-app/src/init.ts
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/firestore-app/src/init.ts
@@ -11,6 +11,7 @@ if (useOrchestrion) {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-firebase/functions/src/init.ts
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/functions/src/init.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-hapi/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-hapi/src/app.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-koa/index.js
+++ b/dev-packages/e2e-tests/test-applications/node-koa/index.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/no-orchestrion.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/no-orchestrion.mjs
@@ -3,6 +3,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/with-orchestrion.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/with-orchestrion.mjs
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/node';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/e2e-tests/test-applications/node-otel-custom-sampler/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-custom-sampler/src/instrument.ts
@@ -4,6 +4,7 @@ import { SentryPropagator, SentrySpanProcessor } from '@sentry/opentelemetry';
 import { CustomSampler } from './custom-sampler';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/src/instrument.ts
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/node');
 const { SentrySpanProcessor, SentryPropagator, SentrySampler } = require('@sentry/opentelemetry');
 
 const sentryClient = Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
@@ -7,6 +7,7 @@ const { UndiciInstrumentation } = require('@opentelemetry/instrumentation-undici
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-otel/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel/src/instrument.ts
@@ -3,6 +3,7 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
 const Sentry = require('@sentry/node');
 
 const sentryClient = Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-profiling-cjs/index.ts
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-cjs/index.ts
@@ -4,6 +4,7 @@ import { nodeProfilingIntegration } from '@sentry/profiling-node';
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
   integrations: [nodeProfilingIntegration()],
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-profiling-electron/index.electron.js
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-electron/index.electron.js
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/electron/main');
 const path = require('node:path');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
   debug: true,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-profiling-esm/index.ts
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-esm/index.ts
@@ -4,6 +4,7 @@ import { nodeProfilingIntegration } from '@sentry/profiling-node';
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
   integrations: [nodeProfilingIntegration()],
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: 'http://localhost:3031/', // proxy server
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.server.config.ts
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/nuxt';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { usePinia, useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0, //  Capture 100% of the transactions
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { /* usePinia,*/ useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0, //  Capture 100% of the transactions
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/react-17/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-17/src/index.tsx
@@ -16,6 +16,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-19/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-19/src/index.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import Index from './pages/Index';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   release: 'e2e-test',

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/index.tsx
@@ -15,6 +15,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   // environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
@@ -16,6 +16,7 @@ import Group from './pages/Group';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   // environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/index.tsx
@@ -15,6 +15,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   // environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-5/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-5/src/index.tsx
@@ -11,6 +11,7 @@ const replay = Sentry.replayIntegration();
 const history = createBrowserHistory();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.REACT_APP_E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/index.tsx
@@ -16,6 +16,7 @@ import Index from './pages/Index';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
@@ -15,6 +15,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
@@ -18,6 +18,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/index.tsx
@@ -18,6 +18,7 @@ import Index from './pages/Index';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
@@ -8,6 +8,7 @@ import { HydratedRouter } from 'react-router/dom';
 const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://username@domain/123',
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/instrument.mjs
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react-router';
 // Initialize Sentry early (before the server starts)
 // The server instrumentations are created in entry.server.tsx
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-node-20-18/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-node-20-18/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-node-20-18/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-node-20-18/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-router';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa-node-20-18/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-router';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
@@ -78,6 +78,7 @@ const lazyRouteManifest = [
 ];
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/main.tsx
@@ -18,6 +18,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/src/index.tsx
@@ -18,6 +18,7 @@ import Index from './pages/Index';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-8-framework/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-framework/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-8-framework/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-framework/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-router';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://username@domain/123',
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/instrument.mjs
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react-router';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-8-spa/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-spa/src/main.tsx
@@ -18,6 +18,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/index.tsx
@@ -16,6 +16,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/entry.client.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Could not find a working way to set the DSN in the browser side from the environment variables
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/remix-server-timing/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-server-timing/app/entry.client.tsx
@@ -20,6 +20,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/remix-server-timing/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/remix-server-timing/instrument.server.cjs
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/remix');
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
@@ -97,6 +97,7 @@ declare module '@tanstack/solid-router' {
 declare const __APP_DSN__: string;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: __APP_DSN__,
   debug: true,
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/solid/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid/src/index.tsx
@@ -5,6 +5,7 @@ import App from './app';
 import './index.css';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   debug: true,
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.client.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
 

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.edge.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dataCollection: { userInfo: true },

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.server.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/svelte-5/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/svelte-5/src/main.ts
@@ -5,6 +5,7 @@ import './app.css';
 import * as Sentry from '@sentry/svelte';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/hooks.client.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/sveltekit';
 import * as Spotlight from '@spotlightjs/spotlight';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/instrumentation.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/instrumentation.server.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/sveltekit';
 import { E2E_TEST_DSN } from '$env/static/private';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.server.ts
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/sveltekit';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.client.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/sveltekit';
 import * as Spotlight from '@spotlightjs/spotlight';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.server.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/sveltekit';
 import { setupSidecar } from '@spotlightjs/spotlight/sidecar';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   release: '1.0.0',

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { E2E_TEST_DSN } from '$env/static/private';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { E2E_TEST_DSN } from '$env/static/private';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { PUBLIC_E2E_TEST_DSN } from '$app/env/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/src/instrumentation.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/src/instrumentation.server.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/sveltekit';
 // With SvelteKit 3 native instrumentation enabled (`experimental.instrumentation.server`),
 // `Sentry.init` runs here instead of in `hooks.server.ts`.
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: env.PUBLIC_E2E_TEST_DSN,
 });
 

--- a/dev-packages/e2e-tests/test-applications/tanstack-router/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/tanstack-router/src/main.tsx
@@ -94,6 +94,7 @@ const router = createRouter({ routeTree });
 declare const __APP_DSN__: string;
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: __APP_DSN__,
   integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/instrument.client.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/instrument.client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/instrument.server.mjs
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/instrument.server.mjs
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/tanstackstart-react';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/src/instrument.client.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/src/instrument.client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/tanstackstart-react';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: __APP_DSN__,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/instrument.client.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/instrument.client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/tanstackstart-react';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: __APP_DSN__,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/tsx-express/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
@@ -13,6 +13,7 @@ const app = createApp(App);
 const pinia = createPinia();
 
 Sentry.init({
+  traceLifecycle: 'static',
   app,
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/vue-tanstack-router/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-tanstack-router/src/main.ts
@@ -57,6 +57,7 @@ declare module '@tanstack/vue-router' {
 const app = createApp(RouterProvider, { router });
 
 Sentry.init({
+  traceLifecycle: 'static',
   app,
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   debug: true,

--- a/dev-packages/e2e-tests/test-applications/webpack-4/entry.js
+++ b/dev-packages/e2e-tests/test-applications/webpack-4/entry.js
@@ -1,6 +1,7 @@
 import { browserTracingIntegration, init } from '@sentry/browser';
 
 init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [browserTracingIntegration()],
   tunnel: 'http://localhost:3031',

--- a/dev-packages/e2e-tests/test-applications/webpack-5/entry.js
+++ b/dev-packages/e2e-tests/test-applications/webpack-5/entry.js
@@ -1,6 +1,7 @@
 import { browserTracingIntegration, init } from '@sentry/browser';
 
 init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [browserTracingIntegration()],
   tunnel: 'http://localhost:3031',

--- a/dev-packages/node-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/app-path.mjs
@@ -12,6 +12,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100, appRootPath: __dirname })],

--- a/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100, maxAnrEvents: 2 })],

--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -6,6 +6,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -6,6 +6,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   debug: true,

--- a/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
@@ -6,6 +6,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/isolated.mjs
@@ -5,6 +5,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -7,6 +7,7 @@ setTimeout(() => {
 const anr = Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   debug: true,

--- a/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/aws-serverless';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/aws-serverless/bedrock/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/bedrock/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/aws-serverless';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/aws-serverless/graphql/useOperationNameForRootSpan/scenario.js
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/graphql/useOperationNameForRootSpan/scenario.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/aws-serverless');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   integrations: [Sentry.graphqlIntegration({ useOperationNameForRootSpan: true })],

--- a/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/app.mjs
+++ b/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/app.mjs
@@ -7,6 +7,7 @@ import { Worker } from 'worker_threads';
 const __dirname = new URL('.', import.meta.url).pathname;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.childProcessIntegration({ captureWorkerErrors: false })],

--- a/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-all.ts
+++ b/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-all.ts
@@ -3,6 +3,7 @@ import { bunRuntimeMetricsIntegration } from '@sentry/bun';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-opt-out.ts
+++ b/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-opt-out.ts
@@ -3,6 +3,7 @@ import { bunRuntimeMetricsIntegration } from '@sentry/bun';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario.ts
@@ -3,6 +3,7 @@ import { bunRuntimeMetricsIntegration } from '@sentry/bun';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/child-process/fork.js
+++ b/dev-packages/node-integration-tests/suites/child-process/fork.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { fork } = require('child_process');
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/child-process/fork.mjs
+++ b/dev-packages/node-integration-tests/suites/child-process/fork.mjs
@@ -6,6 +6,7 @@ import * as path from 'path';
 const __dirname = new URL('.', import.meta.url).pathname;
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/child-process/worker.js
+++ b/dev-packages/node-integration-tests/suites/child-process/worker.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { Worker } = require('worker_threads');
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/child-process/worker.mjs
+++ b/dev-packages/node-integration-tests/suites/child-process/worker.mjs
@@ -6,6 +6,7 @@ import { Worker } from 'worker_threads';
 const __dirname = new URL('.', import.meta.url).pathname;
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/scenario.ts
@@ -4,6 +4,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     transport: loggingTransport,
     beforeSend(event) {

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/scenario.ts
@@ -4,6 +4,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     transport: loggingTransport,
   });

--- a/dev-packages/node-integration-tests/suites/client-reports/periodic-send/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/periodic-send/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   clientReportFlushInterval: 5000,

--- a/dev-packages/node-integration-tests/suites/consola/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/consola/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/contextLines/filename-with-spaces/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/contextLines/filename-with-spaces/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/contextLines/memory-leak/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/contextLines/memory-leak/scenario.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { CronJob } from 'cron';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
 });

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/base/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/base/scenario.ts
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import * as cron from 'node-cron';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/scenario.ts
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import * as cron from 'node-cron';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/cron/node-schedule/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-schedule/scenario.ts
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import * as schedule from 'node-schedule';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
@@ -9,6 +9,7 @@ new iitm.Hook((_, name) => {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/esm/modules-integration/app.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/modules-integration/app.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.modulesIntegration()],

--- a/dev-packages/node-integration-tests/suites/esm/warn-esm/server.js
+++ b/dev-packages/node-integration-tests/suites/esm/warn-esm/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/esm/warn-esm/server.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/warn-esm/server.mjs
@@ -3,6 +3,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 import express from 'express';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-no-tracing.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-no-tracing.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-sample-rate-0.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-sample-rate-0.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/express/late-init/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/late-init/instrument.mjs
@@ -10,6 +10,7 @@ Sentry.preloadOpenTelemetry({ integrations: ['Express'] });
 // existing instrumentation to update its options. The lazy getOptions()
 // in patchLayer ensures the updated options are read at request time.
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // No dsn, means  client is disabled
   // dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/scenario.mjs
@@ -19,6 +19,7 @@ app.get('/test/no-init', (_req, res) => {
 app.get('/test/init', (_req, res) => {
   // Call init again, but with DSN
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/requestUser/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/requestUser/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/express/span-isolationScope/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/span-isolationScope/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/tracing/instrument-filterStatusCode.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/instrument-filterStatusCode.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument-normalized-request.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument-normalized-request.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/tracing/updateName/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/updateName/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/express/tracing/withError/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/withError/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/express/with-http/base/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/base/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-always.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-always.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-default.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-default.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-medium.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-medium.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-none.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-none.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-small.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-small.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/basic/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/basic/scenario.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/withScope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/withScope/scenario.ts
@@ -4,6 +4,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 const flagsIntegration = Sentry.featureFlagsIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onSpan/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onSpan/scenario.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onError/basic/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onError/basic/scenario.ts
@@ -59,6 +59,7 @@ class GrowthBookWrapper {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onSpan/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onSpan/scenario.ts
@@ -44,6 +44,7 @@ class GrowthBookWrapper {
 const gb = new GrowthBookWrapper();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-errors-only.mjs
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-errors-only.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-paths-only.mjs
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-paths-only.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/hono-sdk/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/hono-sdk/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/hono/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/integrations/console/filter/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/integrations/console/filter/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/ipv6/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/ipv6/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@[2001:db8::1]/1337',
   defaultIntegrations: false,
   sendClientReports: false,

--- a/dev-packages/node-integration-tests/suites/modules/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/modules/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/modules/server.js
+++ b/dev-packages/node-integration-tests/suites/modules/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-all.ts
+++ b/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-all.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-opt-out.ts
+++ b/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-opt-out.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/pino/instrument-auto-off.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/instrument-auto-off.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/pino/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/proxy/basic.js
+++ b/dev-packages/node-integration-tests/suites/proxy/basic.js
@@ -7,6 +7,7 @@ proxy.listen(0, () => {
   const proxyPort = proxy.address().port;
 
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: process.env.SENTRY_DSN,
     transportOptions: {
       proxy: `http://localhost:${proxyPort}`,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
@@ -15,5 +15,5 @@ export async function resolve(specifier, context, nextResolve) {
 (async () => {
   const Sentry = await import('@sentry/node');
 
-  Sentry.init({});
+  Sentry.init({ traceLifecycle: 'static' });
 })();

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-disabled.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-disabled.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   dataCollection: { stackFrameVariables: false },

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-filtered.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-filtered.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   dataCollection: { stackFrameVariables: { deny: ['secretVar'] } },

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-instrument.cjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-instrument.cjs
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-name-matching.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-name-matching.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app-default.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app-default.js
@@ -11,6 +11,7 @@ function in_app_function() {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   includeLocalVariables: true,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app.js
@@ -6,6 +6,7 @@ const externalFunctionFile = require.resolve('./node_modules/out-of-app-function
 const { out_of_app_function } = require(externalFunctionFile);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   includeLocalVariables: true,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-rethrow.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-rethrow.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/basic.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/basic.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/log-entire-error-to-console.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/log-entire-error-to-console.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.onUncaughtExceptionIntegration({

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.onUncaughtExceptionIntegration({

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 0,
   debug: false,

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 0,
   debug: false,

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/bindScopeToEmitter/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/bindScopeToEmitter/scenario.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -23,7 +23,7 @@ test('should work inside catch block', async () => {
                   expect.objectContaining({
                     context_line: "  throw new Error('catched_error');",
                     pre_context: [
-                      'Sentry.init({',
+                      "  traceLifecycle: 'static',",
                       "  dsn: 'https://public@dsn.ingest.sentry.io/1337',",
                       "  release: '1.0',",
                       '  transport: loggingTransport,',

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/empty-obj/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/empty-obj/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/simple-error/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/simple-error/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/parameterized_message/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/parameterized_message/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/configureScope/clear_scope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/configureScope/clear_scope/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/configureScope/set_properties/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/configureScope/set_properties/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/metrics/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/metrics/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/metrics/server-address-option/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/metrics/server-address-option/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/metrics/server-address/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/metrics/server-address/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-custom-name.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-custom-name.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.onUnhandledRejectionIntegration({

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-default.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-default.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   // Use default mode: 'warn' - integration is active but should ignore AI_NoOutputGeneratedError
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'none' })],
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'strict' })],
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-strict.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-strict.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-warn.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-warn.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/simple-context/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/simple-context/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/simple-extra/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/simple-extra/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setMeasurement/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setMeasurement/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/public-api/setTag/with-primitives/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setTag/with-primitives/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setTags/with-primitives/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setTags/with-primitives/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope-with-parentSpanId/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope-with-parentSpanId/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/updateName-method/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/updateName-method/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/updateSpanName-function/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/updateSpanName-function/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/with-nested-spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/with-nested-spans/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/withMonitor/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/withMonitor/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/sessions/server.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/server.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/system-error/basic-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/system-error/basic-pii.mjs
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import { readFileSync } from 'fs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   dataCollection: { userInfo: true },

--- a/dev-packages/node-integration-tests/suites/system-error/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/system-error/basic.mjs
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import { readFileSync } from 'fs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/app-path.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/app-path.mjs
@@ -13,6 +13,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration({ appRootPath: __dirname })],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-disabled.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-disabled.mjs
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 15000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: process.env.SENTRY_DSN,
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-multiple.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-multiple.mjs
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration({ maxEventsPerHour: 2 })],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.js
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.js
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration()],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.mjs
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 12000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration()],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/indefinite.mjs
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration()],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { eventLoopBlockIntegration } from '@sentry/node-native';
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: process.env.SENTRY_DSN,
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit-forced.js
@@ -3,6 +3,7 @@ const { eventLoopBlockIntegration } = require('@sentry/node-native');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit.js
@@ -3,6 +3,7 @@ const { eventLoopBlockIntegration } = require('@sentry/node-native');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/tracing/amqplib/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/amqplib/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument-dc.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument-dc.mjs
@@ -8,6 +8,7 @@ const { graphqlIntegration } = Sentry.diagnosticsChannelInjectionIntegrations();
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/dataloader/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/dataloader/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/double-baggage/no-spans/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/double-baggage/no-spans/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // explicitly not setting tracesSampleRate,

--- a/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-no-parent/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-no-parent/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-parent/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-parent/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-events.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-events.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-headers.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-headers.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/fastify/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/fastify/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument-trivial.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument-trivial.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument-disabled.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument-disabled.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/hapi/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/hapi/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-error/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-forward-request-hook/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-forward-request-hook/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-headers-to-span-attributes/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-headers-to-span-attributes/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-strip-query/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-strip-query/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-basic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-basic/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument-mitigation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument-mitigation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-strip-query/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-strip-query/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-overwrite-server-emit.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-overwrite-server-emit.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreIncomingRequests.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreIncomingRequests.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/node');
 const url = process.env.SERVER_URL;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreStaticAssets.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreStaticAssets.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-traceStaticAssets.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-traceStaticAssets.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/koa/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/koa/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-agent.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-agent.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink-nested.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink-nested.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks-nested.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks-nested.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-span-options.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-span-options.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/maxSpans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/maxSpans/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/no-server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/no-server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/server.js
@@ -2,6 +2,7 @@ const { loggingTransport, startExpressServerAndSendPortToRunner } = require('@se
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-sdk-disabled.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-sdk-disabled.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-tracesSampleRate-zero.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-tracesSampleRate-zero.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v4/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v4/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v6/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v6/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v8/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v8/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v9/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v9/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-root-span.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-root-span.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-root-span.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-root-span.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-ignoreConnect.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-ignoreConnect.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion-ignoreConnect.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion-ignoreConnect.mjs
@@ -10,6 +10,7 @@ const { postgresIntegration } = Sentry.diagnosticsChannelInjectionIntegrations()
 
 Sentry.experimentalUseDiagnosticsChannelInjection();
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion.mjs
@@ -9,6 +9,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument-requestHook.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument-requestHook.mjs
@@ -24,6 +24,7 @@ const postgresJsIntegration =
     : Sentry.postgresJsIntegration({ requestHook });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument-basic-tracer-provider.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument-basic-tracer-provider.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-ioredis.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-ioredis.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-4.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-4.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-5.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-5.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-dc/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-dc/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.nativeNodeFetchIntegration({ tracePropagation: false })],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing-no-spans/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing-no-spans/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-unsampled/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-unsampled/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-maxed-out-sockets/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-maxed-out-sockets/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.httpIntegration({ tracePropagation: false, spans: false })],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/traceparent/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/traceparent/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rand-propagation/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rand-propagation/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampleRate: 0.00000001, // It's important that this is not 1, so that we also check logic for NonRecordingSpans, which is usually the edge-case

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/no-tracing-enabled/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/no-tracing-enabled/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate-0/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate-0/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampleRate: 0,

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampleRate: 0.69,

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampler/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampler/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampler: ({ inheritOrSampleWith }) => {

--- a/dev-packages/node-integration-tests/suites/tracing/sampling-static/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/sampling-static/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampler: ({ inheritOrSampleWith, name }) => {

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-explicit-org-id.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-explicit-org-id.ts
@@ -4,6 +4,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@o01234987.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-org-id.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-org-id.ts
@@ -4,6 +4,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@public.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server.ts
@@ -4,6 +4,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@o0000987.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/traceid-recycling-with-spans/instrument.cjs
+++ b/dev-packages/node-integration-tests/suites/tracing/traceid-recycling-with-spans/instrument.cjs
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/traceid-recycling/server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/traceid-recycling/server.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/tracer-start-active-span-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tracer-start-active-span-error/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/vercel/sigterm-flush/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/vercel/sigterm-flush/scenario.ts
@@ -22,6 +22,7 @@ function bufferedLoggingTransport(_options: BaseTransportOptions): Transport {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: bufferedLoggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/winston/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/winston/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/packages/ember/tests/dummy/app/app.ts
+++ b/packages/ember/tests/dummy/app/app.ts
@@ -5,6 +5,7 @@ import Resolver from 'ember-resolver';
 import config from './config/environment';
 
 Sentry.init({
+  traceLifecycle: 'static',
   replaysSessionSampleRate: 1,
   replaysOnErrorSampleRate: 1,
 });

--- a/packages/node/test/integration/scope.test.ts
+++ b/packages/node/test/integration/scope.test.ts
@@ -263,7 +263,7 @@ describe('Integration | Scope', () => {
       expect(globalScope.getScopeData().tags).toEqual({ tag1: 'val1', tag2: 'val2' });
 
       // Now when we call init, the global scope remains intact
-      Sentry.init({ dsn: 'https://username@domain/123', defaultIntegrations: false });
+      Sentry.init({ traceLifecycle: 'static', dsn: 'https://username@domain/123', defaultIntegrations: false });
 
       expect(globalScope.getClient()).toBeUndefined();
       expect(Sentry.getGlobalScope()).toBe(globalScope);
@@ -320,7 +320,7 @@ describe('Integration | Scope', () => {
       expect(isolationScope.getScopeData().tags).toEqual({ tag1: 'val1', tag2: 'val2' });
 
       // Now when we call init, the isolation scope remains intact
-      Sentry.init({ dsn: 'https://username@domain/123', defaultIntegrations: false });
+      Sentry.init({ traceLifecycle: 'static', dsn: 'https://username@domain/123', defaultIntegrations: false });
 
       // client is only attached to global scope by default
       expect(isolationScope.getClient()).toBeUndefined();
@@ -471,7 +471,7 @@ describe('Integration | Scope', () => {
       expect(currentScope.getScopeData().tags).toEqual({ tag1: 'val1', tag2: 'val2' });
 
       // Now when we call init, the current scope remains intact
-      Sentry.init({ dsn: 'https://username@domain/123', defaultIntegrations: false });
+      Sentry.init({ traceLifecycle: 'static', dsn: 'https://username@domain/123', defaultIntegrations: false });
 
       // client is attached to current scope
       expect(currentScope.getClient()).toBeDefined();

--- a/packages/vue/test/integration/VueIntegration.test.ts
+++ b/packages/vue/test/integration/VueIntegration.test.ts
@@ -50,6 +50,7 @@ describe('Sentry.VueIntegration', () => {
 
   it('allows to initialize integration later', () => {
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
     });
@@ -73,6 +74,7 @@ describe('Sentry.VueIntegration', () => {
 
   it('warns when mounting before SDK.VueIntegration', () => {
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
     });
@@ -99,6 +101,7 @@ describe('Sentry.VueIntegration', () => {
     // where VNodes in console arguments would trigger recursive warning spam with captureConsoleIntegration
 
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
       normalizeDepth: 10, // High depth that would cause the issue

--- a/packages/vue/test/integration/init.test.ts
+++ b/packages/vue/test/integration/init.test.ts
@@ -94,6 +94,7 @@ describe('Sentry.init', () => {
     });
 
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
       integrations: [],
@@ -117,5 +118,6 @@ function runInit(options: Partial<Options>): Client | undefined {
     defaultIntegrations: false,
     integrations: [integration],
     ...options,
+    traceLifecycle: 'static',
   });
 }

--- a/packages/vue/test/integration/normalize.test.ts
+++ b/packages/vue/test/integration/normalize.test.ts
@@ -16,6 +16,7 @@ const PUBLIC_DSN = 'https://username@domain/123';
 describe('@sentry/vue init() normalize stringifier', () => {
   beforeEach(() => {
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
       integrations: [],


### PR DESCRIPTION
Prework for enabling span streaming by default without breaking existing transaction-asserting tests.

These tests explicitly stay on the static trace lifecycle for now. We'll gradually migrate them after span streaming is enabled by default.

Refs #22344