### PR TITLE
test(e2e): Disable span streaming in e2e test applications

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-17/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-18/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-18/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-19/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-19/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-20/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-20/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-21/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-21/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/angular-22/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-22/src/main.ts
@@ -5,6 +5,7 @@ import { appConfig } from './app/app.config';
 import * as Sentry from '@sentry/angular';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // Cannot use process.env here, so we hardcode the DSN
   dsn: 'https://3b6c388182fb435097f41d181be2b2ba@o4504321058471936.ingest.sentry.io/4504321066008576',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-4/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-4/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-4/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-4/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-5/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-5/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/sentry.server.config.js
@@ -3,6 +3,7 @@ import handler from '@astrojs/cloudflare/entrypoints/server';
 
 export default Sentry.withSentry(
   env => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-6/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-6/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-6/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-6/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7-orchestrion/sentry.server.config.js
@@ -7,6 +7,7 @@ import { experimentalUseDiagnosticsChannelInjection } from '@sentry/node';
 experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7/sentry.client.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7/sentry.client.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/astro-7/sentry.server.config.js
+++ b/dev-packages/e2e-tests/test-applications/astro-7/sentry.server.config.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/astro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/browser-mfe-vite/apps/shell/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/browser-mfe-vite/apps/shell/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import * as Sentry from '@sentry/react';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: import.meta.env.MODE || 'development',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
@@ -3,6 +3,7 @@ import MyWorker2 from './worker2.ts?worker';
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: import.meta.env.MODE || 'development',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/bun-bytecode/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/bun-bytecode/src/main.ts
@@ -4,6 +4,7 @@
 import * as Sentry from '@sentry/bun';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   tracesSampleRate: 0,
 });

--- a/dev-packages/e2e-tests/test-applications/bun-mysql/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/bun-mysql/src/app.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/bun';
 import mysql from 'mysql';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker/index.ts
