### PR TITLE
test: Disable span streaming in remaining test suites

### DIFF
--- a/dev-packages/bun-integration-tests/suites/hono-sdk/index.ts
+++ b/dev-packages/bun-integration-tests/suites/hono-sdk/index.ts
@@ -7,6 +7,7 @@ app.use(
   sentry(app, {
     dsn: process.env.SENTRY_DSN,
     tracesSampleRate: 1.0,
+    traceLifecycle: 'static',
   }),
 );
 

--- a/dev-packages/deno-integration-tests/suites/direct-client-acs/scenario.mjs
+++ b/dev-packages/deno-integration-tests/suites/direct-client-acs/scenario.mjs
@@ -16,6 +16,7 @@ let nested = false;
 const client = new DenoClient({
   dsn: 'https://username@domain/123',
   tracesSampleRate: 1,
+  traceLifecycle: 'static',
   integrations: getDefaultIntegrations({}),
   stackParser: createStackParser(nodeStackLineParser()),
   beforeSendTransaction(event) {

--- a/dev-packages/deno-integration-tests/suites/orchestrion-amqplib/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-amqplib/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('amqplib instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Amqplib'), `Amqplib should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('amqplib instrumentation: orchestrion:amqplib:publish channel produces
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-anthropic/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-anthropic/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('anthropic instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Anthropic_AI'), `Anthropic_AI should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('anthropic instrumentation: orchestrion @anthropic-ai/sdk:chat channel
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-aws/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-aws/test.ts
@@ -11,7 +11,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('aws-sdk instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Aws'), `Aws should be in defaults, got ${names.join(', ')}`);
 });
@@ -26,6 +26,7 @@ Deno.test('aws-sdk instrumentation: orchestrion @smithy/smithy-client:send chann
   resetGlobals();
   const sink = transactionSink();
   const client = init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-express/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-express/test.ts
@@ -11,7 +11,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('express instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Express'), `Express should be in defaults, got ${names.join(', ')}`);
 });
