### PR TITLE
feat(angular)!: Use `ui.mount` and `function` span ops for tracing decorators

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-17/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/tests/performance.test.ts
@@ -261,22 +261,22 @@ test.describe('TraceDirective', () => {
       expect.arrayContaining([
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<sample-component>', // custom component name passed to trace directive
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
         }),
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<app-sample-component>', // fallback selector name
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
@@ -305,11 +305,11 @@ test.describe('TraceClass Decorator', () => {
     expect(classDecoratorSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
         },
         description: '<ComponentTrackingComponent>',
-        op: 'ui.angular.init',
+        op: 'ui.mount',
         origin: 'auto.ui.angular.trace_class_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -329,17 +329,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngOnInit');
+    const ngInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngOnInit',
+    );
 
     expect(ngInitSpan).toBeDefined();
     expect(ngInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngOnInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngOnInit',
         },
         description: '<ngOnInit>',
-        op: 'ui.angular.ngOnInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -357,17 +360,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngAfterViewInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngAfterViewInit');
+    const ngAfterViewInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngAfterViewInit',
+    );
 
     expect(ngAfterViewInitSpan).toBeDefined();
     expect(ngAfterViewInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngAfterViewInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngAfterViewInit',
         },
         description: '<unnamed>',
-        op: 'ui.angular.ngAfterViewInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),

--- a/dev-packages/e2e-tests/test-applications/angular-18/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-18/tests/performance.test.ts
@@ -260,11 +260,11 @@ test.describe('TraceDirective', () => {
     expect(traceDirectiveSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
         },
         description: '<sample-component>',
-        op: 'ui.angular.init',
+        op: 'ui.mount',
         origin: 'auto.ui.angular.trace_directive',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -292,11 +292,11 @@ test.describe('TraceClass Decorator', () => {
     expect(classDecoratorSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
         },
         description: '<ComponentTrackingComponent>',
-        op: 'ui.angular.init',
+        op: 'ui.mount',
         origin: 'auto.ui.angular.trace_class_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -316,17 +316,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngOnInit');
+    const ngInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngOnInit',
+    );
 
     expect(ngInitSpan).toBeDefined();
     expect(ngInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngOnInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngOnInit',
         },
         description: '<ngOnInit>',
-        op: 'ui.angular.ngOnInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -344,17 +347,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngAfterViewInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngAfterViewInit');
+    const ngAfterViewInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngAfterViewInit',
+    );
 
     expect(ngAfterViewInitSpan).toBeDefined();
     expect(ngAfterViewInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngAfterViewInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngAfterViewInit',
         },
         description: '<unnamed>',
-        op: 'ui.angular.ngAfterViewInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),

--- a/dev-packages/e2e-tests/test-applications/angular-19/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-19/tests/performance.test.ts
@@ -261,22 +261,22 @@ test.describe('TraceDirective', () => {
       expect.arrayContaining([
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<sample-component>', // custom component name passed to trace directive
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
         }),
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<app-sample-component>', // fallback selector name
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
@@ -305,11 +305,11 @@ test.describe('TraceClass Decorator', () => {
     expect(classDecoratorSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
         },
         description: '<ComponentTrackingComponent>',
-        op: 'ui.angular.init',
+        op: 'ui.mount',
         origin: 'auto.ui.angular.trace_class_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -329,17 +329,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngOnInit');
+    const ngInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngOnInit',
+    );
 
     expect(ngInitSpan).toBeDefined();
     expect(ngInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngOnInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngOnInit',
         },
         description: '<ngOnInit>',
-        op: 'ui.angular.ngOnInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -357,17 +360,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngAfterViewInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngAfterViewInit');
+    const ngAfterViewInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngAfterViewInit',
+    );
 
     expect(ngAfterViewInitSpan).toBeDefined();
     expect(ngAfterViewInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngAfterViewInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngAfterViewInit',
         },
         description: '<unnamed>',
-        op: 'ui.angular.ngAfterViewInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),

