### PR TITLE
ref(node): Remove vendored express instrumentation

### DIFF
--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -1,23 +1,6 @@
-// Automatic istrumentation for Express using OTel
-import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
-import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation';
-
-import { generateInstrumentOnce } from '../../otel/instrument';
 import { ensureIsWrapped } from '../../utils/ensureIsWrapped';
-import {
-  type ExpressIntegrationOptions,
-  debug,
-  patchExpressModule,
-  SDK_VERSION,
-  setupExpressErrorHandler as coreSetupExpressErrorHandler,
-  type ExpressHandlerOptions,
-} from '@sentry/core';
+import { setupExpressErrorHandler as coreSetupExpressErrorHandler, type ExpressHandlerOptions } from '@sentry/core';
 export { expressErrorHandler } from '@sentry/core';
-import { DEBUG_BUILD } from '../../debug-build';
-import { setHttpServerSpanRouteAttribute } from '../../utils/setHttpServerSpanRouteAttribute';
-
-const INTEGRATION_NAME = 'Express' as const;
-const SUPPORTED_VERSIONS = ['>=4.0.0 <6'];
 
 export function setupExpressErrorHandler(
   //oxlint-disable-next-line no-explicit-any
@@ -26,42 +9,4 @@ export function setupExpressErrorHandler(
 ): void {
   coreSetupExpressErrorHandler(app, options);
   ensureIsWrapped(app.use, 'express');
-}
-
-export type ExpressInstrumentationConfig = InstrumentationConfig &
-  Omit<ExpressIntegrationOptions, 'express' | 'onRouteResolved'>;
-
-export const instrumentExpress = generateInstrumentOnce(
-  INTEGRATION_NAME,
-  (options?: ExpressInstrumentationConfig) => new ExpressInstrumentation(options),
-);
-
-export class ExpressInstrumentation extends InstrumentationBase<ExpressInstrumentationConfig> {
-  public constructor(config: ExpressInstrumentationConfig = {}) {
-    super('sentry-express', SDK_VERSION, config);
-  }
-  public init(): InstrumentationNodeModuleDefinition {
-    const module = new InstrumentationNodeModuleDefinition(
-      'express',
-      SUPPORTED_VERSIONS,
-      express => {
-        try {
-          patchExpressModule(express, () => ({
-            ...this.getConfig(),
-            onRouteResolved(route) {
-              if (route) {
-                setHttpServerSpanRouteAttribute(route);
-              }
-            },
-          }));
-        } catch (e) {
-          DEBUG_BUILD && debug.error('Failed to patch express module:', e);
-        }
-        return express;
-      },
-      // we do not ever actually unpatch in our SDKs
-      express => express,
-    );
-    return module;
-  }
 }


### PR DESCRIPTION
## What

Removes the dead OpenTelemetry `ExpressInstrumentation` class (and `instrumentExpress`) from `@sentry/node`. Keeps `setupExpressErrorHandler` / `expressErrorHandler`.

## Why

The express integration is now provided by the channel-based implementation in `@sentry/server-utils` (the default since #22501). The vendored instrumentation is no longer wired up; only the Sentry-specific error handler remains user-facing.

Ref: #22346