@@ -20,6 +20,7 @@ Deno.test('express instrumentation: orchestrion:express:handle channel produces 
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-firebase/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-firebase/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('firebase instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Firebase'), `Firebase should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('firebase instrumentation: orchestrion @firebase/firestore:add-doc cha
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-generic-pool/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-generic-pool/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('generic-pool instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('GenericPool'), `GenericPool should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('generic-pool instrumentation: orchestrion:generic-pool:acquire channe
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-google-genai/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-google-genai/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('google-genai instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Google_GenAI'), `Google_GenAI should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('google-genai instrumentation: orchestrion @google/genai:generate-cont
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-graphql/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-graphql/test.ts
@@ -16,6 +16,7 @@ async function assertParseSpan(channelName: string): Promise<void> {
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,
@@ -47,7 +48,7 @@ async function assertParseSpan(channelName: string): Promise<void> {
 
 Deno.test('graphql instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Graphql'), `Graphql should be in defaults, got ${names.join(', ')}`);
 });

--- a/dev-packages/deno-integration-tests/suites/orchestrion-hapi/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-hapi/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('hapi instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Hapi'), `Hapi should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('hapi instrumentation: orchestrion:@hapi/hapi:route channel wraps the 
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-kafkajs/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-kafkajs/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('kafkajs instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Kafka'), `Kafka should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('kafkajs instrumentation: orchestrion:kafkajs:send_batch channel produ
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-koa/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-koa/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('koa instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Koa'), `Koa should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('koa instrumentation: orchestrion:koa:use channel wraps middleware int
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-langchain/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-langchain/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('langchain instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('LangChain'), `LangChain should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('langchain instrumentation: orchestrion @langchain/openai:embedQuery c
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-langgraph/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-langgraph/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('langgraph instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('LangGraph'), `LangGraph should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('langgraph instrumentation: orchestrion stateGraphCompile channel prod
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-lru-memoizer/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-lru-memoizer/test.ts
@@ -11,7 +11,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('lru-memoizer instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('LruMemoizer'), `LruMemoizer should be in defaults, got ${names.join(', ')}`);
 });
@@ -26,6 +26,7 @@ Deno.test('lru-memoizer instrumentation: restores the caller scope onto the memo
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-mongo/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-mongo/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('mongodb instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Mongo'), `Mongo should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('mongodb instrumentation: orchestrion:mongodb:command channel produces
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-mongoose/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-mongoose/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('mongoose instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Mongoose'), `Mongoose should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('mongoose instrumentation: orchestrion:mongoose:model_save channel pro
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-mysql2/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-mysql2/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('mysql2 instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Mysql2'), `Mysql2 should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('mysql2 instrumentation: orchestrion:mysql2:query channel produces a n
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-openai/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-openai/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('openai instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('OpenAI'), `OpenAI should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('openai instrumentation: orchestrion:openai:chat channel produces a ne
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-postgresjs/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-postgresjs/test.ts
@@ -10,7 +10,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('postgres.js instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('PostgresJs'), `PostgresJs should be in defaults, got ${names.join(', ')}`);
 });
@@ -19,6 +19,7 @@ Deno.test('postgres.js instrumentation: orchestrion:postgres:handle channel prod
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-tedious/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-tedious/test.ts
@@ -11,7 +11,7 @@ import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
 
 Deno.test('tedious instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
-  const client = init({ dsn: 'https://username@domain/123' }) as DenoClient;
+  const client = init({ traceLifecycle: 'static', dsn: 'https://username@domain/123' }) as DenoClient;
   const names = client.getOptions().integrations.map(i => i.name);
   assert(names.includes('Tedious'), `Tedious should be in defaults, got ${names.join(', ')}`);
 });
@@ -20,6 +20,7 @@ Deno.test('tedious instrumentation: orchestrion:tedious:execSql channel produces
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/deno-integration-tests/suites/orchestrion-vercel-ai/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-vercel-ai/test.ts
@@ -19,6 +19,7 @@ Deno.test('vercel-ai instrumentation: orchestrion:ai:generateText channel produc
   resetGlobals();
   const sink = transactionSink();
   init({
+    traceLifecycle: 'static',
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     beforeSendTransaction: sink.beforeSendTransaction,

--- a/dev-packages/node-integration-tests/suites/tracing/mysql/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/mysql/instrument.mjs
@@ -10,5 +10,5 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  traceLifecycle: process.env.STREAMED === 'true' ? 'stream' : undefined,
+  traceLifecycle: process.env.STREAMED === 'true' ? 'stream' : 'static',
 });

--- a/packages/browser/test/profiling/UIProfiler.test.ts
+++ b/packages/browser/test/profiling/UIProfiler.test.ts
@@ -11,6 +11,7 @@ function getBaseOptionsForTraceLifecycle(sendMock: Mock<any>, enableTracing = tr
   return {
     dsn: 'https://public@o.ingest.sentry.io/1',
     ...(enableTracing ? { tracesSampleRate: 1 } : {}),
+    traceLifecycle: 'static',
     profileSessionSampleRate: 1,
     profileLifecycle: 'trace',
     integrations: [Sentry.browserProfilingIntegration()],
@@ -711,6 +712,7 @@ function getBaseOptionsForManualLifecycle(sendMock: Mock<any>, enableTracing = t
   return {
     dsn: 'https://public@o.ingest.sentry.io/1',
     ...(enableTracing ? { tracesSampleRate: 1 } : {}),
+    traceLifecycle: 'static',
     profileSessionSampleRate: 1,
     profileLifecycle: 'manual',
     integrations: [Sentry.browserProfilingIntegration()],

--- a/packages/browser/test/profiling/integration.test.ts
+++ b/packages/browser/test/profiling/integration.test.ts
@@ -39,6 +39,7 @@ describe('BrowserProfilingIntegration', () => {
     const send = vi.fn().mockImplementation(() => Promise.resolve());
     const client = Sentry.init({
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       profilesSampleRate: 1,
       environment: 'test-environment',
       dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
@@ -134,6 +135,7 @@ describe('BrowserProfilingIntegration', () => {
       const send = vi.fn().mockResolvedValue(undefined);
       const client = Sentry.init({
         tracesSampleRate: 1,
+        traceLifecycle: 'static',
         profilesSampleRate: 1,
         dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
         transport: _opts => ({

--- a/packages/bun/test/init.test.ts
+++ b/packages/bun/test/init.test.ts
@@ -35,7 +35,7 @@ describe('init()', () => {
 
   describe('integrations', () => {
     it("doesn't install default integrations if told not to", () => {
-      init({ dsn: PUBLIC_DSN, defaultIntegrations: false });
+      init({ dsn: PUBLIC_DSN, defaultIntegrations: false, traceLifecycle: 'static' });
 
       const client = getClient();
 
@@ -132,7 +132,7 @@ describe('init()', () => {
 
   describe('initWithoutDefaultIntegrations()', () => {
     it('installs no default integrations', () => {
-      initWithoutDefaultIntegrations({ dsn: PUBLIC_DSN });
+      initWithoutDefaultIntegrations({ dsn: PUBLIC_DSN, traceLifecycle: 'static' });
 
       const client = getClient();
 
@@ -143,7 +143,11 @@ describe('init()', () => {
     it('still installs user-provided integrations', () => {
       const customIntegration = new MockIntegration('Custom integration');
 
-      initWithoutDefaultIntegrations({ dsn: PUBLIC_DSN, integrations: [customIntegration] });
+      initWithoutDefaultIntegrations({
+        dsn: PUBLIC_DSN,
+        integrations: [customIntegration],
+        traceLifecycle: 'static',
+      });
 
       const client = getClient();
 

--- a/packages/cloudflare/test/instrumentations/worker/instrumentEmail.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentEmail.test.ts
@@ -245,6 +245,7 @@ describe('instrumentEmail', () => {
         env => ({
           dsn: env.SENTRY_DSN,
           tracesSampleRate: 1,
+          traceLifecycle: 'static',
           beforeSendTransaction(event) {
             sentryEvent = event;
             return null;

--- a/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
@@ -258,6 +258,7 @@ describe('instrumentQueue', () => {
         env => ({
           dsn: env.SENTRY_DSN,
           tracesSampleRate: 1,
+          traceLifecycle: 'static',
           beforeSendTransaction(event) {
             sentryEvent = event;
             return null;

--- a/packages/cloudflare/test/instrumentations/worker/instrumentScheduled.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentScheduled.test.ts
@@ -240,6 +240,7 @@ describe('instrumentScheduled', () => {
         env => ({
           dsn: env.SENTRY_DSN,
           tracesSampleRate: 1,
+          traceLifecycle: 'static',
           beforeSendTransaction(event) {
             sentryEvent = event;
             return null;

--- a/packages/cloudflare/test/opentelemetry.test.ts
+++ b/packages/cloudflare/test/opentelemetry.test.ts
@@ -16,6 +16,7 @@ describe('opentelemetry compatibility', () => {
     const client = init({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       skipOpenTelemetrySetup: true,
       beforeSendTransaction: event => {
         transactionEvents.push(event);
@@ -46,6 +47,7 @@ describe('opentelemetry compatibility', () => {
     const client = init({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;
@@ -106,6 +108,7 @@ describe('opentelemetry compatibility', () => {
     const client = init({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;
@@ -149,6 +152,7 @@ describe('opentelemetry compatibility', () => {
     const client = init({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;
@@ -176,6 +180,7 @@ describe('opentelemetry compatibility', () => {
     const client = init({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;

--- a/packages/cloudflare/test/request.test.ts
+++ b/packages/cloudflare/test/request.test.ts
@@ -12,6 +12,7 @@ import { wrapRequestHandler } from '../src/request';
 
 const MOCK_OPTIONS: CloudflareOptions = {
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  traceLifecycle: 'static',
 };
 
 const NODE_MAJOR_VERSION = parseInt(process.versions.node.split('.')[0]!);

--- a/packages/cloudflare/test/workflow.test.ts
+++ b/packages/cloudflare/test/workflow.test.ts
@@ -64,6 +64,7 @@ function getSentryOptions() {
     dsn: 'https://8@ingest.sentry.io/4',
     release: '1.0.0',
     tracesSampleRate: 1.0,
+    traceLifecycle: 'static' as const,
     transport: () => mockTransport,
   };
 }

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -14,6 +14,7 @@ export function getDefaultTestClientOptions(options: Partial<TestClientOptions> 
   return {
     integrations: [],
     sendClientReports: true,
+    traceLifecycle: 'static',
     transport: () =>
       createTransport(
         {

--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -48,7 +48,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "?",
               in_app: true,
-              lineno: 43,
+              lineno: 44,
               post_context: [
                 "",
                 "  await delay(200);",
@@ -74,7 +74,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "something",
               in_app: true,
-              lineno: 40,
+              lineno: 41,
               post_context: [
                 "  }",
                 "",

--- a/packages/deno/test/deno-http.test.ts
+++ b/packages/deno/test/deno-http.test.ts
@@ -107,6 +107,7 @@ Deno.test({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
       beforeSendTransaction: sink.beforeSendTransaction,
+      traceLifecycle: 'static',
     });
 
     const server = http.createServer((_req, res) => {
@@ -148,6 +149,7 @@ Deno.test({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
       beforeSendTransaction: sink.beforeSendTransaction,
+      traceLifecycle: 'static',
     });
 
     // Use Deno.serve for the target so the test does not depend on the

--- a/packages/deno/test/deno-redis.test.ts
+++ b/packages/deno/test/deno-redis.test.ts
@@ -67,6 +67,7 @@ Deno.test('denoRedisIntegration: node-redis:command channel produces a db.redis 
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: sink.beforeSendTransaction,
   });
 
@@ -105,6 +106,7 @@ Deno.test('denoRedisIntegration: errors on the command channel set span status',
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: sink.beforeSendTransaction,
   });
 
@@ -141,6 +143,7 @@ Deno.test('denoRedisIntegration: ioredis:command channel produces a db.redis chi
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: sink.beforeSendTransaction,
   });
 

--- a/packages/deno/test/deno-serve.test.ts
+++ b/packages/deno/test/deno-serve.test.ts
@@ -34,6 +34,7 @@ Deno.test('Deno.serve should create http.server spans', async () => {
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -72,6 +73,7 @@ Deno.test('Deno.serve should isolate context between concurrent requests', async
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -198,6 +200,7 @@ Deno.test('Deno.serve should handle OPTIONS and HEAD requests without creating s
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -239,6 +242,7 @@ Deno.test('Deno.serve should work with handler in options object', async () => {
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -276,6 +280,7 @@ Deno.test('Deno.serve should capture request headers and set response context', 
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     sendDefaultPii: true,
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
@@ -328,6 +333,7 @@ Deno.test('Deno.serve should capture client address and port when userInfo data 
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     dataCollection: { userInfo: true },
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
@@ -363,6 +369,7 @@ Deno.test('Deno.serve should capture client address and port when sendDefaultPii
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     sendDefaultPii: true,
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
@@ -398,6 +405,7 @@ Deno.test('Deno.serve should not capture client address by default', async () =>
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -432,6 +440,7 @@ Deno.test('Deno.serve should keep PII request headers when dataCollection enable
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     dataCollection: { httpHeaders: { request: true } },
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
@@ -468,6 +477,7 @@ Deno.test('Deno.serve should filter PII request headers by default', async () =>
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -503,6 +513,7 @@ Deno.test('Deno.serve should support distributed tracing with sentry-trace heade
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -551,6 +562,7 @@ Deno.test('Deno.serve should handle streaming responses', async () => {
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: (event: TransactionEvent) => {
       transactionEvents.push(event);
       return null;
@@ -596,6 +608,7 @@ Deno.test('Deno.serve should work when manually capturing exceptions within hand
   init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSend: (event: ErrorEvent) => {
       errorEvents.push(event);
       return null;

--- a/packages/deno/test/mod.test.ts
+++ b/packages/deno/test/mod.test.ts
@@ -13,6 +13,7 @@ function getTestClient(callback: (event?: Event) => void): DenoClient {
     integrations: getDefaultIntegrations({}),
     stackParser: createStackParser(nodeStackLineParser()),
     attachStacktrace: false,
+    traceLifecycle: 'static',
     transport: makeTestTransport(envelope => {
       callback(getNormalizedEvent(envelope));
     }),

--- a/packages/deno/test/opentelemetry.test.ts
+++ b/packages/deno/test/opentelemetry.test.ts
@@ -29,6 +29,7 @@ Deno.test('should not capture spans emitted via @opentelemetry/api when skipOpen
   const client = init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     skipOpenTelemetrySetup: true,
     beforeSendTransaction: event => {
       transactionEvents.push(event);
@@ -60,6 +61,7 @@ Deno.test('should capture spans emitted via @opentelemetry/api', async () => {
   const client = init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: event => {
       transactionEvents.push(event);
       return null;
@@ -112,6 +114,7 @@ Deno.test('opentelemetry spans should interop with Sentry spans', async () => {
   const client = init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: event => {
       transactionEvents.push(event);
       return null;
@@ -156,6 +159,7 @@ Deno.test('should override pre-existing OTel provider with Sentry provider', asy
   const client = init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: event => {
       transactionEvents.push(event);
       return null;
@@ -187,6 +191,7 @@ Deno.test('name parameter should take precedence over options.name in startSpan'
   const client = init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: event => {
       transactionEvents.push(event);
       return null;
@@ -216,6 +221,7 @@ Deno.test('name parameter should take precedence over options.name in startActiv
   const client = init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     beforeSendTransaction: event => {
       transactionEvents.push(event);
       return null;
@@ -252,6 +258,7 @@ Deno.test('should override native Deno OpenTelemetry when enabled', async () => 
     const client = init({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;

--- a/packages/node/test/helpers/getDefaultNodeClientOptions.ts
+++ b/packages/node/test/helpers/getDefaultNodeClientOptions.ts
@@ -5,6 +5,7 @@ export function getDefaultNodeClientOptions(options: Partial<NodeClientOptions> 
   return {
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     integrations: [],
     transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => resolvedSyncPromise({})),
     stackParser: () => [],

--- a/packages/node/test/helpers/mockSdkInit.ts
+++ b/packages/node/test/helpers/mockSdkInit.ts
@@ -22,6 +22,7 @@ export function mockSdkInit(options?: Partial<NodeClientOptions>) {
     sendClientReports: false,
     // Use a mock transport to prevent network calls
     transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => resolvedSyncPromise({})),
+    traceLifecycle: 'static',
     ...options,
   });
 }

--- a/packages/node/test/sdk/client.test.ts
+++ b/packages/node/test/sdk/client.test.ts
@@ -32,6 +32,7 @@ describe('NodeClient', () => {
       dsn: expect.any(String),
       integrations: [],
       transport: options.transport,
+      traceLifecycle: 'static',
       transportOptions: {
         headers: {
           'user-agent': `sentry.javascript.node/${SDK_VERSION}`,

--- a/packages/opentelemetry/test/helpers/TestClient.ts
+++ b/packages/opentelemetry/test/helpers/TestClient.ts
@@ -66,6 +66,7 @@ export function init(options: Partial<Options> = {}): Client {
 export function getDefaultTestClientOptions(options: Partial<Options> = {}): ClientOptions {
   return {
     integrations: [],
+    traceLifecycle: 'static',
     transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => resolvedSyncPromise({})),
     stackParser: () => [],
     ...options,

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -13,6 +13,7 @@ function makeLegacySpanProfilingClient(): [Sentry.NodeClient, Transport] {
     stackParser: Sentry.defaultStackParser,
     tracesSampleRate: 1,
     profilesSampleRate: 1,
+    traceLifecycle: 'static',
     debug: true,
     environment: 'test-environment',
     dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
@@ -34,6 +35,7 @@ function makeLegacyContinuousProfilingClient(): [Sentry.NodeClient, Transport] {
   const client = new Sentry.NodeClient({
     stackParser: Sentry.defaultStackParser,
     tracesSampleRate: 1,
+    traceLifecycle: 'static',
     debug: true,
     environment: 'test-environment',
     dsn: 'https://7fa19397baaf433f919fbe02228d5470@o1137848.ingest.sentry.io/6625302',
@@ -956,6 +958,7 @@ describe('ProfilingIntegration', () => {
 
       it('sends a profile_chunk envelope type', async () => {
         const [client, transport] = makeCurrentSpanProfilingClient({
+          traceLifecycle: 'static',
           profileLifecycle: 'trace',
           profileSessionSampleRate: 1,
         });

--- a/packages/svelte/test/performance.test.ts
+++ b/packages/svelte/test/performance.test.ts
@@ -29,6 +29,7 @@ describe('Sentry.trackComponent()', () => {
     init({
       dsn: PUBLIC_DSN,
       tracesSampleRate: 1,
+      traceLifecycle: 'static',
       beforeSendTransaction,
     });
   });

--- a/packages/sveltekit/test/utils.ts
+++ b/packages/sveltekit/test/utils.ts
@@ -4,6 +4,7 @@ import { createTransport, resolvedSyncPromise } from '@sentry/core';
 export function getDefaultNodeClientOptions(options: Partial<ClientOptions> = {}): ClientOptions {
   return {
     dsn: 'http://examplePublicKey@localhost/0',
+    traceLifecycle: 'static',
     integrations: [],
     transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => resolvedSyncPromise({})),
     stackParser: () => [],


### PR DESCRIPTION
Explicitly sets `'static'` trace lifecycle in more tests as prework for getsentry/sentry-javascript#22642. Mostly Deno and Bun tests this time but also some leftover unit tests.

ref getsentry/sentry-javascript#22344