### PR TITLE
fix(v10/gatsby): Add React 19 to peer dependency range

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "gatsby": "^3.0.0 || ^4.0.0 || ^5.0.0",
-    "react": "16.x || 17.x || 18.x"
+    "react": "16.x || 17.x || 18.x || 19.x"
   },
   "devDependencies": {
     "@testing-library/react": "^15.0.5",


### PR DESCRIPTION
Backport of: #22672