### PR TITLE
feat(browser)!: Use `browser.paint` span op for paint entries

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
@@ -18,7 +18,7 @@ sentryTest('should capture FP vital.', async ({ browserName, getLocalTestUrl, pa
   const fpSpan = eventData.spans?.filter(({ description }) => description === 'first-paint')[0];
 
   expect(fpSpan).toBeDefined();
-  expect(fpSpan?.op).toBe('paint');
+  expect(fpSpan?.op).toBe('browser.paint');
   expect(fpSpan?.parent_span_id).toBe(eventData.contexts?.trace?.span_id);
 });
 
@@ -36,6 +36,6 @@ sentryTest('should capture FCP vital.', async ({ getLocalTestUrl, page }) => {
   const fcpSpan = eventData.spans?.filter(({ description }) => description === 'first-contentful-paint')[0];
 
   expect(fcpSpan).toBeDefined();
-  expect(fcpSpan?.op).toBe('paint');
+  expect(fcpSpan?.op).toBe('browser.paint');
   expect(fcpSpan?.parent_span_id).toBe(eventData.contexts?.trace?.span_id);
 });

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -26,7 +26,7 @@ import { getActivationStart } from './web-vitals/lib/getActivationStart';
 import { getNavigationEntry } from './web-vitals/lib/getNavigationEntry';
 import { getVisibilityWatcher } from './web-vitals/lib/getVisibilityWatcher';
 import { DEBUG_BUILD } from '../debug-build';
-import { URL_FULL } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
 import { BROWSER_BROWSER_PAINT_SPAN_OP } from '@sentry/conventions/op';
 interface NavigatorNetworkInformation {
   readonly connection?: NetworkInformation;
@@ -484,8 +484,8 @@ function _addPaintSpan(
 
   startAndEndSpan(span, startTimestamp, startTimestamp + duration, {
     name: entry.name,
-    op: BROWSER_BROWSER_PAINT_SPAN_OP,
     attributes: {
+      [SENTRY_OP]: BROWSER_BROWSER_PAINT_SPAN_OP,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
     },
   });

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -27,6 +27,7 @@ import { getNavigationEntry } from './web-vitals/lib/getNavigationEntry';
 import { getVisibilityWatcher } from './web-vitals/lib/getVisibilityWatcher';
 import { DEBUG_BUILD } from '../debug-build';
 import { URL_FULL } from '@sentry/conventions/attributes';
+import { BROWSER_BROWSER_PAINT_SPAN_OP } from '@sentry/conventions/op';
 interface NavigatorNetworkInformation {
   readonly connection?: NetworkInformation;
 }
@@ -483,7 +484,7 @@ function _addPaintSpan(
 
   startAndEndSpan(span, startTimestamp, startTimestamp + duration, {
     name: entry.name,
-    op: entry.entryType,
+    op: BROWSER_BROWSER_PAINT_SPAN_OP,
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
     },


### PR DESCRIPTION
Rename the raw `paint` op to the registered `browser.paint` for `first-paint` and `first-contentful-paint` spans.

Part of https://github.com/getsentry/sentry-javascript/issues/22446