### PR TITLE
feat(cloudflare): Instrument Agents automatically

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/.gitignore
@@ -1,0 +1,4 @@
+dist
+.wrangler
+test-results
+pnpm-lock.yaml

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "cloudflare-autoinstrument",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "wrangler dev --var \"E2E_TEST_DSN:$E2E_TEST_DSN\" --log-level=$(test $CI && echo 'none' || echo 'log')",
+    "test": "playwright test",
+    "typecheck": "tsc --noEmit",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm typecheck && pnpm test"
+  },
+  "dependencies": {
+    "@cloudflare/ai-chat": "^0.10.0",
+    "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",
+    "agents": "^0.20.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^8.0.1",
+    "@babel/plugin-proposal-decorators": "^8.0.2",
+    "@cloudflare/vite-plugin": "^1.47.0",
+    "@cloudflare/workers-types": "^5.20260727.1",
+    "@playwright/test": "~1.56.0",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "@types/node": "^26.1.2",
+    "@types/ws": "^8.18.1",
+    "typescript": "~6.0.3",
+    "vite": "^8.1.5",
+    "wrangler": "^4.114.0",
+    "ws": "^8.21.1"
+  },
+  "volta": {
+    "node": "24.15.0",
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/playwright.config.ts
@@ -1,0 +1,16 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+// `vite build` runs the Sentry auto-instrument transform over the worker entry;
+// `pnpm preview` (`wrangler dev`, following the vite plugin's `.wrangler/deploy`
+// redirect) serves the built output. The tests therefore assert on the wrapping
+// the plugin injected at build time, not on anything in the source entry.
+export default getPlaywrightConfig(
+  {
+    startCommand: 'pnpm preview',
+    port: 8787,
+  },
+  {
+    workers: '100%',
+    retries: 0,
+  },
+);

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/base.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/base.ts
@@ -1,0 +1,12 @@
+import { Agent } from 'agents';
+
+/**
+ * An Agent base class living outside the worker entry. `DerivedAgent` in
+ * `index.ts` extends this, so the plugin only learns it is an Agent by
+ * following the import into this module and resolving `MyBase -> Agent`.
+ */
+export class MyBase extends Agent<Env> {
+  async onRequest(): Promise<Response> {
+    return Response.json({ agent: 'derived' });
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/env.d.ts
@@ -1,0 +1,7 @@
+interface Env {
+  E2E_TEST_DSN: string;
+  MyAgent: DurableObjectNamespace;
+  MyChatAgent: DurableObjectNamespace;
+  DerivedAgent: DurableObjectNamespace;
+  PlainDO: DurableObjectNamespace;
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/index.ts
@@ -1,0 +1,73 @@
+import { AIChatAgent } from '@cloudflare/ai-chat';
+import { Agent, callable, routeAgentRequest } from 'agents';
+import { DurableObject } from 'cloudflare:workers';
+import { MyBase } from './base';
+
+// NOTE: this file deliberately contains NO `Sentry.*` calls and no import of
+// `@sentry/cloudflare`. Everything below is wrapped at build time by
+// `sentryCloudflareVitePlugin({ _experimental: { autoInstrumentation: true } })`,
+// which reads wrangler.jsonc, wraps the default export with `withSentry`, and
+// picks a wrapper per class: `instrumentAgentWithSentry` for the three Agents,
+// `instrumentDurableObjectWithSentry` for the plain Durable Object.
+//
+// Options come from `instrument.server.ts` next to this entry.
+
+/** Agent whose base class (`Agent`) is imported directly into the entry. */
+export class MyAgent extends Agent<Env> {
+  @callable()
+  async greet(name: string): Promise<string> {
+    return `Hello, ${name}! (from MyAgent)`;
+  }
+
+  async onRequest(): Promise<Response> {
+    return Response.json({ agent: 'plain' });
+  }
+}
+
+/** Chat agent — `AIChatAgent` extends `Agent` inside `@cloudflare/ai-chat`. */
+export class MyChatAgent extends AIChatAgent<Env> {
+  @callable()
+  async greet(name: string): Promise<string> {
+    return `Hello, ${name}! (from MyChatAgent)`;
+  }
+
+  async onRequest(): Promise<Response> {
+    return Response.json({ agent: 'chat' });
+  }
+}
+
+/** Agent whose base class lives in `./base` — resolvable only across modules. */
+export class DerivedAgent extends MyBase {
+  @callable()
+  async greet(name: string): Promise<string> {
+    return `Hello, ${name}! (from DerivedAgent)`;
+  }
+}
+
+/**
+ * A genuine Durable Object. Configured identically to the Agents above, so it
+ * proves detection discriminates rather than upgrading every DO binding.
+ */
+export class PlainDO extends DurableObject<Env> {
+  async fetch(): Promise<Response> {
+    return Response.json({ durableObject: true });
+  }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/plain-do') {
+      const stub = env.PlainDO.get(env.PlainDO.idFromName('do-instance'));
+      return stub.fetch(request);
+    }
+
+    const agentResponse = await routeAgentRequest(request, env);
+    if (agentResponse) {
+      return agentResponse;
+    }
+
+    return new Response('Not found', { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/instrument.server.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/src/instrument.server.ts
@@ -1,0 +1,14 @@
+// The auto-instrument plugin picks this file up by convention (it sits next to
+// the worker entry named in wrangler's `main`) and imports its default export as
+// the options callback for every wrapper it injects.
+export default (env: Env) => ({
+  traceLifecycle: 'static' as const,
+  dsn: env.E2E_TEST_DSN,
+  environment: 'qa',
+  tunnel: 'http://localhost:3031/',
+  tracesSampleRate: 1.0,
+  enableRpcTracePropagation: true,
+  transportOptions: {
+    bufferSize: 1000,
+  },
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'cloudflare-autoinstrument',
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tests/agent-socket.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tests/agent-socket.ts
@@ -1,0 +1,46 @@
+import WebSocket from 'ws';
+
+type AgentReply = { type?: string; id?: string; done?: boolean; result?: unknown };
+
+/**
+ * Opens a WebSocket to `/agents/<binding>/<instance>`, sends one RPC frame, and
+ * resolves with the reply's `result` — the method's return value — once it arrives.
+ */
+export function callRpc(
+  baseURL: string,
+  options: { binding: string; instance: string; method: string; args: unknown[] },
+): Promise<unknown> {
+  const id = `rpc-${options.method}`;
+  const frame = { type: 'rpc', id, method: options.method, args: options.args };
+  const wsUrl = `${baseURL.replace(/^http/, 'ws')}/agents/${options.binding}/${options.instance}`;
+
+  return new Promise<unknown>((resolveSocket, rejectSocket) => {
+    const socket = new WebSocket(wsUrl);
+    const timeout = setTimeout(() => {
+      socket.close();
+      rejectSocket(new Error(`Timed out waiting for RPC reply to "${options.method}"`));
+    }, 15_000);
+
+    socket.on('open', () => {
+      socket.send(JSON.stringify(frame));
+    });
+
+    socket.on('message', data => {
+      try {
+        const parsed = JSON.parse(data.toString()) as AgentReply;
+        if (parsed.type === 'rpc' && parsed.id === id && parsed.done) {
+          clearTimeout(timeout);
+          socket.close();
+          resolveSocket(parsed.result);
+        }
+      } catch {
+        // Ignore non-JSON / unrelated frames.
+      }
+    });
+
+    socket.on('error', err => {
+      clearTimeout(timeout);
+      rejectSocket(err);
+    });
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tests/autoinstrument.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tests/autoinstrument.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+import { callRpc } from './agent-socket';
+
+// The worker entry (`src/index.ts`) contains no Sentry calls at all — every
+// wrapper below was injected by the Vite auto-instrument plugin at build time.
+// Any transaction arriving here therefore proves the injection happened.
+
+test('wraps the default export with withSentry (options from instrument.server.ts)', async ({ baseURL }) => {
+  const transactionPromise = waitForTransaction('cloudflare-autoinstrument', event => {
+    return event.contexts?.trace?.op === 'http.server' && (event.request?.url ?? '').includes('/plain-do');
+  });
+
+  const res = await fetch(`${baseURL}/plain-do`);
+  expect(res.status).toBe(200);
+  await expect(res.json()).resolves.toEqual({ durableObject: true });
+
+  const transaction = await transactionPromise;
+
+  expect(transaction.contexts?.trace?.origin).toBe('auto.http.cloudflare');
+  // `environment: 'qa'` is only set in `instrument.server.ts`, so seeing it here
+  // proves the plugin sourced its options callback from that file rather than
+  // falling back to reading configuration off `env`.
+  expect(transaction.environment).toBe('qa');
+});
+
+// Each of these three classes is registered in wrangler.jsonc exactly like the
+// plain Durable Object below — only the base-class chain marks them as Agents.
+// An `rpc` span with origin `auto.faas.cloudflare.agents` is produced solely by
+// `instrumentAgentWithSentry`, so its presence is what distinguishes a correct
+// agent upgrade from a plain `instrumentDurableObjectWithSentry` wrap.
+for (const { title, binding, agentClass } of [
+  {
+    title: 'an Agent subclass declared in the entry',
+    binding: 'my-agent',
+    agentClass: 'MyAgent',
+  },
+  {
+    title: 'an AIChatAgent subclass declared in the entry',
+    binding: 'my-chat-agent',
+    agentClass: 'MyChatAgent',
+  },
+  {
+    title: 'an Agent subclass whose base class lives in another module',
+    binding: 'derived-agent',
+    agentClass: 'DerivedAgent',
+  },
+]) {
+  test(`applies agent instrumentation to ${title}`, async ({ baseURL }) => {
+    const instance = `${binding}-instance`;
+
+    const transactionPromise = waitForTransaction('cloudflare-autoinstrument', event => {
+      return (
+        event.transaction === 'webSocketMessage' &&
+        (event.spans ?? []).some(span => span.op === 'rpc' && span.description === 'greet')
+      );
+    });
+
+    // Each agent's greet() returns a string naming its class, so the reply
+    // identifies exactly which class handled the call.
+    const reply = await callRpc(baseURL!, { binding, instance, method: 'greet', args: ['World'] });
+    expect(reply).toBe(`Hello, World! (from ${agentClass})`);
+
+    const transaction = await transactionPromise;
+    const rpcSpan = (transaction.spans ?? []).find(span => span.op === 'rpc' && span.description === 'greet');
+
+    expect(rpcSpan).toEqual(
+      expect.objectContaining({
+        op: 'rpc',
+        description: 'greet',
+        origin: 'auto.faas.cloudflare.agents',
+        data: expect.objectContaining({
+          // Read back off the instance at runtime (`_ParentClass.name`), so it
+          // confirms the wrapper landed on the user's real class. Matched loosely
+          // because the transform renames the class it wraps to
+          // `__SENTRY_ORIGINAL_<name>__` and the bundler infers that name.
+          'cloudflare.agent.class': expect.stringContaining(agentClass),
+          'cloudflare.agent.name': instance,
+        }),
+      }),
+    );
+  });
+}
+
+test('applies plain Durable Object instrumentation to a non-Agent class', async ({ baseURL }) => {
+  const transactionPromise = waitForTransaction('cloudflare-autoinstrument', event => {
+    return event.contexts?.trace?.op === 'http.server' && (event.request?.url ?? '').includes('/plain-do');
+  });
+
+  const res = await fetch(`${baseURL}/plain-do`);
+  expect(res.status).toBe(200);
+
+  const transaction = await transactionPromise;
+
+  // A plain Durable Object must NOT pick up agent instrumentation: detection has
+  // to discriminate, not blanket-upgrade every `durable_objects` binding.
+  const agentSpans = (transaction.spans ?? []).filter(span => span.origin === 'auto.faas.cloudflare.agents');
+  expect(agentSpans).toEqual([]);
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types", "node"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/vite.config.ts
@@ -1,0 +1,19 @@
+import { cloudflare } from '@cloudflare/vite-plugin';
+import { sentryCloudflareVitePlugin } from '@sentry/cloudflare/vite';
+import agents from 'agents/vite';
+import { defineConfig } from 'vite';
+
+// `agents()` supplies the TC39 decorator transform that `@callable()` needs.
+// `autoInstrumentation` is the plugin under test: it rewrites `src/index.ts` at
+// build time so the entry itself contains no Sentry calls.
+export default defineConfig({
+  plugins: [
+    agents(),
+    cloudflare(),
+    sentryCloudflareVitePlugin({
+      _experimental: {
+        autoInstrumentation: true,
+      },
+    }),
+  ],
+});

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/wrangler.jsonc
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/wrangler.jsonc
@@ -1,0 +1,32 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "cloudflare-autoinstrument",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-05-20",
+  "compatibility_flags": ["nodejs_compat"],
+
+  // Every class below is registered the same way — as a Durable Object binding.
+  // An `agents` Agent *is* a Durable Object, so wrangler offers no way to say
+  // "this one is an Agent". Only the base-class chain distinguishes them, which
+  // is exactly what the plugin's detection has to work out at build time:
+  //
+  //   MyAgent       -> extends Agent         (entry-local)      => agent
+  //   MyChatAgent   -> extends AIChatAgent   (entry-local)      => agent
+  //   DerivedAgent  -> extends ./base#MyBase -> Agent           => agent
+  //   PlainDO       -> extends DurableObject                    => durableObject
+  "durable_objects": {
+    "bindings": [
+      { "name": "MyAgent", "class_name": "MyAgent" },
+      { "name": "MyChatAgent", "class_name": "MyChatAgent" },
+      { "name": "DerivedAgent", "class_name": "DerivedAgent" },
+      { "name": "PlainDO", "class_name": "PlainDO" },
+    ],
+  },
+
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["MyAgent", "MyChatAgent", "DerivedAgent", "PlainDO"],
+    },
+  ],
+}

--- a/packages/cloudflare/src/vite/agentClass.ts
+++ b/packages/cloudflare/src/vite/agentClass.ts
@@ -1,0 +1,232 @@
+import { readFileSync } from 'node:fs';
+import { DEFAULT_EXPORT, type ModuleShape, shapeFromAst, shapeFromSource, type SuperRef } from './moduleShape';
+import type { ProgramBody } from './transform';
+
+/**
+ * Agent base classes, keyed by the module specifier they are imported from. A class extending any
+ * of these — directly or through a chain of local/imported subclasses — is an `agents` Agent rather
+ * than a plain Durable Object.
+ *
+ * `McpAgent`, `AIChatAgent` and `Think` all extend `Agent` themselves, but they live in packages
+ * whose sources we never walk into (see {@link followImport}), so each needs its own entry.
+ */
+const AGENT_BASE_CLASSES: Record<string, ReadonlySet<string>> = {
+  agents: new Set(['Agent']),
+  'agents/mcp': new Set(['McpAgent']),
+  '@cloudflare/ai-chat': new Set(['AIChatAgent']),
+  '@cloudflare/think': new Set(['Think']),
+};
+
+/**
+ * How many modules deep the base-class chain is followed. Guards against pathological module graphs;
+ * real Agent hierarchies are only a few levels deep.
+ */
+const MAX_DEPTH = 8;
+
+/**
+ * The subset of the Vite/Rollup plugin context needed to walk the module graph.
+ *
+ * `resolve` is optional: without it detection still works, but only for base-class chains declared
+ * inside the entry module itself. `readFile` is injectable for tests and defaults to reading disk.
+ *
+ * Deliberately **no `load`**: awaiting the plugin context's `load()` from inside a `transform` hook
+ * deadlocks the build — the module cannot finish loading while its own transform is still pending
+ * (Rollup documents this hazard, and Vite's Rolldown pipeline is stricter still). Sibling modules
+ * are therefore read straight off disk; see {@link getModuleShape}.
+ */
+export interface ModuleResolver {
+  parse(code: string): ProgramBody;
+  resolve?(source: string, importer: string): Promise<{ id: string } | null | undefined>;
+  readFile?(id: string): string | undefined;
+}
+
+interface DetectContext {
+  resolver: ModuleResolver;
+  modules: Map<string, ModuleShape | undefined>;
+}
+
+/**
+ * Find which of `candidates` (top-level class names in the entry module) are Cloudflare
+ * [`agents`](https://www.npmjs.com/package/agents) Agents.
+ *
+ * An Agent is a Durable Object under the hood, so wrangler configures it as one and the transform
+ * would otherwise reach for `instrumentDurableObjectWithSentry`. Detecting the Agent base chain lets
+ * it pick `instrumentAgentWithSentry` instead, which adds the Agent-specific telemetry on top.
+ *
+ * Unlike `WorkerEntrypoint` detection, the chain is followed *across* modules: base classes commonly
+ * live in their own file (`import { MyBase } from './base'`), and there is no runtime fallback that
+ * would catch a missed one. Resolution stops at package boundaries — a base class imported from
+ * `node_modules` is only recognized when it is one of {@link AGENT_BASE_CLASSES}.
+ */
+export async function detectAgentClasses(
+  ast: ProgramBody,
+  entryId: string,
+  candidates: Iterable<string>,
+  resolver: ModuleResolver,
+): Promise<Set<string>> {
+  // The entry's shape comes from the AST Vite already handed us (TypeScript stripped, full
+  // fidelity); only sibling modules fall back to source scanning.
+  const ctx: DetectContext = { resolver, modules: new Map([[entryId, shapeFromAst(ast)]]) };
+
+  const detected = new Set<string>();
+  for (const name of candidates) {
+    // A fresh cycle guard per candidate: a shared one would record "not an Agent" for bindings
+    // visited while resolving an earlier candidate that turned out to be unrelated.
+    if (await isAgentBinding(ctx, entryId, name, 0, new Set())) {
+      detected.add(name);
+    }
+  }
+  return detected;
+}
+
+/**
+ * The local class names in the entry that a configured class name could refer to — either declared
+ * under that name directly, or aliased to it by an `export { Local as Configured }` specifier.
+ *
+ * Keeps detection (which reads and scans other modules) off classes that no binding points at.
+ */
+export function collectAgentCandidates(ast: ProgramBody, configuredNames: Iterable<string>): Set<string> {
+  const shape = shapeFromAst(ast);
+  const candidates = new Set<string>();
+
+  for (const configured of configuredNames) {
+    if (shape.classes.has(configured)) {
+      candidates.add(configured);
+    }
+    const local = shape.localExports.get(configured);
+    if (local && shape.classes.has(local)) {
+      candidates.add(local);
+    }
+  }
+
+  return candidates;
+}
+
+async function isAgentBinding(
+  ctx: DetectContext,
+  moduleId: string,
+  name: string,
+  depth: number,
+  visited: Set<string>,
+): Promise<boolean> {
+  if (depth > MAX_DEPTH) return false;
+
+  const key = `${moduleId} ${name}`;
+  if (visited.has(key)) return false;
+  visited.add(key);
+
+  const shape = await getModuleShape(ctx, moduleId);
+  if (!shape) return false;
+
+  if (shape.classes.has(name)) {
+    return extendsAgent(ctx, shape, moduleId, shape.classes.get(name), depth, visited);
+  }
+
+  const imported = shape.imports.get(name);
+  if (imported) {
+    return followImport(ctx, moduleId, imported.source, imported.imported, depth, visited);
+  }
+
+  if (name === DEFAULT_EXPORT) {
+    if (shape.defaultExportIsClass) {
+      return extendsAgent(ctx, shape, moduleId, shape.defaultExportSuper, depth, visited);
+    }
+    if (shape.defaultExportName) {
+      return isAgentBinding(ctx, moduleId, shape.defaultExportName, depth + 1, visited);
+    }
+  }
+
+  // `export { Local as Requested }` — the caller asked by exported name.
+  const localName = shape.localExports.get(name);
+  if (localName) {
+    return isAgentBinding(ctx, moduleId, localName, depth + 1, visited);
+  }
+
+  const reexport = shape.reexports.get(name);
+  if (reexport) {
+    return followImport(ctx, moduleId, reexport.source, reexport.imported, depth, visited);
+  }
+
+  // Barrel modules (`export * from './base'`) don't name the binding, so every star source is a
+  // candidate home for it.
+  for (const source of shape.starExports) {
+    if (await followImport(ctx, moduleId, source, name, depth, visited)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Whether a superclass reference resolves to an Agent base — a bare identifier (imported, or a
+ * subclass declared in the same module) or `ns.Agent` off a namespace import.
+ */
+async function extendsAgent(
+  ctx: DetectContext,
+  shape: ModuleShape,
+  moduleId: string,
+  superClass: SuperRef | undefined,
+  depth: number,
+  visited: Set<string>,
+): Promise<boolean> {
+  if (!superClass) return false;
+
+  if (superClass.kind === 'identifier') {
+    return isAgentBinding(ctx, moduleId, superClass.name, depth + 1, visited);
+  }
+
+  const source = shape.namespaces.get(superClass.object);
+  if (source) {
+    return followImport(ctx, moduleId, source, superClass.property, depth, visited);
+  }
+
+  return false;
+}
+
+/** Resolve an import to its module and continue the search there, stopping at package boundaries. */
+async function followImport(
+  ctx: DetectContext,
+  importerId: string,
+  source: string,
+  importedName: string,
+  depth: number,
+  visited: Set<string>,
+): Promise<boolean> {
+  if (AGENT_BASE_CLASSES[source]?.has(importedName)) return true;
+
+  if (!ctx.resolver.resolve) return false;
+
+  let resolved: { id: string } | null | undefined;
+  try {
+    resolved = await ctx.resolver.resolve(source, importerId);
+  } catch {
+    return false;
+  }
+  if (!resolved?.id) return false;
+
+  // Third-party sources are not walked: they are large, may not be plain JS by the time we see
+  // them, and any Agent base worth knowing about is listed in AGENT_BASE_CLASSES.
+  if (resolved.id.includes('/node_modules/') || resolved.id.includes('\\node_modules\\')) return false;
+
+  return isAgentBinding(ctx, resolved.id, importedName, depth + 1, visited);
+}
+
+async function getModuleShape(ctx: DetectContext, moduleId: string): Promise<ModuleShape | undefined> {
+  if (ctx.modules.has(moduleId)) return ctx.modules.get(moduleId);
+
+  let shape: ModuleShape | undefined;
+  try {
+    const code = ctx.resolver.readFile
+      ? ctx.resolver.readFile(moduleId)
+      : readFileSync(moduleId.replace(/[?#].*$/, ''), 'utf8');
+    if (typeof code === 'string') {
+      shape = shapeFromSource(code);
+    }
+  } catch {
+    // Unreadable or not a source file — treat as "not an Agent" rather than failing the build.
+  }
+
+  ctx.modules.set(moduleId, shape);
+  return shape;
+}

--- a/packages/cloudflare/src/vite/autoInstrument.ts
+++ b/packages/cloudflare/src/vite/autoInstrument.ts
@@ -1,3 +1,4 @@
+import { collectAgentCandidates, detectAgentClasses, type ModuleResolver } from './agentClass';
 import { buildOptionsImport, ENV_FALLBACK_OPTIONS_FN, resolveInstrumentFile } from './instrumentFile';
 import { applyAutoInstrumentTransforms, type ClassWrapperKind, type ProgramBody } from './transform';
 import { resolveWranglerConfig, type WranglerConfig } from './wranglerConfig';
@@ -47,11 +48,11 @@ export function sentryCloudflareAutoInstrumentPlugin() {
       }
     },
 
-    transform(
-      this: { parse(code: string): ProgramBody; warn?(msg: string): void; environment?: { name?: string } },
+    async transform(
+      this: ModuleResolver & { warn?(msg: string): void; environment?: { name?: string } },
       code: string,
       id: string,
-    ): { code: string; map: unknown } | undefined {
+    ): Promise<{ code: string; map: unknown } | undefined> {
       if (!wranglerConfig || !entryFilePath) return undefined;
 
       // The worker entry never belongs to the client (browser) environment.
@@ -89,12 +90,32 @@ export function sentryCloudflareAutoInstrumentPlugin() {
         classWrappers.set(className, 'workerEntrypoint');
       }
 
+      // An `agents` Agent is a Durable Object, so wrangler lists it among the DO bindings and only
+      // its base-class chain tells the two apart. Detection walks the module graph (base classes
+      // usually live in their own file), so it is limited to the configured DO classes.
+      //
+      // Only `resolve` is handed over — never `load`: awaiting `load()` from inside a transform
+      // hook deadlocks the build, since the module can't finish loading while this transform is
+      // still pending. `agentClass` reads sibling modules off disk instead.
+      const agentCandidates = collectAgentCandidates(
+        ast,
+        [...classWrappers].filter(([, kind]) => kind === 'durableObject').map(([name]) => name),
+      );
+      const agentClasses =
+        agentCandidates.size > 0
+          ? await detectAgentClasses(ast, normalizedId, agentCandidates, {
+              parse: code => this.parse(code),
+              resolve: this.resolve ? (source, importer) => this.resolve!(source, importer) : undefined,
+            })
+          : undefined;
+
       // No registration import is injected here: the orchestrion plugin's
       // subscribe-injection makes each bundled package self-register its channel
       // subscriber on the global marker, so wrapping the entry with `withSentry`
       // is all this plugin needs to do.
       const result = applyAutoInstrumentTransforms(code, ast, {
         classWrappers,
+        agentClasses,
         optionsFn,
         optionsImport,
       });

--- a/packages/cloudflare/src/vite/moduleShape.ts
+++ b/packages/cloudflare/src/vite/moduleShape.ts
@@ -257,12 +257,39 @@ export function shapeFromSource(rawCode: string): ModuleShape {
 
 /** Pull the superclass out of the text between a class name and its body. */
 function superRefFromHeader(header: string): SuperRef | undefined {
-  // Skip any generic parameter list, then read the (possibly dotted) base name. Trailing generic
-  // args on the base (`extends Agent<Env>`) stop the match naturally.
-  const match = /\bextends\s+([A-Za-z_$][\w$]*)\s*(?:\.\s*([A-Za-z_$][\w$]*))?/.exec(header);
+  // The header still carries the class's own generic parameter list (`<T extends S>`), whose
+  // constraint `extends` would otherwise be mistaken for the superclass clause. Strip a leading
+  // balanced `<...>` first, then read the (possibly dotted) base name. Trailing generic args on the
+  // base (`extends Agent<Env>`) stop the match naturally.
+  const withoutParams = stripLeadingGenerics(header);
+  const match = /\bextends\s+([A-Za-z_$][\w$]*)\s*(?:\.\s*([A-Za-z_$][\w$]*))?/.exec(withoutParams);
   if (!match) return undefined;
 
   return match[2] ? { kind: 'member', object: match[1]!, property: match[2] } : { kind: 'identifier', name: match[1]! };
+}
+
+/**
+ * Remove a leading `<...>` generic parameter list, honoring nesting (`<T extends Map<K, V>>`).
+ * Anything after the balanced close — the superclass clause — is returned unchanged. When the
+ * header doesn't start with `<` (no generics), it is returned as-is.
+ */
+function stripLeadingGenerics(header: string): string {
+  const start = header.indexOf('<');
+  // Only treat it as a parameter list when `<` is the first meaningful token — a `<` appearing
+  // later is part of the superclass's own generic args and must be left alone.
+  if (start === -1 || header.slice(0, start).trim() !== '') return header;
+
+  let depth = 0;
+  for (let i = start; i < header.length; i++) {
+    const char = header[i];
+    if (char === '<') depth++;
+    else if (char === '>') {
+      depth--;
+      if (depth === 0) return header.slice(i + 1);
+    }
+  }
+  // Unbalanced `<` — fall back to the untouched header rather than dropping the superclass.
+  return header;
 }
 
 /** Parse `a, b as c` into `{ imported: 'b', local: 'c' }` pairs (type-only specifiers dropped). */

--- a/packages/cloudflare/src/vite/moduleShape.ts
+++ b/packages/cloudflare/src/vite/moduleShape.ts
@@ -1,0 +1,362 @@
+import type { BaseNode, ProgramBody } from './transform';
+
+// ---------------------------------------------------------------------------
+// Minimal ESTree node shapes for structural Agent detection.
+// ---------------------------------------------------------------------------
+
+interface IdentifierNode extends BaseNode {
+  name: string;
+}
+
+interface ClassNode extends BaseNode {
+  id?: IdentifierNode | null;
+  superClass?: BaseNode | null;
+}
+
+interface MemberExpressionNode extends BaseNode {
+  object?: { type: string; name?: string };
+  property?: { type: string; name?: string };
+}
+
+interface ImportSpecifierNode {
+  type: string;
+  imported?: { type: string; name?: string };
+  local?: { type: string; name?: string };
+}
+
+interface ImportDeclarationNode extends BaseNode {
+  source?: { value?: unknown };
+  specifiers?: ImportSpecifierNode[];
+}
+
+interface ExportSpecifierNode {
+  type: string;
+  local?: { type: string; name?: string };
+  exported?: { type: string; name?: string };
+}
+
+interface ExportNamedNode extends BaseNode {
+  declaration?: BaseNode | null;
+  source?: { value?: unknown } | null;
+  specifiers?: ExportSpecifierNode[];
+}
+
+interface ExportDefaultNode extends BaseNode {
+  declaration: BaseNode;
+}
+
+interface ExportAllNode extends BaseNode {
+  source?: { value?: unknown };
+  exported?: { type: string; name?: string } | null;
+}
+
+/** Binding name used for a module's default export. */
+export const DEFAULT_EXPORT = 'default';
+
+/** A resolved superclass reference: a bare identifier or a `ns.Member` expression. */
+export type SuperRef = { kind: 'identifier'; name: string } | { kind: 'member'; object: string; property: string };
+
+/** The declarations of a single module that binding resolution needs. */
+export interface ModuleShape {
+  /** Top-level class names → their superclass reference (absent when the class has no `extends`). */
+  classes: Map<string, SuperRef | undefined>;
+  /** Local binding name → the import it came from (`imported` is `default` for a default import). */
+  imports: Map<string, { source: string; imported: string }>;
+  /** Local binding name → module specifier, for `import * as ns from '...'`. */
+  namespaces: Map<string, string>;
+  /** Exported name → the re-export it came from, for `export { x as y } from '...'`. */
+  reexports: Map<string, { source: string; imported: string }>;
+  /** Exported name → local binding name, for `export { x as y }` without a source. */
+  localExports: Map<string, string>;
+  /** Module specifiers of bare `export * from '...'` declarations. */
+  starExports: string[];
+  /** `export default <Identifier>` — the local name it refers to. */
+  defaultExportName?: string;
+  /** True when the module's default export is a class declaration/expression. */
+  defaultExportIsClass?: boolean;
+  /** Superclass of an anonymous `export default class extends X`. */
+  defaultExportSuper?: SuperRef;
+}
+
+function emptyShape(): ModuleShape {
+  return {
+    classes: new Map(),
+    imports: new Map(),
+    namespaces: new Map(),
+    reexports: new Map(),
+    localExports: new Map(),
+    starExports: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Shape from a parsed AST (used for the entry module)
+// ---------------------------------------------------------------------------
+
+/** Collect the shape of a module from its parsed AST — used for the already-parsed entry module. */
+export function shapeFromAst(ast: ProgramBody): ModuleShape {
+  const shape = emptyShape();
+
+  for (const node of ast.body) {
+    switch (node.type) {
+      case 'ClassDeclaration':
+        addAstClass(shape, node as ClassNode);
+        break;
+      case 'ImportDeclaration':
+        addAstImports(shape, node as ImportDeclarationNode);
+        break;
+      case 'ExportNamedDeclaration':
+        addAstNamedExport(shape, node as ExportNamedNode);
+        break;
+      case 'ExportDefaultDeclaration': {
+        const decl = (node as ExportDefaultNode).declaration;
+        if (decl.type === 'ClassDeclaration' || decl.type === 'ClassExpression') {
+          shape.defaultExportIsClass = true;
+          shape.defaultExportSuper = superRefFromNode((decl as ClassNode).superClass);
+          // `export default class Foo {}` also binds `Foo` locally.
+          addAstClass(shape, decl as ClassNode);
+        } else if (decl.type === 'Identifier') {
+          shape.defaultExportName = (decl as IdentifierNode).name;
+        }
+        break;
+      }
+      case 'ExportAllDeclaration': {
+        const starNode = node as ExportAllNode;
+        // `export * as ns from '...'` binds a namespace object, not the individual exports.
+        const source = starNode.exported ? undefined : asString(starNode.source?.value);
+        if (source) shape.starExports.push(source);
+        break;
+      }
+    }
+  }
+
+  return shape;
+}
+
+function superRefFromNode(superClass: BaseNode | null | undefined): SuperRef | undefined {
+  if (!superClass) return undefined;
+
+  if (superClass.type === 'Identifier') {
+    return { kind: 'identifier', name: (superClass as IdentifierNode).name };
+  }
+
+  if (superClass.type === 'MemberExpression') {
+    const member = superClass as MemberExpressionNode;
+    const object = member.object?.type === 'Identifier' ? member.object.name : undefined;
+    const property = member.property?.name;
+    if (object && property) return { kind: 'member', object, property };
+  }
+
+  return undefined;
+}
+
+function addAstClass(shape: ModuleShape, classNode: ClassNode): void {
+  if (classNode.id?.name) shape.classes.set(classNode.id.name, superRefFromNode(classNode.superClass));
+}
+
+function addAstImports(shape: ModuleShape, node: ImportDeclarationNode): void {
+  const source = asString(node.source?.value);
+  if (!source) return;
+
+  for (const specifier of node.specifiers ?? []) {
+    const local = specifier.local?.name;
+    if (!local) continue;
+
+    if (specifier.type === 'ImportSpecifier' && specifier.imported?.name) {
+      shape.imports.set(local, { source, imported: specifier.imported.name });
+    } else if (specifier.type === 'ImportDefaultSpecifier') {
+      shape.imports.set(local, { source, imported: DEFAULT_EXPORT });
+    } else if (specifier.type === 'ImportNamespaceSpecifier') {
+      shape.namespaces.set(local, source);
+    }
+  }
+}
+
+function addAstNamedExport(shape: ModuleShape, node: ExportNamedNode): void {
+  if (node.declaration?.type === 'ClassDeclaration') {
+    addAstClass(shape, node.declaration as ClassNode);
+    return;
+  }
+
+  const source = asString(node.source?.value);
+  for (const specifier of node.specifiers ?? []) {
+    const exported = specifier.exported?.name;
+    const local = specifier.local?.name;
+    if (!exported || !local) continue;
+
+    if (source) {
+      shape.reexports.set(exported, { source, imported: local });
+    } else {
+      shape.localExports.set(exported, local);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shape from raw source (used for sibling modules read off disk)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the module shape from **unprocessed source**.
+ *
+ * Sibling modules are read straight from disk (the plugin context's `load()` would deadlock inside a
+ * transform hook), so they may still be TypeScript — which no JS parser will accept. Only
+ * import/export statements and `class X extends Y` headers matter here, and those are
+ * declaration-level syntax a scan can pick out reliably; class bodies, type annotations and generics
+ * are irrelevant and simply skipped.
+ */
+export function shapeFromSource(rawCode: string): ModuleShape {
+  const code = stripComments(rawCode);
+  const shape = emptyShape();
+
+  // `class X extends Y {` / `class X<T> extends Y<T> {`, optionally exported and/or abstract.
+  const CLASS_RE = /\b(?:export\s+(?:default\s+)?)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)([^{]*)\{/g;
+  for (const match of code.matchAll(CLASS_RE)) {
+    const className = match[1]!;
+    const isDefault = /\bexport\s+default\b/.test(match[0]);
+    const superRef = superRefFromHeader(match[2] ?? '');
+
+    shape.classes.set(className, superRef);
+    if (isDefault) {
+      shape.defaultExportIsClass = true;
+      shape.defaultExportSuper = superRef;
+    }
+  }
+
+  // `export default Identifier;`
+  const defaultExprMatch = /\bexport\s+default\s+([A-Za-z_$][\w$]*)\s*;/.exec(code);
+  if (defaultExprMatch && !shape.defaultExportIsClass) {
+    shape.defaultExportName = defaultExprMatch[1];
+  }
+
+  // `export * from '...'` (but not `export * as ns from '...'`).
+  for (const match of code.matchAll(/\bexport\s*\*\s*from\s*['"]([^'"]+)['"]/g)) {
+    if (match[1]) shape.starExports.push(match[1]);
+  }
+
+  // `export { a, b as c } from '...'` and `export { a, b as c }`.
+  for (const match of code.matchAll(/\bexport\s*\{([^}]*)\}\s*(?:from\s*['"]([^'"]+)['"])?/g)) {
+    const source = match[2];
+    for (const { imported, local } of parseSpecifierList(match[1] ?? '')) {
+      // In an export clause the first name is local and the alias is the exported name.
+      if (source) {
+        shape.reexports.set(local, { source, imported });
+      } else {
+        shape.localExports.set(local, imported);
+      }
+    }
+  }
+
+  // `import Default, { a as b }, * as ns from '...'` in its various shapes.
+  for (const match of code.matchAll(/\bimport\s+([^'";]+?)\s+from\s*['"]([^'"]+)['"]/g)) {
+    addSourceImports(shape, match[1] ?? '', match[2]!);
+  }
+
+  return shape;
+}
+
+/** Pull the superclass out of the text between a class name and its body. */
+function superRefFromHeader(header: string): SuperRef | undefined {
+  // Skip any generic parameter list, then read the (possibly dotted) base name. Trailing generic
+  // args on the base (`extends Agent<Env>`) stop the match naturally.
+  const match = /\bextends\s+([A-Za-z_$][\w$]*)\s*(?:\.\s*([A-Za-z_$][\w$]*))?/.exec(header);
+  if (!match) return undefined;
+
+  return match[2] ? { kind: 'member', object: match[1]!, property: match[2] } : { kind: 'identifier', name: match[1]! };
+}
+
+/** Parse `a, b as c` into `{ imported: 'b', local: 'c' }` pairs (type-only specifiers dropped). */
+function parseSpecifierList(clause: string): Array<{ imported: string; local: string }> {
+  const specifiers: Array<{ imported: string; local: string }> = [];
+
+  for (const rawPart of clause.split(',')) {
+    const part = rawPart.trim().replace(/^type\s+/, '');
+    if (!part) continue;
+
+    const aliased = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(part);
+    if (aliased) {
+      specifiers.push({ imported: aliased[1]!, local: aliased[2]! });
+    } else if (/^[A-Za-z_$][\w$]*$/.test(part)) {
+      specifiers.push({ imported: part, local: part });
+    }
+  }
+
+  return specifiers;
+}
+
+function addSourceImports(shape: ModuleShape, clause: string, source: string): void {
+  // Type-only imports never contribute a runtime base class.
+  if (/^type\s/.test(clause.trim())) return;
+
+  const namespaceMatch = /\*\s*as\s+([A-Za-z_$][\w$]*)/.exec(clause);
+  if (namespaceMatch) {
+    shape.namespaces.set(namespaceMatch[1]!, source);
+  }
+
+  const bracesMatch = /\{([^}]*)\}/.exec(clause);
+  if (bracesMatch) {
+    for (const { imported, local } of parseSpecifierList(bracesMatch[1] ?? '')) {
+      shape.imports.set(local, { source, imported });
+    }
+  }
+
+  // A leading bare identifier (before any brace/star) is the default import.
+  const defaultMatch = /^\s*([A-Za-z_$][\w$]*)\s*(?:,|$)/.exec(clause);
+  if (defaultMatch) {
+    shape.imports.set(defaultMatch[1]!, { source, imported: DEFAULT_EXPORT });
+  }
+}
+
+/** Remove line and block comments, leaving string literals (module specifiers) intact. */
+function stripComments(code: string): string {
+  let result = '';
+  let index = 0;
+
+  while (index < code.length) {
+    const char = code[index]!;
+    const next = code[index + 1];
+
+    if (char === '/' && next === '/') {
+      while (index < code.length && code[index] !== '\n') index++;
+      continue;
+    }
+
+    if (char === '/' && next === '*') {
+      index += 2;
+      while (index < code.length && !(code[index] === '*' && code[index + 1] === '/')) index++;
+      index += 2;
+      // Keep a separator so `*/class` doesn't fuse into one token.
+      result += ' ';
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      const quote = char;
+      result += char;
+      index++;
+      while (index < code.length) {
+        const inner = code[index]!;
+        result += inner;
+        index++;
+        if (inner === '\\') {
+          if (index < code.length) {
+            result += code[index]!;
+            index++;
+          }
+          continue;
+        }
+        if (inner === quote) break;
+      }
+      continue;
+    }
+
+    result += char;
+    index++;
+  }
+
+  return result;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value ? value : undefined;
+}

--- a/packages/cloudflare/src/vite/transform.ts
+++ b/packages/cloudflare/src/vite/transform.ts
@@ -79,7 +79,7 @@ function isCallToMethod(node: BaseNode, methodName: string): boolean {
  * config providing only a fallback for self-bound entrypoints whose base class
  * lives in another module.
  */
-export type ClassWrapperKind = 'durableObject' | 'workflow' | 'workerEntrypoint';
+export type ClassWrapperKind = 'durableObject' | 'agent' | 'workflow' | 'workerEntrypoint';
 
 /**
  * The `@sentry/cloudflare` helper each wrapper kind emits. All share the same
@@ -88,6 +88,7 @@ export type ClassWrapperKind = 'durableObject' | 'workflow' | 'workerEntrypoint'
  */
 const WRAPPER_METHODS: Record<ClassWrapperKind, string> = {
   durableObject: 'instrumentDurableObjectWithSentry',
+  agent: 'instrumentAgentWithSentry',
   workflow: 'instrumentWorkflowWithSentry',
   workerEntrypoint: 'withSentry',
 };
@@ -99,6 +100,11 @@ export interface TransformContext {
    * each class's base type.
    */
   classWrappers: Map<string, ClassWrapperKind>;
+  /**
+   * Local class names detected as `agents` Agents. An Agent is configured as a Durable Object in
+   * wrangler, so this upgrades those entries from `durableObject` to `agent`.
+   */
+  agentClasses?: ReadonlySet<string>;
   optionsFn: string;
   /** Import statement prepended when `optionsFn` references a separate module. */
   optionsImport?: string;
@@ -145,6 +151,7 @@ export function applyAutoInstrumentTransforms(
     topLevelClasses,
     renamedLocals: new Set<string>(),
     classWrappers: ctx.classWrappers,
+    agentClasses: ctx.agentClasses ?? new Set<string>(),
     workerEntrypointClasses: detectWorkerEntrypointClasses(ast),
   };
   const { wrappedClasses } = state;
@@ -198,6 +205,8 @@ interface TransformState {
   renamedLocals: Set<string>;
   /** Class name → wrapper kind, keyed by the *exported* name (from config). */
   classWrappers: Map<string, ClassWrapperKind>;
+  /** Local class names detected as `agents` Agents (see {@link TransformContext.agentClasses}). */
+  agentClasses: ReadonlySet<string>;
   /**
    * Local class names detected as `WorkerEntrypoint` subclasses in this module,
    * so they can be wrapped without a config entry.
@@ -213,6 +222,10 @@ interface TransformState {
  * base class this module can't see. Otherwise a structurally-detected
  * `WorkerEntrypoint` subclass (matched by its *local* name) gets wrapped with
  * `withSentry`.
+ *
+ * The one case where config is refined rather than obeyed is an `agents` Agent:
+ * it *is* a Durable Object, so wrangler can only ever describe it as one, and
+ * only the detected base chain distinguishes the two.
  */
 function resolveWrapperKind(
   exportedName: string,
@@ -220,6 +233,7 @@ function resolveWrapperKind(
   state: TransformState,
 ): ClassWrapperKind | undefined {
   const configured = state.classWrappers.get(exportedName);
+  if (configured === 'durableObject' && localName && state.agentClasses.has(localName)) return 'agent';
   if (configured) return configured;
   if (localName && state.workerEntrypointClasses.has(localName)) return 'workerEntrypoint';
   return undefined;
@@ -286,7 +300,14 @@ function collectManuallyWrappedClassExports(
   for (const declarator of varDecl.declarations ?? []) {
     const name = declarator.id?.type === 'Identifier' ? declarator.id.name : undefined;
     const kind = name ? ctx.classWrappers.get(name) : undefined;
-    if (name && kind && declarator.init && isCallToMethod(declarator.init, WRAPPER_METHODS[kind])) {
+    if (!name || !kind || !declarator.init) continue;
+
+    // A hand-wrapped Agent is configured as a Durable Object, so accept either helper there —
+    // otherwise an already-instrumented Agent would be reported as unwrapped.
+    const accepted =
+      kind === 'durableObject' ? [WRAPPER_METHODS.durableObject, WRAPPER_METHODS.agent] : [WRAPPER_METHODS[kind]];
+
+    if (accepted.some(method => isCallToMethod(declarator.init as BaseNode, method))) {
       state.wrappedClasses.add(name);
     }
   }

--- a/packages/cloudflare/test/vite/agentClass.test.ts
+++ b/packages/cloudflare/test/vite/agentClass.test.ts
@@ -203,6 +203,33 @@ describe('detectAgentClasses', () => {
     expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
   });
 
+  // A constrained generic (`<T extends S>`) puts an `extends` before the superclass clause; the
+  // source scan must skip the parameter list rather than latch onto the constraint.
+  it('resolves a base class past a constrained generic parameter', async () => {
+    const code = ["import { MyBase } from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/base.js': [
+        "import { Agent } from 'agents';",
+        'interface Constraint { name: string }',
+        'export class MyBase<T extends Constraint> extends Agent<Env> {',
+        '  private field?: T;',
+        '}',
+      ].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('resolves a base class past a nested generic constraint', async () => {
+    const code = ["import { MyBase } from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/base.js': [
+        "import { Agent } from 'agents';",
+        'export class MyBase<T extends Map<string, number>> extends Agent<Env> {}',
+      ].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
   it('ignores an `extends` that only appears inside a comment or string', async () => {
     const code = ["import { MyBase } from './base';", 'export class MyDO extends MyBase {}'].join('\n');
     const modules = {

--- a/packages/cloudflare/test/vite/agentClass.test.ts
+++ b/packages/cloudflare/test/vite/agentClass.test.ts
@@ -1,0 +1,260 @@
+import { parse } from 'acorn';
+import { describe, expect, it } from 'vitest';
+import { collectAgentCandidates, detectAgentClasses, type ModuleResolver } from '../../src/vite/agentClass';
+
+function parseJS(code: string) {
+  return parse(code, { ecmaVersion: 'latest', sourceType: 'module' }) as unknown as { body: any[] };
+}
+
+const ENTRY = '/app/src/index.js';
+
+/**
+ * A resolver over an in-memory module graph. Relative specifiers resolve against `/app/src`, bare
+ * ones into `/app/node_modules`, mirroring how Vite reports third-party ids.
+ */
+function createResolver(modules: Record<string, string>): ModuleResolver & { loaded: string[] } {
+  const loaded: string[] = [];
+  return {
+    loaded,
+    parse: (code: string) => parseJS(code),
+    async resolve(source: string, _importer: string) {
+      if (source.startsWith('.')) {
+        const id = `/app/src/${source.replace(/^\.\//, '')}.js`;
+        return { id };
+      }
+      return { id: `/app/node_modules/${source}/dist/index.js` };
+    },
+    readFile(id: string) {
+      loaded.push(id);
+      return modules[id];
+    },
+  };
+}
+
+async function detect(entryCode: string, modules: Record<string, string> = {}, resolver?: ModuleResolver) {
+  const ast = parseJS(entryCode);
+  const candidates = collectAgentCandidates(ast, extractClassNames(entryCode));
+  return detectAgentClasses(ast, ENTRY, candidates, resolver ?? createResolver(modules));
+}
+
+/** Every class name mentioned in the entry, so tests don't have to restate the wrangler config. */
+function extractClassNames(code: string): string[] {
+  return [...code.matchAll(/class\s+(\w+)/g)].map(match => match[1]!);
+}
+
+describe('detectAgentClasses', () => {
+  it('detects a class extending `Agent` from `agents`', async () => {
+    const code = ["import { Agent } from 'agents';", 'export class MyAgent extends Agent {}'].join('\n');
+    expect(await detect(code)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('does not detect a plain Durable Object', async () => {
+    const code = ["import { DurableObject } from 'cloudflare:workers';", 'export class MyDO extends DurableObject {}'];
+    expect(await detect(code.join('\n'))).toEqual(new Set());
+  });
+
+  it('detects `AIChatAgent` from `@cloudflare/ai-chat`', async () => {
+    const code = [
+      "import { AIChatAgent } from '@cloudflare/ai-chat';",
+      'export class Chat extends AIChatAgent {}',
+    ].join('\n');
+    expect(await detect(code)).toEqual(new Set(['Chat']));
+  });
+
+  it('detects `McpAgent` from `agents/mcp`', async () => {
+    const code = ["import { McpAgent } from 'agents/mcp';", 'export class MyMCP extends McpAgent {}'].join('\n');
+    expect(await detect(code)).toEqual(new Set(['MyMCP']));
+  });
+
+  it('detects `Think` from `@cloudflare/think`', async () => {
+    const code = ["import { Think } from '@cloudflare/think';", 'export class Thinker extends Think {}'].join('\n');
+    expect(await detect(code)).toEqual(new Set(['Thinker']));
+  });
+
+  it('resolves a chain of subclasses declared in the entry', async () => {
+    const code = [
+      "import { Agent } from 'agents';",
+      'class Base extends Agent {}',
+      'class Middle extends Base {}',
+      'export class Leaf extends Middle {}',
+    ].join('\n');
+    expect(await detect(code)).toContain('Leaf');
+  });
+
+  it('resolves a base class imported from another module', async () => {
+    const code = ["import { MyBase } from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/base.js': ["import { Agent } from 'agents';", 'export class MyBase extends Agent {}'].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('resolves a base class several modules deep', async () => {
+    const code = ["import { Level1 } from './l1';", 'export class MyAgent extends Level1 {}'].join('\n');
+    const modules = {
+      '/app/src/l1.js': ["import { Level2 } from './l2';", 'export class Level1 extends Level2 {}'].join('\n'),
+      '/app/src/l2.js': ["import { Agent } from 'agents';", 'export class Level2 extends Agent {}'].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('resolves a base class through a barrel re-export', async () => {
+    const code = ["import { MyBase } from './barrel';", 'export class MyAgent extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/barrel.js': "export { MyBase } from './base';",
+      '/app/src/base.js': ["import { Agent } from 'agents';", 'export class MyBase extends Agent {}'].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('resolves a base class through a star re-export', async () => {
+    const code = ["import { MyBase } from './barrel';", 'export class MyAgent extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/barrel.js': "export * from './base';",
+      '/app/src/base.js': ["import { Agent } from 'agents';", 'export class MyBase extends Agent {}'].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('resolves a renamed re-export', async () => {
+    const code = ["import { Renamed } from './barrel';", 'export class MyAgent extends Renamed {}'].join('\n');
+    const modules = {
+      '/app/src/barrel.js': "export { MyBase as Renamed } from './base';",
+      '/app/src/base.js': ["import { Agent } from 'agents';", 'export class MyBase extends Agent {}'].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('resolves a default-exported base class', async () => {
+    const code = ["import MyBase from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/base.js': ["import { Agent } from 'agents';", 'export default class MyBase extends Agent {}'].join(
+        '\n',
+      ),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('resolves a namespace-imported Agent base', async () => {
+    const code = ["import * as agents from 'agents';", 'export class MyAgent extends agents.Agent {}'].join('\n');
+    expect(await detect(code)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('does not detect a non-Agent base class from another module', async () => {
+    const code = ["import { MyBase } from './base';", 'export class MyDO extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/base.js': [
+        "import { DurableObject } from 'cloudflare:workers';",
+        'export class MyBase extends DurableObject {}',
+      ].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set());
+  });
+
+  it('does not walk into node_modules for unknown packages', async () => {
+    const code = ["import { Base } from 'some-pkg';", 'export class MyDO extends Base {}'].join('\n');
+    const resolver = createResolver({
+      '/app/node_modules/some-pkg/dist/index.js': [
+        "import { Agent } from 'agents';",
+        'export class Base extends Agent {}',
+      ].join('\n'),
+    });
+
+    expect(await detect(code, {}, resolver)).toEqual(new Set());
+    expect(resolver.loaded).not.toContain('/app/node_modules/some-pkg/dist/index.js');
+  });
+
+  it('survives a circular module graph', async () => {
+    const code = ["import { A } from './a';", 'export class MyAgent extends A {}'].join('\n');
+    const modules = {
+      '/app/src/a.js': ["import { B } from './b';", 'export class A extends B {}'].join('\n'),
+      '/app/src/b.js': ["import { A } from './a';", 'export class B extends A {}'].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set());
+  });
+
+  it('tolerates an unresolvable module', async () => {
+    const code = ["import { Missing } from './missing';", 'export class MyDO extends Missing {}'].join('\n');
+    expect(await detect(code, {})).toEqual(new Set());
+  });
+
+  it('tolerates an unparseable module', async () => {
+    const code = ["import { Broken } from './broken';", 'export class MyDO extends Broken {}'].join('\n');
+    expect(await detect(code, { '/app/src/broken.js': 'this is ) not ( javascript' })).toEqual(new Set());
+  });
+
+  // Sibling modules are read raw off disk, so they are usually still TypeScript. A JS parser would
+  // choke on all of this; the source scan only needs the declaration-level syntax.
+  it('resolves a base class through unstripped TypeScript', async () => {
+    const code = ["import { MyBase } from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/base.js': [
+        "import { Agent } from 'agents';",
+        "import type { Something } from './types';",
+        '',
+        'interface Props { name: string }',
+        '',
+        'export abstract class MyBase<Env = unknown> extends Agent<Env, Props> {',
+        '  private readonly field: Map<string, number> = new Map();',
+        '  protected async method(arg: string): Promise<void> {}',
+        '}',
+      ].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set(['MyAgent']));
+  });
+
+  it('ignores an `extends` that only appears inside a comment or string', async () => {
+    const code = ["import { MyBase } from './base';", 'export class MyDO extends MyBase {}'].join('\n');
+    const modules = {
+      '/app/src/base.js': [
+        "import { DurableObject } from 'cloudflare:workers';",
+        "import { Agent } from 'agents';",
+        '// export class MyBase extends Agent {}',
+        '/* class MyBase extends Agent {} */',
+        'export class MyBase extends DurableObject {',
+        '  hint = "class Other extends Agent {}";',
+        '}',
+      ].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set());
+  });
+
+  it('ignores a type-only import of an Agent base', async () => {
+    const code = ["import { MyBase } from './base';", 'export class MyDO extends MyBase {}'].join('\n');
+    const modules = {
+      // `Agent` is imported for types only, so `MyBase` genuinely extends the DO base at runtime.
+      '/app/src/base.js': [
+        "import type { Agent } from 'agents';",
+        "import { DurableObject } from 'cloudflare:workers';",
+        'export class MyBase extends DurableObject {}',
+      ].join('\n'),
+    };
+    expect(await detect(code, modules)).toEqual(new Set());
+  });
+
+  it('works without resolve/readFile (entry-local chains only)', async () => {
+    const resolver: ModuleResolver = { parse: (c: string) => parseJS(c) };
+    const local = ["import { Agent } from 'agents';", 'export class MyAgent extends Agent {}'].join('\n');
+    expect(await detect(local, {}, resolver)).toEqual(new Set(['MyAgent']));
+
+    const crossModule = ["import { MyBase } from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+    expect(await detect(crossModule, {}, resolver)).toEqual(new Set());
+  });
+});
+
+describe('collectAgentCandidates', () => {
+  it('only returns configured names that are classes in this module', async () => {
+    const code = ['class MyAgent {}', 'class Unrelated {}'].join('\n');
+    expect(collectAgentCandidates(parseJS(code), ['MyAgent', 'Elsewhere'])).toEqual(new Set(['MyAgent']));
+  });
+
+  it('maps a configured name back to its aliased local class', async () => {
+    const code = ['class LocalAgent {}', 'export { LocalAgent as ConfiguredAgent };'].join('\n');
+    expect(collectAgentCandidates(parseJS(code), ['ConfiguredAgent'])).toEqual(new Set(['LocalAgent']));
+  });
+
+  it('returns nothing when no configured class is declared here', async () => {
+    const code = "export { MyAgent } from './agent';";
+    expect(collectAgentCandidates(parseJS(code), ['MyAgent'])).toEqual(new Set());
+  });
+});

--- a/packages/cloudflare/test/vite/autoInstrument.test.ts
+++ b/packages/cloudflare/test/vite/autoInstrument.test.ts
@@ -46,16 +46,16 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     return { transform: boundTransform, entryPath, plugin };
   }
 
-  it('transforms the entry file', () => {
+  it('transforms the entry file', async () => {
     const { transform: tx, entryPath } = createPlugin('main = "src/index.ts"');
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    const result = tx(code, entryPath);
+    const result = await tx(code, entryPath);
     expect(result).toBeDefined();
     expect(result.code).toContain('__SENTRY__.withSentry(');
   });
 
-  it('leaves an already-manually-wrapped entry untouched', () => {
+  it('leaves an already-manually-wrapped entry untouched', async () => {
     const { transform: tx, entryPath } = createPlugin('main = "src/index.ts"');
 
     const code = [
@@ -63,17 +63,17 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
       'export default withSentry((env) => ({}), { fetch() {} });',
     ].join('\n');
     // No DO classes configured and nothing to wrap → no transform result.
-    expect(tx(code, entryPath)).toBeUndefined();
+    expect(await tx(code, entryPath)).toBeUndefined();
   });
 
-  it('skips non-entry files', () => {
+  it('skips non-entry files', async () => {
     const { transform: tx } = createPlugin('main = "src/index.ts"');
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    expect(tx(code, '/some/other/file.ts')).toBeUndefined();
+    expect(await tx(code, '/some/other/file.ts')).toBeUndefined();
   });
 
-  it('tolerates query params in module IDs', () => {
+  it('tolerates query params in module IDs', async () => {
     const { transform: tx, entryPath } = createPlugin('main = "src/index.ts"');
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
@@ -81,7 +81,7 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     expect(result).toBeDefined();
   });
 
-  it('tolerates JS-flavored extension mismatches', () => {
+  it('tolerates JS-flavored extension mismatches', async () => {
     const { transform: tx, entryPath } = createPlugin('main = "src/index.ts"');
     const jsPath = entryPath.replace(/\.ts$/, '.js');
 
@@ -90,27 +90,27 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     expect(result).toBeDefined();
   });
 
-  it('does not match a non-JS sibling sharing the entry basename', () => {
+  it('does not match a non-JS sibling sharing the entry basename', async () => {
     const { transform: tx, entryPath } = createPlugin('main = "src/index.ts"');
     const cssPath = entryPath.replace(/\.ts$/, '.css');
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    expect(tx(code, cssPath)).toBeUndefined();
+    expect(await tx(code, cssPath)).toBeUndefined();
   });
 
-  it('matches Windows-style module IDs against the entry path', () => {
+  it('matches Windows-style module IDs against the entry path', async () => {
     const { transform: tx, entryPath } = createPlugin('main = "src/index.ts"');
     const windowsId = entryPath.replace(/\//g, '\\');
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    expect(tx(code, windowsId)).toBeDefined();
+    expect(await tx(code, windowsId)).toBeDefined();
   });
 
-  it('skips modules served to the client environment', () => {
+  it('skips modules served to the client environment', async () => {
     const { entryPath, plugin } = createPlugin('main = "src/index.ts"');
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    const result = plugin.transform.call(
+    const result = await plugin.transform.call(
       { parse: (c: string) => parseJS(c), environment: { name: 'client' } },
       code,
       entryPath,
@@ -118,7 +118,7 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     expect(result).toBeUndefined();
   });
 
-  it('wraps a configured workflow class in the entry', () => {
+  it('wraps a configured workflow class in the entry', async () => {
     const dir = writeTempDir({
       'wrangler.toml': [
         'main = "index.ts"',
@@ -133,13 +133,13 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     plugin.configResolved({ root: dir });
 
     const code = ['class WorkflowEntrypoint {}', 'export class MyWorkflow extends WorkflowEntrypoint {}'].join('\n');
-    const result = plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
+    const result = await plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
 
     expect(result).toBeDefined();
     expect(result.code).toContain('__SENTRY__.instrumentWorkflowWithSentry(');
   });
 
-  it('wraps a directly-exported WorkerEntrypoint class (structural, no config)', () => {
+  it('wraps a directly-exported WorkerEntrypoint class (structural, no config)', async () => {
     const { transform: tx, entryPath } = createPlugin('main = "index.ts"');
 
     const code = [
@@ -148,7 +148,7 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
       '  fetch() { return new Response("admin"); }',
       '}',
     ].join('\n');
-    const result = tx(code, entryPath);
+    const result = await tx(code, entryPath);
 
     expect(result).toBeDefined();
     expect(result.code).toBe(
@@ -164,7 +164,7 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     );
   });
 
-  it('wraps a self-bound WorkerEntrypoint whose base class lives in another module (config fallback)', () => {
+  it('wraps a self-bound WorkerEntrypoint whose base class lives in another module (config fallback)', async () => {
     const dir = writeTempDir({
       'wrangler.json': JSON.stringify({
         name: 'worker-self',
@@ -178,13 +178,13 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     // Base class is imported, so structural detection can't see it — the config
     // self-binding supplies the name instead.
     const code = ["import { BaseEntry } from './base';", 'export class AdminEntry extends BaseEntry {}'].join('\n');
-    const result = plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
+    const result = await plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
 
     expect(result).toBeDefined();
     expect(result.code).toContain('export const AdminEntry = __SENTRY__.withSentry(');
   });
 
-  it('wraps a WorkerEntrypoint named via a services[].entrypoint self-binding (jsonc config)', () => {
+  it('wraps a WorkerEntrypoint named via a services[].entrypoint self-binding (jsonc config)', async () => {
     // Mirrors the `worker-workerentrypoint-rpc` integration test, which declares
     // its entrypoints through `services[].entrypoint` in a wrangler.jsonc.
     const dir = writeTempDir({
@@ -207,13 +207,13 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
       "import { BaseEntrypoint } from './base';",
       'export class BindingEntrypoint extends BaseEntrypoint {}',
     ].join('\n');
-    const result = plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
+    const result = await plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
 
     expect(result).toBeDefined();
     expect(result.code).toContain('export const BindingEntrypoint = __SENTRY__.withSentry(');
   });
 
-  it('does not wrap an entrypoint that is neither detected nor self-bound', () => {
+  it('does not wrap an entrypoint that is neither detected nor self-bound', async () => {
     const dir = writeTempDir({
       'wrangler.json': JSON.stringify({
         name: 'worker-self',
@@ -227,12 +227,108 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
     // Base class imported (structural blind), and the only service binding is
     // outward (names `worker-x`'s export), so there is nothing to wrap here.
     const code = ["import { BaseEntry } from './base';", 'export class RemoteEntry extends BaseEntry {}'].join('\n');
-    const result = plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
+    const result = await plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'index.ts'));
 
     expect(result).toBeUndefined();
   });
 
-  it('warns when a configured DO class cannot be wrapped', () => {
+  // An Agent is a Durable Object, so wrangler can only ever list it under
+  // `durable_objects.bindings` — the base class is what tells the two apart.
+  describe('agent classes', () => {
+    const AGENT_WRANGLER = [
+      'main = "index.ts"',
+      '',
+      '[[durable_objects.bindings]]',
+      'name = "MY_AGENT"',
+      'class_name = "MyAgent"',
+    ].join('\n');
+
+    /**
+     * Plugin bound to a real temp directory. Sibling modules are written to disk because that is
+     * how detection reads them — the plugin context intentionally exposes no `load`, since awaiting
+     * it inside a transform hook deadlocks the build.
+     */
+    function createAgentPlugin(files: Record<string, string>, wrangler = AGENT_WRANGLER) {
+      const dir = writeTempDir({ 'wrangler.toml': wrangler, ...files });
+      const plugin = sentryCloudflareAutoInstrumentPlugin();
+      plugin.configResolved({ root: dir });
+
+      const ctx = {
+        parse: (c: string) => parseJS(c),
+        resolve: async (source: string) => ({ id: join(dir, `${source.replace(/^\.\//, '')}.ts`) }),
+      };
+
+      return (code: string) => plugin.transform.call(ctx, code, join(dir, 'index.ts'));
+    }
+
+    it('wraps an Agent declared in the entry with instrumentAgentWithSentry', async () => {
+      const tx = createAgentPlugin({});
+      const code = ["import { Agent } from 'agents';", 'export class MyAgent extends Agent {}'].join('\n');
+
+      const result = await tx(code);
+      expect(result.code).toContain('export const MyAgent = __SENTRY__.instrumentAgentWithSentry(');
+      expect(result.code).not.toContain('instrumentDurableObjectWithSentry');
+    });
+
+    it('wraps an AIChatAgent subclass with instrumentAgentWithSentry', async () => {
+      const tx = createAgentPlugin({});
+      const code = [
+        "import { AIChatAgent } from '@cloudflare/ai-chat';",
+        'export class MyAgent extends AIChatAgent {}',
+      ].join('\n');
+
+      const result = await tx(code);
+      expect(result.code).toContain('export const MyAgent = __SENTRY__.instrumentAgentWithSentry(');
+    });
+
+    it('wraps an Agent whose base class lives in another module', async () => {
+      const tx = createAgentPlugin({
+        'base.ts': ["import { Agent } from 'agents';", 'export class MyBase extends Agent {}'].join('\n'),
+      });
+      const code = ["import { MyBase } from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+
+      const result = await tx(code);
+      expect(result.code).toContain('export const MyAgent = __SENTRY__.instrumentAgentWithSentry(');
+    });
+
+    it('keeps the Durable Object helper for a DO whose base class lives in another module', async () => {
+      const tx = createAgentPlugin({
+        'base.ts': [
+          "import { DurableObject } from 'cloudflare:workers';",
+          'export class MyBase extends DurableObject {}',
+        ].join('\n'),
+      });
+      const code = ["import { MyBase } from './base';", 'export class MyAgent extends MyBase {}'].join('\n');
+
+      const result = await tx(code);
+      expect(result.code).toContain('export const MyAgent = __SENTRY__.instrumentDurableObjectWithSentry(');
+      expect(result.code).not.toContain('instrumentAgentWithSentry');
+    });
+
+    it('does not warn about an Agent that was wrapped manually', async () => {
+      const dir = writeTempDir({ 'wrangler.toml': AGENT_WRANGLER });
+      const plugin = sentryCloudflareAutoInstrumentPlugin();
+      plugin.configResolved({ root: dir });
+
+      const warnings: string[] = [];
+      const code = [
+        "import * as Sentry from '@sentry/cloudflare';",
+        "import { Agent } from 'agents';",
+        'class MyAgentBase extends Agent {}',
+        'export const MyAgent = Sentry.instrumentAgentWithSentry((env) => ({}), MyAgentBase);',
+      ].join('\n');
+
+      await plugin.transform.call(
+        { parse: (c: string) => parseJS(c), warn: (msg: string) => warnings.push(msg) },
+        code,
+        join(dir, 'index.ts'),
+      );
+
+      expect(warnings).toEqual([]);
+    });
+  });
+
+  it('warns when a configured DO class cannot be wrapped', async () => {
     const dir = writeTempDir({
       'wrangler.toml': [
         'main = "index.ts"',
@@ -247,7 +343,7 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
 
     const warnings: string[] = [];
     const code = "export { MyDO } from './do';";
-    plugin.transform.call(
+    await plugin.transform.call(
       { parse: (c: string) => parseJS(c), warn: (msg: string) => warnings.push(msg) },
       code,
       join(dir, 'index.ts'),
@@ -277,51 +373,51 @@ describe('instrument file auto-detection', () => {
     return { transform: boundTransform, entryPath, dir };
   }
 
-  it('imports the callback from an instrument.server file next to the entry', () => {
+  it('imports the callback from an instrument.server file next to the entry', async () => {
     const { transform: tx, entryPath } = createPluginWithDir({
       'wrangler.toml': 'main = "index.ts"',
       'instrument.server.ts': 'export default (env) => ({ dsn: env.SENTRY_DSN });',
     });
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    const result = tx(code, entryPath)!;
+    const result = await tx(code, entryPath)!;
     expect(result).toBeDefined();
     expect(result.code).toContain("import __SENTRY_OPTIONS_CALLBACK__ from './instrument.server.ts';");
     expect(result.code).toContain('__SENTRY__.withSentry(__SENTRY_OPTIONS_CALLBACK__,');
   });
 
-  it('detects alternative extensions (e.g. .mjs)', () => {
+  it('detects alternative extensions (e.g. .mjs)', async () => {
     const { transform: tx, entryPath } = createPluginWithDir({
       'wrangler.toml': 'main = "index.ts"',
       'instrument.server.mjs': 'export default () => ({ dsn: "x" });',
     });
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    const result = tx(code, entryPath)!;
+    const result = await tx(code, entryPath)!;
     expect(result.code).toContain("import __SENTRY_OPTIONS_CALLBACK__ from './instrument.server.mjs';");
   });
 
-  it('emits a resolvable import for .cjs instrument files', () => {
+  it('emits a resolvable import for .cjs instrument files', async () => {
     const { transform: tx, entryPath } = createPluginWithDir({
       'wrangler.toml': 'main = "index.ts"',
       'instrument.server.cjs': 'module.exports = () => ({ dsn: "x" });',
     });
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    const result = tx(code, entryPath)!;
+    const result = await tx(code, entryPath)!;
     expect(result.code).toContain("import __SENTRY_OPTIONS_CALLBACK__ from './instrument.server.cjs';");
   });
 
-  it('falls back to an env-based callback when no instrument file exists', () => {
+  it('falls back to an env-based callback when no instrument file exists', async () => {
     const { transform: tx, entryPath } = createPluginWithDir({ 'wrangler.toml': 'main = "index.ts"' });
 
     const code = 'export default { fetch() { return new Response("ok"); } };';
-    const result = tx(code, entryPath)!;
+    const result = await tx(code, entryPath)!;
     expect(result.code).not.toContain('__SENTRY_OPTIONS_CALLBACK__');
     expect(result.code).toContain('__SENTRY__.withSentry(() => undefined,');
   });
 
-  it('applies the detected callback to Durable Object classes too', () => {
+  it('applies the detected callback to Durable Object classes too', async () => {
     const { transform: tx, entryPath } = createPluginWithDir({
       'wrangler.toml': [
         'main = "index.ts"',
@@ -334,7 +430,7 @@ describe('instrument file auto-detection', () => {
     });
 
     const code = ['class DurableObject {}', 'export class MyDO extends DurableObject {}'].join('\n');
-    const result = tx(code, entryPath)!;
+    const result = await tx(code, entryPath)!;
     expect(result.code).toContain('__SENTRY__.instrumentDurableObjectWithSentry(__SENTRY_OPTIONS_CALLBACK__,');
   });
 });

--- a/packages/cloudflare/test/vite/transform.test.ts
+++ b/packages/cloudflare/test/vite/transform.test.ts
@@ -423,6 +423,143 @@ describe('WorkerEntrypoint class wrapping (config fallback)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Agent classes (configured as Durable Objects, upgraded by detection)
+// ---------------------------------------------------------------------------
+
+describe('agent class wrapping', () => {
+  it('wraps a detected Agent with instrumentAgentWithSentry instead of the DO helper', () => {
+    const code = ["import { Agent } from 'agents';", 'export class MyAgent extends Agent {}'].join('\n');
+
+    const result = transform(code, {
+      classWrappers: doWrappers('MyAgent'),
+      agentClasses: new Set(['MyAgent']),
+      optionsFn: '(env) => ({})',
+    })!;
+
+    expect(result.code).toContain('export const MyAgent = __SENTRY__.instrumentAgentWithSentry(');
+    expect(result.code).not.toContain('instrumentDurableObjectWithSentry');
+    expect(result.wrappedClasses).toEqual(new Set(['MyAgent']));
+  });
+
+  it('still wraps an undetected DO with the Durable Object helper', () => {
+    const code = ["import { DurableObject } from 'cloudflare:workers';", 'export class MyDO extends DurableObject {}'];
+
+    const result = transform(code.join('\n'), {
+      classWrappers: doWrappers('MyDO'),
+      agentClasses: new Set(),
+      optionsFn: '(env) => ({})',
+    })!;
+
+    expect(result.code).toContain('export const MyDO = __SENTRY__.instrumentDurableObjectWithSentry(');
+    expect(result.code).not.toContain('instrumentAgentWithSentry');
+  });
+
+  it('wraps an Agent and a plain DO in the same entry with their respective helpers', () => {
+    const code = [
+      "import { Agent } from 'agents';",
+      "import { DurableObject } from 'cloudflare:workers';",
+      'export class MyAgent extends Agent {}',
+      'export class MyDO extends DurableObject {}',
+    ].join('\n');
+
+    const result = transform(code, {
+      classWrappers: doWrappers('MyAgent', 'MyDO'),
+      agentClasses: new Set(['MyAgent']),
+      optionsFn: '(env) => ({})',
+    })!;
+
+    expect(result.code).toContain('export const MyAgent = __SENTRY__.instrumentAgentWithSentry(');
+    expect(result.code).toContain('export const MyDO = __SENTRY__.instrumentDurableObjectWithSentry(');
+  });
+
+  it('emits the expected source for a mixed Agent/chat-agent/DO entry', () => {
+    const code = [
+      "import { Agent } from 'agents';",
+      "import { AIChatAgent } from '@cloudflare/ai-chat';",
+      "import { DurableObject } from 'cloudflare:workers';",
+      'export class MyAgent extends Agent {}',
+      'export class MyChat extends AIChatAgent {}',
+      'export class MyDO extends DurableObject {}',
+      'export default { fetch() {} };',
+    ].join('\n');
+
+    const result = transform(code, {
+      classWrappers: doWrappers('MyAgent', 'MyChat', 'MyDO'),
+      agentClasses: new Set(['MyAgent', 'MyChat']),
+      optionsFn: '(env) => ({ dsn: env.SENTRY_DSN })',
+    })!;
+
+    expect(result.code).toBe(
+      [
+        "import * as __SENTRY__ from '@sentry/cloudflare';",
+        "import { Agent } from 'agents';",
+        "import { AIChatAgent } from '@cloudflare/ai-chat';",
+        "import { DurableObject } from 'cloudflare:workers';",
+        'class __SENTRY_ORIGINAL_MyAgent__ extends Agent {}',
+        'export const MyAgent = __SENTRY__.instrumentAgentWithSentry((env) => ({ dsn: env.SENTRY_DSN }), __SENTRY_ORIGINAL_MyAgent__);',
+        '',
+        'class __SENTRY_ORIGINAL_MyChat__ extends AIChatAgent {}',
+        'export const MyChat = __SENTRY__.instrumentAgentWithSentry((env) => ({ dsn: env.SENTRY_DSN }), __SENTRY_ORIGINAL_MyChat__);',
+        '',
+        'class __SENTRY_ORIGINAL_MyDO__ extends DurableObject {}',
+        'export const MyDO = __SENTRY__.instrumentDurableObjectWithSentry((env) => ({ dsn: env.SENTRY_DSN }), __SENTRY_ORIGINAL_MyDO__);',
+        '',
+        'const __SENTRY_DEFAULT_EXPORT__ = { fetch() {} };',
+        'export default __SENTRY__.withSentry((env) => ({ dsn: env.SENTRY_DSN }), __SENTRY_DEFAULT_EXPORT__);',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('upgrades a specifier-exported Agent, matching detection on the local name', () => {
+    const code = [
+      "import { Agent } from 'agents';",
+      'class LocalAgent extends Agent {}',
+      'export { LocalAgent as ConfiguredAgent };',
+    ].join('\n');
+
+    const result = transform(code, {
+      classWrappers: doWrappers('ConfiguredAgent'),
+      agentClasses: new Set(['LocalAgent']),
+      optionsFn: '(env) => ({})',
+    })!;
+
+    expect(result.code).toContain('const LocalAgent = __SENTRY__.instrumentAgentWithSentry(');
+  });
+
+  it('does not report a manually Agent-wrapped export as unwrapped', () => {
+    const code = [
+      "import * as Sentry from '@sentry/cloudflare';",
+      "import { Agent } from 'agents';",
+      'class MyAgentBase extends Agent {}',
+      'export const MyAgent = Sentry.instrumentAgentWithSentry((env) => ({}), MyAgentBase);',
+    ].join('\n');
+
+    const result = transform(code, {
+      classWrappers: doWrappers('MyAgent'),
+      agentClasses: new Set(),
+      optionsFn: '(env) => ({})',
+    })!;
+
+    expect(result.wrappedClasses).toEqual(new Set(['MyAgent']));
+  });
+
+  it('leaves the DO helper accepted for a manually wrapped Durable Object', () => {
+    const code = [
+      "import * as Sentry from '@sentry/cloudflare';",
+      'export const MyDO = Sentry.instrumentDurableObjectWithSentry((env) => ({}), class {});',
+    ].join('\n');
+
+    const result = transform(code, {
+      classWrappers: doWrappers('MyDO'),
+      optionsFn: '(env) => ({})',
+    })!;
+
+    expect(result.wrappedClasses).toEqual(new Set(['MyDO']));
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Combined transforms (DO + Workflow + default export)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Since `instrumentAgentWithSentry` is here, it also needs to be supported within the Vite plugin and its `autoInstrument` flag. The issue here is that we need to parse through the imports in order to understand where the `Agent` import is coming from. (The majority of the changes are tests again)

It could also be that external libraries are extending from `Agent`, such as `McpAgent`, and these need to be wrapped too. It is super hacky but it works. 

For the tests I wished to add them in the `cloudflare-integration-tests`, but unfortunately `agents` needs Node v20+ and locally we run with v18, so it wouldn't work without either bumping Nodejs or making the tests their own package so they are independent.