### PR TITLE
test(e2e): fix sveltekit-3 test, turn on VOLTA_FEATURE_PNPM

### DIFF
--- a/dev-packages/e2e-tests/run.ts
+++ b/dev-packages/e2e-tests/run.ts
@@ -183,6 +183,13 @@ async function run(): Promise<void> {
   const env = {
     ...process.env,
     ...envVarsToInject,
+    // Volta applies a project's node pin only to commands it manages, and it
+    // manages pnpm only when this is set. Without it, the `volta run pnpm`
+    // calls below build each app on whatever node is already on PATH rather
+    // than the version its package.json pins. CI reads that pin directly
+    // (see `node-version-file` in .github/workflows/build.yml), so leaving
+    // this unset makes local runs fail on apps CI passes.
+    VOLTA_FEATURE_PNPM: '1',
   };
 
   console.log('Syncing packed tarball symlinks...');

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/tsconfig.json
@@ -1,5 +1,10 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
+  // Kit 3 generates the parent config at `node_modules/$app/tsconfig`
+  // and never writes `.svelte-kit/tsconfig.json`. `svelte-kit sync`
+  // creates a placeholder there before it loads `src/env.ts`, so the
+  // transform no longer races the generated file.
+  "extends": "$app/tsconfig",
+  "include": ["src"],
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": true,
@@ -11,7 +16,4 @@
     "allowImportingTsExtensions": true
   }
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
-  //
-  // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
-  // from the referenced tsconfig.json - TypeScript does not merge them in
 }


### PR DESCRIPTION
This updates the tsconfig error that was failing the sveltekit-3 test. Also, setting `VOLTA_FEATURE_PNPM=1` in the environment allows it to pass locally, otherwise it'd use the volta pinned node v20, which fails with `Promise.withResolvers is not a function`, because the e2e test requires node 22.
