### PR TITLE
feat(sveltekit): Auto-wire orchestrion build-time instrumentation

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/package.json
@@ -18,7 +18,6 @@
   },
   "//": "Need to use ioredis 5.10.1 because that's the last version before they support tracing channels",
   "dependencies": {
-    "@sentry/server-utils": "file:../../packed/sentry-server-utils-packed.tgz",
     "@sentry/sveltekit": "file:../../packed/sentry-sveltekit-packed.tgz",
     "ioredis": "5.10.1",
     "mysql": "^2.18.1"

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/vite.config.ts
@@ -1,18 +1,15 @@
 import { sentrySvelteKit } from '@sentry/sveltekit';
-import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [
+    // `sentrySvelteKit()` wires up the orchestrion code transform automatically, so
+    // instrumented DB drivers (mysql, ioredis) get `diagnostics_channel` publishers
+    // injected into the SSR bundle with no manual plugin needed.
     sentrySvelteKit({
       autoUploadSourceMaps: false,
     }),
-
-    // Runs the orchestrion code transform on the SvelteKit SSR bundle so
-    // instrumented DB drivers (mysql, ioredis) get `diagnostics_channel`
-    // publishers injected at build time.
-    sentryOrchestrionPlugin(),
 
     sveltekit(),
   ],

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -60,6 +60,7 @@
     "@sentry/core": "10.67.0",
     "@sentry/conventions": "^0.16.0",
     "@sentry/node": "10.67.0",
+    "@sentry/server-utils": "10.67.0",
     "@sentry/svelte": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",
     "@sveltejs/acorn-typescript": "^1.0.9",

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -55,9 +55,7 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     );
   }
 
-  // Auto-instrument server-side dependencies at build time (mysql, ioredis, …) by injecting
-  // `diagnostics_channel` publishers. The plugin self-scopes to the SSR build and honors
-  // `buildTimeInstrumentation: false` itself. Cloudflare/workerd is not supported yet.
+  // TODO: Cloudflare needs different wiring
   if (mergedOptions.adapter !== 'cloudflare') {
     sentryPlugins.push(sentryOrchestrionPlugin({ buildTimeInstrumentation: mergedOptions.buildTimeInstrumentation }));
   }

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -1,4 +1,5 @@
 import { consoleSandbox } from '@sentry/core';
+import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 import * as fs from 'fs';
 import * as path from 'path';
 import type { Plugin } from 'vite';
@@ -52,6 +53,13 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
         onlyInstrumentClient: kitTracingEnabled,
       }),
     );
+  }
+
+  // Auto-instrument server-side dependencies at build time (mysql, ioredis, …) by injecting
+  // `diagnostics_channel` publishers. The plugin self-scopes to the SSR build and honors
+  // `buildTimeInstrumentation: false` itself. Cloudflare/workerd is not supported yet.
+  if (mergedOptions.adapter !== 'cloudflare') {
+    sentryPlugins.push(sentryOrchestrionPlugin({ buildTimeInstrumentation: mergedOptions.buildTimeInstrumentation }));
   }
 
   const sentryVitePluginsOptions = generateVitePluginOptions(mergedOptions);

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -17,6 +17,15 @@ vi.mock('fs', async () => {
   };
 });
 
+// Stub the orchestrion plugin so these stay pure wiring tests (no apm code transformer pulled in).
+// Mirror the real plugin's contract: `buildTimeInstrumentation: false` yields the inert variant.
+const orchestrionVite = vi.fn((options?: { buildTimeInstrumentation?: boolean }) => ({
+  name: options?.buildTimeInstrumentation === false ? 'sentry-orchestrion-disabled' : 'sentry-orchestrion-vite',
+}));
+vi.mock('@sentry/server-utils/orchestrion/vite', () => ({
+  sentryOrchestrionPlugin: (options?: { buildTimeInstrumentation?: boolean }) => orchestrionVite(options),
+}));
+
 vi.spyOn(console, 'log').mockImplementation(() => {
   /* noop */
 });
