### PR TITLE
chore(skills): Write framework-updates digest to repo-relative path

### DIFF
--- a/.agents/skills/track-framework-updates/SKILL.md
+++ b/.agents/skills/track-framework-updates/SKILL.md
@@ -107,19 +107,15 @@ For each release or RFC that plausibly needs SDK work, draft one concrete, actio
 
 ### Step 6: Write output artifacts
 
-The `collect_updates.py` script in Step 1 prints its output path, e.g.:
+Write all files to `.agents/skills/track-framework-updates/output/` **relative to the repository root** — never relative paths like `output/` from the workspace root.
 
-```
-Wrote /abs/path/to/.agents/skills/track-framework-updates/output/framework-updates-raw.json: ...
-```
-
-Use that printed path to derive the output directory. All three files must be written to the **same directory** as `framework-updates-raw.json` — never relative paths like `output/` from the workspace root.
+Do NOT reuse the absolute directory printed by `collect_updates.py` in Step 1: in CI, Bash commands run in a sandbox where the workspace is mounted at a different absolute path (e.g. `/github/workspace/...`) that does not exist for the Write tool. The repo-relative path is valid in both contexts.
 
 Produce **three files**:
 
-1. The raw JSON was already written by Step 1 — no action needed.
-2. **`<output-dir>/framework-updates-digest.json`** — structured, machine-readable digest. Follow the schema in `assets/digest-schema.json`.
-3. **`<output-dir>/framework-updates-digest.md`** — human-readable digest. Follow the structure in `assets/digest-template.md`:
+1. `.agents/skills/track-framework-updates/output/framework-updates-raw.json` — already written by Step 1, no action needed.
+2. **`.agents/skills/track-framework-updates/output/framework-updates-digest.json`** — structured, machine-readable digest. Follow the schema in `assets/digest-schema.json`.
+3. **`.agents/skills/track-framework-updates/output/framework-updates-digest.md`** — human-readable digest. Follow the structure in `assets/digest-template.md`:
    - Group by Client-Side / Server-Side / Meta-Framework / Platform / Libraries.
    - Omit frameworks with no activity.
    - Include a "Run notes" section only if a fetcher reported errors.

--- a/.agents/skills/track-framework-updates/scripts/collect_updates.py
+++ b/.agents/skills/track-framework-updates/scripts/collect_updates.py
@@ -116,8 +116,16 @@ def main() -> None:
         len(f["discussions"]) + len(f["rfcs"]) + len(f["rssItems"])
         for f in frameworks
     )
+    # Report a cwd-relative path: in CI this script runs inside a sandbox whose
+    # absolute paths (e.g. /github/workspace/...) don't exist outside it, so an
+    # absolute path would mislead the digest-writing step.
+    out_display = args.out
+    try:
+        out_display = os.path.relpath(args.out)
+    except ValueError:
+        pass
     print(
-        f"Wrote {args.out}: {len(frameworks)} frameworks with activity, "
+        f"Wrote {out_display}: {len(frameworks)} frameworks with activity, "
         f"{total_releases} releases, {total_links} links "
         f"(last {args.since_days} days)."
     )

--- a/.github/workflows/track-framework-updates.yml
+++ b/.github/workflows/track-framework-updates.yml
@@ -74,6 +74,15 @@ jobs:
           DIGEST=".agents/skills/track-framework-updates/output/framework-updates-digest.md"
           SCRIPT=".agents/skills/track-framework-updates/scripts/write_job_summary.py"
 
+          # The digest may land elsewhere if Claude derived the output dir from a
+          # sandboxed absolute path — fall back to searching the workspace.
+          if [ ! -f "$DIGEST" ]; then
+            FOUND=$(find . -name framework-updates-digest.md -not -path './node_modules/*' -print -quit)
+            if [ -n "$FOUND" ]; then
+              DIGEST="$FOUND"
+            fi
+          fi
+
           if [ -f "$EXEC_FILE" ]; then
             python3 "$SCRIPT" "$EXEC_FILE" "$DIGEST" >> "$GITHUB_STEP_SUMMARY"
           elif [ -f "$DIGEST" ]; then


### PR DESCRIPTION
This should fix printing the summary in the action output. 