### PR TITLE
feat(google-cloud-serverless)!: Use `http.client` span op for GCP HTTP requests

### DIFF
--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0"
   },

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
@@ -1,9 +1,13 @@
 import type * as common from '@google-cloud/common';
+import { HTTP_REQUEST_METHOD, SERVER_ADDRESS } from '@sentry/conventions/attributes';
+import { WEB_SERVER_HTTP_CLIENT_SPAN_OP } from '@sentry/conventions/op';
 import type { Client, IntegrationFn } from '@sentry/core';
 import {
   defineIntegration,
   fill,
   getClient,
+  isURLObjectRelative,
+  parseStringToURLObject,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SentryNonRecordingSpan,
 } from '@sentry/core';
@@ -54,9 +58,11 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
       ? startInactiveSpan({
           name: `${httpMethod} ${reqOpts.uri}`,
           onlyIfParent: true,
-          op: `http.client.${identifyService(this.apiEndpoint)}`,
+          op: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
+            [HTTP_REQUEST_METHOD]: httpMethod,
+            [SERVER_ADDRESS]: getServerAddress(this.apiEndpoint),
           },
         })
       : new SentryNonRecordingSpan();
@@ -67,8 +73,8 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
   };
 }
 
-/** Identifies service by its base url */
-function identifyService(apiEndpoint: string): string {
-  const match = apiEndpoint.match(/^https:\/\/(\w+)\.googleapis.com$/);
-  return match?.[1] || apiEndpoint.replace(/^(http|https)?:\/\//, '');
+/** Extracts the host of the API endpoint the request is sent to */
+function getServerAddress(apiEndpoint: string): string {
+  const url = parseStringToURLObject(apiEndpoint);
+  return url && !isURLObjectRelative(url) ? url.host : apiEndpoint;
 }

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
@@ -1,5 +1,5 @@
 import type * as common from '@google-cloud/common';
-import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS } from '@sentry/conventions/attributes';
+import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS, URL_FULL } from '@sentry/conventions/attributes';
 import { WEB_SERVER_HTTP_CLIENT_SPAN_OP } from '@sentry/conventions/op';
 import type { Client, IntegrationFn } from '@sentry/core';
 import {
@@ -63,6 +63,7 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
             [HTTP_REQUEST_METHOD]: httpMethod,
             [SERVER_ADDRESS]: getServerAddress(this.apiEndpoint),
+            [URL_FULL]: reqOpts.uri,
           },
         })
       : new SentryNonRecordingSpan();

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
@@ -1,5 +1,5 @@
 import type * as common from '@google-cloud/common';
-import { HTTP_REQUEST_METHOD, SERVER_ADDRESS } from '@sentry/conventions/attributes';
+import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS } from '@sentry/conventions/attributes';
 import { WEB_SERVER_HTTP_CLIENT_SPAN_OP } from '@sentry/conventions/op';
 import type { Client, IntegrationFn } from '@sentry/core';
 import {
@@ -58,8 +58,8 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
       ? startInactiveSpan({
           name: `${httpMethod} ${reqOpts.uri}`,
           onlyIfParent: true,
-          op: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
           attributes: {
+            [SENTRY_OP]: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
             [HTTP_REQUEST_METHOD]: httpMethod,
             [SERVER_ADDRESS]: getServerAddress(this.apiEndpoint),

--- a/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
+++ b/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
@@ -76,19 +76,23 @@ describe('GoogleCloudHttp tracing', () => {
       const resp = await bigquery.query('SELECT true AS foo');
       expect(resp).toEqual([[{ foo: true }]]);
       expect(mockStartInactiveSpan).toBeCalledWith({
-        op: 'http.client.bigquery',
+        op: 'http.client',
         name: 'POST /jobs',
         onlyIfParent: true,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
+          'http.request.method': 'POST',
+          'server.address': 'bigquery.googleapis.com',
         },
       });
       expect(mockStartInactiveSpan).toBeCalledWith({
-        op: 'http.client.bigquery',
+        op: 'http.client',
         name: expect.stringMatching(/^GET \/queries\/.+/),
         onlyIfParent: true,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
+          'http.request.method': 'GET',
+          'server.address': 'bigquery.googleapis.com',
         },
       });
     });

--- a/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
+++ b/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
@@ -1,4 +1,6 @@
 import { BigQuery } from '@google-cloud/bigquery';
+import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS } from '@sentry/conventions/attributes';
+import { WEB_SERVER_HTTP_CLIENT_SPAN_OP } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { createTransport, NodeClient, setCurrentClient } from '@sentry/node';
 import * as fs from 'fs';
@@ -76,23 +78,23 @@ describe('GoogleCloudHttp tracing', () => {
       const resp = await bigquery.query('SELECT true AS foo');
       expect(resp).toEqual([[{ foo: true }]]);
       expect(mockStartInactiveSpan).toBeCalledWith({
-        op: 'http.client',
         name: 'POST /jobs',
         onlyIfParent: true,
         attributes: {
+          [SENTRY_OP]: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
-          'http.request.method': 'POST',
-          'server.address': 'bigquery.googleapis.com',
+          [HTTP_REQUEST_METHOD]: 'POST',
+          [SERVER_ADDRESS]: 'bigquery.googleapis.com',
         },
       });
       expect(mockStartInactiveSpan).toBeCalledWith({
-        op: 'http.client',
         name: expect.stringMatching(/^GET \/queries\/.+/),
         onlyIfParent: true,
         attributes: {
+          [SENTRY_OP]: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
-          'http.request.method': 'GET',
-          'server.address': 'bigquery.googleapis.com',
+          [HTTP_REQUEST_METHOD]: 'GET',
+          [SERVER_ADDRESS]: 'bigquery.googleapis.com',
         },
       });
     });

--- a/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
+++ b/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
@@ -1,5 +1,5 @@
 import { BigQuery } from '@google-cloud/bigquery';
-import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS } from '@sentry/conventions/attributes';
+import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS, URL_FULL } from '@sentry/conventions/attributes';
 import { WEB_SERVER_HTTP_CLIENT_SPAN_OP } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { createTransport, NodeClient, setCurrentClient } from '@sentry/node';
@@ -85,6 +85,7 @@ describe('GoogleCloudHttp tracing', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
           [HTTP_REQUEST_METHOD]: 'POST',
           [SERVER_ADDRESS]: 'bigquery.googleapis.com',
+          [URL_FULL]: '/jobs',
         },
       });
       expect(mockStartInactiveSpan).toBeCalledWith({
@@ -95,6 +96,7 @@ describe('GoogleCloudHttp tracing', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
           [HTTP_REQUEST_METHOD]: 'GET',
           [SERVER_ADDRESS]: 'bigquery.googleapis.com',
+          [URL_FULL]: expect.stringMatching(/^\/queries\/.+/),
         },
       });
     });


### PR DESCRIPTION
Use `http.client` instead of `http.client.<service>` in `googleCloudHttpIntegration`. The service is now identified by the new `server.address` attribute. Also added `http.request.method`.

Part of https://github.com/getsentry/sentry-javascript/issues/22446

> Note: MIGRATION.md will be one combined follow up PR