### PR TITLE
fix(cloudflare): restore type inference for env parameter in withSentry

### DIFF
--- a/packages/cloudflare/src/withSentry.ts
+++ b/packages/cloudflare/src/withSentry.ts
@@ -29,12 +29,20 @@ export function withSentry<
   Env = typeof cloudflareEnv,
   QueueHandlerMessage = unknown,
   CfHostMetadata = unknown,
-  T extends ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata> | WorkerEntrypointConstructor = ExportedHandler<
+  H extends ExportedHandler<Env, QueueHandlerMessage, CfHostMetadata> = ExportedHandler<
     Env,
     QueueHandlerMessage,
     CfHostMetadata
   >,
->(optionsCallback: (env: Env) => CloudflareOptions | undefined, handler: T): T {
+>(optionsCallback: (env: Env) => CloudflareOptions | undefined, handler: H): H;
+export function withSentry<T extends WorkerEntrypointConstructor>(
+  optionsCallback: (env: any) => CloudflareOptions | undefined,
+  handler: T,
+): T;
+export function withSentry(
+  optionsCallback: (env: any) => CloudflareOptions | undefined,
+  handler: any,
+): any {
   if (isCloudflareClass(handler, 'WorkerEntrypoint')) {
     // oxlint-disable-next-line typescript/no-explicit-any
     return instrumentWorkerEntrypoint(optionsCallback as any, handler);


### PR DESCRIPTION
## Summary

Closes #18294

Fixes type inference for the `env` parameter in `withSentry` options callback.

Previously, combining union generic parameters `ExportedHandler | WorkerEntrypointConstructor` caused TypeScript to fail type inference for `Env`, defaulting `env` to `unknown` / `typeof cloudflareEnv`.

By overloading `withSentry` separately for `ExportedHandler` and `WorkerEntrypointConstructor`, TypeScript correctly infers `Env` from the passed handler.

## Changes

- `packages/cloudflare/src/withSentry.ts`: Added function overloads for `withSentry` for `ExportedHandler` and `WorkerEntrypointConstructor`.