--- a/dev-packages/e2e-tests/test-applications/angular-20/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-20/tests/performance.test.ts
@@ -261,22 +261,22 @@ test.describe('TraceDirective', () => {
       expect.arrayContaining([
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<sample-component>', // custom component name passed to trace directive
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
         }),
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<app-sample-component>', // fallback selector name
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
@@ -305,11 +305,11 @@ test.describe('TraceClass Decorator', () => {
     expect(classDecoratorSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
         },
         description: '<ComponentTrackingComponent>',
-        op: 'ui.angular.init',
+        op: 'ui.mount',
         origin: 'auto.ui.angular.trace_class_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -329,17 +329,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngOnInit');
+    const ngInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngOnInit',
+    );
 
     expect(ngInitSpan).toBeDefined();
     expect(ngInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngOnInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngOnInit',
         },
         description: '<ngOnInit>',
-        op: 'ui.angular.ngOnInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -357,17 +360,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngAfterViewInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngAfterViewInit');
+    const ngAfterViewInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngAfterViewInit',
+    );
 
     expect(ngAfterViewInitSpan).toBeDefined();
     expect(ngAfterViewInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngAfterViewInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngAfterViewInit',
         },
         description: '<unnamed>',
-        op: 'ui.angular.ngAfterViewInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),

--- a/dev-packages/e2e-tests/test-applications/angular-21/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-21/tests/performance.test.ts
@@ -261,22 +261,22 @@ test.describe('TraceDirective', () => {
       expect.arrayContaining([
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<sample-component>', // custom component name passed to trace directive
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
         }),
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<app-sample-component>', // fallback selector name
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
@@ -305,11 +305,11 @@ test.describe('TraceClass Decorator', () => {
     expect(classDecoratorSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
         },
         description: '<ComponentTrackingComponent>',
-        op: 'ui.angular.init',
+        op: 'ui.mount',
         origin: 'auto.ui.angular.trace_class_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -329,17 +329,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngOnInit');
+    const ngInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngOnInit',
+    );
 
     expect(ngInitSpan).toBeDefined();
     expect(ngInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngOnInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngOnInit',
         },
         description: '<ngOnInit>',
-        op: 'ui.angular.ngOnInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -357,17 +360,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngAfterViewInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngAfterViewInit');
+    const ngAfterViewInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngAfterViewInit',
+    );
 
     expect(ngAfterViewInitSpan).toBeDefined();
     expect(ngAfterViewInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngAfterViewInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngAfterViewInit',
         },
         description: '<unnamed>',
-        op: 'ui.angular.ngAfterViewInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),

