### PR TITLE
fix(core): Resolve `genAI` collection options per call instead of at wrap time

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/index.ts
@@ -28,6 +28,7 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
+    dataCollection: { genAI: { inputs: false, outputs: true } },
     streamGenAiSpans: true,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/test.ts
@@ -6,6 +6,7 @@ import {
   GEN_AI_REQUEST_TEMPERATURE,
   GEN_AI_RESPONSE_ID,
   GEN_AI_RESPONSE_MODEL,
+  GEN_AI_RESPONSE_TEXT,
   GEN_AI_SYSTEM,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
@@ -45,6 +46,8 @@ it('traces a basic message creation request with the anthropic SDK', async ({ si
           [GEN_AI_REQUEST_MODEL]: { value: 'claude-3-haiku-20240307', type: 'string' },
           [GEN_AI_REQUEST_TEMPERATURE]: { value: 0.7, type: 'double' },
           [GEN_AI_REQUEST_MAX_TOKENS]: { value: 100, type: 'integer' },
+          // collect only LLM output
+          [GEN_AI_RESPONSE_TEXT]: { value: 'Hello from Anthropic!', type: 'string' },
           [GEN_AI_RESPONSE_ID]: { value: 'msg_mock123', type: 'string' },
           [GEN_AI_RESPONSE_MODEL]: { value: 'claude-3-haiku-20240307', type: 'string' },
           [GEN_AI_USAGE_INPUT_TOKENS]: { value: 10, type: 'integer' },

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/index.ts
@@ -46,6 +46,7 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
+    dataCollection: { genAI: { inputs: true } },
     streamGenAiSpans: true,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/test.ts
@@ -1,16 +1,20 @@
 import { expect, it } from 'vitest';
 import type { SerializedStreamedSpan } from '@sentry/core';
 import {
+  GEN_AI_EMBEDDINGS_INPUT,
+  GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
   GEN_AI_REQUEST_MAX_TOKENS,
   GEN_AI_REQUEST_MODEL,
   GEN_AI_REQUEST_TEMPERATURE,
   GEN_AI_REQUEST_TOP_P,
+  GEN_AI_RESPONSE_TEXT,
   GEN_AI_SYSTEM,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE } from '../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
 import { createRunner } from '../../../runner';
 
 // This test runs the `@google/genai` SDK on the Workers runtime (with a
@@ -46,6 +50,10 @@ it('traces Google GenAI chat, generateContent, and embedContent calls', async ({
           [GEN_AI_SYSTEM]: { value: 'google_genai', type: 'string' },
           [GEN_AI_OPERATION_NAME]: { value: 'chat', type: 'string' },
           [GEN_AI_REQUEST_MODEL]: { value: 'gemini-1.5-pro', type: 'string' },
+          // collect LLM input and outputs (default true)
+          [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: { value: 1, type: 'integer' },
+          [GEN_AI_INPUT_MESSAGES]: { value: '[{"role":"user","content":"Tell me a joke"}]', type: 'string' },
+          [GEN_AI_RESPONSE_TEXT]: { value: 'Hello from Google GenAI!', type: 'string' },
           [GEN_AI_USAGE_INPUT_TOKENS]: { value: 8, type: 'integer' },
           [GEN_AI_USAGE_OUTPUT_TOKENS]: { value: 12, type: 'integer' },
           [GEN_AI_USAGE_TOTAL_TOKENS]: { value: 20, type: 'integer' },
@@ -70,9 +78,15 @@ it('traces Google GenAI chat, generateContent, and embedContent calls', async ({
           [GEN_AI_REQUEST_TEMPERATURE]: { value: 0.7, type: 'double' },
           [GEN_AI_REQUEST_TOP_P]: { value: 0.9, type: 'double' },
           [GEN_AI_REQUEST_MAX_TOKENS]: { value: 100, type: 'integer' },
+          [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: { value: 1, type: 'integer' },
+          [GEN_AI_INPUT_MESSAGES]: {
+            value: '[{"role":"user","parts":[{"text":"What is the capital of France?"}]}]',
+            type: 'string',
+          },
           [GEN_AI_USAGE_INPUT_TOKENS]: { value: 8, type: 'integer' },
           [GEN_AI_USAGE_OUTPUT_TOKENS]: { value: 12, type: 'integer' },
           [GEN_AI_USAGE_TOTAL_TOKENS]: { value: 20, type: 'integer' },
+          [GEN_AI_RESPONSE_TEXT]: { value: 'Hello from Google GenAI!', type: 'string' },
         },
       });
 
@@ -91,6 +105,7 @@ it('traces Google GenAI chat, generateContent, and embedContent calls', async ({
           [GEN_AI_SYSTEM]: { value: 'google_genai', type: 'string' },
           [GEN_AI_OPERATION_NAME]: { value: 'embeddings', type: 'string' },
           [GEN_AI_REQUEST_MODEL]: { value: 'text-embedding-004', type: 'string' },
+          [GEN_AI_EMBEDDINGS_INPUT]: { value: 'Hello world', type: 'string' },
         },
       });
     })

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/openai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/openai/index.ts
@@ -33,6 +33,7 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
+    dataCollection: { genAI: { inputs: true, outputs: false } },
     streamGenAiSpans: true,
   }),
   {

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/openai/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/openai/test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from 'vitest';
 import {
+  GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
   GEN_AI_REQUEST_MODEL,
   GEN_AI_REQUEST_TEMPERATURE,
@@ -7,10 +8,12 @@ import {
   GEN_AI_RESPONSE_ID,
   GEN_AI_RESPONSE_MODEL,
   GEN_AI_SYSTEM,
+  GEN_AI_SYSTEM_INSTRUCTIONS,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE } from '../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
 import { createRunner } from '../../../runner';
 
 // This test runs the `openai` SDK on the Workers runtime (with a canned
@@ -44,6 +47,16 @@ it('traces a basic chat completion request with the openai SDK', async ({ signal
           [GEN_AI_OPERATION_NAME]: { value: 'chat', type: 'string' },
           [GEN_AI_REQUEST_MODEL]: { value: 'gpt-3.5-turbo', type: 'string' },
           [GEN_AI_REQUEST_TEMPERATURE]: { value: 0.7, type: 'double' },
+          // collect only LLM input
+          [GEN_AI_SYSTEM_INSTRUCTIONS]: {
+            value: '[{"type":"text","content":"You are a helpful assistant."}]',
+            type: 'string',
+          },
+          [GEN_AI_INPUT_MESSAGES]: {
+            value: '[{"role":"user","content":"What is the capital of France?"}]',
+            type: 'string',
+          },
+          [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: { value: 1, type: 'integer' },
           [GEN_AI_RESPONSE_ID]: { value: 'chatcmpl-mock123', type: 'string' },
           [GEN_AI_RESPONSE_MODEL]: { value: 'gpt-3.5-turbo', type: 'string' },
           [GEN_AI_USAGE_INPUT_TOKENS]: { value: 10, type: 'integer' },

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/index.ts
@@ -13,6 +13,7 @@ export default Sentry.withSentry(
     dsn: env.SENTRY_DSN,
     traceLifecycle: 'static',
     tracesSampleRate: 1.0,
+    dataCollection: { genAI: { inputs: true, outputs: true } },
     // Keep gen_ai spans embedded in the transaction (instead of streamed as a
     // separate envelope container) so they can be asserted on `transaction.spans`.
     streamGenAiSpans: false,

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/test.ts
@@ -1,16 +1,23 @@
 import {
+  GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
+  GEN_AI_OUTPUT_MESSAGES,
   GEN_AI_PROVIDER_NAME,
   GEN_AI_REQUEST_MAX_TOKENS,
   GEN_AI_REQUEST_MODEL,
   GEN_AI_REQUEST_TEMPERATURE,
   GEN_AI_RESPONSE_STREAMING,
+  GEN_AI_RESPONSE_TEXT,
+  GEN_AI_SYSTEM_INSTRUCTIONS,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
 import { expect, it } from 'vitest';
-import { GEN_AI_REQUEST_STREAM_ATTRIBUTE } from '../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
+import {
+  GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE,
+  GEN_AI_REQUEST_STREAM_ATTRIBUTE,
+} from '../../../../../packages/core/src/tracing/ai/gen-ai-attributes';
 import { createRunner } from '../../../runner';
 
 // These tests are not exhaustive because the instrumentation is
@@ -53,6 +60,13 @@ it('traces a basic Workers AI text generation request', async ({ signal }) => {
                 [GEN_AI_USAGE_INPUT_TOKENS]: 12,
                 [GEN_AI_USAGE_OUTPUT_TOKENS]: 7,
                 [GEN_AI_USAGE_TOTAL_TOKENS]: 19,
+                // collect input and output messages
+                [GEN_AI_SYSTEM_INSTRUCTIONS]: '[{"type":"text","content":"You are a helpful assistant."}]',
+                [GEN_AI_INPUT_MESSAGES]: '[{"role":"user","content":"What is the capital of France?"}]',
+                [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: 1,
+                [GEN_AI_OUTPUT_MESSAGES]:
+                  '[{"role":"assistant","parts":[{"type":"text","content":"The capital of France is Paris."}]}]',
+                [GEN_AI_RESPONSE_TEXT]: 'The capital of France is Paris.',
               },
             }),
           ],
@@ -98,6 +112,12 @@ it('traces a streaming Workers AI text generation request', async ({ signal }) =
                 [GEN_AI_USAGE_INPUT_TOKENS]: 12,
                 [GEN_AI_USAGE_OUTPUT_TOKENS]: 7,
                 [GEN_AI_USAGE_TOTAL_TOKENS]: 19,
+                [GEN_AI_INPUT_MESSAGES]: '[{"role":"user","content":"What is the capital of France?"}]',
+                [GEN_AI_INPUT_MESSAGES_ORIGINAL_LENGTH_ATTRIBUTE]: 1,
+                // Accumulated from the streamed chunks rather than read off a single response body.
+                [GEN_AI_OUTPUT_MESSAGES]:
+                  '[{"role":"assistant","parts":[{"type":"text","content":"The capital of France is Paris."}]}]',
+                [GEN_AI_RESPONSE_TEXT]: 'The capital of France is Paris.',
               },
             }),
           ],

--- a/packages/core/src/tracing/anthropic-ai/index.ts
+++ b/packages/core/src/tracing/anthropic-ai/index.ts
@@ -270,10 +270,13 @@ function instrumentMethod<T extends unknown[], R>(
   methodPath: string,
   instrumentedMethod: InstrumentedMethodEntry,
   context: unknown,
-  options: AnthropicAiOptions,
+  userOptions: AnthropicAiOptions,
 ): (...args: T) => R | Promise<R> {
   return new Proxy(originalMethod, {
     apply(target, thisArg, args: T): R | Promise<R> {
+      // Resolved per call: clients are often wrapped before Sentry.init(), when there is no client to read
+      const options = resolveAIRecordingOptions(userOptions);
+
       // Preserve the caller's `this` so instrumentation stays transparent: the SDK's methods
       // rely on private fields bound to the real instance, and internal delegation (e.g.
       // `messages.stream()` calling `this.create()`) must resolve against the same object it
@@ -406,5 +409,5 @@ function instrumentClientInPlace<T extends object>(client: T, options: Anthropic
  * @returns The instrumented client with the same type as the input
  */
 export function instrumentAnthropicAiClient<T extends object>(anthropicAiClient: T, options?: AnthropicAiOptions): T {
-  return instrumentClientInPlace(anthropicAiClient, resolveAIRecordingOptions(options));
+  return instrumentClientInPlace(anthropicAiClient, options ?? {});
 }

--- a/packages/core/src/tracing/google-genai/index.ts
+++ b/packages/core/src/tracing/google-genai/index.ts
@@ -273,12 +273,15 @@ function instrumentMethod<T extends unknown[], R>(
   methodPath: string,
   instrumentedMethod: InstrumentedMethodEntry,
   context: unknown,
-  options: GoogleGenAIOptions,
+  userOptions: GoogleGenAIOptions,
 ): (...args: T) => R | Promise<R> {
   const isEmbeddings = instrumentedMethod.operation === 'embeddings';
 
   return new Proxy(originalMethod, {
     apply(target, _, args: T): R | Promise<R> {
+      // Resolved per call: clients are often wrapped before Sentry.init(), when there is no client to read
+      const options = resolveAIRecordingOptions(userOptions);
+
       const operationName = instrumentedMethod.operation || 'unknown';
       const params = args[0] as Record<string, unknown> | undefined;
       const requestAttributes = extractRequestAttributes(operationName, params, context);
@@ -425,5 +428,5 @@ function createDeepProxy<T extends object>(target: T, currentPath = '', options:
  * ```
  */
 export function instrumentGoogleGenAIClient<T extends object>(client: T, options?: GoogleGenAIOptions): T {
-  return createDeepProxy(client, '', resolveAIRecordingOptions(options));
+  return createDeepProxy(client, '', options ?? {});
 }

--- a/packages/core/src/tracing/openai/index.ts
+++ b/packages/core/src/tracing/openai/index.ts
@@ -149,9 +149,12 @@ function instrumentMethod<T extends unknown[], R>(
   methodPath: string,
   instrumentedMethod: InstrumentedMethodEntry,
   context: unknown,
-  options: OpenAiOptions,
+  userOptions: OpenAiOptions,
 ): (...args: T) => Promise<R> {
   return function instrumentedCall(...args: T): Promise<R> {
+    // Resolved per call: clients are often wrapped before Sentry.init(), when there is no client to read
+    const options = resolveAIRecordingOptions(userOptions);
+
     const operationName = instrumentedMethod.operation || 'unknown';
     const requestAttributes = extractRequestAttributes(args, operationName);
     const model = (requestAttributes[GEN_AI_REQUEST_MODEL] as string) || 'unknown';
@@ -275,5 +278,5 @@ function createDeepProxy<T extends object>(target: T, currentPath = '', options:
  * Can be used across Node.js, Cloudflare Workers, and Vercel Edge
  */
 export function instrumentOpenAiClient<T extends object>(client: T, options?: OpenAiOptions): T {
-  return createDeepProxy(client, '', resolveAIRecordingOptions(options));
+  return createDeepProxy(client, '', options ?? {});
 }

--- a/packages/core/src/tracing/workers-ai/index.ts
+++ b/packages/core/src/tracing/workers-ai/index.ts
@@ -24,9 +24,12 @@ function isReadableStream(value: unknown): value is ReadableStream<Uint8Array> {
 function instrumentRun(
   originalRun: (...args: unknown[]) => Promise<unknown>,
   context: unknown,
-  options: WorkersAiOptions & Required<Pick<WorkersAiOptions, 'recordInputs' | 'recordOutputs'>>,
+  userOptions?: WorkersAiOptions,
 ): (...args: unknown[]) => Promise<unknown> {
   return function instrumentedRun(...args: unknown[]): Promise<unknown> {
+    // Resolved per call: clients are often wrapped before Sentry.init(), when there is no client to read
+    const options = resolveAIRecordingOptions(userOptions);
+
     const [model, inputs, runOptions] = args as [unknown, unknown, Record<string, unknown> | undefined];
 
     const operationName = getOperationName(inputs);
@@ -114,20 +117,16 @@ function instrumentRun(
  * ```
  */
 export function instrumentWorkersAiClient<T extends object>(client: T, options?: WorkersAiOptions): T {
-  const resolvedOptions = resolveAIRecordingOptions(options);
-
-  const instrumented = new Proxy(client, {
+  return new Proxy(client, {
     get(target: object, prop: string | symbol, receiver: unknown): unknown {
       const value = Reflect.get(target, prop, receiver);
 
       if (prop === 'run' && typeof value === 'function') {
-        return instrumentRun(value as (...args: unknown[]) => Promise<unknown>, target, resolvedOptions);
+        return instrumentRun(value as (...args: unknown[]) => Promise<unknown>, target, options);
       }
 
       // Bind passed-through functions to the original target to preserve `this` (e.g. private fields).
       return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(target) : value;
     },
   }) as T;
-
-  return instrumented;
 }

--- a/packages/core/test/lib/tracing/workers-ai.test.ts
+++ b/packages/core/test/lib/tracing/workers-ai.test.ts
@@ -1,7 +1,40 @@
-import { describe, expect, it, vi } from 'vitest';
+import { GEN_AI_INPUT_MESSAGES, GEN_AI_OUTPUT_MESSAGES } from '@sentry/conventions/attributes';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Span } from '../../../src';
+import { getCurrentScope, getGlobalScope, getIsolationScope, setCurrentClient, spanToJSON } from '../../../src';
 import { instrumentWorkersAiClient } from '../../../src/tracing/workers-ai';
+import type { DataCollection } from '../../../src/types/datacollection';
+import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
+
+function setupClient(dataCollection?: DataCollection): Span[] {
+  const client = new TestClient(
+    getDefaultTestClientOptions({
+      dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      tracesSampleRate: 1,
+      dataCollection,
+    }),
+  );
+  setCurrentClient(client);
+  client.init();
+
+  const endedSpans: Span[] = [];
+  client.on('spanEnd', span => endedSpans.push(span));
+  return endedSpans;
+}
 
 describe('instrumentWorkersAiClient', () => {
+  beforeEach(() => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+  });
+
+  afterEach(() => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+  });
+
   it('passes through non-run methods bound to the original client', () => {
     class FakeAi {
       #internal = 'secret';
@@ -27,5 +60,50 @@ describe('instrumentWorkersAiClient', () => {
 
     expect(client.run).toHaveBeenCalledWith('@cf/meta/llama-3.1-8b-instruct', { prompt: 'Hello' });
     expect(result).toEqual({ response: 'Paris' });
+  });
+
+  // `@sentry/cloudflare` wraps the `env.AI` binding outside of a request, which can run before
+  // `withSentry` initializes the SDK. Recording options must therefore be resolved per `run` call,
+  // otherwise `dataCollection.genAI` is silently ignored for the lifetime of the isolate.
+  it('honors dataCollection.genAI when the binding is wrapped before the SDK is initialized', async () => {
+    const client = { run: vi.fn().mockResolvedValue({ response: 'Paris' }) };
+    const instrumented = instrumentWorkersAiClient(client);
+
+    const endedSpans = setupClient({ genAI: { inputs: false, outputs: false } });
+
+    await instrumented.run('@cf/meta/llama-3.1-8b-instruct', { messages: [{ role: 'user', content: 'Hello' }] });
+
+    expect(endedSpans).toHaveLength(1);
+    const data = spanToJSON(endedSpans[0]!).data;
+    expect(data[GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+    expect(data[GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
+  });
+
+  it('records inputs and outputs when dataCollection.genAI enables them', async () => {
+    const client = { run: vi.fn().mockResolvedValue({ response: 'Paris' }) };
+    const instrumented = instrumentWorkersAiClient(client);
+
+    const endedSpans = setupClient({ genAI: { inputs: true, outputs: true } });
+
+    await instrumented.run('@cf/meta/llama-3.1-8b-instruct', { messages: [{ role: 'user', content: 'Hello' }] });
+
+    expect(endedSpans).toHaveLength(1);
+    const data = spanToJSON(endedSpans[0]!).data;
+    expect(data[GEN_AI_INPUT_MESSAGES]).toBe('[{"role":"user","content":"Hello"}]');
+    expect(data[GEN_AI_OUTPUT_MESSAGES]).toBe('[{"role":"assistant","parts":[{"type":"text","content":"Paris"}]}]');
+  });
+
+  it('prefers explicit recording options over dataCollection.genAI', async () => {
+    const client = { run: vi.fn().mockResolvedValue({ response: 'Paris' }) };
+    const instrumented = instrumentWorkersAiClient(client, { recordInputs: false, recordOutputs: false });
+
+    const endedSpans = setupClient({ genAI: { inputs: true, outputs: true } });
+
+    await instrumented.run('@cf/meta/llama-3.1-8b-instruct', { messages: [{ role: 'user', content: 'Hello' }] });
+
+    expect(endedSpans).toHaveLength(1);
+    const data = spanToJSON(endedSpans[0]!).data;
+    expect(data[GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+    expect(data[GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
   });
 });


### PR DESCRIPTION
⚠️  First merge this: https://github.com/getsentry/sentry-javascript/pull/22706

The Cloudflare AI helpers resolved `recordInputs`/`recordOutputs` at wrap time. 

On Cloudflare Workers, clients and the `env.AI` binding are wrapped at module scope or at the top of the fetch handler (before `withSentry` initializes the SDK) so there was no client to read, and the fallback value was used for the lifetime of the isolate (as it was inside the `Proxy`). `dataCollection.genAI` was ignored entirely.

The previous implementation was using what the defaults provided (not what was in `dataCollection.genAI`). Each Cloudflare integration test now uses a different `dataCollection.genAI` combination to test different scenarios.


