### PR TITLE
feat(core)!: Remove deprecated `_experiments.enableLogs` option

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -326,7 +326,7 @@ Sentry.init({
 });
 ```
 
-- The `_experiments.enableLogs` option was removed, use the top-level `enableLogs` option instead.
+- The `_experiments.enableLogs` option was removed. Logs are now enabled by default, so if you were opting in via `_experiments.enableLogs: true` you can simply omit the option. Use the top-level `enableLogs: false` to opt out.
 
 ```js
 // before
@@ -336,9 +336,12 @@ Sentry.init({
   },
 });
 
-// after
+// after: logs are enabled by default, no option needed
+Sentry.init({});
+
+// or, to opt out
 Sentry.init({
-  enableLogs: true,
+  enableLogs: false,
 });
 ```
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -326,6 +326,22 @@ Sentry.init({
 });
 ```
 
+- The `_experiments.enableLogs` option was removed, use the top-level `enableLogs` option instead.
+
+```js
+// before
+Sentry.init({
+  _experiments: {
+    enableLogs: true,
+  },
+});
+
+// after
+Sentry.init({
+  enableLogs: true,
+});
+```
+
 - The deprecated `trackFetchStreamPerformance` option of `browserTracingIntegration` was removed. To track the duration of streamed fetch response bodies, add `fetchStreamPerformanceIntegration()` to your `integrations` array instead.
 
 ```js

--- a/dev-packages/browser-integration-tests/suites/public-api/logger/integration/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/logger/integration/init.js
@@ -6,10 +6,5 @@ Sentry.init({
   traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   enableLogs: true,
-  // Purposefully specifying the experimental flag here
-  // to ensure the top level option is used instead.
-  _experiments: {
-    enableLogs: false,
-  },
   integrations: [Sentry.consoleLoggingIntegration()],
 });

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -264,7 +264,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       });
     }
 
-    this._options.enableLogs = this._options.enableLogs ?? true;
+    this._options.enableLogs ??= true;
 
     // Setup log flushing with weight and timeout tracking
     if (this._options.enableLogs) {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -264,10 +264,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       });
     }
 
-    // Backfill enableLogs option from _experiments.enableLogs
-    // todo(v11): Remove the experimental flag
-    // eslint-disable-next-line typescript/no-deprecated
-    this._options.enableLogs = this._options.enableLogs ?? this._options._experiments?.enableLogs ?? true;
+    this._options.enableLogs = this._options.enableLogs ?? true;
 
     // Setup log flushing with weight and timeout tracking
     if (this._options.enableLogs) {

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -449,14 +449,6 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
      * @deprecated Use the top level`beforeSendMetric` option instead.
      */
     beforeSendMetric?: (metric: Metric) => Metric | null;
-
-    /**
-     * Determines if logs support should be enabled.
-     *
-     * @default false
-     * @deprecated Use the top level `enableLogs` option instead.
-     */
-    enableLogs?: boolean;
   };
 
   /**

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -2954,22 +2954,6 @@ describe('Client', () => {
       const client = new TestClient(options);
       expect(client.getOptions().enableLogs).toBe(false);
     });
-
-    it('can be disabled via the experimental option', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, _experiments: { enableLogs: false } });
-      const client = new TestClient(options);
-      expect(client.getOptions().enableLogs).toBe(false);
-    });
-
-    test('top-level option takes precedence over experimental option', () => {
-      const options = getDefaultTestClientOptions({
-        dsn: PUBLIC_DSN,
-        enableLogs: false,
-        _experiments: { enableLogs: true },
-      });
-      const client = new TestClient(options);
-      expect(client.getOptions().enableLogs).toBe(false);
-    });
   });
 
   describe('log weight-based flushing', () => {


### PR DESCRIPTION
Removes the deprecated `_experiments.enableLogs` option, which has been superseded by the top-level `enableLogs` flag. Drops the type field, the constructor backfill, the now-redundant experimental-path tests, and the precedence override in the browser integration fixture, and documents the removal in `MIGRATION.md`.

Fixes getsentry/sentry-javascript#22634