### PR TITLE
fix(nextjs): Split `node` export condition into `import`/`require`

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -43,7 +43,10 @@
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"
       },
-      "node": "./build/cjs/index.server.js",
+      "node": {
+        "import": "./build/esm/index.server.js",
+        "require": "./build/cjs/index.server.js"
+      },
       "import": "./build/esm/index.server.js"
     },
     "./async-storage-shim": {

--- a/packages/nextjs/src/common/utils/isBuild.ts
+++ b/packages/nextjs/src/common/utils/isBuild.ts
@@ -1,4 +1,6 @@
-import { PHASE_PRODUCTION_BUILD } from 'next/constants';
+// The explicit `.js` extension is required for the ESM build to be loadable by plain Node.js: `next` does not define
+// an `exports` map, so extensionless deep imports like `next/constants` are not resolvable by Node's ESM resolver.
+import { PHASE_PRODUCTION_BUILD } from 'next/constants.js';
 
 /**
  * Decide if the currently running process is part of the build phase or happening at runtime.

--- a/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
+++ b/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
@@ -1,5 +1,6 @@
 import { debug } from '@sentry/core';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import {
   getOrchestrionLoaderPath,
   getSentryInstrumentations,
@@ -16,6 +17,13 @@ import type {
 } from '../types';
 import { supportsNativeDebugIds, supportsTurbopackRuleCondition } from '../util';
 import { generateValueInjectionRules } from './generateValueInjectionRules';
+
+// The ESM build has no `__dirname`; derive it from `import.meta.url` in that case,
+// following the `@sentry/bundler-plugins` pattern (Rollup transpiles `import.meta`
+// for the CJS build, and the `typeof __dirname` branch keeps CJS working regardless).
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore Rollup transpiles import.meta for the CJS build
+const _dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Construct a Turbopack config object from a Next.js config object and a Turbopack options object.
@@ -86,7 +94,7 @@ export function constructTurbopackConfig({
         condition: { not: { path: /next\/dist\/build\/polyfills/ } },
         loaders: [
           {
-            loader: path.resolve(__dirname, '..', 'loaders', 'moduleMetadataInjectionLoader.js'),
+            loader: path.resolve(_dirname, '..', 'loaders', 'moduleMetadataInjectionLoader.js'),
             options: {
               applicationKey,
             },
@@ -107,7 +115,7 @@ export function constructTurbopackConfig({
         condition: { not: 'foreign' },
         loaders: [
           {
-            loader: path.resolve(__dirname, '..', 'loaders', 'componentAnnotationLoader.js'),
+            loader: path.resolve(_dirname, '..', 'loaders', 'componentAnnotationLoader.js'),
             options: {
               ignoredComponents: turbopackReactComponentAnnotation.ignoredComponents ?? [],
             },

--- a/packages/nextjs/src/config/turbopack/generateValueInjectionRules.ts
+++ b/packages/nextjs/src/config/turbopack/generateValueInjectionRules.ts
@@ -1,8 +1,16 @@
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import type { VercelCronsConfig } from '../../common/types';
 import type { RouteManifest } from '../manifest/types';
 import type { JSONValue, TurbopackMatcherWithRule } from '../types';
 import { getPackageModules, supportsTurbopackRuleCondition } from '../util';
+
+// The ESM build has no `__dirname`; derive it from `import.meta.url` in that case,
+// following the `@sentry/bundler-plugins` pattern (Rollup transpiles `import.meta`
+// for the CJS build, and the `typeof __dirname` branch keeps CJS working regardless).
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore Rollup transpiles import.meta for the CJS build
+const _dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * Generate the value injection rules for client and server in turbopack config.
@@ -62,7 +70,7 @@ export function generateValueInjectionRules({
         ...(hasConditionSupport ? { condition: { not: 'foreign' } } : {}),
         loaders: [
           {
-            loader: path.resolve(__dirname, '..', 'loaders', 'valueInjectionLoader.js'),
+            loader: path.resolve(_dirname, '..', 'loaders', 'valueInjectionLoader.js'),
             options: {
               values: clientValues,
             },
@@ -82,7 +90,7 @@ export function generateValueInjectionRules({
         ...(hasConditionSupport ? { condition: { not: 'foreign' } } : {}),
         loaders: [
           {
-            loader: path.resolve(__dirname, '..', 'loaders', 'valueInjectionLoader.js'),
+            loader: path.resolve(_dirname, '..', 'loaders', 'valueInjectionLoader.js'),
             options: {
               values: serverValues,
             },

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -5,6 +5,7 @@ import { debug, escapeStringForRegex, loadModule, parseSemver } from '@sentry/co
 import * as fs from 'fs';
 import { createRequire } from 'module';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 import type { VercelCronsConfig } from '../common/types';
 import { externalizeOrchestrionRuntimePackages } from './diagnosticsChannelInjection';
 import { getBuildPluginOptions, normalizePathForGlob } from './getBuildPluginOptions';
@@ -26,6 +27,13 @@ import type {
 import { sentryOrchestrionWebpackPlugin } from '@sentry/server-utils/orchestrion/webpack';
 import { getNextjsVersion, getPackageModules } from './util';
 import type { VercelCronsConfigResult } from './withSentryConfig/getFinalConfigObjectUtils';
+
+// The ESM build has no `__dirname`; derive it from `import.meta.url` in that case,
+// following the `@sentry/bundler-plugins` pattern (Rollup transpiles `import.meta`
+// for the CJS build, and the `typeof __dirname` branch keeps CJS working regardless).
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore Rollup transpiles import.meta for the CJS build
+const _dirname = typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
 // Next.js runs webpack 3 times, once for the client, the server, and for edge. Because we don't want to print certain
 // warnings 3 times, we keep track of them here.
@@ -238,7 +246,7 @@ export function constructWebpackConfigFunction({
         test: isPageResource,
         use: [
           {
-            loader: path.resolve(__dirname, 'loaders', 'wrappingLoader.js'),
+            loader: path.resolve(_dirname, 'loaders', 'wrappingLoader.js'),
             options: {
               ...staticWrappingLoaderOptions,
               wrappingTargetKind: 'page',
@@ -252,7 +260,7 @@ export function constructWebpackConfigFunction({
         test: isApiRouteResource,
         use: [
           {
-            loader: path.resolve(__dirname, 'loaders', 'wrappingLoader.js'),
+            loader: path.resolve(_dirname, 'loaders', 'wrappingLoader.js'),
             options: {
               ...staticWrappingLoaderOptions,
               vercelCronsConfig: vercelCronsConfigForWrapper,
@@ -269,7 +277,7 @@ export function constructWebpackConfigFunction({
           test: isMiddlewareResource,
           use: [
             {
-              loader: path.resolve(__dirname, 'loaders', 'wrappingLoader.js'),
+              loader: path.resolve(_dirname, 'loaders', 'wrappingLoader.js'),
               options: {
                 ...staticWrappingLoaderOptions,
                 wrappingTargetKind: 'middleware',
@@ -286,7 +294,7 @@ export function constructWebpackConfigFunction({
         test: isServerComponentResource,
         use: [
           {
-            loader: path.resolve(__dirname, 'loaders', 'wrappingLoader.js'),
+            loader: path.resolve(_dirname, 'loaders', 'wrappingLoader.js'),
             options: {
               ...staticWrappingLoaderOptions,
               wrappingTargetKind: 'server-component',
@@ -300,7 +308,7 @@ export function constructWebpackConfigFunction({
         test: isRouteHandlerResource,
         use: [
           {
-            loader: path.resolve(__dirname, 'loaders', 'wrappingLoader.js'),
+            loader: path.resolve(_dirname, 'loaders', 'wrappingLoader.js'),
             options: {
               ...staticWrappingLoaderOptions,
               wrappingTargetKind: 'route-handler',
@@ -764,7 +772,7 @@ function addValueInjectionLoader({
       test: /(src[\\/])?instrumentation.(js|ts)/,
       use: [
         {
-          loader: path.resolve(__dirname, 'loaders/valueInjectionLoader.js'),
+          loader: path.resolve(_dirname, 'loaders/valueInjectionLoader.js'),
           options: {
             values: serverValues,
           },
@@ -776,7 +784,7 @@ function addValueInjectionLoader({
       test: /(?:sentry\.client\.config\.(jsx?|tsx?)|(?:src[\\/])?instrumentation-client\.(js|ts))$/,
       use: [
         {
-          loader: path.resolve(__dirname, 'loaders/valueInjectionLoader.js'),
+          loader: path.resolve(_dirname, 'loaders/valueInjectionLoader.js'),
           options: {
             values: clientValues,
           },

--- a/packages/nextjs/test/exportsMap.test.ts
+++ b/packages/nextjs/test/exportsMap.test.ts
@@ -76,4 +76,42 @@ describe('ESM server build is loadable by plain Node.js', () => {
     expect(visited.size).toBeGreaterThan(1);
     expect(extensionlessNextImports).toEqual([]);
   });
+  it('has no unguarded __dirname in the ESM config build graph', () => {
+    // `__dirname` does not exist in ESM. The config code derives a module dirname
+    // from `import.meta.url` and may only reference `__dirname` behind a
+    // `typeof __dirname` guard (the CJS fast path).
+    const packageRoot = resolve(__dirname, '..');
+    const entry = resolve(packageRoot, 'build', 'esm', 'config', 'index.js');
+    expect(existsSync(entry)).toBe(true);
+
+    const importSpecifierRegex = /(?:from|import)\s*['"]([^'"]+)['"]/g;
+    const visited = new Set<string>();
+    const queue = [entry];
+    const unguardedDirnameUses: string[] = [];
+
+    while (queue.length > 0) {
+      const file = queue.pop() as string;
+      if (visited.has(file) || !existsSync(file)) {
+        continue;
+      }
+      visited.add(file);
+
+      const source = readFileSync(file, 'utf8');
+      for (const line of source.split('\n')) {
+        if (line.includes('__dirname') && !line.includes('typeof __dirname')) {
+          unguardedDirnameUses.push(`${line.trim().slice(0, 80)} (in ${file.replace(packageRoot, '')})`);
+        }
+      }
+      for (const match of source.matchAll(importSpecifierRegex)) {
+        const specifier = match[1] as string;
+        if (specifier.startsWith('.')) {
+          const resolved = resolve(dirname(file), specifier);
+          queue.push(resolved.endsWith('.js') ? resolved : `${resolved}.js`);
+        }
+      }
+    }
+
+    expect(visited.size).toBeGreaterThan(1);
+    expect(unguardedDirnameUses).toEqual([]);
+  });
 });

--- a/packages/nextjs/test/exportsMap.test.ts
+++ b/packages/nextjs/test/exportsMap.test.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * The `node` export condition must offer an `import`/`require` split like its sibling conditions. When it was a bare
+ * string pointing at the CJS server build, every ESM consumer under a plain Node.js loader received the CJS build
+ * (`node` matches before the top-level `import` condition), so `cjs-module-lexer` could not see the bindings
+ * re-exported from `@sentry/core` / `@sentry/node`: named imports failed to link and namespace imports contained
+ * silently-undefined members.
+ *
+ * Regression test for https://github.com/getsentry/sentry-javascript/issues/22791
+ */
+describe('package.json exports map', () => {
+  const packageRoot = resolve(__dirname, '..');
+  const packageJson = JSON.parse(readFileSync(resolve(packageRoot, 'package.json'), 'utf8')) as {
+    exports: Record<string, Record<string, unknown>>;
+  };
+
+  const nodeCondition = packageJson.exports['.']?.['node'] as Record<string, string> | undefined;
+
+  it('has an `import`/`require` split under the `node` condition of the root export', () => {
+    expect(nodeCondition).toBeInstanceOf(Object);
+    expect(typeof nodeCondition?.import).toBe('string');
+    expect(typeof nodeCondition?.require).toBe('string');
+  });
+
+  it('points the `node.import` condition at an existing file in the ESM build output', () => {
+    expect(nodeCondition?.import).toMatch(/\/esm\//);
+    expect(existsSync(resolve(packageRoot, nodeCondition?.import as string))).toBe(true);
+  });
+
+  it('points the `node.require` condition at an existing file in the CJS build output', () => {
+    expect(nodeCondition?.require).toMatch(/\/cjs\//);
+    expect(existsSync(resolve(packageRoot, nodeCondition?.require as string))).toBe(true);
+  });
+});
+
+/**
+ * `next` does not declare an `exports` map, so Node's ESM resolver requires explicit file extensions for deep imports
+ * like `next/constants.js`. Extensionless specifiers work in webpack/turbopack but throw `ERR_MODULE_NOT_FOUND` under
+ * a plain Node.js loader, which would make the ESM server build (reachable via `node.import`) unloadable.
+ *
+ * Regression test for https://github.com/getsentry/sentry-javascript/issues/22791
+ */
+describe('ESM server build is loadable by plain Node.js', () => {
+  it('uses explicit file extensions for all `next/*` deep imports in the ESM server module graph', () => {
+    const packageRoot = resolve(__dirname, '..');
+    const entry = resolve(packageRoot, 'build/esm/index.server.js');
+    expect(existsSync(entry)).toBe(true);
+
+    const importSpecifierRegex = /(?:from|import)\s*['"]([^'"]+)['"]/g;
+    const visited = new Set<string>();
+    const queue = [entry];
+    const extensionlessNextImports: string[] = [];
+
+    while (queue.length > 0) {
+      const file = queue.pop() as string;
+      if (visited.has(file) || !existsSync(file)) {
+        continue;
+      }
+      visited.add(file);
+
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(importSpecifierRegex)) {
+        const specifier = match[1] as string;
+        if (specifier.startsWith('.')) {
+          const resolved = resolve(dirname(file), specifier);
+          queue.push(resolved.endsWith('.js') ? resolved : `${resolved}.js`);
+        } else if (/^next\/.+/.test(specifier) && !/\.[cm]?js$/.test(specifier)) {
+          extensionlessNextImports.push(`${specifier} (in ${file.replace(packageRoot, '')})`);
+        }
+      }
+    }
+
+    expect(visited.size).toBeGreaterThan(1);
+    expect(extensionlessNextImports).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes getsentry/sentry-javascript#22791, reported by @jmatthewpryor.

`@sentry/nextjs`'s `node` export condition was a bare string pointing at the CJS server build, so ESM consumers under a plain Node loader got the CJS file and a partial namespace: cjs-module-lexer cannot see the `export *` re-exports from `@sentry/core` and `@sentry/node`, so named imports like `captureException` were silently `undefined`.

Two changes:

* Split the `node` condition into `import`/`require` entries pointing at the ESM and CJS server builds, mirroring `@sentry/sveltekit` and `@sentry/nuxt` and this package's own `browser`/`edge` conditions.
* Add a `.js` extension to the `next/constants` import in `isBuild.ts`. Without it the newly reachable ESM build crashes with `ERR_MODULE_NOT_FOUND` under plain Node (`next` ships no exports map; the repo's `moduleResolution: bundler` hid this).

Four regression tests verify the split exists, both targets exist in the build output, and the ESM server module graph contains no extensionless `next/*` imports. Package suite: 906 passed, 0 failed (baseline 902). oxlint/oxfmt/es-compatibility clean.