### PR TITLE
ref(opentelemetry): Use `sentry.graphql.operation` from conventions

### DIFF
--- a/packages/node/src/integrations/tracing/graphql/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/tracing/graphql/vendored/instrumentation.ts
@@ -65,8 +65,9 @@ import {
   startInactiveSpan,
   withActiveSpan,
 } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION } from '@sentry/opentelemetry';
+
 import type { GraphQLInstrumentationConfig, GraphQLInstrumentationParsedConfig } from './types';
+import { SENTRY_GRAPHQL_OPERATION } from '@sentry/conventions/attributes';
 
 const PACKAGE_NAME = '@sentry/instrumentation-graphql';
 
@@ -267,7 +268,7 @@ export class GraphQLInstrumentation extends InstrumentationBase<GraphQLInstrumen
     const rootSpan = getRootSpan(span);
     const rootSpanAttributes = spanToJSON(rootSpan).data;
 
-    const existingOperations = rootSpanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION] || [];
+    const existingOperations = rootSpanAttributes[SENTRY_GRAPHQL_OPERATION] || [];
 
     const newOperation = operationName ? `${operationType} ${operationName}` : `${operationType}`;
 
@@ -275,11 +276,11 @@ export class GraphQLInstrumentation extends InstrumentationBase<GraphQLInstrumen
     // This can either be a string, or an array of strings (if there are multiple operations)
     if (Array.isArray(existingOperations)) {
       (existingOperations as string[]).push(newOperation);
-      rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION, existingOperations);
+      rootSpan.setAttribute(SENTRY_GRAPHQL_OPERATION, existingOperations);
     } else if (typeof existingOperations === 'string') {
-      rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION, [existingOperations, newOperation]);
+      rootSpan.setAttribute(SENTRY_GRAPHQL_OPERATION, [existingOperations, newOperation]);
     } else {
-      rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION, newOperation);
+      rootSpan.setAttribute(SENTRY_GRAPHQL_OPERATION, newOperation);
     }
 
     if (!spanToJSON(rootSpan).data['original-description']) {

--- a/packages/opentelemetry/src/exports.ts
+++ b/packages/opentelemetry/src/exports.ts
@@ -1,5 +1,3 @@
-export { SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION } from './semanticAttributes';
-
 export { getRequestSpanData } from './utils/getRequestSpanData';
 
 export { getScopesFromContext } from './utils/contextData';

--- a/packages/opentelemetry/src/semanticAttributes.ts
+++ b/packages/opentelemetry/src/semanticAttributes.ts
@@ -1,5 +1,2 @@
 /** If this attribute is true, it means that the parent is a remote span. */
 export const SEMANTIC_ATTRIBUTE_SENTRY_PARENT_IS_REMOTE = 'sentry.parentIsRemote';
-
-// These are not standardized yet, but used by the graphql instrumentation
-export const SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION = 'sentry.graphql.operation';

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -11,6 +11,7 @@ import {
   HTTP_URL,
   MESSAGING_SYSTEM,
   RPC_SERVICE,
+  SENTRY_GRAPHQL_OPERATION,
   SENTRY_KIND,
   URL_FULL,
 } from '@sentry/conventions/attributes';
@@ -25,7 +26,6 @@ import {
   spanToJSON,
   stripUrlQueryAndFragment,
 } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION } from '../semanticAttributes';
 import type { AbstractSpan } from '../types';
 import { spanHasAttributes, spanHasName } from './spanTypes';
 
@@ -175,7 +175,7 @@ export function descriptionForHttpMethod(
     return { ...getUserUpdatedNameAndSource(name, attributes), op: opParts.join('.') };
   }
 
-  const graphqlOperationsAttribute = attributes[SEMANTIC_ATTRIBUTE_SENTRY_GRAPHQL_OPERATION];
+  const graphqlOperationsAttribute = attributes[SENTRY_GRAPHQL_OPERATION];
 
   // Ex. GET /api/users
   const baseDescription = `${httpMethod} ${urlPath}`;


### PR DESCRIPTION
Removing this export from opentelemetry package, instead using this from conventions.