### PR TITLE
test(cloudflare): Disable span streaming in integration tests

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/basic/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/basic/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
   }),
   {
     async fetch(_request, _env, _ctx) {

--- a/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
@@ -9,6 +9,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/double-instrumentation/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/double-instrumentation/index.ts
@@ -17,5 +17,5 @@ const handler = {
 // This simulates scenarios where the module is re-evaluated or the handler
 // is wrapped multiple times. The SDK should handle this gracefully
 // without double-wrapping (which would cause duplicate error reports).
-const once = Sentry.withSentry((env: Env) => ({ dsn: env.SENTRY_DSN }), handler);
-export default Sentry.withSentry((env: Env) => ({ dsn: env.SENTRY_DSN }), once);
+const once = Sentry.withSentry((env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static' }), handler);
+export default Sentry.withSentry((env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static' }), once);

--- a/dev-packages/cloudflare-integration-tests/suites/hono-sdk/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/hono-sdk/index.ts
@@ -10,6 +10,7 @@ const app = new Hono<{ Bindings: Env }>();
 app.use(
   sentry(app, {
     dsn: process.env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
 );

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     integrations: [Sentry.httpServerIntegration({ maxRequestBodySize: 'none' })],
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     integrations: integrations => integrations.filter(i => i.name !== 'HttpServer'),
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     integrations: [
       Sentry.httpServerIntegration({
         ignoreRequestBody: url => url.includes('/health') || url.includes('/upload'),

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     integrations: [Sentry.httpServerIntegration({ maxRequestBodySize: 'small' })],
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/index.ts
@@ -8,6 +8,7 @@ export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
     attachStacktrace: false,
+    traceLifecycle: 'static',
   }),
   {
     async fetch(request, _env, _ctx) {

--- a/dev-packages/cloudflare-integration-tests/suites/prisma/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/prisma/index.ts
@@ -11,6 +11,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1,
     integrations: [Sentry.prismaIntegration()],
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/public-api/metrics/server-address/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/public-api/metrics/server-address/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     release: '1.0.0',
     environment: 'test',
     serverName: 'mi-servidor.com',

--- a/dev-packages/cloudflare-integration-tests/suites/queue/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/queue/index.ts
@@ -9,6 +9,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/r2/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/r2/index.ts
@@ -9,6 +9,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/ratelimit/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/ratelimit/index.ts
@@ -13,6 +13,7 @@ function json(data: unknown): Response {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/index.ts
@@ -26,6 +26,7 @@ const client = Sentry.instrumentAnthropicAiClient(new Anthropic({ apiKey: 'mock-
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     streamGenAiSpans: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/d1/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/d1/index.ts
@@ -8,6 +8,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/dsc-url-source/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/dsc-url-source/index.ts
@@ -10,6 +10,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links-sync/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links-sync/index.ts
@@ -25,6 +25,7 @@ class SyncAlarmDurableObjectBase extends DurableObject<Env> {
 export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -34,6 +35,7 @@ export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links/index.ts
@@ -23,6 +23,7 @@ class AlarmDurableObjectBase extends DurableObject<Env> {
 export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -32,6 +33,7 @@ export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/index.ts
@@ -30,6 +30,7 @@ class TestDurableObjectBase extends DurableObject<Env> {
 export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     instrumentPrototypeMethods: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sql/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sql/index.ts
@@ -30,6 +30,7 @@ class SqlDurableObjectBase extends DurableObject<Env> {
 export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   SqlDurableObjectBase,
@@ -38,6 +39,7 @@ export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sync-kv/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sync-kv/index.ts
@@ -24,6 +24,7 @@ class SyncKvDurableObjectBase extends DurableObject<Env> {
 export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   SyncKvDurableObjectBase,
@@ -32,6 +33,7 @@ export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/index.ts
@@ -44,6 +44,7 @@ class TestDurableObjectBase extends DurableObject<Env> {
 export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -53,6 +54,7 @@ export const TestDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/index.ts
@@ -44,6 +44,7 @@ const client = Sentry.instrumentGoogleGenAIClient(new GoogleGenAI({ apiKey: 'moc
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     streamGenAiSpans: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/headers/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/headers/index.ts
@@ -8,6 +8,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     propagateTraceparent: true,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/instrument-fetcher/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/instrument-fetcher/index.ts
@@ -22,6 +22,7 @@ class EchoHeadersDurableObjectBase extends DurableObject<Env> {
 export const EchoHeadersDurableObject = instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   EchoHeadersDurableObjectBase,
@@ -30,6 +31,7 @@ export const EchoHeadersDurableObject = instrumentDurableObjectWithSentry(
 export default withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/index.ts
@@ -29,6 +29,7 @@ const mockFetch: typeof fetch = async () =>
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     streamGenAiSpans: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
@@ -8,6 +8,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     dataCollection: { genAI: { inputs: true, outputs: true } },
     streamGenAiSpans: true,

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/openai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/openai/index.ts
@@ -31,6 +31,7 @@ const client = Sentry.instrumentOpenAiClient(new OpenAI({ apiKey: 'mock-api-key'
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     streamGenAiSpans: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/no-propagation-worker-do/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/no-propagation-worker-do/index.ts
@@ -16,6 +16,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   MyDurableObjectBase,
@@ -24,6 +25,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc-disabled/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc-disabled/index.ts
@@ -19,6 +19,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   MyDurableObjectBase,
@@ -27,6 +28,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc/index.ts
@@ -19,6 +19,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -28,6 +29,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do/index.ts
@@ -16,6 +16,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -25,6 +26,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/index-sub-worker.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/index-sub-worker.ts
@@ -13,6 +13,7 @@ const myWorker = {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   myWorker,

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/index.ts
@@ -8,6 +8,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/index-sub-worker.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/index-sub-worker.ts
@@ -15,6 +15,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -24,6 +25,7 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/index.ts
@@ -8,6 +8,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/index-sub-worker.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/index-sub-worker.ts
@@ -44,6 +44,7 @@ class MySubWorkerEntrypointBase extends BaseEntrypoint {
 export const BindingEntrypoint = Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
     initialScope: { tags: { initial_scope: 'applied' } },
@@ -59,6 +60,7 @@ export const BindingEntrypoint = Sentry.withSentry(
 export const NoPropagationEntrypoint = Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     transportOptions: { fetch: fetch.bind(globalThis) },
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/index.ts
@@ -20,13 +20,14 @@ class LoopbackEntrypointBase extends WorkerEntrypoint<Env> {
 }
 
 export const LoopbackEntrypoint = Sentry.withSentry(
-  (env: Env) => ({ dsn: env.SENTRY_DSN, tracesSampleRate: 0 }),
+  (env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static', tracesSampleRate: 0 }),
   LoopbackEntrypointBase,
 );
 
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc-disabled/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc-disabled/index.ts
@@ -19,6 +19,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   MyDurableObjectBase,
@@ -43,6 +44,7 @@ class MyWorkerEntrypointBase extends WorkerEntrypoint {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   MyWorkerEntrypointBase,

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc/index.ts
@@ -19,6 +19,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -48,6 +49,7 @@ class MyWorkerEntrypointBase extends WorkerEntrypoint {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/index-sub-worker.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/index-sub-worker.ts
@@ -15,6 +15,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -39,6 +40,7 @@ class MySubWorkerEntrypointBase extends WorkerEntrypoint {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/index.ts
@@ -23,6 +23,7 @@ class MyWorkerEntrypointBase extends WorkerEntrypoint {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workflow-do/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workflow-do/index.ts
@@ -17,6 +17,7 @@ class MyDurableObjectBase extends DurableObject<Env> {
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   MyDurableObjectBase,
@@ -36,6 +37,7 @@ class MyWorkflowBase extends WorkflowEntrypoint<Env> {
 export const MyWorkflow = Sentry.instrumentWorkflowWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),
@@ -45,6 +47,7 @@ export const MyWorkflow = Sentry.instrumentWorkflowWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     enableRpcTracePropagation: true,
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/scheduled/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/scheduled/index.ts
@@ -7,6 +7,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/als_v6/index.ts
@@ -9,6 +9,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1,
     integrations: [Sentry.vercelAIIntegration()],
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/compat_v6/index.ts
@@ -9,6 +9,7 @@ interface Env {
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1,
     integrations: [Sentry.vercelAIIntegration()],
   }),

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
@@ -11,6 +11,7 @@ const ai = instrumentWorkersAiClient(new MockAi());
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
     // Keep gen_ai spans embedded in the transaction (instead of streamed as a
     // separate envelope container) so they can be asserted on `transaction.spans`.

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workflow/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workflow/index.ts
@@ -22,6 +22,7 @@ class MyWorkflowBase extends WorkflowEntrypoint<Env> {
 export const MyWorkflow = Sentry.instrumentWorkflowWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   MyWorkflowBase,
@@ -30,6 +31,7 @@ export const MyWorkflow = Sentry.instrumentWorkflowWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
     tracesSampleRate: 1.0,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-chained/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-chained/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-manual-mixed/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-manual-mixed/index.ts
@@ -32,7 +32,7 @@ class CounterImpl extends DurableObject<Env> {
 // untouched (no double-wrap) while still auto-wrapping the plain entrypoint and
 // default export in the same file.
 export const Counter = Sentry.instrumentDurableObjectWithSentry(
-  (env: Env) => ({ dsn: env.SENTRY_DSN, tracesSampleRate: 1.0 }),
+  (env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static', tracesSampleRate: 1.0 }),
   CounterImpl,
 );
 

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-manual-mixed/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-manual-mixed/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/default-export/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/default-export/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-manual-wrap/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-manual-wrap/index.ts
@@ -19,7 +19,7 @@ class CounterImpl extends DurableObject<Env> {
 // leave it untouched — no second wrap — while still wrapping the plain default
 // export below.
 export const Counter = Sentry.instrumentDurableObjectWithSentry(
-  (env: Env) => ({ dsn: env.SENTRY_DSN, tracesSampleRate: 1.0 }),
+  (env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static', tracesSampleRate: 1.0 }),
   CounterImpl,
 );
 

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-manual-wrap/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-manual-wrap/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-mixed/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-mixed/index.ts
@@ -19,7 +19,7 @@ class ManualImpl extends DurableObject<Env> {
 
 // Manually wrapped — the transform must leave this alone.
 export const Manual = Sentry.instrumentDurableObjectWithSentry(
-  (env: Env) => ({ dsn: env.SENTRY_DSN, tracesSampleRate: 1.0 }),
+  (env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static', tracesSampleRate: 1.0 }),
   ManualImpl,
 );
 

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-mixed/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-mixed/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-multiple/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-multiple/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-reexport-instrumented/counter.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-reexport-instrumented/counter.ts
@@ -17,6 +17,6 @@ class CounterImpl extends DurableObject<Env> {
 // The Durable Object is manually instrumented here, in a module *separate* from
 // the worker entry. The entry only imports and re-exports the wrapped class.
 export const Counter = Sentry.instrumentDurableObjectWithSentry(
-  (env: Env) => ({ dsn: env.SENTRY_DSN, tracesSampleRate: 1.0 }),
+  (env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static', tracesSampleRate: 1.0 }),
   CounterImpl,
 );

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-reexport-instrumented/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-reexport-instrumented/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier-alias/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier-alias/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-manual-mixed/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-manual-mixed/index.ts
@@ -20,7 +20,7 @@ class CounterImpl extends DurableObject<Env> {
 // existing `instrumentDurableObjectWithSentry` call — matched by the DO-kind
 // wrapper method, not the workflow one — and leave it untouched (no double-wrap).
 export const Counter = Sentry.instrumentDurableObjectWithSentry(
-  (env: Env) => ({ dsn: env.SENTRY_DSN, tracesSampleRate: 1.0 }),
+  (env: Env) => ({ dsn: env.SENTRY_DSN, traceLifecycle: 'static', tracesSampleRate: 1.0 }),
   CounterImpl,
 );
 

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-manual-mixed/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-manual-mixed/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-specifier/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-specifier/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workerentrypoint/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workerentrypoint/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workflow/instrument.server.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workflow/instrument.server.ts
@@ -2,5 +2,6 @@ import { defineCloudflareOptions } from '@sentry/cloudflare';
 
 export default defineCloudflareOptions((env: { SENTRY_DSN: string }) => ({
   dsn: env.SENTRY_DSN,
+  traceLifecycle: 'static',
   tracesSampleRate: 1.0,
 }));

--- a/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/index.ts
@@ -42,6 +42,7 @@ class StepContextTestWorkflowBase extends WorkflowEntrypoint<Env, WorkflowParams
 export const StepContextTestWorkflow = Sentry.instrumentWorkflowWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
   }),
   StepContextTestWorkflowBase,
 );
@@ -49,6 +50,7 @@ export const StepContextTestWorkflow = Sentry.instrumentWorkflowWithSentry(
 export default Sentry.withSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
   }),
   {
     async fetch(request, env, _ctx) {


### PR DESCRIPTION
Add the missing Cloudflare integration-test slice from #22577.

Non-streaming suites now explicitly stay on the static trace lifecycle, while the suites that specifically exercise span streaming remain unchanged. This is preparation to enabling span streaming by default. Once enabled, we'll gradually migrate transaction-based tests over to streaming.

Refs #22344