### PR TITLE
feat(core)!: Enable logs by default

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/logger/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/logger/init.js
@@ -5,8 +5,4 @@ window.Sentry = Sentry;
 Sentry.init({
   traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  // purposefully testing against the experimental flag here
-  _experiments: {
-    enableLogs: true,
-  },
 });

--- a/dev-packages/e2e-tests/test-applications/deno-streamed/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno-streamed/src/app.ts
@@ -22,7 +22,6 @@ Sentry.init({
   traceLifecycle: 'stream',
   tracesSampleRate: 1,
   dataCollection: { userInfo: true },
-  enableLogs: true,
 });
 
 const port = 3030;

--- a/dev-packages/e2e-tests/test-applications/deno/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/src/app.ts
@@ -25,7 +25,6 @@ Sentry.init({
   tunnel: 'http://localhost:3031/',
   tracesSampleRate: 1,
   dataCollection: { userInfo: true },
-  enableLogs: true,
 });
 
 const port = 3030;

--- a/dev-packages/e2e-tests/test-applications/effect-3-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/effect-3-browser/src/index.js
@@ -20,7 +20,6 @@ const AppLayer = Layer.mergeAll(
     release: 'e2e-test',
     environment: 'qa',
     tunnel: 'http://localhost:3031',
-    enableLogs: true,
   }),
   Layer.setTracer(Sentry.SentryEffectTracer),
   Logger.replace(Logger.defaultLogger, Sentry.SentryEffectLogger),

--- a/dev-packages/e2e-tests/test-applications/effect-3-node/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-3-node/src/app.ts
@@ -16,7 +16,6 @@ const SentryLive = Layer.mergeAll(
     debug: !!process.env.DEBUG,
     tunnel: 'http://localhost:3031/',
     tracesSampleRate: 1,
-    enableLogs: true,
   }),
   Layer.setTracer(Sentry.SentryEffectTracer),
   Logger.replace(Logger.defaultLogger, Sentry.SentryEffectLogger),

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/src/index.js
@@ -20,7 +20,6 @@ const AppLayer = Layer.mergeAll(
     release: 'e2e-test',
     environment: 'qa',
     tunnel: 'http://localhost:3031',
-    enableLogs: true,
   }),
   Logger.layer([Sentry.SentryEffectLogger]),
   Layer.succeed(Tracer.Tracer, Sentry.SentryEffectTracer),

--- a/dev-packages/e2e-tests/test-applications/effect-4-node/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-4-node/src/app.ts
@@ -17,7 +17,6 @@ const SentryLive = Layer.mergeAll(
     debug: !!process.env.DEBUG,
     tunnel: 'http://localhost:3031/',
     tracesSampleRate: 1,
-    enableLogs: true,
   }),
   Logger.layer([Sentry.SentryEffectLogger]),
   Layer.succeed(Tracer.Tracer, Sentry.SentryEffectTracer),

