### PR TITLE
feat(cloudflare): Add wranglerConfigPath to Vite options

### DIFF
--- a/packages/cloudflare/src/vite/autoInstrument.ts
+++ b/packages/cloudflare/src/vite/autoInstrument.ts
@@ -1,3 +1,4 @@
+import { basename } from 'node:path';
 import { collectAgentCandidates, detectAgentClasses, type ModuleResolver } from './agentClass';
 import { buildOptionsImport, ENV_FALLBACK_OPTIONS_FN, resolveInstrumentFile } from './instrumentFile';
 import { applyAutoInstrumentTransforms, type ClassWrapperKind, type ProgramBody } from './transform';
@@ -32,7 +33,7 @@ export function sentryCloudflareAutoInstrumentPlugin(options: { wranglerConfigPa
         // `configPath` handed to @cloudflare/vite-plugin) are discoverable.
         config.logger?.warn(
           options.wranglerConfigPath
-            ? `[sentry] Could not find or parse the wrangler config at "${options.wranglerConfigPath}" ` +
+            ? `[sentry] Could not find or parse the wrangler config "${basename(options.wranglerConfigPath)}" ` +
                 '(resolved against the Vite root) — auto-instrumentation disabled.'
             : '[sentry] No parseable wrangler config found — auto-instrumentation disabled. ' +
                 'Set `wranglerConfigPath` if your config uses a custom name.',

--- a/packages/cloudflare/src/vite/autoInstrument.ts
+++ b/packages/cloudflare/src/vite/autoInstrument.ts
@@ -14,7 +14,7 @@ function normalizePath(path: string): string {
 // `.html`, … — sharing the entry's basename must never be treated as the entry.
 const JS_EXTENSION_REGEX = /\.[cm]?[jt]sx?$/;
 
-export function sentryCloudflareAutoInstrumentPlugin() {
+export function sentryCloudflareAutoInstrumentPlugin(options: { wranglerConfigPath?: string } = {}) {
   let wranglerConfig: WranglerConfig | undefined;
   let entryFilePath: string | undefined;
 
@@ -25,9 +25,18 @@ export function sentryCloudflareAutoInstrumentPlugin() {
     name: 'sentry-cloudflare-auto-instrument',
 
     configResolved(config: { root: string; logger?: { warn(msg: string): void } }): void {
-      const result = resolveWranglerConfig(config.root);
+      const result = resolveWranglerConfig(config.root, options.wranglerConfigPath);
       if (!result) {
-        config.logger?.warn('[sentry] No parseable wrangler config found — auto-instrumentation disabled.');
+        // An explicit path that fails is a misconfiguration worth naming;
+        // without one, hint at the option so custom-named configs (e.g. a
+        // `configPath` handed to @cloudflare/vite-plugin) are discoverable.
+        config.logger?.warn(
+          options.wranglerConfigPath
+            ? `[sentry] Could not find or parse the wrangler config at "${options.wranglerConfigPath}" ` +
+                '(resolved against the Vite root) — auto-instrumentation disabled.'
+            : '[sentry] No parseable wrangler config found — auto-instrumentation disabled. ' +
+                'Set `wranglerConfigPath` if your config uses a custom name.',
+        );
         return;
       }
 

--- a/packages/cloudflare/src/vite/index.ts
+++ b/packages/cloudflare/src/vite/index.ts
@@ -11,6 +11,17 @@ import { sentryCloudflareAutoInstrumentPlugin } from './autoInstrument';
  */
 export interface SentryCloudflareVitePluginOptions {
   /**
+   * Path to the wrangler config, relative to the Vite root (or absolute).
+   * Set this when your config doesn't use a default name — e.g. when you
+   * pass `configPath: './wrangler.agent.jsonc'` to `@cloudflare/vite-plugin`,
+   * which the Sentry plugin cannot see. When set, only this file is read
+   * (no default-name probing), and a warning is emitted if it is missing or
+   * unparseable.
+   *
+   * @default undefined (probes `wrangler.json`, `wrangler.jsonc`, `wrangler.toml` at the Vite root)
+   */
+  wranglerConfigPath?: string;
+  /**
    * Experimental options that may change or be removed without notice.
    */
   _experimental?: {
@@ -80,6 +91,8 @@ export function sentryCloudflareVitePlugin(options: SentryCloudflareVitePluginOp
     ...(options._experimental?.useDiagnosticsChannelInjection
       ? [sentryOrchestrionPlugin({ injectChannelSubscribers: true })]
       : []),
-    ...(options._experimental?.autoInstrumentation ? [sentryCloudflareAutoInstrumentPlugin()] : []),
+    ...(options._experimental?.autoInstrumentation
+      ? [sentryCloudflareAutoInstrumentPlugin({ wranglerConfigPath: options.wranglerConfigPath })]
+      : []),
   ];
 }

--- a/packages/cloudflare/test/vite/autoInstrument.test.ts
+++ b/packages/cloudflare/test/vite/autoInstrument.test.ts
@@ -391,14 +391,16 @@ describe('wranglerConfigPath option', () => {
     expect(await tx(join(dir, 'src/agent.ts'))).toBeDefined();
   });
 
-  it('warns with the explicit path when it cannot be read', () => {
+  it('warns with only the basename when the explicit path cannot be read', () => {
     const dir = writeTempDir({});
     const warnings: string[] = [];
-    const plugin = sentryCloudflareAutoInstrumentPlugin({ wranglerConfigPath: './wrangler.agent.jsonc' });
+    const plugin = sentryCloudflareAutoInstrumentPlugin({ wranglerConfigPath: 'nested/dir/wrangler.agent.jsonc' });
     plugin.configResolved({ root: dir, logger: { warn: msg => warnings.push(msg) } });
 
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('./wrangler.agent.jsonc');
+    expect(warnings[0]).toContain('wrangler.agent.jsonc');
+    // The full path may leak a location the user doesn't want in build logs.
+    expect(warnings[0]).not.toContain('nested/dir');
   });
 
   it('hints at the option when no default-named config is found', () => {

--- a/packages/cloudflare/test/vite/autoInstrument.test.ts
+++ b/packages/cloudflare/test/vite/autoInstrument.test.ts
@@ -354,6 +354,64 @@ describe('sentryCloudflareAutoInstrumentPlugin', () => {
   });
 });
 
+describe('wranglerConfigPath option', () => {
+  it('reads a custom-named wrangler config (e.g. wrangler.agent.jsonc)', async () => {
+    const dir = writeTempDir({ 'wrangler.agent.jsonc': '{ "main": "src/agent.ts" }' });
+    const plugin = sentryCloudflareAutoInstrumentPlugin({ wranglerConfigPath: './wrangler.agent.jsonc' });
+    plugin.configResolved({ root: dir });
+
+    const code = 'export default { fetch() { return new Response("ok"); } };';
+    const result = await plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, join(dir, 'src/agent.ts'));
+
+    expect(result).toBeDefined();
+    expect(result.code).toBe(
+      [
+        "import * as __SENTRY__ from '@sentry/cloudflare';",
+        'const __SENTRY_DEFAULT_EXPORT__ = { fetch() { return new Response("ok"); } };',
+        'export default __SENTRY__.withSentry(() => undefined, __SENTRY_DEFAULT_EXPORT__);',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('prefers the explicit path over default-name configs', async () => {
+    const dir = writeTempDir({
+      'wrangler.toml': 'main = "src/default.ts"',
+      'wrangler.agent.jsonc': '{ "main": "src/agent.ts" }',
+    });
+    const plugin = sentryCloudflareAutoInstrumentPlugin({ wranglerConfigPath: 'wrangler.agent.jsonc' });
+    plugin.configResolved({ root: dir });
+
+    const code = 'export default { fetch() { return new Response("ok"); } };';
+    const tx = (id: string) => plugin.transform.call({ parse: (c: string) => parseJS(c) }, code, id);
+
+    // The probed default config's entry must not be treated as the worker entry…
+    expect(await tx(join(dir, 'src/default.ts'))).toBeUndefined();
+    // …while the explicit config's entry is.
+    expect(await tx(join(dir, 'src/agent.ts'))).toBeDefined();
+  });
+
+  it('warns with the explicit path when it cannot be read', () => {
+    const dir = writeTempDir({});
+    const warnings: string[] = [];
+    const plugin = sentryCloudflareAutoInstrumentPlugin({ wranglerConfigPath: './wrangler.agent.jsonc' });
+    plugin.configResolved({ root: dir, logger: { warn: msg => warnings.push(msg) } });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('./wrangler.agent.jsonc');
+  });
+
+  it('hints at the option when no default-named config is found', () => {
+    const dir = writeTempDir({});
+    const warnings: string[] = [];
+    const plugin = sentryCloudflareAutoInstrumentPlugin();
+    plugin.configResolved({ root: dir, logger: { warn: msg => warnings.push(msg) } });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('`wranglerConfigPath`');
+  });
+});
+
 // ---------------------------------------------------------------------------
 // instrument.server.* auto-detection (config from a conventional module)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
In the Cloudflare Vite plugin there is the `configPath` option that lets you define the wrangler config path. When this is set we can't find the wrangler config, as it is set somewhere else. 

Unfortunately we can't retrieve the options directly from their plugin, so it has to be set in our plugin too in order to get the correct wrangler config.

This adds the option `wranglerConfigPath` and would be used as the following:

```js
export default defineConfig({
  plugins: [
    cloudflare({ configPath: "./wrangler.agent.jsonc" }),
    sentryCloudflareVitePlugin({
      wranglerConfigPath: "./wrangler.agent.jsonc",
      _experimental: {
        autoInstrumentation: true,
      },
    }),
  ],
});
```