### PR TITLE
feat(node)!: Use `function.gcp` span op for Firebase functions

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-firebase/tests/functions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/tests/functions.test.ts
@@ -24,12 +24,12 @@ test.fixme('should only call the function once without any extra calls', async (
           'faas.provider': 'firebase',
           'faas.trigger': 'http.request',
           'sentry.kind': 'server',
-          'sentry.op': 'http.request',
+          'sentry.op': 'function.gcp',
           'sentry.origin': 'auto.firebase.orchestrion.functions',
           'sentry.sample_rate': expect.any(Number),
           'sentry.source': 'route',
         },
-        op: 'http.request',
+        op: 'function.gcp',
         origin: 'auto.firebase.orchestrion.functions',
         span_id: expect.any(String),
         status: 'ok',
@@ -101,13 +101,29 @@ test.fixme('should create a document and trigger onDocumentCreated and another w
       'faas.provider': 'firebase',
       'faas.trigger': 'http.request',
       'sentry.kind': 'server',
+<<<<<<< HEAD
       'sentry.op': 'http.request',
       'sentry.origin': 'auto.firebase.orchestrion.functions',
+||||||| parent of e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
+      'sentry.op': 'http.request',
+      'sentry.origin': 'auto.firebase.otel.functions',
+=======
+      'sentry.op': 'function.gcp',
+      'sentry.origin': 'auto.firebase.otel.functions',
+>>>>>>> e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
       'sentry.sample_rate': expect.any(Number),
       'sentry.source': 'route',
     },
+<<<<<<< HEAD
     op: 'http.request',
     origin: 'auto.firebase.orchestrion.functions',
+||||||| parent of e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
+    op: 'http.request',
+    origin: 'auto.firebase.otel.functions',
+=======
+    op: 'function.gcp',
+    origin: 'auto.firebase.otel.functions',
+>>>>>>> e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
     span_id: expect.any(String),
     status: 'ok',
     trace_id: expect.any(String),

--- a/dev-packages/e2e-tests/test-applications/node-firebase/tests/functions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/tests/functions.test.ts
@@ -101,29 +101,13 @@ test.fixme('should create a document and trigger onDocumentCreated and another w
       'faas.provider': 'firebase',
       'faas.trigger': 'http.request',
       'sentry.kind': 'server',
-<<<<<<< HEAD
-      'sentry.op': 'http.request',
-      'sentry.origin': 'auto.firebase.orchestrion.functions',
-||||||| parent of e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
-      'sentry.op': 'http.request',
-      'sentry.origin': 'auto.firebase.otel.functions',
-=======
       'sentry.op': 'function.gcp',
-      'sentry.origin': 'auto.firebase.otel.functions',
->>>>>>> e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
+      'sentry.origin': 'auto.firebase.orchestrion.functions',
       'sentry.sample_rate': expect.any(Number),
       'sentry.source': 'route',
     },
-<<<<<<< HEAD
-    op: 'http.request',
-    origin: 'auto.firebase.orchestrion.functions',
-||||||| parent of e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
-    op: 'http.request',
-    origin: 'auto.firebase.otel.functions',
-=======
     op: 'function.gcp',
-    origin: 'auto.firebase.otel.functions',
->>>>>>> e1785e3201 (feat(node)!: Use `function.gcp` span op for Firebase functions)
+    origin: 'auto.firebase.orchestrion.functions',
     span_id: expect.any(String),
     status: 'ok',
     trace_id: expect.any(String),

--- a/packages/node/src/integrations/tracing/firebase/otel/patches/functions.ts
+++ b/packages/node/src/integrations/tracing/firebase/otel/patches/functions.ts
@@ -2,6 +2,7 @@ import type { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { InstrumentationNodeModuleDefinition, isWrapped } from '@opentelemetry/instrumentation';
 import { InstrumentationNodeModuleFile } from '../../../InstrumentationNodeModuleFile';
 import { SENTRY_KIND } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import type { SpanAttributes } from '@sentry/core';
 import {
   captureException,
@@ -87,7 +88,7 @@ export function patchV2Functions<T extends FirebaseFunctions = FirebaseFunctions
         return startSpanManual(
           {
             name: `firebase.function.${triggerType}`,
-            op: 'http.request',
+            op: FAAS_FUNCTION_GCP_SPAN_OP,
             attributes,
           },
           async span => {

--- a/packages/node/src/integrations/tracing/firebase/otel/patches/functions.ts
+++ b/packages/node/src/integrations/tracing/firebase/otel/patches/functions.ts
@@ -1,7 +1,7 @@
 import type { InstrumentationBase } from '@opentelemetry/instrumentation';
 import { InstrumentationNodeModuleDefinition, isWrapped } from '@opentelemetry/instrumentation';
 import { InstrumentationNodeModuleFile } from '../../../InstrumentationNodeModuleFile';
-import { SENTRY_KIND } from '@sentry/conventions/attributes';
+import { SENTRY_KIND, SENTRY_OP } from '@sentry/conventions/attributes';
 import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import type { SpanAttributes } from '@sentry/core';
 import {
@@ -69,6 +69,7 @@ export function patchV2Functions<T extends FirebaseFunctions = FirebaseFunctions
         const functionName = process.env.FUNCTION_TARGET || process.env.K_SERVICE || 'unknown';
 
         const attributes: SpanAttributes = {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
           [SENTRY_KIND]: 'server',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.firebase.otel.functions',
           'faas.name': functionName,
@@ -88,7 +89,6 @@ export function patchV2Functions<T extends FirebaseFunctions = FirebaseFunctions
         return startSpanManual(
           {
             name: `firebase.function.${triggerType}`,
-            op: FAAS_FUNCTION_GCP_SPAN_OP,
             attributes,
           },
           async span => {


### PR DESCRIPTION
Replace `http.request` with `function.gcp` for Firebase function triggers. The Firebase Functions wrapper instruments every v2 trigger type. A non-HTTP trigger such as `onDocumentCreated` was therefore previously reported as an HTTP operation.

Part of #22446

> Note: MIGRATION.md will be one combined follow up PR