--- a/dev-packages/e2e-tests/test-applications/node-express-streaming/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-streaming/src/app.ts
@@ -7,7 +7,6 @@ Sentry.init({
   debug: !!process.env.DEBUG,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
-  enableLogs: true,
   traceLifecycle: 'stream',
   integrations: [
     Sentry.spanStreamingIntegration(),

--- a/dev-packages/e2e-tests/test-applications/node-express-v5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/src/app.ts
@@ -14,7 +14,6 @@ Sentry.init({
   debug: !!process.env.DEBUG,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
-  enableLogs: true,
   integrations: [Sentry.nodeRuntimeMetricsIntegration({ collectionIntervalMs: 1_000 })],
 });
 

--- a/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
@@ -14,7 +14,6 @@ Sentry.init({
   debug: !!process.env.DEBUG,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
-  enableLogs: true,
   integrations: [
     Sentry.nativeNodeFetchIntegration({
       headersToSpanAttributes: {

--- a/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/node-otel-without-tracing/src/instrument.ts
@@ -18,7 +18,6 @@ Sentry.init({
   // Tracing is completely disabled
   // Custom OTEL setup
   skipOpenTelemetrySetup: true,
-  enableLogs: true,
 });
 
 // Create and configure NodeTracerProvider

--- a/dev-packages/e2e-tests/test-applications/tsx-express/instrument.mjs
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/instrument.mjs
@@ -7,5 +7,4 @@ Sentry.init({
   debug: !!process.env.DEBUG,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,
-  enableLogs: true,
 });

--- a/dev-packages/node-integration-tests/suites/consola/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/consola/instrument.mjs
@@ -6,6 +6,5 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',
-  enableLogs: true,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/pino/instrument-auto-off.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/instrument-auto-off.mjs
@@ -5,6 +5,5 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   tracesSampleRate: 1.0,
-  enableLogs: true,
   integrations: [Sentry.pinoIntegration({ autoInstrument: false })],
 });

--- a/dev-packages/node-integration-tests/suites/pino/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/pino/instrument.mjs
@@ -5,6 +5,5 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   release: '1.0',
   tracesSampleRate: 1.0,
-  enableLogs: true,
   integrations: [Sentry.pinoIntegration({ error: { levels: ['error', 'fatal'] } })],
 });

--- a/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logger/scenario.ts
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',
-  enableLogs: true,
   transport: loggingTransport,
 });
 

--- a/dev-packages/node-integration-tests/suites/public-api/logs-disabled/subject.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logs-disabled/subject.ts
@@ -14,11 +14,14 @@ scope.setClient(client);
 client.init();
 
 async function run(): Promise<void> {
-  // Should be dropped because logs are disabled.
   Sentry.logger.info('this log should not be captured', {}, { scope });
 
-  // Should be delivered — used as a sentinel so the test has a deterministic
-  // envelope to match instead of asserting on the absence of one.
+  // Flush the log buffer before the sentinel is captured. If the disable path is
+  // broken, the leaked log envelope is sent here and arrives before the error,
+  // failing the ordered `event` expectation. If logs are correctly disabled,
+  // the buffer is empty and only the sentinel error is delivered.
+  await client.flush();
+
   scope.captureException(new Error('sentinel_error'));
 
   await client.flush();

--- a/dev-packages/node-integration-tests/suites/public-api/logs-disabled/subject.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logs-disabled/subject.ts
@@ -1,0 +1,28 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+const client = new Sentry.NodeClient({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  enableLogs: false,
+  transport: loggingTransport,
+  stackParser: Sentry.defaultStackParser,
+  integrations: [],
+});
+
+const scope = new Sentry.Scope();
+scope.setClient(client);
+client.init();
+
+async function run(): Promise<void> {
+  // Should be dropped because logs are disabled.
+  Sentry.logger.info('this log should not be captured', {}, { scope });
+
+  // Should be delivered — used as a sentinel so the test has a deterministic
+  // envelope to match instead of asserting on the absence of one.
+  scope.captureException(new Error('sentinel_error'));
+
+  await client.flush();
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+void run();

--- a/dev-packages/node-integration-tests/suites/public-api/logs-disabled/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logs-disabled/test.ts
@@ -1,0 +1,30 @@
+import { afterAll, describe, test } from 'vitest';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+describe('logs disabled', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  // With `enableLogs: false` the log is dropped at capture time, so it never reaches
+  // the transport. The sentinel error is the only envelope we expect — if a log
+  // envelope were emitted, it would arrive before the error and fail the assertion.
+  test('does not capture logs when enableLogs is disabled', async () => {
+    const runner = createRunner(__dirname, 'subject.ts')
+      .expect({
+        event: {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'sentinel_error',
+              },
+            ],
+          },
+        },
+      })
+      .start();
+
+    await runner.completed();
+  });
+});

--- a/dev-packages/node-integration-tests/suites/public-api/logs/subject.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/logs/subject.ts
@@ -6,7 +6,6 @@ const client = new Sentry.NodeClient({
   transport: loggingTransport,
   stackParser: Sentry.defaultStackParser,
   integrations: [],
-  enableLogs: true,
   dataCollection: { userInfo: true },
 });
 

--- a/dev-packages/node-integration-tests/suites/winston/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/winston/instrument.mjs
@@ -6,7 +6,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0.0',
   environment: 'test',
-  enableLogs: true,
   transport: loggingTransport,
   debug: true,
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -267,7 +267,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     // Backfill enableLogs option from _experiments.enableLogs
     // TODO(v11): Remove or change default value
     // eslint-disable-next-line typescript/no-deprecated
-    this._options.enableLogs = this._options.enableLogs ?? this._options._experiments?.enableLogs;
+    this._options.enableLogs = this._options.enableLogs ?? this._options._experiments?.enableLogs ?? true;
 
     // Setup log flushing with weight and timeout tracking
     if (this._options.enableLogs) {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -265,7 +265,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     }
 
     // Backfill enableLogs option from _experiments.enableLogs
-    // TODO(v11): Remove or change default value
+    // todo(v11): Remove the experimental flag
     // eslint-disable-next-line typescript/no-deprecated
     this._options.enableLogs = this._options.enableLogs ?? this._options._experiments?.enableLogs ?? true;
 

--- a/packages/core/src/integrations/consola.ts
+++ b/packages/core/src/integrations/consola.ts
@@ -191,7 +191,7 @@ export interface ConsolaLogObject {
 const DEFAULT_CAPTURED_LEVELS: Array<LogSeverityLevel> = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 
 /**
- * Creates a new Sentry reporter for Consola that forwards logs to Sentry. Requires the `enableLogs` option to be enabled.
+ * Creates a new Sentry reporter for Consola that forwards logs to Sentry.
  *
  * **Note: This integration supports Consola v3.x only.** The reporter interface and log object structure
  * may differ in other versions of Consola.
@@ -205,7 +205,7 @@ const DEFAULT_CAPTURED_LEVELS: Array<LogSeverityLevel> = ['trace', 'debug', 'inf
  * import { consola } from 'consola';
  *
  * Sentry.init({
- *   enableLogs: true,
+ *   dsn: '__DSN__',
  * });
  *
  * const sentryReporter = Sentry.createConsolaReporter({

--- a/packages/core/src/logs/console-integration.ts
+++ b/packages/core/src/logs/console-integration.ts
@@ -95,7 +95,7 @@ const _consoleLoggingIntegration = ((options: Partial<CaptureConsoleOptions> = {
 }) satisfies IntegrationFn;
 
 /**
- * Captures calls to the `console` API as logs in Sentry. Requires the `enableLogs` option to be enabled.
+ * Captures calls to the `console` API as logs in Sentry.
  *
  * @experimental This feature is experimental and may be changed or removed in future versions.
  *
@@ -109,7 +109,6 @@ const _consoleLoggingIntegration = ((options: Partial<CaptureConsoleOptions> = {
  * import * as Sentry from '@sentry/browser';
  *
  * Sentry.init({
- *   enableLogs: true,
  *   integrations: [Sentry.consoleLoggingIntegration({ levels: ['error', 'warn'] })],
  * });
  * ```

--- a/packages/core/src/logs/internal.ts
+++ b/packages/core/src/logs/internal.ts
@@ -84,13 +84,8 @@ export function _INTERNAL_captureLog(
     return;
   }
 
-  const { release, environment, _experiments, enableLogs, beforeSendLog } = client.getOptions();
-
-  // todo(v11): Remove the experimental flag
-  // eslint-disable-next-line typescript/no-deprecated
-  const logsEnabled = enableLogs ?? _experiments?.enableLogs ?? true;
-
-  if (!logsEnabled) {
+  const { release, environment, enableLogs = true, beforeSendLog } = client.getOptions();
+  if (!enableLogs) {
     DEBUG_BUILD && debug.warn('logging option not enabled, log will not be captured.');
     return;
   }

--- a/packages/core/src/logs/internal.ts
+++ b/packages/core/src/logs/internal.ts
@@ -84,8 +84,13 @@ export function _INTERNAL_captureLog(
     return;
   }
 
-  const { release, environment, enableLogs = false, beforeSendLog } = client.getOptions();
-  if (!enableLogs) {
+  const { release, environment, _experiments, enableLogs, beforeSendLog } = client.getOptions();
+
+  // todo(v11): Remove the experimental flag
+  // eslint-disable-next-line typescript/no-deprecated
+  const logsEnabled = enableLogs ?? _experiments?.enableLogs ?? true;
+
+  if (!logsEnabled) {
     DEBUG_BUILD && debug.warn('logging option not enabled, log will not be captured.');
     return;
   }

--- a/packages/core/src/logs/public-api.ts
+++ b/packages/core/src/logs/public-api.ts
@@ -30,7 +30,7 @@ interface CaptureLogMetadata {
 }
 
 /**
- * @summary Capture a log with the `trace` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `trace` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { userId: 100, route: '/dashboard' }.
@@ -64,7 +64,7 @@ export function trace(
 }
 
 /**
- * @summary Capture a log with the `debug` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `debug` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { component: 'Header', state: 'loading' }.
@@ -99,7 +99,7 @@ export function debug(
 }
 
 /**
- * @summary Capture a log with the `info` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `info` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { feature: 'checkout', status: 'completed' }.
@@ -134,7 +134,7 @@ export function info(
 }
 
 /**
- * @summary Capture a log with the `warn` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `warn` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { browser: 'Chrome', version: '91.0' }.
@@ -170,7 +170,7 @@ export function warn(
 }
 
 /**
- * @summary Capture a log with the `error` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `error` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { error: 'NetworkError', url: '/api/data' }.
@@ -207,7 +207,7 @@ export function error(
 }
 
 /**
- * @summary Capture a log with the `fatal` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `fatal` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { appState: 'corrupted', sessionId: 'abc-123' }.

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -572,7 +572,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   /**
    * If logs support should be enabled.
    *
-   * @default false
+   * @default true
    */
   enableLogs?: boolean;
 

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -2256,7 +2256,7 @@ describe('Client', () => {
         .spyOn(logsInternalModule, '_INTERNAL_flushLogsBuffer')
         .mockImplementation(() => undefined);
 
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
 
       await client.close();
@@ -2938,32 +2938,32 @@ describe('Client', () => {
   });
 
   describe('enableLogs', () => {
-    it('defaults to  `undefined`', () => {
+    it('defaults to `true`', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
-      expect(client.getOptions().enableLogs).toBeUndefined();
-    });
-
-    it('can be set as a top-level option', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
-      const client = new TestClient(options);
       expect(client.getOptions().enableLogs).toBe(true);
     });
 
-    it('can be set as an experimental option', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, _experiments: { enableLogs: true } });
+    it('can be disabled via the top-level option', () => {
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: false });
       const client = new TestClient(options);
-      expect(client.getOptions().enableLogs).toBe(true);
+      expect(client.getOptions().enableLogs).toBe(false);
+    });
+
+    it('can be disabled via the experimental option', () => {
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, _experiments: { enableLogs: false } });
+      const client = new TestClient(options);
+      expect(client.getOptions().enableLogs).toBe(false);
     });
 
     test('top-level option takes precedence over experimental option', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
-        _experiments: { enableLogs: false },
+        enableLogs: false,
+        _experiments: { enableLogs: true },
       });
       const client = new TestClient(options);
