### PR TITLE
fix(node): Unpin `@apm-js-collab/code-transformer-bundler-plugins`

### DIFF
--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+    "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
     "@sentry/core": "10.67.0",
     "@sentry/conventions": "^0.16.0",
     "@sentry/node": "10.67.0",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -101,7 +101,7 @@
     "@sentry/core": "10.67.0"
   },
   "devDependencies": {
-    "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+    "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
     "@apm-js-collab/tracing-hooks": "^0.13.0",
     "@types/node": "^18.19.1",
     "meriyah": "^6.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,10 +404,10 @@
   dependencies:
     json-schema-to-ts "^3.1.1"
 
-"@apm-js-collab/code-transformer-bundler-plugins@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.1.tgz#f9e7128b87cdabb50e91f2ce3a5c48505b511c41"
-  integrity sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==
+"@apm-js-collab/code-transformer-bundler-plugins@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.3.tgz#c439f6d63306c1800a430733aac3af6e496d9fe8"
+  integrity sha512-qNbPwuMZ8f5ZuGj/ttPeB7a6C/S1bB6tNYaEL5vNiRKydSAxa4AU0gxCWgaP4fVju+AuwhcumSFjrEcGF9Dv7Q==
   dependencies:
     "@apm-js-collab/code-transformer" "^0.18.0"
     es-module-lexer "^2.1.0"


### PR DESCRIPTION
## What

Bump `@apm-js-collab/code-transformer-bundler-plugins` from `^0.7.1` to `^0.7.3` in `@sentry/server-utils` and `@sentry/bun`, walking back the pin from getsentry/sentry-javascript#22497.

* `packages/server-utils/package.json`: `^0.7.1` -> `^0.7.3`
* `packages/bun/package.json`: `^0.7.1` -> `^0.7.3`
* `yarn.lock`: resolves to 0.7.3

## Why

getsentry/sentry-javascript#22497 pinned to 0.7.1 to work around the `generic-ts3.8` e2e test (0.7.2 shipped `.d.cts`/`.d.mts` files TS 3.8 could not parse). But 0.7.1's `.d.cts` has a broken `./instrumentation-serde` re-export, which breaks modern TypeScript in consumers.

0.7.3 was released upstream specifically for [apm-js-collab/code-transformer-bundler-plugins#45](<https://github.com/apm-js-collab/code-transformer-bundler-plugins/issues/45>) ("TS 3.8 cannot parse mixed type imports"). It moves to plain `.d.ts` files with a resolvable `./instrumentation-serde.js` re-export, fixing both sides: modern TS resolves the module, and TS 3.8 no longer chokes on the type-import syntax.

Fixes getsentry/sentry-javascript#22626  <br>Fixes getsentry/sentry-javascript#22646