### PR TITLE
docs(migration): Note raised Fastify minimum version (3.21)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -53,7 +53,7 @@ We raised the minimum supported versions of several frameworks and libraries:
 - **Astro:** dropped Astro 3 (minimum is now 4).
 - **React Router (framework mode):** minimum is now 7.15.
 - **Remix:** dropped `@remix-run/node` v1 (minimum is now v2).
-- **Fastify:** dropped Fastify 3.0 through 3.20 (minimum is now 3.21). Fastify is now instrumented via Node diagnostics channels, which require Fastify 3.21 or higher.
+- **Fastify:** dropped Fastify 3.0 through 3.20 (minimum is now 3.21).
 
 <!-- TODO(v11): Evaluate whether we can move to Sentry CLI v4 already. -->
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -53,6 +53,7 @@ We raised the minimum supported versions of several frameworks and libraries:
 - **Astro:** dropped Astro 3 (minimum is now 4).
 - **React Router (framework mode):** minimum is now 7.15.
 - **Remix:** dropped `@remix-run/node` v1 (minimum is now v2).
+- **Fastify:** dropped Fastify 3.0 through 3.20 (minimum is now 3.21). Fastify is now instrumented via Node diagnostics channels, which require Fastify 3.21 or higher.
 
 <!-- TODO(v11): Evaluate whether we can move to Sentry CLI v4 already. -->
 


### PR DESCRIPTION
## What

Add a v11 migration guide entry noting that the minimum supported Fastify version is now 3.21.

## Why

Fastify is instrumented via Node diagnostics channels, which are only available from Fastify 3.21. Dropping 3.0 through 3.20 is user-visible and belongs in the framework support changes list. The OTel fallback that covered the older range is being removed separately, so this only documents the change.

Closes: getsentry/sentry-javascript#21840