-      expect(client.getOptions().enableLogs).toBe(true);
+      expect(client.getOptions().enableLogs).toBe(false);
     });
   });
 
@@ -2979,7 +2979,6 @@ describe('Client', () => {
     it('flushes logs when weight exceeds 800KB', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -2997,7 +2996,6 @@ describe('Client', () => {
     it('accumulates log weight without flushing when under threshold', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -3015,7 +3013,6 @@ describe('Client', () => {
     it('flushes logs after idle timeout', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -3037,7 +3034,6 @@ describe('Client', () => {
     it('does not reset idle timeout when new logs are captured', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -3064,7 +3060,6 @@ describe('Client', () => {
     it('starts new timer after timeout completes and flushes', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -3096,7 +3091,6 @@ describe('Client', () => {
     it('flushes logs on flush event', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -3117,6 +3111,7 @@ describe('Client', () => {
     it('does not flush logs when logs are disabled', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
+        enableLogs: false,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -3136,7 +3131,6 @@ describe('Client', () => {
 
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -3154,9 +3148,7 @@ describe('Client', () => {
 
     it('flush() drains the log buffer when client has no transport', async () => {
       // Client without DSN — _transport is undefined
-      const options = getDefaultTestClientOptions({
-        enableLogs: true,
-      });
+      const options = getDefaultTestClientOptions({});
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -103,7 +103,12 @@ describe('Client', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, test: true });
       const client = new TestClient(options);
 
-      expect(client.getOptions()).toEqual({ attachStacktrace: true, traceLifecycle: 'stream', ...options, enableLogs: true });
+      expect(client.getOptions()).toEqual({
+        attachStacktrace: true,
+        traceLifecycle: 'stream',
+        ...options,
+        enableLogs: true,
+      });
     });
 
     test('defaults traceLifecycle to stream', () => {

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -103,7 +103,7 @@ describe('Client', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, test: true });
       const client = new TestClient(options);
 
-      expect(client.getOptions()).toEqual({ attachStacktrace: true, traceLifecycle: 'stream', ...options });
+      expect(client.getOptions()).toEqual({ attachStacktrace: true, traceLifecycle: 'stream', ...options, enableLogs: true });
     });
 
     test('defaults traceLifecycle to stream', () => {

--- a/packages/core/test/lib/integrations/consola.test.ts
+++ b/packages/core/test/lib/integrations/consola.test.ts
@@ -32,10 +32,8 @@ describe('createConsolaReporter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Create a test client with enableLogs: true
     mockClient = new TestClient({
       ...getDefaultTestClientOptions({ dsn: 'https://username@domain/123' }),
-      enableLogs: true,
       normalizeDepth: 3,
       normalizeMaxBreadth: 1000,
     });

--- a/packages/core/test/lib/logs/console-integration.test.ts
+++ b/packages/core/test/lib/logs/console-integration.test.ts
@@ -44,7 +44,6 @@ describe('consoleLoggingIntegration', () => {
 
     client = new TestClient({
       ...getDefaultTestClientOptions({ dsn: 'https://username@domain/123' }),
-      enableLogs: true,
       normalizeDepth: 3,
       normalizeMaxBreadth: 1000,
     });
@@ -418,7 +417,6 @@ describe('consoleLoggingIntegration', () => {
     it('only captures configured levels', () => {
       const filteredClient = new TestClient({
         ...getDefaultTestClientOptions({ dsn: 'https://username@domain/123' }),
-        enableLogs: true,
       });
       vi.mocked(getClient).mockReturnValue(filteredClient);
 

--- a/packages/core/test/lib/logs/internal.test.ts
+++ b/packages/core/test/lib/logs/internal.test.ts
@@ -22,7 +22,7 @@ describe('_INTERNAL_captureLog', () => {
     _INTERNAL_resetSequenceNumber();
   });
   it('captures and sends logs', () => {
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -43,9 +43,9 @@ describe('_INTERNAL_captureLog', () => {
     );
   });
 
-  it('does not capture logs when enableLogs is not enabled', () => {
+  it('does not capture logs when enableLogs is disabled', () => {
     const logWarnSpy = vi.spyOn(loggerModule.debug, 'warn').mockImplementation(() => undefined);
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: false });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -59,7 +59,7 @@ describe('_INTERNAL_captureLog', () => {
   });
 
   it('includes trace context when available', () => {
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -81,7 +81,6 @@ describe('_INTERNAL_captureLog', () => {
   it('includes release and environment in log attributes when available', () => {
     const options = getDefaultTestClientOptions({
       dsn: PUBLIC_DSN,
-      enableLogs: true,
       release: '1.0.0',
       environment: 'test',
     });
@@ -108,7 +107,6 @@ describe('_INTERNAL_captureLog', () => {
   it('includes SDK metadata in log attributes when available', () => {
     const options = getDefaultTestClientOptions({
       dsn: PUBLIC_DSN,
-      enableLogs: true,
     });
     const client = new TestClient(options);
     const scope = new Scope();
@@ -140,7 +138,6 @@ describe('_INTERNAL_captureLog', () => {
   it('does not include SDK metadata in log attributes when not available', () => {
     const options = getDefaultTestClientOptions({
       dsn: PUBLIC_DSN,
-      enableLogs: true,
     });
     const client = new TestClient(options);
     const scope = new Scope();
@@ -161,7 +158,7 @@ describe('_INTERNAL_captureLog', () => {
 
   describe('attributes', () => {
     it('includes custom attributes in log', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -190,7 +187,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('applies scope attributes attributes to log', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -251,7 +248,7 @@ describe('_INTERNAL_captureLog', () => {
   });
 
   it('flushes logs buffer when it reaches max size', () => {
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -273,7 +270,7 @@ describe('_INTERNAL_captureLog', () => {
   });
 
   it('does not flush logs buffer when it is empty', () => {
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
 
     const mockSendEnvelope = vi.spyOn(client as any, 'sendEnvelope').mockImplementation(() => {});
@@ -282,7 +279,7 @@ describe('_INTERNAL_captureLog', () => {
   });
 
   it('handles parameterized strings correctly', () => {
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -310,7 +307,7 @@ describe('_INTERNAL_captureLog', () => {
   });
 
   it('does not set the template attribute if there are no parameters', () => {
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -332,7 +329,6 @@ describe('_INTERNAL_captureLog', () => {
 
     const options = getDefaultTestClientOptions({
       dsn: PUBLIC_DSN,
-      enableLogs: true,
       beforeSendLog,
     });
     const client = new TestClient(options);
@@ -396,7 +392,6 @@ describe('_INTERNAL_captureLog', () => {
 
     const options = getDefaultTestClientOptions({
       dsn: PUBLIC_DSN,
-      enableLogs: true,
       beforeSendLog,
     });
     const client = new TestClient(options);
@@ -422,7 +417,7 @@ describe('_INTERNAL_captureLog', () => {
 
   it('emits beforeCaptureLog and afterCaptureLog events', () => {
     const beforeCaptureLogSpy = vi.spyOn(TestClient.prototype, 'emit');
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);
     const scope = new Scope();
     scope.setClient(client);
@@ -442,7 +437,7 @@ describe('_INTERNAL_captureLog', () => {
 
   describe('replay integration with onlyIfSampled', () => {
     it('includes replay ID for sampled sessions', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -474,7 +469,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('excludes replay ID for unsampled sessions when onlyIfSampled=true', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -501,7 +496,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('includes replay ID for buffer mode sessions', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -536,7 +531,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('handles missing replay integration gracefully', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -555,7 +550,6 @@ describe('_INTERNAL_captureLog', () => {
     it('combines replay ID with other log attributes', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         release: '1.0.0',
         environment: 'test',
       });
@@ -607,7 +601,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('does not set replay ID attribute when getReplayId returns null or undefined', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -635,7 +629,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('sets replay_is_buffering attribute when replay is in buffer mode', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -668,7 +662,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('does not set replay_is_buffering attribute when replay is in session mode', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -698,7 +692,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('does not set replay_is_buffering attribute when replay is undefined mode', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -728,7 +722,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('does not set replay_is_buffering attribute when no replay ID is available', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -756,7 +750,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('does not set replay_is_buffering attribute when replay integration is missing', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -777,7 +771,6 @@ describe('_INTERNAL_captureLog', () => {
     it('combines replay_is_buffering with other replay attributes', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         release: '1.0.0',
         environment: 'test',
       });
@@ -837,7 +830,6 @@ describe('_INTERNAL_captureLog', () => {
     it('includes user data in log attributes', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
       });
       const client = new TestClient(options);
       const scope = new Scope();
@@ -871,7 +863,6 @@ describe('_INTERNAL_captureLog', () => {
     it('includes partial user data when only some fields are available', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         sendDefaultPii: true,
       });
       const client = new TestClient(options);
@@ -897,7 +888,6 @@ describe('_INTERNAL_captureLog', () => {
     it('includes user email and username without id', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         sendDefaultPii: true,
       });
       const client = new TestClient(options);
@@ -928,7 +918,6 @@ describe('_INTERNAL_captureLog', () => {
     it('does not include user data when user object is empty', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         sendDefaultPii: true,
       });
       const client = new TestClient(options);
@@ -947,7 +936,6 @@ describe('_INTERNAL_captureLog', () => {
     it('combines user data with other log attributes', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         sendDefaultPii: true,
         release: '1.0.0',
         environment: 'test',
@@ -1002,7 +990,6 @@ describe('_INTERNAL_captureLog', () => {
     it('handles user data with non-string values', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         sendDefaultPii: true,
       });
       const client = new TestClient(options);
@@ -1033,7 +1020,6 @@ describe('_INTERNAL_captureLog', () => {
     it('preserves existing user attributes in log and does not override them', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         sendDefaultPii: true,
       });
       const client = new TestClient(options);
@@ -1077,7 +1063,6 @@ describe('_INTERNAL_captureLog', () => {
     it('only adds scope user data for attributes that do not already exist', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        enableLogs: true,
         sendDefaultPii: true,
       });
       const client = new TestClient(options);
@@ -1127,7 +1112,6 @@ describe('_INTERNAL_captureLog', () => {
   it('overrides user-provided system attributes with SDK values', () => {
     const options = getDefaultTestClientOptions({
       dsn: PUBLIC_DSN,
-      enableLogs: true,
       release: 'sdk-release-1.0.0',
       environment: 'sdk-environment',
     });
@@ -1188,7 +1172,7 @@ describe('_INTERNAL_captureLog', () => {
     it('increments the sequence number across consecutive logs', () => {
       vi.spyOn(timeModule, 'timestampInSeconds').mockReturnValue(1000.001);
 
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1215,7 +1199,7 @@ describe('_INTERNAL_captureLog', () => {
         return log;
       });
 
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true, beforeSendLog });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSendLog });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1235,7 +1219,7 @@ describe('_INTERNAL_captureLog', () => {
     it('produces monotonically increasing sequence numbers within the same millisecond', () => {
       vi.spyOn(timeModule, 'timestampInSeconds').mockReturnValue(1000.001);
 
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1258,7 +1242,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('resets the sequence number via _INTERNAL_resetSequenceNumber', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1280,7 +1264,7 @@ describe('_INTERNAL_captureLog', () => {
 
   describe.runIf(hasToWellFormed)('lone surrogate sanitization', () => {
     it('sanitizes lone surrogates in log message body', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1292,7 +1276,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('sanitizes lone surrogates in parameterized (fmt) log message body', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1305,7 +1289,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('sanitizes lone surrogates in log attribute values', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1327,7 +1311,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('sanitizes lone surrogates in log attribute keys', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);
@@ -1349,7 +1333,7 @@ describe('_INTERNAL_captureLog', () => {
     });
 
     it('preserves valid emoji in log messages and attributes', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableLogs: true });
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
       const scope = new Scope();
       scope.setClient(client);

--- a/packages/deno/test/mod.test.ts
+++ b/packages/deno/test/mod.test.ts
@@ -117,7 +117,6 @@ Deno.test('logger.info captures a log envelope item', async () => {
   const envelopes: Array<Envelope> = [];
   const client = new DenoClient({
     dsn: 'https://233a45e5efe34c47a3536797ce15dafa@nothing.here/5650507',
-    enableLogs: true,
     integrations: getDefaultIntegrations({}),
     stackParser: createStackParser(nodeStackLineParser()),
     transport: makeTestTransport(envelope => {
@@ -153,7 +152,6 @@ Deno.test('logger.info captures a log envelope item', async () => {
 Deno.test('adds server.address to log attributes', () => {
   const client = new DenoClient({
     dsn: 'https://233a45e5efe34c47a3536797ce15dafa@nothing.here/5650507',
-    enableLogs: true,
     serverName: 'test-server',
     integrations: getDefaultIntegrations({}),
     stackParser: createStackParser(nodeStackLineParser()),
@@ -169,7 +167,6 @@ Deno.test('adds server.address to log attributes', () => {
 Deno.test('preserves existing log attributes when adding server.address', () => {
   const client = new DenoClient({
     dsn: 'https://233a45e5efe34c47a3536797ce15dafa@nothing.here/5650507',
-    enableLogs: true,
     serverName: 'test-server',
     integrations: getDefaultIntegrations({}),
     stackParser: createStackParser(nodeStackLineParser()),

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -27,7 +27,6 @@ const SentryLive = Layer.mergeAll(
   Sentry.effectLayer({
     dsn: '__DSN__',
     tracesSampleRate: 1.0,
-    enableLogs: true,
   }),
   Layer.setTracer(Sentry.SentryEffectTracer),
   Logger.replace(Logger.defaultLogger, Sentry.SentryEffectLogger),
@@ -59,7 +58,6 @@ const SentryLive = Layer.mergeAll(
   Sentry.effectLayer({
     dsn: '__DSN__',
     tracesSampleRate: 1.0,
-    enableLogs: true,
   }),
   Layer.succeed(Tracer.Tracer, Sentry.SentryEffectTracer),
   Logger.layer([Sentry.SentryEffectLogger]),

--- a/packages/node/src/integrations/pino.ts
+++ b/packages/node/src/integrations/pino.ts
@@ -79,8 +79,7 @@ type PinoOptions = {
    */
   log: {
     /**
-     * Levels that trigger capturing of logs. Logs are only captured if
-     * `enableLogs` is enabled.
+     * Levels that trigger capturing of logs.
      *
      * @default ["trace", "debug", "info", "warn", "error", "fatal"]
      */

--- a/packages/node/src/integrations/winston.ts
+++ b/packages/node/src/integrations/winston.ts
@@ -45,7 +45,7 @@ interface WinstonTransportOptions {
 }
 
 /**
- * Creates a new Sentry Winston transport that fowards logs to Sentry. Requires the `enableLogs` option to be enabled.
+ * Creates a new Sentry Winston transport that fowards logs to Sentry.
  *
  * Supports Winston 3.x.x.
  *

--- a/packages/node/src/logs/exports.ts
+++ b/packages/node/src/logs/exports.ts
@@ -1,7 +1,7 @@
 import { captureLog, type CaptureLogArgs } from './capture';
 
 /**
- * @summary Capture a log with the `trace` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `trace` level.
  *
  * You can either pass a message and attributes or a message template, params and attributes.
  *
@@ -28,7 +28,7 @@ export function trace(...args: CaptureLogArgs): void {
 }
 
 /**
- * @summary Capture a log with the `debug` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `debug` level.
  *
  * You can either pass a message and attributes or a message template, params and attributes.
  *
@@ -55,7 +55,7 @@ export function debug(...args: CaptureLogArgs): void {
 }
 
 /**
- * @summary Capture a log with the `info` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `info` level.
  *
  * You can either pass a message and attributes or a message template, params and attributes.
  *
@@ -82,7 +82,7 @@ export function info(...args: CaptureLogArgs): void {
 }
 
 /**
- * @summary Capture a log with the `warn` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `warn` level.
  *
  * You can either pass a message and attributes or a message template, params and attributes.
  *
@@ -110,7 +110,7 @@ export function warn(...args: CaptureLogArgs): void {
 }
 
 /**
- * @summary Capture a log with the `error` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `error` level.
  *
  * You can either pass a message and attributes or a message template, params and attributes.
  *
@@ -138,7 +138,7 @@ export function error(...args: CaptureLogArgs): void {
 }
 
 /**
- * @summary Capture a log with the `fatal` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `fatal` level.
  *
  * You can either pass a message and attributes or a message template, params and attributes.
  *

--- a/packages/node/test/sdk/client.test.ts
+++ b/packages/node/test/sdk/client.test.ts
@@ -55,6 +55,7 @@ describe('NodeClient', () => {
       runtime: { name: 'node', version: expect.any(String) },
       serverName: expect.any(String),
       tracesSampleRate: 1,
+      enableLogs: true,
     });
   });
 
@@ -301,7 +302,7 @@ describe('NodeClient', () => {
 
   describe('log capture', () => {
     it('adds server name to log attributes', () => {
-      const options = getDefaultNodeClientOptions({ enableLogs: true });
+      const options = getDefaultNodeClientOptions();
       const client = new NodeClient(options);
 
       const log: Log = { level: 'info', message: 'test message', attributes: {} };
@@ -314,7 +315,7 @@ describe('NodeClient', () => {
 
     it('preserves existing log attributes', () => {
       const serverName = 'test-server';
-      const options = getDefaultNodeClientOptions({ serverName, enableLogs: true });
+      const options = getDefaultNodeClientOptions({ serverName });
       const client = new NodeClient(options);
 
       const log: Log = { level: 'info', message: 'test message', attributes: { 'existing.attr': 'value' } };
@@ -375,7 +376,7 @@ describe('NodeClient', () => {
     it('stops log capture if it was started', async () => {
       const processOffSpy = vi.spyOn(process, 'off');
 
-      const client = new NodeClient(getDefaultNodeClientOptions({ enableLogs: true }));
+      const client = new NodeClient(getDefaultNodeClientOptions());
 
       const result = await client.close();
 

--- a/packages/vercel-edge/src/logs/exports.ts
+++ b/packages/vercel-edge/src/logs/exports.ts
@@ -19,7 +19,7 @@ function captureLog(
 }
 
 /**
- * @summary Capture a log with the `trace` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `trace` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { userId: 100, route: '/dashboard' }.
@@ -48,7 +48,7 @@ export function trace(message: ParameterizedString, attributes?: Log['attributes
 }
 
 /**
- * @summary Capture a log with the `debug` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `debug` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { component: 'Header', state: 'loading' }.
@@ -78,7 +78,7 @@ export function debug(message: ParameterizedString, attributes?: Log['attributes
 }
 
 /**
- * @summary Capture a log with the `info` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `info` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { feature: 'checkout', status: 'completed' }.
@@ -108,7 +108,7 @@ export function info(message: ParameterizedString, attributes?: Log['attributes'
 }
 
 /**
- * @summary Capture a log with the `warn` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `warn` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { browser: 'Chrome', version: '91.0' }.
@@ -139,7 +139,7 @@ export function warn(message: ParameterizedString, attributes?: Log['attributes'
 }
 
 /**
- * @summary Capture a log with the `error` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `error` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { error: 'NetworkError', url: '/api/data' }.
@@ -171,7 +171,7 @@ export function error(message: ParameterizedString, attributes?: Log['attributes
 }
 
 /**
- * @summary Capture a log with the `fatal` level. Requires the `enableLogs` option to be enabled.
+ * @summary Capture a log with the `fatal` level.
  *
  * @param message - The message to log.
  * @param attributes - Arbitrary structured data that stores information about the log - e.g., { appState: 'corrupted', sessionId: 'abc-123' }.


### PR DESCRIPTION
This flips the `enableLogs` client option to default to `true` so users get Sentry Logs without opting in manually, matching how `enableMetrics` already behaves. Nothing is captured unless the `Sentry.logger` API is called or a logging integration is explicitly enabled, and an explicit `enableLogs: false` still turns it off.

Fixes getsentry/sentry-javascript#20639