### PR TITLE
test: Disable span streaming in remaining tests

### DIFF
--- a/dev-packages/bun-integration-tests/suites/basic/index.ts
+++ b/dev-packages/bun-integration-tests/suites/basic/index.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/bun';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 });

--- a/dev-packages/bundler-tests/fixtures/basic/index.js
+++ b/dev-packages/bundler-tests/fixtures/basic/index.js
@@ -1,5 +1,6 @@
 import { init } from '@sentry/browser';
 
 init({
+  traceLifecycle: 'static',
   dsn: 'https://00000000000000000000000000000000@o000000.ingest.sentry.io/0000000',
 });

--- a/dev-packages/deno-integration-tests/suites/orchestrion-mysql/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-mysql/test.ts
@@ -56,7 +56,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
 
 Deno.test('mysql instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Mysql'), `Mysql should be in defaults, got ${names.join(', ')}`);
 });
@@ -99,6 +99,7 @@ Deno.test('mysql instrumentation: orchestrion:mysql:query channel produces a nes
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-postgres/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-postgres/test.ts
@@ -56,7 +56,7 @@ function withTimeout<T>(p: Promise<T>, ms: number, what: string): Promise<T> {
 
 Deno.test('pg instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Postgres'), `Postgres should be in defaults, got ${names.join(', ')}`);
 });
@@ -99,6 +99,7 @@ Deno.test('pg instrumentation: orchestrion:pg:query channel produces a nested db
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/packages/ember/tests/dummy/app/app.ts
+++ b/packages/ember/tests/dummy/app/app.ts
@@ -5,6 +5,7 @@ import Resolver from 'ember-resolver';
 import config from './config/environment';
 
 Sentry.init({
+  traceLifecycle: 'static',
   replaysSessionSampleRate: 1,
   replaysOnErrorSampleRate: 1,
 });

--- a/packages/node/test/integration/scope.test.ts
+++ b/packages/node/test/integration/scope.test.ts
@@ -263,7 +263,7 @@ describe('Integration | Scope', () => {
       expect(globalScope.getScopeData().tags).toEqual({ tag1: 'val1', tag2: 'val2' });
 
       // Now when we call init, the global scope remains intact
-      Sentry.init({ dsn: 'https://username@domain/123', defaultIntegrations: false });
+      Sentry.init({ traceLifecycle: 'static', dsn: 'https://username@domain/123', defaultIntegrations: false });
 
       expect(globalScope.getClient()).toBeUndefined();
       expect(Sentry.getGlobalScope()).toBe(globalScope);
@@ -320,7 +320,7 @@ describe('Integration | Scope', () => {
       expect(isolationScope.getScopeData().tags).toEqual({ tag1: 'val1', tag2: 'val2' });
 
       // Now when we call init, the isolation scope remains intact
-      Sentry.init({ dsn: 'https://username@domain/123', defaultIntegrations: false });
+      Sentry.init({ traceLifecycle: 'static', dsn: 'https://username@domain/123', defaultIntegrations: false });
 
       // client is only attached to global scope by default
       expect(isolationScope.getClient()).toBeUndefined();
@@ -471,7 +471,7 @@ describe('Integration | Scope', () => {
       expect(currentScope.getScopeData().tags).toEqual({ tag1: 'val1', tag2: 'val2' });
 
       // Now when we call init, the current scope remains intact
-      Sentry.init({ dsn: 'https://username@domain/123', defaultIntegrations: false });
+      Sentry.init({ traceLifecycle: 'static', dsn: 'https://username@domain/123', defaultIntegrations: false });
 
       // client is attached to current scope
       expect(currentScope.getClient()).toBeDefined();

--- a/packages/vue/test/integration/VueIntegration.test.ts
+++ b/packages/vue/test/integration/VueIntegration.test.ts
@@ -50,6 +50,7 @@ describe('Sentry.VueIntegration', () => {
 
   it('allows to initialize integration later', () => {
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
     });
@@ -73,6 +74,7 @@ describe('Sentry.VueIntegration', () => {
 
   it('warns when mounting before SDK.VueIntegration', () => {
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
     });
@@ -99,6 +101,7 @@ describe('Sentry.VueIntegration', () => {
     // where VNodes in console arguments would trigger recursive warning spam with captureConsoleIntegration
 
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
       normalizeDepth: 10, // High depth that would cause the issue

--- a/packages/vue/test/integration/init.test.ts
+++ b/packages/vue/test/integration/init.test.ts
@@ -94,6 +94,7 @@ describe('Sentry.init', () => {
     });
 
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
       integrations: [],
@@ -117,5 +118,6 @@ function runInit(options: Partial<Options>): Client | undefined {
     defaultIntegrations: false,
     integrations: [integration],
     ...options,
+    traceLifecycle: 'static',
   });
 }

--- a/packages/vue/test/integration/normalize.test.ts
+++ b/packages/vue/test/integration/normalize.test.ts
@@ -16,6 +16,7 @@ const PUBLIC_DSN = 'https://username@domain/123';
 describe('@sentry/vue init() normalize stringifier', () => {
   beforeEach(() => {
     Sentry.init({
+      traceLifecycle: 'static',
       dsn: PUBLIC_DSN,
       defaultIntegrations: false,
       integrations: [],


### PR DESCRIPTION
Prework for enabling span streaming by default without breaking the remaining transaction-asserting tests.

The affected Bun, Deno, bundler, Ember, Node, and Vue tests explicitly stay on the static trace lifecycle for now. This is the remaining-tests slice of getsentry/sentry-javascript#22577 and is independent of the other split PRs.

Refs getsentry/sentry-javascript#22344