### PR TITLE
feat(node): Add build-time instrumentation opt-out to bundler plugins

### DIFF
--- a/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
+++ b/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
@@ -127,6 +127,11 @@ export interface BuildTimeOptionsBase {
   bundleSizeOptimizations?: BundleSizeOptimizationsOptions;
 
   /**
+   * Options related to automatic build-time instrumentation of server-side dependencies.
+   */
+  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
+
+  /**
    * A key that is used to identify the application in the Sentry bundler plugins.
    * This key is used by the `thirdPartyErrorFilterIntegration` to filter out errors
    * originating from third-party scripts.
@@ -134,6 +139,21 @@ export interface BuildTimeOptionsBase {
    * @see https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
    */
   applicationKey?: string;
+}
+
+/**
+ * Options related to automatic instrumentation of server-side dependencies at build time.
+ *
+ * @internal Only meant for Sentry-internal SDK usage.
+ * @hidden
+ */
+export interface BuildTimeInstrumentationOptions {
+  /**
+   * If set to `true`, disables automatic instrumentation of server-side dependencies at build time.
+   *
+   * @default false
+   */
+  disable?: boolean;
 }
 
 /**

--- a/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
+++ b/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
@@ -127,9 +127,13 @@ export interface BuildTimeOptionsBase {
   bundleSizeOptimizations?: BundleSizeOptimizationsOptions;
 
   /**
-   * Options related to automatic build-time instrumentation of server-side dependencies.
+   * Automatic instrumentation of server-side dependencies at build time.
+   *
+   * Set to `false` to turn it off.
+   *
+   * @default true
    */
-  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
+  buildTimeInstrumentation?: boolean;
 
   /**
    * A key that is used to identify the application in the Sentry bundler plugins.
@@ -139,21 +143,6 @@ export interface BuildTimeOptionsBase {
    * @see https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-thirdpartyerrorfilterintegration
    */
   applicationKey?: string;
-}
-
-/**
- * Options related to automatic instrumentation of server-side dependencies at build time.
- *
- * @internal Only meant for Sentry-internal SDK usage.
- * @hidden
- */
-export interface BuildTimeInstrumentationOptions {
-  /**
-   * If set to `true`, disables automatic instrumentation of server-side dependencies at build time.
-   *
-   * @default false
-   */
-  disable?: boolean;
 }
 
 /**

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -520,6 +520,7 @@ export type { LegacyCSPReport } from './types/csp';
 export type { SerializedLog, SerializedLogContainer } from './types/log';
 export type {
   BuildTimeOptionsBase,
+  BuildTimeInstrumentationOptions,
   UnstableVitePluginOptions,
   UnstableRollupPluginOptions,
   UnstableWebpackPluginOptions,

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -520,7 +520,6 @@ export type { LegacyCSPReport } from './types/csp';
 export type { SerializedLog, SerializedLogContainer } from './types/log';
 export type {
   BuildTimeOptionsBase,
-  BuildTimeInstrumentationOptions,
   UnstableVitePluginOptions,
   UnstableRollupPluginOptions,
   UnstableWebpackPluginOptions,

--- a/packages/node/src/bundler-plugin/esbuild.ts
+++ b/packages/node/src/bundler-plugin/esbuild.ts
@@ -1,6 +1,5 @@
 import { sentryEsbuildPlugin as sentryEsbuildBundlerPlugin } from '@sentry/bundler-plugins/esbuild';
 import type { SentryEsbuildPluginOptions as SentryEsbuildPluginOptionsBase } from '@sentry/bundler-plugins/esbuild';
-import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/esbuild';
 
 export type SentryEsbuildPluginOptions = SentryEsbuildPluginOptionsBase & {
@@ -10,11 +9,13 @@ export type SentryEsbuildPluginOptions = SentryEsbuildPluginOptionsBase & {
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
 
   /**
-   * Options related to automatic instrumentation of server-side dependencies at build time.
+   * Automatic instrumentation of server-side dependencies at build time.
    *
-   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   * Set to `false` to turn it off.
+   *
+   * @default true
    */
-  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
+  buildTimeInstrumentation?: boolean;
 };
 
 type EsbuildPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
