### PR TITLE
fix(cloudflare): Remove conflicting `faas.queue` op on queue consumer spans

### DIFF
--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "magic-string": "~0.30.21"

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
@@ -16,6 +16,7 @@ import { addCloudResourceContext } from '../../scope-utils';
 import { init } from '../../sdk';
 import { instrumentContext } from '../../utils/instrumentContext';
 import { instrumentEnv } from './instrumentEnv';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 /**
  * Core queue handler logic - wraps execution with Sentry instrumentation.
@@ -36,9 +37,9 @@ function wrapQueueHandler(
 
     return startSpan(
       {
-        op: MESSAGING_QUEUE_PROCESS_SPAN_OP,
         name: `process ${batch.queue}`,
         attributes: {
+          [SENTRY_OP]: MESSAGING_QUEUE_PROCESS_SPAN_OP,
           'faas.trigger': 'pubsub',
           'messaging.destination.name': batch.queue,
           'messaging.system': 'cloudflare',

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
@@ -1,5 +1,6 @@
 import type { ExportedHandler, MessageBatch } from '@cloudflare/workers-types';
 import type { env as cloudflareEnv, WorkerEntrypoint } from 'cloudflare:workers';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 import { MESSAGING_QUEUE_PROCESS_SPAN_OP } from '@sentry/conventions/op';
 import {
   captureException,
@@ -16,7 +17,6 @@ import { addCloudResourceContext } from '../../scope-utils';
 import { init } from '../../sdk';
 import { instrumentContext } from '../../utils/instrumentContext';
 import { instrumentEnv } from './instrumentEnv';
-import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 /**
  * Core queue handler logic - wraps execution with Sentry instrumentation.

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
@@ -1,8 +1,8 @@
 import type { ExportedHandler, MessageBatch } from '@cloudflare/workers-types';
 import type { env as cloudflareEnv, WorkerEntrypoint } from 'cloudflare:workers';
+import { MESSAGING_QUEUE_PROCESS_SPAN_OP } from '@sentry/conventions/op';
 import {
   captureException,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   startSpan,
@@ -36,7 +36,7 @@ function wrapQueueHandler(
 
     return startSpan(
       {
-        op: 'faas.queue',
+        op: MESSAGING_QUEUE_PROCESS_SPAN_OP,
         name: `process ${batch.queue}`,
         attributes: {
           'faas.trigger': 'pubsub',
@@ -46,7 +46,6 @@ function wrapQueueHandler(
           'messaging.operation.name': 'process',
           'messaging.batch.message_count': batch.messages.length,
           'messaging.message.retry.count': batch.messages.reduce((acc, message) => acc + message.attempts - 1, 0),
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'queue.process',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.faas.cloudflare.queue',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',
         },


### PR DESCRIPTION
The queue consumer span passed both `op: 'faas.queue'` and a `sentry.op` attribute of `queue.process`. The attribute wins, so `faas.queue` was dead. Emitted spans are unchanged.

Part of https://github.com/getsentry/sentry-javascript/issues/22446