### PR TITLE
feat(google-cloud-serverless)!: Use `grpc` span op for GCP gRPC calls

### DIFF
--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -41,6 +41,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0"
   },

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
@@ -1,4 +1,4 @@
-import { RPC_METHOD, RPC_SERVICE, RPC_SYSTEM_NAME } from '@sentry/conventions/attributes';
+import { RPC_METHOD, RPC_SERVICE, RPC_SYSTEM_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
 import { FAAS_GRPC_SPAN_OP } from '@sentry/conventions/op';
 import type { Client, IntegrationFn } from '@sentry/core';
 import { defineIntegration, fill, getClient, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
@@ -108,8 +108,8 @@ export function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodNa
         const span = startInactiveSpan({
           name: `${callType} ${methodName}`,
           onlyIfParent: true,
-          op: FAAS_GRPC_SPAN_OP,
           attributes: {
+            [SENTRY_OP]: FAAS_GRPC_SPAN_OP,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.grpc.serverless',
             [RPC_SYSTEM_NAME]: 'grpc',
             [RPC_SERVICE]: serviceIdentifier,

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
@@ -1,3 +1,5 @@
+import { RPC_METHOD, RPC_SERVICE, RPC_SYSTEM_NAME } from '@sentry/conventions/attributes';
+import { FAAS_GRPC_SPAN_OP } from '@sentry/conventions/op';
 import type { Client, IntegrationFn } from '@sentry/core';
 import { defineIntegration, fill, getClient, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { startInactiveSpan } from '@sentry/node';
@@ -106,9 +108,12 @@ export function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodNa
         const span = startInactiveSpan({
           name: `${callType} ${methodName}`,
           onlyIfParent: true,
-          op: `grpc.${serviceIdentifier}`,
+          op: FAAS_GRPC_SPAN_OP,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.grpc.serverless',
+            [RPC_SYSTEM_NAME]: 'grpc',
+            [RPC_SERVICE]: serviceIdentifier,
+            [RPC_METHOD]: methodName,
           },
         });
         ret.on('status', () => {

--- a/packages/google-cloud-serverless/test/integrations/google-cloud-grpc.test.ts
+++ b/packages/google-cloud-serverless/test/integrations/google-cloud-grpc.test.ts
@@ -142,9 +142,12 @@ describe('GoogleCloudGrpc tracing', () => {
       expect(mockStartInactiveSpan).toHaveBeenCalledWith({
         name: 'unary call unaryMethod',
         onlyIfParent: true,
-        op: 'grpc.test-service',
+        op: 'grpc',
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.grpc.serverless',
+          'rpc.system.name': 'grpc',
+          'rpc.service': 'test-service',
+          'rpc.method': 'unaryMethod',
         },
       });
     });

--- a/packages/google-cloud-serverless/test/integrations/google-cloud-grpc.test.ts
+++ b/packages/google-cloud-serverless/test/integrations/google-cloud-grpc.test.ts
@@ -1,3 +1,4 @@
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 import { createTransport, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, setCurrentClient } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -142,8 +143,8 @@ describe('GoogleCloudGrpc tracing', () => {
       expect(mockStartInactiveSpan).toHaveBeenCalledWith({
         name: 'unary call unaryMethod',
         onlyIfParent: true,
-        op: 'grpc',
         attributes: {
+          [SENTRY_OP]: 'grpc',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.grpc.serverless',
           'rpc.system.name': 'grpc',
           'rpc.service': 'test-service',


### PR DESCRIPTION
Use `grpc` instead of `grpc.<service>` in `googleCloudGrpcIntegration`. The service is now identified by the new `rpc.service` attribute. Also added `rpc.system.name` and `rpc.method`.

Part of https://github.com/getsentry/sentry-javascript/issues/22446