### PR TITLE
fix(gatsby): Add React 19 to peer dependency range

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -44,7 +44,7 @@
   },
   "peerDependencies": {
     "gatsby": "^3.0.0 || ^4.0.0 || ^5.0.0",
-    "react": "17.x || 18.x"
+    "react": "17.x || 18.x || 19.x"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.5",


### PR DESCRIPTION
Gatsby supports React 19 as of 5.16.0, but `@sentry/gatsby` still declared `react: 17.x || 18.x`. The package just delegates to `@sentry/react`, which already declares `19.x`, so no source changes are needed.

came up in review of #22665.