@@ -35,14 +36,13 @@ type EsbuildPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
  */
 export function sentryEsbuildPlugin(options?: SentryEsbuildPluginOptions): EsbuildPlugin {
   const bundlerPlugin = sentryEsbuildBundlerPlugin(options) as EsbuildPlugin;
+  const orchestrionPlugin = sentryOrchestrionPlugin(options);
 
   return {
     name: 'sentry-node-esbuild',
     async setup(build): Promise<void> {
       await bundlerPlugin.setup(build);
-      if (!options?.buildTimeInstrumentation?.disable) {
-        await sentryOrchestrionPlugin(options).setup(build);
-      }
+      await orchestrionPlugin.setup(build);
     },
   };
 }

--- a/packages/node/src/bundler-plugin/esbuild.ts
+++ b/packages/node/src/bundler-plugin/esbuild.ts
@@ -1,5 +1,6 @@
 import { sentryEsbuildPlugin as sentryEsbuildBundlerPlugin } from '@sentry/bundler-plugins/esbuild';
 import type { SentryEsbuildPluginOptions as SentryEsbuildPluginOptionsBase } from '@sentry/bundler-plugins/esbuild';
+import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/esbuild';
 
 export type SentryEsbuildPluginOptions = SentryEsbuildPluginOptionsBase & {
@@ -7,6 +8,13 @@ export type SentryEsbuildPluginOptions = SentryEsbuildPluginOptionsBase & {
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
+
+  /**
+   * Options related to automatic instrumentation of server-side dependencies at build time.
+   *
+   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   */
+  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
 };
 
 type EsbuildPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
@@ -27,13 +35,14 @@ type EsbuildPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
  */
 export function sentryEsbuildPlugin(options?: SentryEsbuildPluginOptions): EsbuildPlugin {
   const bundlerPlugin = sentryEsbuildBundlerPlugin(options) as EsbuildPlugin;
-  const orchestrionPlugin = sentryOrchestrionPlugin(options);
 
   return {
     name: 'sentry-node-esbuild',
     async setup(build): Promise<void> {
       await bundlerPlugin.setup(build);
-      await orchestrionPlugin.setup(build);
+      if (!options?.buildTimeInstrumentation?.disable) {
+        await sentryOrchestrionPlugin(options).setup(build);
+      }
     },
   };
 }

--- a/packages/node/src/bundler-plugin/rollup.ts
+++ b/packages/node/src/bundler-plugin/rollup.ts
@@ -1,6 +1,5 @@
 import { sentryRollupPlugin as sentryRollupBundlerPlugin } from '@sentry/bundler-plugins/rollup';
 import type { SentryRollupPluginOptions as SentryRollupPluginOptionsBase } from '@sentry/bundler-plugins/rollup';
-import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/rollup';
 
 export type SentryRollupPluginOptions = SentryRollupPluginOptionsBase & {
@@ -10,11 +9,13 @@ export type SentryRollupPluginOptions = SentryRollupPluginOptionsBase & {
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
 
   /**
-   * Options related to automatic instrumentation of server-side dependencies at build time.
+   * Automatic instrumentation of server-side dependencies at build time.
    *
-   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   * Set to `false` to turn it off.
+   *
+   * @default true
    */
-  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
+  buildTimeInstrumentation?: boolean;
 };
 
 type RollupPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
@@ -36,6 +37,5 @@ type RollupPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
  */
 export function sentryRollupPlugin(options?: SentryRollupPluginOptions): RollupPlugin[] {
   const bundlerPlugins = sentryRollupBundlerPlugin(options);
-  const isOrchestrionDisabled = options?.buildTimeInstrumentation?.disable;
-  return [...bundlerPlugins, ...(isOrchestrionDisabled ? [] : [sentryOrchestrionPlugin(options)])];
+  return [...bundlerPlugins, sentryOrchestrionPlugin(options)];
 }

--- a/packages/node/src/bundler-plugin/rollup.ts
+++ b/packages/node/src/bundler-plugin/rollup.ts
@@ -1,5 +1,6 @@
 import { sentryRollupPlugin as sentryRollupBundlerPlugin } from '@sentry/bundler-plugins/rollup';
 import type { SentryRollupPluginOptions as SentryRollupPluginOptionsBase } from '@sentry/bundler-plugins/rollup';
+import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/rollup';
 
 export type SentryRollupPluginOptions = SentryRollupPluginOptionsBase & {
@@ -7,6 +8,13 @@ export type SentryRollupPluginOptions = SentryRollupPluginOptionsBase & {
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
+
+  /**
+   * Options related to automatic instrumentation of server-side dependencies at build time.
+   *
+   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   */
+  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
 };
 
 type RollupPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
@@ -27,5 +35,7 @@ type RollupPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
  * ```
  */
 export function sentryRollupPlugin(options?: SentryRollupPluginOptions): RollupPlugin[] {
-  return [...sentryRollupBundlerPlugin(options), sentryOrchestrionPlugin(options)];
+  const bundlerPlugins = sentryRollupBundlerPlugin(options);
+  const isOrchestrionDisabled = options?.buildTimeInstrumentation?.disable;
+  return [...bundlerPlugins, ...(isOrchestrionDisabled ? [] : [sentryOrchestrionPlugin(options)])];
 }

--- a/packages/node/src/bundler-plugin/vite.ts
+++ b/packages/node/src/bundler-plugin/vite.ts
@@ -1,5 +1,6 @@
 import { sentryVitePlugin as sentryViteBundlerPlugin } from '@sentry/bundler-plugins/vite';
 import type { SentryVitePluginOptions as SentryVitePluginOptionsBase } from '@sentry/bundler-plugins/vite';
+import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 
 export type SentryVitePluginOptions = SentryVitePluginOptionsBase & {
@@ -7,6 +8,13 @@ export type SentryVitePluginOptions = SentryVitePluginOptionsBase & {
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
+
+  /**
+   * Options related to automatic instrumentation of server-side dependencies at build time.
+   *
+   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   */
+  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
 };
 
 type VitePlugin = ReturnType<typeof sentryOrchestrionPlugin>;
@@ -28,5 +36,7 @@ type VitePlugin = ReturnType<typeof sentryOrchestrionPlugin>;
  * ```
  */
 export function sentryVitePlugin(options?: SentryVitePluginOptions): VitePlugin[] {
-  return [...sentryViteBundlerPlugin(options), sentryOrchestrionPlugin(options)];
+  const bundlerPlugins = sentryViteBundlerPlugin(options);
+  const isOrchestrionDisabled = options?.buildTimeInstrumentation?.disable;
+  return [...bundlerPlugins, ...(isOrchestrionDisabled ? [] : [sentryOrchestrionPlugin(options)])];
 }

--- a/packages/node/src/bundler-plugin/vite.ts
+++ b/packages/node/src/bundler-plugin/vite.ts
@@ -1,6 +1,5 @@
 import { sentryVitePlugin as sentryViteBundlerPlugin } from '@sentry/bundler-plugins/vite';
 import type { SentryVitePluginOptions as SentryVitePluginOptionsBase } from '@sentry/bundler-plugins/vite';
-import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 
 export type SentryVitePluginOptions = SentryVitePluginOptionsBase & {
@@ -10,11 +9,13 @@ export type SentryVitePluginOptions = SentryVitePluginOptionsBase & {
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
 
   /**
-   * Options related to automatic instrumentation of server-side dependencies at build time.
+   * Automatic instrumentation of server-side dependencies at build time.
    *
-   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   * Set to `false` to turn it off.
+   *
+   * @default true
    */
-  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
+  buildTimeInstrumentation?: boolean;
 };
 
 type VitePlugin = ReturnType<typeof sentryOrchestrionPlugin>;
@@ -37,6 +38,5 @@ type VitePlugin = ReturnType<typeof sentryOrchestrionPlugin>;
  */
 export function sentryVitePlugin(options?: SentryVitePluginOptions): VitePlugin[] {
   const bundlerPlugins = sentryViteBundlerPlugin(options);
-  const isOrchestrionDisabled = options?.buildTimeInstrumentation?.disable;
-  return [...bundlerPlugins, ...(isOrchestrionDisabled ? [] : [sentryOrchestrionPlugin(options)])];
+  return [...bundlerPlugins, sentryOrchestrionPlugin(options)];
 }

--- a/packages/node/src/bundler-plugin/webpack.ts
+++ b/packages/node/src/bundler-plugin/webpack.ts
@@ -1,6 +1,5 @@
 import { sentryWebpackPlugin as sentryWebpackBundlerPlugin } from '@sentry/bundler-plugins/webpack';
 import type { SentryWebpackPluginOptions as SentryWebpackPluginOptionsBase } from '@sentry/bundler-plugins/webpack';
-import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionWebpackPlugin } from '@sentry/server-utils/orchestrion/webpack';
 
 export type SentryWebpackPluginOptions = SentryWebpackPluginOptionsBase & {
@@ -10,11 +9,13 @@ export type SentryWebpackPluginOptions = SentryWebpackPluginOptionsBase & {
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionWebpackPlugin>[0]>['instrumentations'];
 
   /**
-   * Options related to automatic instrumentation of server-side dependencies at build time.
+   * Automatic instrumentation of server-side dependencies at build time.
    *
-   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   * Set to `false` to turn it off.
+   *
+   * @default true
    */
-  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
+  buildTimeInstrumentation?: boolean;
 };
 
 type WebpackCompiler = Parameters<ReturnType<typeof sentryWebpackBundlerPlugin>['apply']>[0];
@@ -37,13 +38,12 @@ export function sentryWebpackPlugin(options?: SentryWebpackPluginOptions): {
   apply: (compiler: WebpackCompiler) => void;
 } {
   const bundlerPlugin = sentryWebpackBundlerPlugin(options) as { apply: (compiler: WebpackCompiler) => void };
+  const orchestrionPlugin = sentryOrchestrionWebpackPlugin(options) as { apply: (compiler: WebpackCompiler) => void };
 
   return {
     apply(compiler: WebpackCompiler): void {
       bundlerPlugin.apply(compiler);
-      if (!options?.buildTimeInstrumentation?.disable) {
-        (sentryOrchestrionWebpackPlugin(options) as { apply: (compiler: WebpackCompiler) => void }).apply(compiler);
-      }
+      orchestrionPlugin.apply(compiler);
     },
   };
 }

--- a/packages/node/src/bundler-plugin/webpack.ts
+++ b/packages/node/src/bundler-plugin/webpack.ts
@@ -1,5 +1,6 @@
 import { sentryWebpackPlugin as sentryWebpackBundlerPlugin } from '@sentry/bundler-plugins/webpack';
 import type { SentryWebpackPluginOptions as SentryWebpackPluginOptionsBase } from '@sentry/bundler-plugins/webpack';
+import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import { sentryOrchestrionWebpackPlugin } from '@sentry/server-utils/orchestrion/webpack';
 
 export type SentryWebpackPluginOptions = SentryWebpackPluginOptionsBase & {
@@ -7,6 +8,13 @@ export type SentryWebpackPluginOptions = SentryWebpackPluginOptionsBase & {
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
   instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionWebpackPlugin>[0]>['instrumentations'];
+
+  /**
+   * Options related to automatic instrumentation of server-side dependencies at build time.
+   *
+   * Set `buildTimeInstrumentation.disable` to `true` to turn it off.
+   */
+  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
 };
 
 type WebpackCompiler = Parameters<ReturnType<typeof sentryWebpackBundlerPlugin>['apply']>[0];
@@ -29,12 +37,13 @@ export function sentryWebpackPlugin(options?: SentryWebpackPluginOptions): {
   apply: (compiler: WebpackCompiler) => void;
 } {
   const bundlerPlugin = sentryWebpackBundlerPlugin(options) as { apply: (compiler: WebpackCompiler) => void };
-  const orchestrionPlugin = sentryOrchestrionWebpackPlugin(options) as { apply: (compiler: WebpackCompiler) => void };
 
   return {
     apply(compiler: WebpackCompiler): void {
       bundlerPlugin.apply(compiler);
-      orchestrionPlugin.apply(compiler);
+      if (!options?.buildTimeInstrumentation?.disable) {
+        (sentryOrchestrionWebpackPlugin(options) as { apply: (compiler: WebpackCompiler) => void }).apply(compiler);
+      }
     },
   };
 }

--- a/packages/node/test/bundler-plugin/bundler-plugin.test.ts
+++ b/packages/node/test/bundler-plugin/bundler-plugin.test.ts
@@ -30,51 +30,26 @@ describe('@sentry/node bundler plugins', () => {
     vi.clearAllMocks();
   });
 
-  describe('by default (no opt-out)', () => {
-    it('vite includes the orchestrion plugin', () => {
-      const plugins = sentryVitePlugin();
-      expect(plugins.map(p => p.name)).toContain('sentry-orchestrion-vite');
-    });
-
-    it('rollup includes the orchestrion plugin', () => {
-      const plugins = sentryRollupPlugin();
-      expect(plugins.map(p => p.name)).toContain('sentry-orchestrion-rollup');
-    });
-
-    it('esbuild runs the orchestrion setup', async () => {
-      await sentryEsbuildPlugin().setup({} as never);
-      expect(orchestrionEsbuildSetup).toHaveBeenCalledTimes(1);
-    });
-
-    it('webpack applies the orchestrion plugin', () => {
-      sentryWebpackPlugin().apply({} as never);
-      expect(orchestrionWebpackApply).toHaveBeenCalledTimes(1);
-    });
+  // The wrappers always wire in the orchestrion plugin. Opting out via
+  // `buildTimeInstrumentation: false` is handled inside the orchestrion plugin
+  // itself (covered in @sentry/server-utils), which returns an inert plugin.
+  it('vite includes the orchestrion plugin', () => {
+    const plugins = sentryVitePlugin();
+    expect(plugins.map(p => p.name)).toContain('sentry-orchestrion-vite');
   });
 
-  describe('with buildTimeInstrumentation.disable', () => {
-    const disabled = { buildTimeInstrumentation: { disable: true } };
+  it('rollup includes the orchestrion plugin', () => {
+    const plugins = sentryRollupPlugin();
+    expect(plugins.map(p => p.name)).toContain('sentry-orchestrion-rollup');
+  });
 
-    it('vite omits the orchestrion plugin entirely', () => {
-      const plugins = sentryVitePlugin(disabled);
-      expect(plugins.map(p => p.name)).not.toContain('sentry-orchestrion-vite');
-      expect(orchestrionVite).not.toHaveBeenCalled();
-    });
+  it('esbuild runs the orchestrion setup', async () => {
+    await sentryEsbuildPlugin().setup({} as never);
+    expect(orchestrionEsbuildSetup).toHaveBeenCalledTimes(1);
+  });
 
-    it('rollup omits the orchestrion plugin entirely', () => {
-      const plugins = sentryRollupPlugin(disabled);
-      expect(plugins.map(p => p.name)).not.toContain('sentry-orchestrion-rollup');
-      expect(orchestrionRollup).not.toHaveBeenCalled();
-    });
-
-    it('esbuild never runs the orchestrion setup', async () => {
-      await sentryEsbuildPlugin(disabled).setup({} as never);
-      expect(orchestrionEsbuildSetup).not.toHaveBeenCalled();
-    });
-
-    it('webpack never applies the orchestrion plugin', () => {
-      sentryWebpackPlugin(disabled).apply({} as never);
-      expect(orchestrionWebpackApply).not.toHaveBeenCalled();
-    });
+  it('webpack applies the orchestrion plugin', () => {
+    sentryWebpackPlugin().apply({} as never);
+    expect(orchestrionWebpackApply).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/node/test/bundler-plugin/bundler-plugin.test.ts
+++ b/packages/node/test/bundler-plugin/bundler-plugin.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sentryEsbuildPlugin } from '../../src/bundler-plugin/esbuild';
+import { sentryRollupPlugin } from '../../src/bundler-plugin/rollup';
+import { sentryVitePlugin } from '../../src/bundler-plugin/vite';
+import { sentryWebpackPlugin } from '../../src/bundler-plugin/webpack';
+
+const orchestrionVite = vi.fn(() => ({ name: 'sentry-orchestrion-vite' }));
+const orchestrionRollup = vi.fn(() => ({ name: 'sentry-orchestrion-rollup' }));
+const orchestrionEsbuildSetup = vi.fn();
+const orchestrionWebpackApply = vi.fn();
+
+vi.mock('@sentry/bundler-plugins/vite', () => ({ sentryVitePlugin: () => [{ name: 'sentry-vite' }] }));
+vi.mock('@sentry/bundler-plugins/rollup', () => ({ sentryRollupPlugin: () => [{ name: 'sentry-rollup' }] }));
+vi.mock('@sentry/bundler-plugins/esbuild', () => ({
+  sentryEsbuildPlugin: () => ({ name: 'sentry-esbuild', setup: vi.fn() }),
+}));
+vi.mock('@sentry/bundler-plugins/webpack', () => ({ sentryWebpackPlugin: () => ({ apply: vi.fn() }) }));
+
+vi.mock('@sentry/server-utils/orchestrion/vite', () => ({ sentryOrchestrionPlugin: () => orchestrionVite() }));
+vi.mock('@sentry/server-utils/orchestrion/rollup', () => ({ sentryOrchestrionPlugin: () => orchestrionRollup() }));
+vi.mock('@sentry/server-utils/orchestrion/esbuild', () => ({
+  sentryOrchestrionPlugin: () => ({ name: 'sentry-orchestrion-esbuild', setup: orchestrionEsbuildSetup }),
+}));
+vi.mock('@sentry/server-utils/orchestrion/webpack', () => ({
+  sentryOrchestrionWebpackPlugin: () => ({ apply: orchestrionWebpackApply }),
+}));
+
+describe('@sentry/node bundler plugins', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('by default (no opt-out)', () => {
+    it('vite includes the orchestrion plugin', () => {
+      const plugins = sentryVitePlugin();
+      expect(plugins.map(p => p.name)).toContain('sentry-orchestrion-vite');
+    });
+
+    it('rollup includes the orchestrion plugin', () => {
+      const plugins = sentryRollupPlugin();
+      expect(plugins.map(p => p.name)).toContain('sentry-orchestrion-rollup');
+    });
+
+    it('esbuild runs the orchestrion setup', async () => {
+      await sentryEsbuildPlugin().setup({} as never);
+      expect(orchestrionEsbuildSetup).toHaveBeenCalledTimes(1);
+    });
+
+    it('webpack applies the orchestrion plugin', () => {
+      sentryWebpackPlugin().apply({} as never);
+      expect(orchestrionWebpackApply).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('with buildTimeInstrumentation.disable', () => {
+    const disabled = { buildTimeInstrumentation: { disable: true } };
+
+    it('vite omits the orchestrion plugin entirely', () => {
+      const plugins = sentryVitePlugin(disabled);
+      expect(plugins.map(p => p.name)).not.toContain('sentry-orchestrion-vite');
+      expect(orchestrionVite).not.toHaveBeenCalled();
+    });
+
+    it('rollup omits the orchestrion plugin entirely', () => {
+      const plugins = sentryRollupPlugin(disabled);
+      expect(plugins.map(p => p.name)).not.toContain('sentry-orchestrion-rollup');
+      expect(orchestrionRollup).not.toHaveBeenCalled();
+    });
+
+    it('esbuild never runs the orchestrion setup', async () => {
+      await sentryEsbuildPlugin(disabled).setup({} as never);
+      expect(orchestrionEsbuildSetup).not.toHaveBeenCalled();
+    });
+
+    it('webpack never applies the orchestrion plugin', () => {
+      sentryWebpackPlugin(disabled).apply({} as never);
+      expect(orchestrionWebpackApply).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/server-utils/src/orchestrion/bundler/esbuild.ts
+++ b/packages/server-utils/src/orchestrion/bundler/esbuild.ts
@@ -30,7 +30,7 @@ function matchesEsbuildExternal(entry: string, moduleName: string): boolean {
  * ```
  */
 export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
-  if (options.buildTimeInstrumentation?.disable) {
+  if (options.buildTimeInstrumentation === false) {
     // Inert plugin — no code transform, so no instrumentation lands in the bundle.
     return { name: 'sentry-orchestrion-disabled', setup: () => undefined };
   }

--- a/packages/server-utils/src/orchestrion/bundler/esbuild.ts
+++ b/packages/server-utils/src/orchestrion/bundler/esbuild.ts
@@ -30,6 +30,11 @@ function matchesEsbuildExternal(entry: string, moduleName: string): boolean {
  * ```
  */
 export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
+  if (options.buildTimeInstrumentation?.disable) {
+    // Inert plugin — no code transform, so no instrumentation lands in the bundle.
+    return { name: 'sentry-orchestrion-disabled', setup: () => undefined };
+  }
+
   const plugin = codeTransformer(orchestrionTransformOptions(options));
   const moduleNames = instrumentedModuleNames(options.instrumentations);
   const setup = plugin.setup;

--- a/packages/server-utils/src/orchestrion/bundler/options.ts
+++ b/packages/server-utils/src/orchestrion/bundler/options.ts
@@ -1,3 +1,4 @@
+import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import type { InstrumentationConfig, CustomTransform } from '..';
 import { SENTRY_INSTRUMENTATIONS } from '../config';
 import { subscribeInjectionOptions } from './subscribeInjection';
@@ -8,6 +9,12 @@ export type PluginOptions = {
    * Additional instrumentations to include with the default instrumentation.
    */
   instrumentations?: InstrumentationConfig[];
+  /**
+   * Options related to automatic build-time instrumentation. Set
+   * `buildTimeInstrumentation.disable` to `true` to make the orchestrion plugin
+   * inert, so no `diagnostics_channel` instrumentation code is injected.
+   */
+  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
   /**
    * Custom transforms that can be applied using the `transform` option in each `InstrumentationConfig`.
    */

--- a/packages/server-utils/src/orchestrion/bundler/options.ts
+++ b/packages/server-utils/src/orchestrion/bundler/options.ts
@@ -1,4 +1,3 @@
-import type { BuildTimeInstrumentationOptions } from '@sentry/core';
 import type { InstrumentationConfig, CustomTransform } from '..';
 import { SENTRY_INSTRUMENTATIONS } from '../config';
 import { subscribeInjectionOptions } from './subscribeInjection';
@@ -10,11 +9,13 @@ export type PluginOptions = {
    */
   instrumentations?: InstrumentationConfig[];
   /**
-   * Options related to automatic build-time instrumentation. Set
-   * `buildTimeInstrumentation.disable` to `true` to make the orchestrion plugin
-   * inert, so no `diagnostics_channel` instrumentation code is injected.
+   * Automatic instrumentation of server-side dependencies at build time.
+   *
+   * Set to `false` to make the plugin inert, so no instrumentation code is injected.
+   *
+   * @default true
    */
-  buildTimeInstrumentation?: BuildTimeInstrumentationOptions;
+  buildTimeInstrumentation?: boolean;
   /**
    * Custom transforms that can be applied using the `transform` option in each `InstrumentationConfig`.
    */

--- a/packages/server-utils/src/orchestrion/bundler/rollup.ts
+++ b/packages/server-utils/src/orchestrion/bundler/rollup.ts
@@ -18,6 +18,11 @@ import { externalizedModulesWarning, orchestrionTransformOptions } from './optio
  * ```
  */
 export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
+  if (options.buildTimeInstrumentation?.disable) {
+    // Inert plugin — no code transform, so no instrumentation lands in the bundle.
+    return { name: 'sentry-orchestrion-disabled' };
+  }
+
   const moduleNames = instrumentedModuleNames(options.instrumentations);
 
   return {

--- a/packages/server-utils/src/orchestrion/bundler/rollup.ts
+++ b/packages/server-utils/src/orchestrion/bundler/rollup.ts
@@ -18,7 +18,7 @@ import { externalizedModulesWarning, orchestrionTransformOptions } from './optio
  * ```
  */
 export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
-  if (options.buildTimeInstrumentation?.disable) {
+  if (options.buildTimeInstrumentation === false) {
     // Inert plugin — no code transform, so no instrumentation lands in the bundle.
     return { name: 'sentry-orchestrion-disabled' };
   }

--- a/packages/server-utils/src/orchestrion/bundler/vite.ts
+++ b/packages/server-utils/src/orchestrion/bundler/vite.ts
@@ -19,6 +19,13 @@ import { externalEntryMatchesModule, externalizedModulesWarning, orchestrionTran
  * ```
  */
 export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
+  if (options.buildTimeInstrumentation?.disable) {
+    // Return an inert plugin so SDKs that unconditionally push it into their
+    // plugin array can still opt out without any code transform, `noExternal`
+    // force-bundling, or injected diagnostics landing in the build.
+    return { name: 'sentry-orchestrion-disabled' };
+  }
+
   return {
     ...codeTransformer(orchestrionTransformOptions(options)),
     applyToEnvironment(environment) {

--- a/packages/server-utils/src/orchestrion/bundler/vite.ts
+++ b/packages/server-utils/src/orchestrion/bundler/vite.ts
@@ -19,7 +19,7 @@ import { externalEntryMatchesModule, externalizedModulesWarning, orchestrionTran
  * ```
  */
 export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
-  if (options.buildTimeInstrumentation?.disable) {
+  if (options.buildTimeInstrumentation === false) {
     // Return an inert plugin so SDKs that unconditionally push it into their
     // plugin array can still opt out without any code transform, `noExternal`
     // force-bundling, or injected diagnostics landing in the build.

--- a/packages/server-utils/src/orchestrion/bundler/webpack.ts
+++ b/packages/server-utils/src/orchestrion/bundler/webpack.ts
@@ -112,7 +112,7 @@ function fixupLoaderPath(compiler: Compiler): void {
  * transform, so a compilation warning is emitted for them.
  */
 export function sentryOrchestrionWebpackPlugin(options: PluginOptions = {}): { apply(compiler: Compiler): void } {
-  if (options.buildTimeInstrumentation?.disable) {
+  if (options.buildTimeInstrumentation === false) {
     // Inert plugin — no code transform, so no instrumentation lands in the bundle.
     return { apply: () => undefined };
   }

--- a/packages/server-utils/src/orchestrion/bundler/webpack.ts
+++ b/packages/server-utils/src/orchestrion/bundler/webpack.ts
@@ -112,6 +112,11 @@ function fixupLoaderPath(compiler: Compiler): void {
  * transform, so a compilation warning is emitted for them.
  */
 export function sentryOrchestrionWebpackPlugin(options: PluginOptions = {}): { apply(compiler: Compiler): void } {
+  if (options.buildTimeInstrumentation?.disable) {
+    // Inert plugin — no code transform, so no instrumentation lands in the bundle.
+    return { apply: () => undefined };
+  }
+
   const plugin = codeTransformerWebpack(orchestrionTransformOptions(options));
   const moduleNames = instrumentedModuleNames(options.instrumentations);
   // The upstream plugin is a class instance, so `apply` is overridden in place

--- a/packages/server-utils/test/orchestrion/bundler.test.ts
+++ b/packages/server-utils/test/orchestrion/bundler.test.ts
@@ -139,6 +139,47 @@ describe('sentryOrchestrionPlugin (vite)', () => {
   });
 });
 
+describe('buildTimeInstrumentation.disable', () => {
+  const disabled = { buildTimeInstrumentation: { disable: true } };
+
+  it('returns an inert vite plugin without the transform hooks', () => {
+    const plugin = vitePlugin(disabled);
+
+    expect(plugin.name).toBe('sentry-orchestrion-disabled');
+    expect(plugin.config).toBeUndefined();
+    expect(plugin.configResolved).toBeUndefined();
+    expect(plugin.applyToEnvironment).toBeUndefined();
+  });
+
+  it('returns an inert rollup plugin without the transform hooks', () => {
+    const plugin = rollupPlugin(disabled);
+
+    expect(plugin.name).toBe('sentry-orchestrion-disabled');
+    expect(plugin.buildStart).toBeUndefined();
+    expect((plugin as { transform?: unknown }).transform).toBeUndefined();
+  });
+
+  it('returns an inert esbuild plugin whose setup is a no-op', () => {
+    const build = { initialOptions: {}, onStart: vi.fn() } as unknown as PluginBuild;
+    const plugin = esbuildPlugin(disabled);
+
+    expect(plugin.name).toBe('sentry-orchestrion-disabled');
+    expect(plugin.setup(build)).toBeUndefined();
+    expect(build.onStart).not.toHaveBeenCalled();
+  });
+
+  it('returns an inert webpack plugin whose apply is a no-op', () => {
+    const tap = vi.fn();
+    const compiler = {
+      options: { externals: ['mysql'] },
+      hooks: { thisCompilation: { tap } },
+    } as unknown as Compiler;
+
+    expect(() => sentryOrchestrionWebpackPlugin(disabled).apply(compiler)).not.toThrow();
+    expect(tap).not.toHaveBeenCalled();
+  });
+});
+
 describe('resolveOrchestrionRuntimeRequest', () => {
   it.each([
     // Self-references — resolve through this package's own exports map to the CJS build.

--- a/packages/server-utils/test/orchestrion/bundler.test.ts
+++ b/packages/server-utils/test/orchestrion/bundler.test.ts
@@ -139,8 +139,8 @@ describe('sentryOrchestrionPlugin (vite)', () => {
   });
 });
 
-describe('buildTimeInstrumentation.disable', () => {
-  const disabled = { buildTimeInstrumentation: { disable: true } };
+describe('buildTimeInstrumentation: false', () => {
+  const disabled = { buildTimeInstrumentation: false };
 
   it('returns an inert vite plugin without the transform hooks', () => {
     const plugin = vitePlugin(disabled);


### PR DESCRIPTION
Adds a shared `buildTimeInstrumentation.disable` option to the build-time options base and wires it through the `@sentry/node` bundler plugins. When `true`, no build-time instrumentation is added to the bundle.

Nested under `buildTimeInstrumentation` to avoid colliding with the existing top-level `disable` and also to provide a space for adding more fine grained options if needed later on (disable instrumentation for certain modules for example?).

closes getsentry/sentry-javascript#22680