### PR TITLE
test(node): Disable span streaming in node-integration tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/app-path.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/app-path.mjs
@@ -12,6 +12,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100, appRootPath: __dirname })],

--- a/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic-multiple.mjs
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100, maxAnrEvents: 2 })],

--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -6,6 +6,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/basic.mjs
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -6,6 +6,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   debug: true,

--- a/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/indefinite.mjs
@@ -6,6 +6,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/isolated.mjs
+++ b/dev-packages/node-integration-tests/suites/anr/isolated.mjs
@@ -5,6 +5,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],

--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -7,6 +7,7 @@ setTimeout(() => {
 const anr = Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   debug: true,

--- a/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/aws-serverless';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/aws-serverless/bedrock/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/bedrock/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/aws-serverless';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/aws-serverless/graphql/useOperationNameForRootSpan/scenario.js
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/graphql/useOperationNameForRootSpan/scenario.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/aws-serverless');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   integrations: [Sentry.graphqlIntegration({ useOperationNameForRootSpan: true })],

--- a/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/app.mjs
+++ b/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/app.mjs
@@ -7,6 +7,7 @@ import { Worker } from 'worker_threads';
 const __dirname = new URL('.', import.meta.url).pathname;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.childProcessIntegration({ captureWorkerErrors: false })],

--- a/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-all.ts
+++ b/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-all.ts
@@ -3,6 +3,7 @@ import { bunRuntimeMetricsIntegration } from '@sentry/bun';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-opt-out.ts
+++ b/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario-opt-out.ts
@@ -3,6 +3,7 @@ import { bunRuntimeMetricsIntegration } from '@sentry/bun';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/bun-runtime-metrics/scenario.ts
@@ -3,6 +3,7 @@ import { bunRuntimeMetricsIntegration } from '@sentry/bun';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/child-process/fork.js
+++ b/dev-packages/node-integration-tests/suites/child-process/fork.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { fork } = require('child_process');
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/child-process/fork.mjs
+++ b/dev-packages/node-integration-tests/suites/child-process/fork.mjs
@@ -6,6 +6,7 @@ import * as path from 'path';
 const __dirname = new URL('.', import.meta.url).pathname;
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/child-process/worker.js
+++ b/dev-packages/node-integration-tests/suites/child-process/worker.js
@@ -4,6 +4,7 @@ const path = require('path');
 const { Worker } = require('worker_threads');
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/child-process/worker.mjs
+++ b/dev-packages/node-integration-tests/suites/child-process/worker.mjs
@@ -6,6 +6,7 @@ import { Worker } from 'worker_threads';
 const __dirname = new URL('.', import.meta.url).pathname;
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/before-send/scenario.ts
@@ -4,6 +4,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     transport: loggingTransport,
     beforeSend(event) {

--- a/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/drop-reasons/event-processors/scenario.ts
@@ -4,6 +4,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 (async () => {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     transport: loggingTransport,
   });

--- a/dev-packages/node-integration-tests/suites/client-reports/periodic-send/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/client-reports/periodic-send/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   clientReportFlushInterval: 5000,

--- a/dev-packages/node-integration-tests/suites/consola/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/consola/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/contextLines/filename-with-spaces/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/contextLines/filename-with-spaces/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/contextLines/memory-leak/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/contextLines/memory-leak/scenario.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/cron/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { CronJob } from 'cron';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
 });

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/base/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/base/scenario.ts
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import * as cron from 'node-cron';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-cron/isolateTrace/scenario.ts
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import * as cron from 'node-cron';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/cron/node-schedule/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/cron/node-schedule/scenario.ts
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import * as schedule from 'node-schedule';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/import-in-the-middle/app.mjs
@@ -9,6 +9,7 @@ new iitm.Hook((_, name) => {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/esm/modules-integration/app.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/modules-integration/app.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.modulesIntegration()],

--- a/dev-packages/node-integration-tests/suites/esm/warn-esm/server.js
+++ b/dev-packages/node-integration-tests/suites/esm/warn-esm/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/esm/warn-esm/server.mjs
+++ b/dev-packages/node-integration-tests/suites/esm/warn-esm/server.mjs
@@ -3,6 +3,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 import express from 'express';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-no-tracing.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-no-tracing.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-sample-rate-0.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-sample-rate-0.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/express/late-init/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/late-init/instrument.mjs
@@ -10,6 +10,7 @@ Sentry.preloadOpenTelemetry({ integrations: ['Express'] });
 // existing instrumentation to update its options. The lazy getOptions()
 // in patchLayer ensures the updated options are read at request time.
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // No dsn, means  client is disabled
   // dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/scenario.mjs
@@ -19,6 +19,7 @@ app.get('/test/no-init', (_req, res) => {
 app.get('/test/init', (_req, res) => {
   // Call init again, but with DSN
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/requestUser/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/requestUser/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/express/span-isolationScope/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/span-isolationScope/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/tracing/instrument-filterStatusCode.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/instrument-filterStatusCode.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument-normalized-request.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument-normalized-request.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/tracesSampler/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/tracing/updateName/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/updateName/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/express/tracing/withError/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/withError/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/express/with-http/base/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/base/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-always.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-always.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-default.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-default.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-medium.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-medium.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-none.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-none.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-small.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-small.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/basic/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/basic/scenario.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/withScope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onError/withScope/scenario.ts
@@ -4,6 +4,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 const flagsIntegration = Sentry.featureFlagsIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onSpan/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/featureFlagsIntegration/onSpan/scenario.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onError/basic/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onError/basic/scenario.ts
@@ -59,6 +59,7 @@ class GrowthBookWrapper {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onSpan/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/featureFlags/growthbook/onSpan/scenario.ts
@@ -44,6 +44,7 @@ class GrowthBookWrapper {
 const gb = new GrowthBookWrapper();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1.0,
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-errors-only.mjs
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-errors-only.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-paths-only.mjs
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument-record-paths-only.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/fs-instrumentation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/hono-sdk/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/hono-sdk/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/hono/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/integrations/console/filter/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/integrations/console/filter/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/ipv6/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/ipv6/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@[2001:db8::1]/1337',
   defaultIntegrations: false,
   sendClientReports: false,

--- a/dev-packages/node-integration-tests/suites/modules/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/modules/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/modules/server.js
+++ b/dev-packages/node-integration-tests/suites/modules/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-all.ts
+++ b/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-all.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-opt-out.ts
+++ b/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario-opt-out.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/node-runtime-metrics/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/pino/instrument-auto-off.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/instrument-auto-off.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/pino/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/proxy/basic.js
+++ b/dev-packages/node-integration-tests/suites/proxy/basic.js
@@ -7,6 +7,7 @@ proxy.listen(0, () => {
   const proxyPort = proxy.address().port;
 
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: process.env.SENTRY_DSN,
     transportOptions: {
       proxy: `http://localhost:${proxyPort}`,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/deny-inspector.mjs
@@ -15,5 +15,5 @@ export async function resolve(specifier, context, nextResolve) {
 (async () => {
   const Sentry = await import('@sentry/node');
 
-  Sentry.init({});
+  Sentry.init({ traceLifecycle: 'static' });
 })();

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-disabled.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-disabled.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   dataCollection: { stackFrameVariables: false },

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-filtered.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-filtered.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   dataCollection: { stackFrameVariables: { deny: ['secretVar'] } },

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-instrument.cjs
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-instrument.cjs
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-name-matching.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-name-matching.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app-default.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app-default.js
@@ -11,6 +11,7 @@ function in_app_function() {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   includeLocalVariables: true,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app.js
@@ -6,6 +6,7 @@ const externalFunctionFile = require.resolve('./node_modules/out-of-app-function
 const { out_of_app_function } = require(externalFunctionFile);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   includeLocalVariables: true,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-rethrow.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-rethrow.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/no-local-variables.js
@@ -3,6 +3,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/basic.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/basic.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/log-entire-error-to-console.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/log-entire-error-to-console.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.onUncaughtExceptionIntegration({

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.onUncaughtExceptionIntegration({

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/no-additional-listener-test-script.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 0,
   debug: false,

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/worker-thread/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 0,
   debug: false,

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/bindScopeToEmitter/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/bindScopeToEmitter/scenario.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -23,7 +23,7 @@ test('should work inside catch block', async () => {
                   expect.objectContaining({
                     context_line: "  throw new Error('catched_error');",
                     pre_context: [
-                      'Sentry.init({',
+                      "  traceLifecycle: 'static',",
                       "  dsn: 'https://public@dsn.ingest.sentry.io/1337',",
                       "  release: '1.0',",
                       '  transport: loggingTransport,',

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/empty-obj/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/empty-obj/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureException/simple-error/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureException/simple-error/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/parameterized_message/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/parameterized_message/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/simple_message_attachStackTrace/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/configureScope/clear_scope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/configureScope/clear_scope/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/configureScope/set_properties/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/configureScope/set_properties/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/metrics/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/metrics/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/metrics/server-address-option/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/metrics/server-address-option/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/metrics/server-address/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/metrics/server-address/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-custom-name.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-custom-name.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [
     Sentry.onUnhandledRejectionIntegration({

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-default.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/ignore-default.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   // Use default mode: 'warn' - integration is active but should ignore AI_NoOutputGeneratedError
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-none.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'none' })],
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-strict.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.onUnhandledRejectionIntegration({ mode: 'strict' })],
 });

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-error.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/mode-warn-string.js
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { expectProcessToExit } = require('../../../utils/expect-process-to-exit');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-strict.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-strict.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-warn.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-warn.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span-ended.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/onUnhandledRejectionIntegration/scenario-with-span.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setContext/simple-context/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setContext/simple-context/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtra/simple-extra/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtra/simple-extra/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setMeasurement/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setMeasurement/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/public-api/setTag/with-primitives/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setTag/with-primitives/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setTags/with-primitives/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setTags/with-primitives/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/unset_user/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/setUser/update_user/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/basic-usage/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-root-spans/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope-with-parentSpanId/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope-with-parentSpanId/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/parallel-spans-in-scope/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/updateName-method/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/updateName-method/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/updateSpanName-function/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/updateSpanName-function/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/startSpan/with-nested-spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startSpan/with-nested-spans/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/public-api/withMonitor/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/withMonitor/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/sessions/server.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/server.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/system-error/basic-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/system-error/basic-pii.mjs
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import { readFileSync } from 'fs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   dataCollection: { userInfo: true },

--- a/dev-packages/node-integration-tests/suites/system-error/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/system-error/basic.mjs
@@ -3,6 +3,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 import { readFileSync } from 'fs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/app-path.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/app-path.mjs
@@ -13,6 +13,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration({ appRootPath: __dirname })],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-disabled.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-disabled.mjs
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 15000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: process.env.SENTRY_DSN,
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-multiple.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic-multiple.mjs
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration({ maxEventsPerHour: 2 })],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.js
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.js
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration()],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/basic.mjs
@@ -9,6 +9,7 @@ setTimeout(() => {
 }, 12000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration()],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/indefinite.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/indefinite.mjs
@@ -8,6 +8,7 @@ setTimeout(() => {
 }, 10000);
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   integrations: [eventLoopBlockIntegration()],

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { eventLoopBlockIntegration } from '@sentry/node-native';
 
 Sentry.init({
+  traceLifecycle: 'static',
   debug: true,
   dsn: process.env.SENTRY_DSN,
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit-forced.js
@@ -3,6 +3,7 @@ const { eventLoopBlockIntegration } = require('@sentry/node-native');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/thread-blocked-native/should-exit.js
@@ -3,6 +3,7 @@ const { eventLoopBlockIntegration } = require('@sentry/node-native');
 
 function configureSentry() {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     debug: true,

--- a/dev-packages/node-integration-tests/suites/tracing/amqplib/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/amqplib/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument-dc.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument-dc.mjs
@@ -8,6 +8,7 @@ const { graphqlIntegration } = Sentry.diagnosticsChannelInjectionIntegrations();
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/resolvers/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/useOperationNameForRootSpan/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/dataloader/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/dataloader/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/double-baggage/no-spans/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/double-baggage/no-spans/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // explicitly not setting tracesSampleRate,

--- a/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-no-parent/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-no-parent/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-parent/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/double-baggage/spans-parent/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-events.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-events.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-headers.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/dsc-txn-name-update/scenario-headers.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span-unsampled/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error-active-span/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/error/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/sampleRate-propagation/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-route/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction-url/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/envelope-header/transaction/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/fastify/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/fastify/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument-trivial.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument-trivial.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/resolvers/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument-disabled.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument-disabled.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/graphql-tracing-channel/useOperationNameForRootSpan/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/hapi/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/hapi/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-basic/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-error/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-forward-request-hook/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-forward-request-hook/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-headers-to-span-attributes/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-headers-to-span-attributes/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-strip-query/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/fetch-strip-query/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-basic/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-basic/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument-mitigation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument-mitigation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-otel-double-instrumentation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-strip-query/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/http-client-spans/http-strip-query/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-overwrite-server-emit.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument-overwrite-server-emit.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreIncomingRequests.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreIncomingRequests.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreOutgoingRequests.js
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/node');
 const url = process.env.SERVER_URL;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreStaticAssets.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-ignoreStaticAssets.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-traceStaticAssets.js
+++ b/dev-packages/node-integration-tests/suites/tracing/httpIntegration/server-traceStaticAssets.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/ioredis-dc/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/kafkajs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/kafkajs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/koa/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/koa/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-agent.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-agent.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink-nested.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink-nested.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLink.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks-nested.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks-nested.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-addLinks.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/linking/scenario-span-options.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/linking/scenario-span-options.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/lru-memoizer/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/maxSpans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/maxSpans/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/no-server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/no-server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp-errors/server.js
@@ -2,6 +2,7 @@ const { loggingTransport, startExpressServerAndSendPortToRunner } = require('@se
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags-twp/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-sdk-disabled.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-sdk-disabled.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-tracesSampleRate-zero.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/server-tracesSampleRate-zero.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/meta-tags/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/meta-tags/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v4/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v4/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v6/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v6/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb-v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb-v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongodb/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongodb/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-tracing-channel/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v8/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v8/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose-v9/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose-v9/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mongoose/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mongoose/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2-tracing-channel/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/mysql2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql2/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/no-parent-span-client-report/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-root-span.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-root-span.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-root-span.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-root-span.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-options.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-options.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-ignoreConnect.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-ignoreConnect.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion-ignoreConnect.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion-ignoreConnect.mjs
@@ -10,6 +10,7 @@ const { postgresIntegration } = Sentry.diagnosticsChannelInjectionIntegrations()
 
 Sentry.experimentalUseDiagnosticsChannelInjection();
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument-orchestrion.mjs
@@ -9,6 +9,7 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgres/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgres/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument-requestHook.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument-requestHook.mjs
@@ -24,6 +24,7 @@ const postgresJsIntegration =
     : Sentry.postgresJsIntegration({ requestHook });
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/postgresjs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument-basic-tracer-provider.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument-basic-tracer-provider.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-ioredis.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-ioredis.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-4.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-4.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-5.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-cache/instrument-redis-5.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis-dc/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis-dc/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/redis/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/redis/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-breadcrumbs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-trace-propagation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.nativeNodeFetchIntegration({ tracePropagation: false })],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing-no-spans/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing-no-spans/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-no-tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-sampled-no-active-span/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/fetch-unsampled/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/fetch-unsampled/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-breadcrumbs/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-maxed-out-sockets/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-maxed-out-sockets/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-trace-propagation/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   integrations: [Sentry.httpIntegration({ tracePropagation: false, spans: false })],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing-no-spans/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-no-tracing/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled-no-active-span/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-sampled/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/http-unsampled/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracePropagationTargets: [/\/v0/, 'v1'],

--- a/dev-packages/node-integration-tests/suites/tracing/requests/traceparent/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/requests/traceparent/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rand-propagation/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rand-propagation/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampleRate: 0.00000001, // It's important that this is not 1, so that we also check logic for NonRecordingSpans, which is usually the edge-case

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/no-tracing-enabled/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/no-tracing-enabled/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate-0/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate-0/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampleRate: 0,

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampleRate/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampleRate: 0.69,

--- a/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampler/server.js
+++ b/dev-packages/node-integration-tests/suites/tracing/sample-rate-propagation/tracesSampler/server.js
@@ -2,6 +2,7 @@ const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: loggingTransport,
   tracesSampler: ({ inheritOrSampleWith }) => {

--- a/dev-packages/node-integration-tests/suites/tracing/sampling-static/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/sampling-static/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampler: ({ inheritOrSampleWith, name }) => {

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-explicit-org-id.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-explicit-org-id.ts
@@ -4,6 +4,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@o01234987.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-org-id.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server-no-org-id.ts
@@ -4,6 +4,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@public.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/baggage-org-id/server.ts
@@ -4,6 +4,7 @@ import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry
 export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@o0000987.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/traceid-recycling-with-spans/instrument.cjs
+++ b/dev-packages/node-integration-tests/suites/tracing/traceid-recycling-with-spans/instrument.cjs
@@ -2,6 +2,7 @@ const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/traceid-recycling/server.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/traceid-recycling/server.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/tracer-start-active-span-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tracer-start-active-span-error/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-no-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-truncation.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument-with-truncation.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument-with-pii.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument-with-pii.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/vercel/sigterm-flush/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/vercel/sigterm-flush/scenario.ts
@@ -22,6 +22,7 @@ function bufferedLoggingTransport(_options: BaseTransportOptions): Transport {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   transport: bufferedLoggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/winston/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/winston/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',


### PR DESCRIPTION
Prework for enabling span streaming by default without breaking existing Node integration tests.

These tests explicitly stay on the static trace lifecycle for now. This is the node-integration-tests slice of #22577 and is independent of the other split PRs.

Refs #22344

Made with [Cursor](https://cursor.com)