@@ -42,9 +51,9 @@ describe('sentrySvelteKit()', () => {
     const plugins = await getSentrySvelteKitPlugins();
 
     expect(plugins).toBeInstanceOf(Array);
-    // 1 browser-tracing variant resolver + 1 auto instrument plugin + 1 global values injection plugin
-    // + 1 modified main plugin + 3 custom plugins
-    expect(plugins).toHaveLength(7);
+    // 1 browser-tracing variant resolver + 1 auto instrument plugin + 1 orchestrion plugin
+    // + 1 global values injection plugin + 1 modified main plugin + 3 custom plugins
+    expect(plugins).toHaveLength(8);
   });
 
   it('returns the custom sentry source maps upload plugin, unmodified sourcemaps plugins and the auto-instrument plugin by default', async () => {
@@ -55,6 +64,8 @@ describe('sentrySvelteKit()', () => {
       'sentry-sveltekit-browser-tracing-variant',
       // auto instrument plugin:
       'sentry-auto-instrumentation',
+      // orchestrion build-time instrumentation plugin:
+      'sentry-orchestrion-vite',
       // global values injection plugin:
       'sentry-sveltekit-global-values-injection-plugin',
       // modified main plugin (writeBundle deferred to closeBundle):
@@ -68,7 +79,7 @@ describe('sentrySvelteKit()', () => {
 
   it("doesn't return the sentry source maps plugins if autoUploadSourcemaps is `false`", async () => {
     const plugins = await getSentrySvelteKitPlugins({ autoUploadSourceMaps: false });
-    expect(plugins).toHaveLength(2); // browser-tracing variant resolver + auto instrument
+    expect(plugins).toHaveLength(3); // browser-tracing variant resolver + auto instrument + orchestrion
   });
 
   it("doesn't return the sentry source maps plugins if `NODE_ENV` is development", async () => {
@@ -78,7 +89,7 @@ describe('sentrySvelteKit()', () => {
     const plugins = await getSentrySvelteKitPlugins({ autoUploadSourceMaps: true, autoInstrument: true });
     const instrumentPlugin = plugins[1];
 
-    expect(plugins).toHaveLength(3); // browser-tracing variant resolver + auto instrument + global values injection
+    expect(plugins).toHaveLength(4); // browser-tracing variant resolver + auto instrument + orchestrion + global values injection
     expect(instrumentPlugin?.name).toEqual('sentry-auto-instrumentation');
 
     process.env.NODE_ENV = previousEnv;
@@ -87,8 +98,31 @@ describe('sentrySvelteKit()', () => {
   it("doesn't return the auto instrument plugin if autoInstrument is `false`", async () => {
     const plugins = await getSentrySvelteKitPlugins({ autoInstrument: false });
     const pluginNames = plugins.map(plugin => plugin.name);
-    expect(plugins).toHaveLength(6); // browser-tracing variant resolver + global values injection + 1 modified main plugin + 3 custom plugins
+    expect(plugins).toHaveLength(7); // browser-tracing variant resolver + orchestrion + global values injection + 1 modified main plugin + 3 custom plugins
     expect(pluginNames).not.toContain('sentry-auto-instrumentation');
+  });
+
+  it('adds the orchestrion plugin by default', async () => {
+    const plugins = await getSentrySvelteKitPlugins();
+    expect(plugins.map(plugin => plugin.name)).toContain('sentry-orchestrion-vite');
+  });
+
+  it('adds an inert orchestrion plugin when `buildTimeInstrumentation` is `false`', async () => {
+    orchestrionVite.mockClear();
+    const plugins = await getSentrySvelteKitPlugins({ buildTimeInstrumentation: false });
+    const pluginNames = plugins.map(plugin => plugin.name);
+    expect(orchestrionVite).toHaveBeenCalledWith({ buildTimeInstrumentation: false });
+    expect(pluginNames).toContain('sentry-orchestrion-disabled');
+    expect(pluginNames).not.toContain('sentry-orchestrion-vite');
+  });
+
+  it("doesn't add the orchestrion plugin for the cloudflare adapter", async () => {
+    orchestrionVite.mockClear();
+    const plugins = await getSentrySvelteKitPlugins({ adapter: 'cloudflare' });
+    const pluginNames = plugins.map(plugin => plugin.name);
+    expect(orchestrionVite).not.toHaveBeenCalled();
+    expect(pluginNames).not.toContain('sentry-orchestrion-vite');
+    expect(pluginNames).not.toContain('sentry-orchestrion-disabled');
   });
 
   it('passes user-specified vite plugin options to the custom sentry source maps plugin', async () => {


### PR DESCRIPTION
`sentrySvelteKit()` now adds the orchestrion bundler plugin (`@sentry/server-utils/orchestrion/vite`) automatically with no manual plugin setup.

The Cloudflare adapter is skipped for and handled [in a follow up](<https://github.com/getsentry/sentry-javascript/issues/22764>)

closes getsentry/sentry-javascript#22681