### PR TITLE
fix(nuxt): Move `@nuxt/kit` to peer/dev deps to avoid duplicate on Nuxt 4

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -44,6 +44,7 @@
     "access": "public"
   },
   "peerDependencies": {
+    "@nuxt/kit": "^3.13.2 || ^4.0.0",
     "nuxt": ">=3.7.0 || 4.x || 5.x",
     "nitro": "2.x || 3.x"
   },
@@ -53,7 +54,6 @@
     }
   },
   "dependencies": {
-    "@nuxt/kit": "^3.13.2",
     "@sentry/browser": "10.67.0",
     "@sentry/cloudflare": "10.67.0",
     "@sentry/core": "10.67.0",
@@ -64,6 +64,7 @@
     "local-pkg": "^1.1.2"
   },
   "devDependencies": {
+    "@nuxt/kit": "^3.13.2",
     "@nuxt/nitro-server": "^3.21.6",
     "nitro": "^3.0.260311-beta",
     "nuxi": "^3.25.1",


### PR DESCRIPTION
## Summary

`@sentry/nuxt` declares `@nuxt/kit: ^3.13.2` as a regular **dependency**. On a Nuxt 4 app (`@nuxt/kit@4.x`), the `^3` cap (`>=3.13.2 <4.0.0`) can't dedupe with the app's 4.x, so a **second copy** of `@nuxt/kit` (3.x) gets installed next to the app's 4.x:

```
@nuxt/kit@4.5.1   ← nuxt 4.5.1
@nuxt/kit@3.21.9  ← @sentry/nuxt
```

Following @s1gr1d's suggestion in the issue, this moves `@nuxt/kit`:

* **out of** `dependencies`
* **into** `devDependencies` (`^3.13.2`) — so the SDK still builds/tests against 3.x
* **into** `peerDependencies` (`^3.13.2 || ^4.0.0`) — so the host Nuxt app supplies the single, deduplicated version

`@nuxt/kit` 4.x is backward compatible with the 3.x APIs the module uses, and `nuxt` is already a required peer (which itself provides `@nuxt/kit`), so a required `@nuxt/kit` peer is safe.

No lockfile change: the `^3.13.2` range is unchanged (now via the devDependency), and yarn classic does not lock peerDependencies.

Closes getsentry/sentry-javascript#22679