--- a/dev-packages/e2e-tests/test-applications/angular-22/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-22/tests/performance.test.ts
@@ -261,22 +261,22 @@ test.describe('TraceDirective', () => {
       expect.arrayContaining([
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<sample-component>', // custom component name passed to trace directive
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
         }),
         expect.objectContaining({
           data: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
           },
           description: '<app-sample-component>', // fallback selector name
-          op: 'ui.angular.init',
+          op: 'ui.mount',
           origin: 'auto.ui.angular.trace_directive',
           start_timestamp: expect.any(Number),
           timestamp: expect.any(Number),
@@ -305,11 +305,11 @@ test.describe('TraceClass Decorator', () => {
     expect(classDecoratorSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.init',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.mount',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
         },
         description: '<ComponentTrackingComponent>',
-        op: 'ui.angular.init',
+        op: 'ui.mount',
         origin: 'auto.ui.angular.trace_class_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -329,17 +329,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngOnInit');
+    const ngInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngOnInit',
+    );
 
     expect(ngInitSpan).toBeDefined();
     expect(ngInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngOnInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngOnInit',
         },
         description: '<ngOnInit>',
-        op: 'ui.angular.ngOnInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),
@@ -357,17 +360,20 @@ test.describe('TraceMethod Decorator', () => {
     // immediately navigate to a different route
     const [_, navigationTxn] = await Promise.all([page.locator('#componentTracking').click(), navigationTxnPromise]);
 
-    const ngAfterViewInitSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.ngAfterViewInit');
+    const ngAfterViewInitSpan = navigationTxn.spans?.find(
+      span => span.op === 'function' && span.data?.['code.function.name'] === 'ngAfterViewInit',
+    );
 
     expect(ngAfterViewInitSpan).toBeDefined();
     expect(ngAfterViewInitSpan).toEqual(
       expect.objectContaining({
         data: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.angular.ngAfterViewInit',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+          'code.function.name': 'ngAfterViewInit',
         },
         description: '<unnamed>',
-        op: 'ui.angular.ngAfterViewInit',
+        op: 'function',
         origin: 'auto.ui.angular.trace_method_decorator',
         start_timestamp: expect.any(Number),
         timestamp: expect.any(Number),

--- a/packages/angular/src/constants.ts
+++ b/packages/angular/src/constants.ts
@@ -1,5 +1,4 @@
 export const ANGULAR_ROUTING_OP = 'ui.angular.routing';
 
-export const ANGULAR_INIT_OP = 'ui.angular.init';
-
-export const ANGULAR_OP = 'ui.angular';
+// TODO(v11): Replace with the `ui.mount` constant from `@sentry/conventions/op` once it is registered there.
+export const ANGULAR_INIT_OP = 'ui.mount';

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -21,6 +21,8 @@ import {
   startInactiveSpan,
   getAbsoluteUrl,
 } from '@sentry/browser';
+import { CODE_FUNCTION_NAME, SENTRY_OP, URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
 import type { Integration, Span } from '@sentry/core';
 import { debug, parseStringToURLObject, stripUrlQueryAndFragment, timestampInSeconds } from '@sentry/core';
 import type { Observable } from 'rxjs';
@@ -29,8 +31,6 @@ import { filter, tap } from 'rxjs/operators';
 import { ANGULAR_INIT_OP, ANGULAR_ROUTING_OP } from './constants';
 import { IS_DEBUG_BUILD } from './flags';
 import { runOutsideAngular } from './zone';
-import { CODE_FUNCTION_NAME, URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
 
 let instrumentationInitialized: boolean;
 
@@ -294,8 +294,10 @@ export class TraceDirective implements OnInit, AfterViewInit {
       this._tracingSpan = runOutsideAngular(() =>
         startInactiveSpan({
           name: `<${this.componentName}>`,
-          op: ANGULAR_INIT_OP,
-          attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive' },
+          attributes: {
+            [SENTRY_OP]: ANGULAR_INIT_OP,
+            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_directive',
+          },
         }),
       );
     }
@@ -343,8 +345,8 @@ export function TraceClass(options?: TraceClassOptions): ClassDecorator {
         startInactiveSpan({
           onlyIfParent: true,
           name: `<${options?.name || 'unnamed'}>`,
-          op: ANGULAR_INIT_OP,
           attributes: {
+            [SENTRY_OP]: ANGULAR_INIT_OP,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_class_decorator',
           },
         }),
@@ -388,9 +390,9 @@ export function TraceMethod(options?: TraceMethodOptions): MethodDecorator {
         startInactiveSpan({
           onlyIfParent: true,
           name: `<${options?.name ? options.name : 'unnamed'}>`,
-          op: GENERAL_FUNCTION_SPAN_OP,
           startTime: now,
           attributes: {
+            [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
             [CODE_FUNCTION_NAME]: String(propertyKey),
           },

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -26,10 +26,11 @@ import { debug, parseStringToURLObject, stripUrlQueryAndFragment, timestampInSec
 import type { Observable } from 'rxjs';
 import { Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
-import { ANGULAR_INIT_OP, ANGULAR_OP, ANGULAR_ROUTING_OP } from './constants';
+import { ANGULAR_INIT_OP, ANGULAR_ROUTING_OP } from './constants';
 import { IS_DEBUG_BUILD } from './flags';
 import { runOutsideAngular } from './zone';
-import { URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { CODE_FUNCTION_NAME, URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
 
 let instrumentationInitialized: boolean;
 
@@ -387,10 +388,11 @@ export function TraceMethod(options?: TraceMethodOptions): MethodDecorator {
         startInactiveSpan({
           onlyIfParent: true,
           name: `<${options?.name ? options.name : 'unnamed'}>`,
-          op: `${ANGULAR_OP}.${String(propertyKey)}`,
+          op: GENERAL_FUNCTION_SPAN_OP,
           startTime: now,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
+            [CODE_FUNCTION_NAME]: String(propertyKey),
           },
         }).end(now);
       });


### PR DESCRIPTION
`TraceDirective` and `TraceClass` now emit `ui.mount` instead of `ui.angular.init`. `TraceMethod` emits `function` instead of `ui.angular.<methodName>` — the suffix was user-controlled and unbounded — with the method name preserved in `code.function.name`.

Note `ui.mount` is not in the conventions registry yet (tracked as its own row in the first table of the issue), so it is a literal here with a TODO to swap in the constant once registered.

Part of https://github.com/getsentry/sentry-javascript/issues/22446