### PR TITLE
test(browser): Unflake streamed XHR span assertions

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-streamed/test.ts
@@ -19,7 +19,11 @@ sentryTest('creates spans for XHR requests', async ({ getLocalTestUrl, page }) =
 
   const allSpans = await spansPromise;
   const pageloadSpan = allSpans.find(s => getSpanOp(s) === 'pageload');
-  const requestSpans = allSpans.filter(s => getSpanOp(s) === 'http.client');
+  const requestSpans = allSpans
+    .filter(s => getSpanOp(s) === 'http.client')
+    .sort((a, b) =>
+      (a.attributes!['http.url']!.value as string).localeCompare(b.attributes!['http.url']!.value as string),
+    );
 
   expect(requestSpans).toHaveLength(3);
 


### PR DESCRIPTION
Sort streamed XHR spans before asserting them to avoid completion-order flakes like [this one](https://github.com/getsentry/sentry-javascript/actions/runs/30090683433/job/89473980039?pr=22591#step:7:749).