@@ -10,6 +10,7 @@ class MyBaseAgent extends Agent {
 
 export const MyAgent = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`,
     tracesSampleRate: 1,
@@ -20,6 +21,7 @@ export const MyAgent = Sentry.instrumentDurableObjectWithSentry(
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`,
     tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/src/index.ts
@@ -22,6 +22,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server
@@ -33,6 +34,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/src/index.ts
@@ -49,6 +49,7 @@ class MyMCPAgentBase extends McpAgent<Env, unknown, Record<string, unknown>> {
 
 export const MyMCPAgent = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tunnel: `http://localhost:3031/`,
@@ -64,6 +65,7 @@ export const MyMCPAgent = Sentry.instrumentDurableObjectWithSentry(
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/src/index.ts
@@ -17,6 +17,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/cloudflare-orchestrion-mysql/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-orchestrion-mysql/src/index.ts
@@ -20,6 +20,7 @@ interface MysqlModule {
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tunnel: 'http://localhost:3031/',

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/src/index.ts
@@ -4,6 +4,7 @@ import { MockLanguageModelV3 } from 'ai/test';
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tunnel: 'http://localhost:3031/',

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-compat/src/index.ts
@@ -4,6 +4,7 @@ import { MockLanguageModelV3 } from 'ai/test';
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tunnel: 'http://localhost:3031/',

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/src/index.ts
@@ -38,6 +38,7 @@ class RetryTestWorkflowBase extends WorkflowEntrypoint<Env, WorkflowParams> {
 
 export const RetryTestWorkflow = Sentry.instrumentWorkflowWithSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     tunnel: 'http://localhost:3031/',
   }),
@@ -46,6 +47,7 @@ export const RetryTestWorkflow = Sentry.instrumentWorkflowWithSentry(
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     tunnel: 'http://localhost:3031/',
   }),

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/src/index.ts
@@ -76,6 +76,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server
@@ -92,6 +93,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/src/index.ts
@@ -63,6 +63,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server
@@ -109,6 +110,7 @@ class MyWorker extends WorkerEntrypoint {
 
 export default Sentry.withSentry(
   env => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/create-react-app/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-react-app/src/index.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import './index.css';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/app/entry.client.tsx
@@ -14,6 +14,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/remix';
 import * as process from 'process';
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/app/entry.client.tsx
@@ -14,6 +14,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/instrument.mjs
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/remix';
 import process from 'process';
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.client.tsx
@@ -20,6 +20,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/app/entry.server.tsx
@@ -19,6 +19,7 @@ installGlobals();
 const ABORT_DELAY = 5_000;
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/instrument.server.cjs
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/remix');
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
@@ -20,6 +20,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/instrument.server.cjs
@@ -11,6 +11,7 @@ if (injectOrchestrion) {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/src/app.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
 });

--- a/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/__snapshots__/server.test.ts.snap
+++ b/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/__snapshots__/server.test.ts.snap
@@ -4,13 +4,13 @@ exports[`Find symbolicated event on sentry 1`] = `
 {
   "colno": 41,
   "contextLine": "const eventId = Sentry.captureException(new Error('Sentry Debug ID E2E Test Error'));",
-  "lineno": 8,
+  "lineno": 9,
   "postContext": [
     "",
     "process.stdout.write(eventId);",
   ],
   "preContext": [
-    "Sentry.init({",
+    "  traceLifecycle: 'static',",
     "  environment: 'qa', // dynamic sampling bias to keep transactions",
     "  dsn: process.env.E2E_TEST_DSN,",
     "});",

--- a/dev-packages/e2e-tests/test-applications/default-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/default-browser/src/index.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/deno-mysql/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-mysql/src/app.ts
@@ -6,6 +6,7 @@ import '@sentry/deno/import';
 import * as Sentry from '@sentry/deno';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/deno-pg/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-pg/src/app.ts
@@ -7,6 +7,7 @@ import '@sentry/deno/import';
 import * as Sentry from '@sentry/deno';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/deno-redis/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-redis/src/app.ts
@@ -3,6 +3,7 @@ import IORedis from 'ioredis';
 import { createClient } from 'redis';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/deno/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/src/app.ts
@@ -18,6 +18,7 @@ import { MockLanguageModelV1 } from 'ai/test';
 import { z } from 'zod';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: Deno.env.get('E2E_TEST_DSN'),
   debug: !!Deno.env.get('DEBUG'),

--- a/dev-packages/e2e-tests/test-applications/effect-3-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/effect-3-browser/src/index.js
@@ -9,6 +9,7 @@ import * as Effect from 'effect/Effect';
 const LogLevelLive = Logger.minimumLogLevel(LogLevel.Debug);
 const AppLayer = Layer.mergeAll(
   Sentry.effectLayer({
+    traceLifecycle: 'static',
     dsn: process.env.E2E_TEST_DSN,
     integrations: [
       Sentry.browserTracingIntegration({

--- a/dev-packages/e2e-tests/test-applications/effect-3-node/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-3-node/src/app.ts
@@ -10,6 +10,7 @@ import { createServer } from 'http';
 
 const SentryLive = Layer.mergeAll(
   Sentry.effectLayer({
+    traceLifecycle: 'static',
     dsn: process.env.E2E_TEST_DSN,
     environment: 'qa',
     debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/src/index.js
@@ -9,6 +9,7 @@ import * as Effect from 'effect/Effect';
 
 const AppLayer = Layer.mergeAll(
   Sentry.effectLayer({
+    traceLifecycle: 'static',
     dsn: process.env.E2E_TEST_DSN,
     integrations: [
       Sentry.browserTracingIntegration({

--- a/dev-packages/e2e-tests/test-applications/effect-4-node/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-4-node/src/app.ts
@@ -11,6 +11,7 @@ import { createServer } from 'http';
 
 const SentryLive = Layer.mergeAll(
   Sentry.effectLayer({
+    traceLifecycle: 'static',
     dsn: process.env.E2E_TEST_DSN,
     environment: 'qa',
     debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/elysia-bun/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/elysia-bun/src/app.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/elysia';
 import { Elysia } from 'elysia';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/elysia-node/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/elysia-node/src/app.ts
@@ -3,6 +3,7 @@ import { Elysia } from 'elysia';
 import { node } from '@elysiajs/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/ember-classic/app/app.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/app/app.ts
@@ -6,6 +6,7 @@ import Resolver from 'ember-resolver';
 import config from './config/environment';
 
 Sentry.init({
+  traceLifecycle: 'static',
   replaysSessionSampleRate: 1,
   replaysOnErrorSampleRate: 1,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/app/app.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/app/app.ts
@@ -5,6 +5,7 @@ import loadInitializers from 'ember-load-initializers';
 import Resolver from 'ember-resolver';
 
 Sentry.init({
+  traceLifecycle: 'static',
   replaysSessionSampleRate: 1,
   replaysOnErrorSampleRate: 1,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/entry.bun.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/entry.bun.ts
@@ -6,6 +6,7 @@ const app = new Hono();
 
 app.use(
   sentry(app, {
+    traceLifecycle: 'static',
     dsn: process.env.E2E_TEST_DSN,
     environment: 'qa',
     tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/entry.cloudflare.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/entry.cloudflare.ts
@@ -6,6 +6,7 @@ const app = new Hono<{ Bindings: { E2E_TEST_DSN: string } }>();
 
 app.use(
   sentry(app, env => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/entry.deno.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/entry.deno.ts
@@ -6,6 +6,7 @@ const app = new Hono();
 
 app.use(
   sentry(app, {
+    traceLifecycle: 'static',
     dsn: Deno.env.get('E2E_TEST_DSN'),
     environment: 'qa',
     dataCollection: {},

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/instrument.node.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/instrument.node.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/hono/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { StrictMode, startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Could not find a working way to set the DSN in the browser side from the environment variables
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/instrument.server.mjs
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/instrument.server.mjs
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react-router';
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
   // Adds request headers and IP for users, for more info visit:
   // https://docs.sentry.io/platforms/javascript/guides/react-router/configuration/options/#dataCollection

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/server.ts
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/server.ts
@@ -34,6 +34,7 @@ export default {
     return wrapRequestHandler(
       {
         options: {
+          traceLifecycle: 'static',
           environment: 'qa', // dynamic sampling bias to keep transactions
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
           tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/lighthouse-react/src/main.tsx
@@ -16,6 +16,7 @@ performance.mark('sentry-sdk-init-start', {
 
 if (import.meta.env.MODE === 'tracing-replay') {
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -27,6 +28,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'tracing') {
   // Tracing + errors, but no replay — isolates the replay integration's cost.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -38,6 +40,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // (We don't recommend this setup anywhere and neither will it work well.
   // this is purely for testing if it changes anything about overhead.)
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -50,6 +53,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'errors-only') {
   // Default integrations only — errors are always captured, no tracing or replay.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -57,6 +61,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'minimal-integrations') {
   // Minimal integratoins setup only (everything necessary to automatically get errors)
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -74,6 +79,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // DSN set but every integration disabled. Isolates the cost of the enabled
   // client itself from the default instrumentation that wraps DOM/timer/network APIs.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -85,6 +91,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // removeEventListener on ~32 prototypes plus setTimeout/setInterval/rAF/XHR.
   // Isolates that global monkey-patching cost from the rest of the defaults.
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -95,6 +102,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // Default integrations minus Breadcrumbs, which adds a lot of monkey patching to
   // DOM and Network APIs as well as event targets and listeners
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -104,6 +112,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
   // Default integrations minus Breadcrumbs, which adds a lot of monkey patching to
   // DOM and Network APIs as well as event targets and listeners
   Sentry.init({
+    traceLifecycle: 'static',
     dsn: import.meta.env.VITE_E2E_TEST_DSN as string | undefined,
     release: 'lighthouse-fixture',
     environment: 'qa',
@@ -113,7 +122,7 @@ if (import.meta.env.MODE === 'tracing-replay') {
 } else if (import.meta.env.MODE === 'init-only') {
   // enabled: false makes the SDK a guaranteed no-op (no transport allocation,
   // no DSN warning). We're measuring pure SDK-loading + tree-shaking cost.
-  Sentry.init({ enabled: false });
+  Sentry.init({ traceLifecycle: 'static', enabled: false });
 }
 
 performance.measure('sentry-sdk-init-duration', {

--- a/dev-packages/e2e-tests/test-applications/nestjs-11/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-11/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-8/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-8/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-bullmq/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-bullmq/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-fastify/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-fastify/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-graphql/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-graphql/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-microservices/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-microservices/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nestjs-orchestrion/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-orchestrion/src/instrument.ts
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/nestjs';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/src/instrument.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/instrumentation.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init({
+      traceLifecycle: 'static',
       environment: 'qa', // dynamic sampling bias to keep transactions
       dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
       tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.SENTRY_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.client.config.ts
@@ -3,6 +3,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.edge.config.ts
@@ -6,6 +6,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/instrumentation-client.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import type { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/sentry.server.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/sentry.server.config.ts
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Use a fake but properly formatted Sentry SaaS DSN for tunnel route testing
   dsn: 'https://public@o12345.ingest.us.sentry.io/67890',

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Use a fake but properly formatted Sentry SaaS DSN for tunnel route testing
   dsn: 'https://public@o12345.ingest.us.sentry.io/67890',

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Use a fake but properly formatted Sentry SaaS DSN for tunnel route testing
   dsn: 'https://public@o12345.ingest.us.sentry.io/67890',

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/instrumentation-client.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import type { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/sentry.server.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import { Log } from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/instrumentation.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init({
+      traceLifecycle: 'static',
       environment: 'qa', // dynamic sampling bias to keep transactions
       dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
       tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.edge.config.ts
@@ -6,6 +6,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/src/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/src/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation-client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/instrumentation.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/nextjs';
 export function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs' || process.env.NEXT_RUNTIME === 'edge') {
     Sentry.init({
+      traceLifecycle: 'static',
       environment: 'qa', // dynamic sampling bias to keep transactions
       dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
       tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nitro-3/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nitro';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nitro-3/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/src/main.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/browser';
 
 // Let's us test trace propagation
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-express-cjs-preload/src/app.js
@@ -38,6 +38,7 @@ async function run() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   Sentry.init({
+    traceLifecycle: 'static',
     environment: 'qa', // dynamic sampling bias to keep transactions
     dsn: process.env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-loader/src/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-preload/src/app.mjs
@@ -53,6 +53,7 @@ async function run() {
   await new Promise(resolve => setTimeout(resolve, 1000));
 
   Sentry.init({
+    traceLifecycle: 'static',
     environment: 'qa', // dynamic sampling bias to keep transactions
     dsn: process.env.E2E_TEST_DSN,
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/src/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/node-express-incorrect-instrumentation/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-incorrect-instrumentation/src/app.ts
@@ -12,6 +12,7 @@ const port = 3030;
 // import and init sentry last for missing instrumentation
 import * as Sentry from '@sentry/node';
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/node-express-orchestrion-cjs/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-express-orchestrion-cjs/src/app.js
@@ -6,6 +6,7 @@ const Sentry = require('@sentry/node');
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/node-express-orchestrion/src/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-express-orchestrion/src/instrument.mjs
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/node';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/src/app.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 let lastTransactionId: string | undefined;
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-express-v5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/src/app.ts
@@ -7,6 +7,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
@@ -7,6 +7,7 @@ declare global {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app-handle-error-override.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/src/app.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app-handle-error-override.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/src/app.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app-handle-error-override.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app-handle-error-override.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
@@ -15,6 +15,7 @@ console.warn = new Proxy(console.warn, {
 });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/node-firebase/firestore-app/src/init.ts
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/firestore-app/src/init.ts
@@ -11,6 +11,7 @@ if (useOrchestrion) {
 }
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-firebase/functions/src/init.ts
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/functions/src/init.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-hapi/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-hapi/src/app.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-koa/index.js
+++ b/dev-packages/e2e-tests/test-applications/node-koa/index.js
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/node');
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,

--- a/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/no-orchestrion.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/no-orchestrion.mjs
@@ -3,6 +3,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/with-orchestrion.mjs
+++ b/dev-packages/e2e-tests/test-applications/node-orchestrion-webpack/src/with-orchestrion.mjs
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/node';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
 });

--- a/dev-packages/e2e-tests/test-applications/node-otel-custom-sampler/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-custom-sampler/src/instrument.ts
@@ -4,6 +4,7 @@ import { SentryPropagator, SentrySpanProcessor } from '@sentry/opentelemetry';
 import { CustomSampler } from './custom-sampler';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/src/instrument.ts
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/node');
 const { SentrySpanProcessor, SentryPropagator, SentrySampler } = require('@sentry/opentelemetry');
 
 const sentryClient = Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
@@ -7,6 +7,7 @@ const { UndiciInstrumentation } = require('@opentelemetry/instrumentation-undici
 const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-otel/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel/src/instrument.ts
@@ -3,6 +3,7 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http')
 const Sentry = require('@sentry/node');
 
 const sentryClient = Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/node-profiling-cjs/index.ts
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-cjs/index.ts
@@ -4,6 +4,7 @@ import { nodeProfilingIntegration } from '@sentry/profiling-node';
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
   integrations: [nodeProfilingIntegration()],
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-profiling-electron/index.electron.js
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-electron/index.electron.js
@@ -4,6 +4,7 @@ const Sentry = require('@sentry/electron/main');
 const path = require('node:path');
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
   debug: true,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/node-profiling-esm/index.ts
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-esm/index.ts
@@ -4,6 +4,7 @@ import { nodeProfilingIntegration } from '@sentry/profiling-node';
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
   integrations: [nodeProfilingIntegration()],
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: 'http://localhost:3031/', // proxy server
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4-orchestrion/sentry.server.config.ts
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/nuxt';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { usePinia, useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0, //  Capture 100% of the transactions
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.client.config.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nuxt';
 import { /* usePinia,*/ useRuntimeConfig } from '#imports';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0, //  Capture 100% of the transactions
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/react-17/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-17/src/index.tsx
@@ -16,6 +16,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-19/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-19/src/index.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import Index from './pages/Index';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   release: 'e2e-test',

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/src/index.tsx
@@ -15,6 +15,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   // environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
@@ -16,6 +16,7 @@ import Group from './pages/Group';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   // environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/src/index.tsx
@@ -15,6 +15,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   // environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-5/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-5/src/index.tsx
@@ -11,6 +11,7 @@ const replay = Sentry.replayIntegration();
 const history = createBrowserHistory();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn:
     process.env.REACT_APP_E2E_TEST_DSN ||

--- a/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/index.tsx
@@ -16,6 +16,7 @@ import Index from './pages/Index';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
@@ -15,6 +15,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
@@ -18,6 +18,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/index.tsx
@@ -18,6 +18,7 @@ import Index from './pages/Index';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/app/entry.client.tsx
@@ -8,6 +8,7 @@ import { HydratedRouter } from 'react-router/dom';
 const tracing = Sentry.reactRouterTracingIntegration({ useInstrumentationAPI: true });
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://username@domain/123',
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/instrument.mjs
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react-router';
 // Initialize Sentry early (before the server starts)
 // The server instrumentations are created in entry.server.tsx
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-router';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
@@ -78,6 +78,7 @@ const lazyRouteManifest = [
 ];
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/main.tsx
@@ -18,6 +18,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/src/index.tsx
@@ -18,6 +18,7 @@ import Index from './pages/Index';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-router-8-framework/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-framework/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // todo: get this from env
   dsn: 'https://username@domain/123',

--- a/dev-packages/e2e-tests/test-applications/react-router-8-framework/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-framework/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/react-router';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/app/entry.client.tsx
@@ -4,6 +4,7 @@ import { hydrateRoot } from 'react-dom/client';
 import { HydratedRouter } from 'react-router/dom';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://username@domain/123',
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-orchestrion/instrument.mjs
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react-router';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://username@domain/123',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/react-router-8-spa/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-spa/src/main.tsx
@@ -18,6 +18,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/src/index.tsx
@@ -16,6 +16,7 @@ import User from './pages/User';
 const replay = Sentry.replayIntegration();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/entry.client.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   // Could not find a working way to set the DSN in the browser side from the environment variables
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/functions/_middleware.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/app/functions/_middleware.ts
@@ -9,6 +9,7 @@ import * as build from '../build/server';
 export const onRequest = [
   (context: EventPluginContext<any, any, any, any>) =>
     sentryPagesPlugin({
+      traceLifecycle: 'static',
       dsn: context.env.E2E_TEST_DSN,
       tracesSampleRate: 1.0,
     })(context),

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/server.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/server.ts
@@ -36,6 +36,7 @@ export default {
     return wrapRequestHandler(
       {
         options: {
+          traceLifecycle: 'static',
           environment: 'qa', // dynamic sampling bias to keep transactions
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
           tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/remix-server-timing/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/remix-server-timing/app/entry.client.tsx
@@ -20,6 +20,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [

--- a/dev-packages/e2e-tests/test-applications/remix-server-timing/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/remix-server-timing/instrument.server.cjs
@@ -1,6 +1,7 @@
 const Sentry = require('@sentry/remix');
 
 Sentry.init({
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
@@ -97,6 +97,7 @@ declare module '@tanstack/solid-router' {
 declare const __APP_DSN__: string;
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: __APP_DSN__,
   debug: true,
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/solid/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid/src/index.tsx
@@ -5,6 +5,7 @@ import App from './app';
 import './index.css';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   debug: true,
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/entry-client.tsx
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/entry-client.tsx
@@ -4,6 +4,7 @@ import { solidRouterBrowserTracingIntegration } from '@sentry/solidstart/solidro
 import { StartClient, mount } from '@solidjs/start/client';
 
 Sentry.init({
+  traceLifecycle: 'static',
   // We can't use env variables here, seems like they are stripped
   // out in production builds.
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/dev-packages/e2e-tests/test-applications/solidstart/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/src/instrument.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.client.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
 

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.edge.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dataCollection: { userInfo: true },

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/sentry.server.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/svelte-5/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/svelte-5/src/main.ts
@@ -5,6 +5,7 @@ import './app.css';
 import * as Sentry from '@sentry/svelte';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/hooks.client.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/sveltekit';
 import * as Spotlight from '@spotlightjs/spotlight';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/instrumentation.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/src/instrumentation.server.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/sveltekit';
 import { E2E_TEST_DSN } from '$env/static/private';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/src/hooks.server.ts
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/sveltekit';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.client.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/sveltekit';
 import * as Spotlight from '@spotlightjs/spotlight';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/src/hooks.server.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/sveltekit';
 import { setupSidecar } from '@spotlightjs/spotlight/sidecar';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   release: '1.0.0',

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { E2E_TEST_DSN } from '$env/static/private';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: !!env.PUBLIC_DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { E2E_TEST_DSN } from '$env/static/private';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { PUBLIC_E2E_TEST_DSN } from '$app/env/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/src/instrumentation.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/src/instrumentation.server.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/sveltekit';
 // With SvelteKit 3 native instrumentation enabled (`experimental.instrumentation.server`),
 // `Sentry.init` runs here instead of in `hooks.server.ts`.
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.client.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: env.PUBLIC_E2E_TEST_DSN,
 });
 

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.server.ts
@@ -6,6 +6,7 @@ export const handleError = handleErrorWithSentry();
 
 export const handle = sequence(
   initCloudflareSentryHandle({
+    traceLifecycle: 'static',
     dsn: E2E_TEST_DSN,
     tracesSampleRate: 1.0,
   }),

--- a/dev-packages/e2e-tests/test-applications/tanstack-router/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/tanstack-router/src/main.tsx
@@ -94,6 +94,7 @@ const router = createRouter({ routeTree });
 declare const __APP_DSN__: string;
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: __APP_DSN__,
   integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/instrument.client.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/instrument.client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/server.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/src/server.ts
@@ -4,6 +4,7 @@ import handler from '@tanstack/react-start/server-entry';
 
 export default Sentry.withSentry(
   (env: Env) => ({
+    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     tunnel: 'http://localhost:3031/',
     tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/instrument.server.mjs
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/instrument.server.mjs
@@ -8,6 +8,7 @@ import * as Sentry from '@sentry/tanstackstart-react';
 Sentry.experimentalUseDiagnosticsChannelInjection();
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/src/instrument.client.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-orchestrion/src/instrument.client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/tanstackstart-react';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: __APP_DSN__,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/instrument.client.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/src/instrument.client.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/tanstackstart-react';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: __APP_DSN__,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/tsx-express/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/instrument.mjs
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
+  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   debug: !!process.env.DEBUG,

--- a/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/src/main.ts
@@ -13,6 +13,7 @@ const app = createApp(App);
 const pinia = createPinia();
 
 Sentry.init({
+  traceLifecycle: 'static',
   app,
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/vue-tanstack-router/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-tanstack-router/src/main.ts
@@ -57,6 +57,7 @@ declare module '@tanstack/vue-router' {
 const app = createApp(RouterProvider, { router });
 
 Sentry.init({
+  traceLifecycle: 'static',
   app,
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   debug: true,

--- a/dev-packages/e2e-tests/test-applications/webpack-4/entry.js
+++ b/dev-packages/e2e-tests/test-applications/webpack-4/entry.js
@@ -1,6 +1,7 @@
 import { browserTracingIntegration, init } from '@sentry/browser';
 
 init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [browserTracingIntegration()],
   tunnel: 'http://localhost:3031',

--- a/dev-packages/e2e-tests/test-applications/webpack-5/entry.js
+++ b/dev-packages/e2e-tests/test-applications/webpack-5/entry.js
@@ -1,6 +1,7 @@
 import { browserTracingIntegration, init } from '@sentry/browser';
 
 init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [browserTracingIntegration()],
   tunnel: 'http://localhost:3031',


### PR DESCRIPTION
Prework for enabling span streaming by default without breaking existing E2E tests.

These test applications explicitly stay on the static trace lifecycle for now. This is the E2E slice of getsentry/sentry-javascript#22577.

Refs getsentry/sentry-javascript#22344