### PR TITLE
feat(core)!: Remove `queryParams` in favor of `urlQueryParams`

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
@@ -6,7 +6,7 @@ interface Env {
   SENTRY_DSN: string;
 }
 
-const ai = instrumentWorkersAiClient(new MockAi());
+const ai = instrumentWorkersAiClient(new MockAi(), { recordInputs: false, recordOutputs: false });
 
 export default Sentry.withSentry(
   (env: Env) => ({

--- a/packages/core/src/types/datacollection.ts
+++ b/packages/core/src/types/datacollection.ts
@@ -44,9 +44,6 @@ export interface DataCollection {
    */
   httpBodies?: HttpBodyCollectionTarget[];
 
-  /** @deprecated Use `urlQueryParams` instead. */
-  queryParams?: CollectBehavior;
-
   /**
    * Controls URL query parameter collection and sensitive value filtering.
    * @default true
@@ -112,8 +109,7 @@ export interface DataCollection {
 /**
  * Fully resolved `DataCollection` with all defaults applied.
  */
-// todo(v11): change `Omit<DataCollection, 'queryParams'>` to just `DataCollection`
-export type ResolvedDataCollection = Required<Omit<DataCollection, 'queryParams'>> & {
+export type ResolvedDataCollection = Required<DataCollection> & {
   httpHeaders: Required<NonNullable<DataCollection['httpHeaders']>>;
   graphQL: Required<NonNullable<DataCollection['graphQL']>>;
   genAI: Required<NonNullable<DataCollection['genAI']>>;

--- a/packages/core/src/utils/data-collection/resolveDataCollectionOptions.ts
+++ b/packages/core/src/utils/data-collection/resolveDataCollectionOptions.ts
@@ -44,8 +44,7 @@ export function resolveDataCollectionOptions(options: {
       response: dc.httpHeaders?.response ?? base.httpHeaders.response,
     },
     httpBodies: dc.httpBodies ?? base.httpBodies,
-    // oxlint-disable-next-line typescript/no-deprecated
-    urlQueryParams: dc.urlQueryParams ?? dc.queryParams ?? base.urlQueryParams,
+    urlQueryParams: dc.urlQueryParams ?? base.urlQueryParams,
     graphQL: {
       document: dc.graphQL?.document ?? base.graphQL.document,
       variables: dc.graphQL?.variables ?? base.graphQL.variables,

--- a/packages/core/test/lib/utils/data-collection/resolveDataCollectionOptions.test.ts
+++ b/packages/core/test/lib/utils/data-collection/resolveDataCollectionOptions.test.ts
@@ -213,36 +213,4 @@ describe('resolveDataCollectionOptions', () => {
       expect(result).toHaveProperty('frameContextLines');
     });
   });
-
-  describe('deprecated queryParams alias', () => {
-    it('honors deprecated queryParams when urlQueryParams is not set', () => {
-      expect(resolveDataCollectionOptions({ dataCollection: { queryParams: false } }).urlQueryParams).toBe(false);
-
-      expect(
-        resolveDataCollectionOptions({ dataCollection: { queryParams: { deny: ['token'] } } }).urlQueryParams,
-      ).toEqual({ deny: ['token'] });
-    });
-
-    it('prefers urlQueryParams over the deprecated queryParams when both are set', () => {
-      // new field wins, even when it is the "off" value
-      expect(
-        resolveDataCollectionOptions({ dataCollection: { urlQueryParams: false, queryParams: true } }).urlQueryParams,
-      ).toBe(false);
-
-      expect(
-        resolveDataCollectionOptions({ dataCollection: { urlQueryParams: true, queryParams: false } }).urlQueryParams,
-      ).toBe(true);
-    });
-
-    it('falls back to the default when neither is set', () => {
-      // dataCollection provided → spec default (collect)
-      expect(resolveDataCollectionOptions({ dataCollection: {} }).urlQueryParams).toBe(true);
-    });
-
-    it('does not leak the deprecated queryParams key into the resolved output', () => {
-      const result = resolveDataCollectionOptions({ dataCollection: { queryParams: false } });
-      expect(result).not.toHaveProperty('queryParams');
-      expect(Object.keys(result)).toHaveLength(10);
-    });
-  });
 });


### PR DESCRIPTION
Migration docs will be added all at once for all `dataCollection` changes.

Closes https://github.com/getsentry/sentry-javascript/issues/22311
