### PR TITLE
fix(core): Use wall clock for structured log timestamps

### DIFF
--- a/packages/core/src/logs/internal.ts
+++ b/packages/core/src/logs/internal.ts
@@ -10,7 +10,7 @@ import { consoleSandbox, debug } from '../utils/debug-logger';
 import { isParameterizedString } from '../utils/is';
 import { getCombinedScopeData } from '../utils/scopeData';
 import { _getSpanForScope } from '../utils/spanOnScope';
-import { timestampInSeconds } from '../utils/time';
+import { dateTimestampInSeconds } from '../utils/time';
 import { getSequenceAttribute } from '../utils/timestampSequence';
 import { _getTraceInfoFromScope } from '../utils/trace-info';
 import { SEVERITY_TEXT_TO_SEVERITY_NUMBER } from './constants';
@@ -156,7 +156,13 @@ export function _INTERNAL_captureLog(
 
   const { level, message, attributes: logAttributes = {}, severityNumber } = log;
 
-  const timestamp = timestampInSeconds();
+  // Use the wall-clock (`Date.now()`) rather than `timestampInSeconds()`, which is derived from
+  // `performance.timeOrigin + performance.now()`. On some platforms (notably React Native/Hermes) that performance
+  // clock is anchored to process/device uptime instead of the UNIX epoch, which would stamp logs with a timestamp off
+  // by a large, constant offset. Using the wall clock keeps log timestamps consistent with error-event timestamps
+  // (which also use `dateTimestampInSeconds()`). Sub-second ordering is preserved via the `sentry.timestamp.sequence`
+  // attribute below. See: https://github.com/getsentry/sentry-react-native/issues/6510
+  const timestamp = dateTimestampInSeconds();
   const sequenceAttr = getSequenceAttribute(timestamp);
 
   const serializedLog: SerializedLog = {

--- a/packages/core/test/lib/logs/internal.test.ts
+++ b/packages/core/test/lib/logs/internal.test.ts
@@ -43,6 +43,30 @@ describe('_INTERNAL_captureLog', () => {
     );
   });
 
+  it('stamps logs with the wall clock (`dateTimestampInSeconds`), not the performance clock', () => {
+    // On platforms where the performance clock is not anchored to the UNIX epoch (e.g. React Native/Hermes),
+    // `timestampInSeconds()` would be off by a large constant. Logs must use the wall clock so their timestamps match
+    // error-event timestamps. See https://github.com/getsentry/sentry-react-native/issues/6510
+    const wallClockSeconds = 1_784_820_130.576;
+    const performanceClockSeconds = 1_784_453_353.186;
+    const dateSpy = vi.spyOn(timeModule, 'dateTimestampInSeconds').mockReturnValue(wallClockSeconds);
+    const perfSpy = vi.spyOn(timeModule, 'timestampInSeconds').mockReturnValue(performanceClockSeconds);
+
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const client = new TestClient(options);
+    const scope = new Scope();
+    scope.setClient(client);
+
+    _INTERNAL_captureLog({ level: 'info', message: 'clock check' }, scope);
+
+    expect(_INTERNAL_getLogBuffer(client)?.[0]?.timestamp).toBe(wallClockSeconds);
+    expect(dateSpy).toHaveBeenCalled();
+    expect(perfSpy).not.toHaveBeenCalled();
+
+    dateSpy.mockRestore();
+    perfSpy.mockRestore();
+  });
+
   it('does not capture logs when enableLogs is not enabled', () => {
     const logWarnSpy = vi.spyOn(loggerModule.debug, 'warn').mockImplementation(() => undefined);
     const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
@@ -1186,7 +1210,7 @@ describe('_INTERNAL_captureLog', () => {
 
   describe('sentry.timestamp.sequence', () => {
     it('increments the sequence number across consecutive logs', () => {
-      vi.spyOn(timeModule, 'timestampInSeconds').mockReturnValue(1000.001);
+      vi.spyOn(timeModule, 'dateTimestampInSeconds').mockReturnValue(1000.001);
 
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
       const client = new TestClient(options);
@@ -1206,7 +1230,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('does not increment the sequence number for dropped logs', () => {
-      vi.spyOn(timeModule, 'timestampInSeconds').mockReturnValue(1000.001);
+      vi.spyOn(timeModule, 'dateTimestampInSeconds').mockReturnValue(1000.001);
 
       const beforeSendLog = vi.fn().mockImplementation(log => {
         if (log.message === 'drop me') {
@@ -1233,7 +1257,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('produces monotonically increasing sequence numbers within the same millisecond', () => {
-      vi.spyOn(timeModule, 'timestampInSeconds').mockReturnValue(1000.001);
+      vi.spyOn(timeModule, 'dateTimestampInSeconds').mockReturnValue(1000.001);
 
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
       const client = new TestClient(options);


### PR DESCRIPTION
Before submitting a pull request, please take a look at our  <br>[Contributing](<https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md>) guidelines and verify:

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [X] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

Closes getsentry/sentry-react-native#6510

---

Structured logs (`Sentry.logger.*`) are stamped with a timestamp that can be wrong by a large, constant offset on platforms where the Performance API is not anchored to the UNIX epoch — notably React Native/Hermes, where `performance.timeOrigin + performance.now()` tracks device uptime rather than wall-clock time. In one report the offset was \~4.25 days, while error events (which use `Date.now()`) were correct.

Log timestamps are produced by `timestampInSeconds()`, which returns `performance.timeOrigin + performance.now()` without any wall-clock sanity check. This PR switches the log path to `dateTimestampInSeconds()` (i.e. `Date.now()`), so log timestamps use the wall clock and match error-event timestamps on every platform.

Sub-second ordering is unaffected: logs already carry the `sentry.timestamp.sequence` attribute, which is the mechanism used to break ties when two logs share the same timestamp.

**Scope:** this is intentionally limited to the log path only. `timestampInSeconds()` and all of its other consumers (spans, sessions, breadcrumbs, metrics) are left unchanged, so tracing behavior is not affected.

### Background

The regression was introduced in [#16133](<https://github.com/getsentry/sentry-javascript/issues/16133>) (`ref(core): Switch to standardized log envelope`), first shipped in `@sentry/core@9.16.0`. Before that change, logs were stamped with `new Date().getTime()` (wall clock); the refactor switched them to `timestampInSeconds()`.

Related: [#2590](<https://github.com/getsentry/sentry-javascript/issues/2590>) (Performance-clock vs wall-clock skew).

### How was it tested?

* Added a unit test asserting that `_INTERNAL_captureLog` stamps logs with `dateTimestampInSeconds()` (wall clock) and does not call `timestampInSeconds()`.
* Updated the `sentry.timestamp.sequence` tests, which mocked `timestampInSeconds()`, to mock `dateTimestampInSeconds()` accordingly.
* `packages/core` logs test suites pass (104 tests).