### PR TITLE
test(cloudflare): Pin mcp as agent depends on it

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
@@ -14,7 +14,7 @@
     "test:dev": "TEST_ENV=development playwright test"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",
     "agents": "0.11.9",
     "zod": "^4.3.6"


### PR DESCRIPTION
`cloudflare-mcp-agent` tests are failing on `develop`. This one is fixing it. It seems that the types changed in that version, but the `agents` anyways [required this specific version](https://github.com/cloudflare/agents/blob/f089c5b6a13f98ad728f9c9cb9d729469b945233/packages/agents/package.json#L64), so it's better to keep the fixed version.