### PR TITLE
test(nextjs): Add test case to assert no duplicate root spans for pages router

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tests/api-route-transaction.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tests/api-route-transaction.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+// A pages-router API route sees both Next.js's own `BaseServer.handleRequest` OTEL transaction and the
+// transaction created by `wrapApiHandlerWithSentry`. Exactly one of them must be sent for a request, never
+// both. This guards against regressing back to duplicate root transactions for the same API route.
+test('Sends exactly one transaction for a pages-router API route', async ({ request }) => {
+  const apiRouteTransactions: string[] = [];
+
+  // Never resolves; we accumulate every matching transaction and assert on the total after a grace period.
+  const collectorPromise = waitForTransaction('nextjs-pages-dir', transactionEvent => {
+    if (transactionEvent?.transaction === 'GET /api/endpoint') {
+      apiRouteTransactions.push(transactionEvent.contexts?.trace?.trace_id ?? '<no-trace-id>');
+    }
+    return false;
+  });
+
+  const response = await request.get('/api/endpoint');
+  expect(await response.json()).toStrictEqual({ name: 'John Doe' });
+
+  await Promise.race([collectorPromise, new Promise(resolve => setTimeout(resolve, 6000))]);
+
+  expect(apiRouteTransactions).toHaveLength(1);
+});

--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tests/api-route-transaction.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/tests/api-route-transaction.test.ts
@@ -7,8 +7,9 @@ import { waitForTransaction } from '@sentry-internal/test-utils';
 test('Sends exactly one transaction for a pages-router API route', async ({ request }) => {
   const apiRouteTransactions: string[] = [];
 
-  // Never resolves; we accumulate every matching transaction and assert on the total after a grace period.
-  const collectorPromise = waitForTransaction('nextjs-pages-dir', transactionEvent => {
+  // Accumulate every matching transaction and assert on the total after a grace period. This predicate never
+  // returns true, so the promise never resolves; we just let it collect while we wait out the grace period.
+  void waitForTransaction('nextjs-pages-dir', transactionEvent => {
     if (transactionEvent?.transaction === 'GET /api/endpoint') {
       apiRouteTransactions.push(transactionEvent.contexts?.trace?.trace_id ?? '<no-trace-id>');
     }
@@ -18,7 +19,7 @@ test('Sends exactly one transaction for a pages-router API route', async ({ requ
   const response = await request.get('/api/endpoint');
   expect(await response.json()).toStrictEqual({ name: 'John Doe' });
 
-  await Promise.race([collectorPromise, new Promise(resolve => setTimeout(resolve, 6000))]);
+  await new Promise(resolve => setTimeout(resolve, 6000));
 
   expect(apiRouteTransactions).toHaveLength(1);
 });


### PR DESCRIPTION
Adds a test to verify the changes in subsequent PRs #18394 and #22685

It asserts we do not produce duplicate root transactions, I have run this against each PR and it verified the outcome:

- against #22685: The test fails because the PR drops transaction deduping.
- against the stack: Passes because #18394 drops the `startSpan` call that forces the second transaction