### PR TITLE
ref(core)!: Stop setting deprecated `gen_ai.tool.type` span attribute

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -266,6 +266,7 @@ Affected SDKs: All SDKs.
 - The `gen_ai.tool.input` span attribute was renamed to `gen_ai.tool.call.arguments` across all AI integrations.
 - The `gen_ai.tool.output` span attribute was renamed to `gen_ai.tool.call.result` across all AI integrations.
 - The Vercel AI token attributes `gen_ai.usage.input_tokens.cached`, `gen_ai.usage.input_tokens.cache_write`, and `gen_ai.usage.output_tokens.reasoning` were renamed to `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`, and `gen_ai.usage.reasoning.output_tokens`.
+- The deprecated `gen_ai.tool.type` span attribute is no longer set on tool spans.
 - Span attributes now use the shared `@sentry/conventions` package under the hood.
 
 If you reference these attributes in custom instrumentation, `beforeSendSpan`, dashboards, or alerts, update them to the new names.

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
@@ -397,7 +397,6 @@ describe('LangGraph integration', () => {
                   [SEMANTIC_ATTRIBUTE_SENTRY_OP]: expect.objectContaining({ value: 'gen_ai.execute_tool' }),
                   [GEN_AI_OPERATION_NAME]: expect.objectContaining({ value: 'execute_tool' }),
                   [GEN_AI_TOOL_NAME]: expect.objectContaining({ value: 'add' }),
-                  'gen_ai.tool.type': expect.objectContaining({ value: 'function' }),
                 }),
               }),
             );
@@ -409,7 +408,6 @@ describe('LangGraph integration', () => {
                   [SEMANTIC_ATTRIBUTE_SENTRY_OP]: expect.objectContaining({ value: 'gen_ai.execute_tool' }),
                   [GEN_AI_OPERATION_NAME]: expect.objectContaining({ value: 'execute_tool' }),
                   [GEN_AI_TOOL_NAME]: expect.objectContaining({ value: 'multiply' }),
-                  'gen_ai.tool.type': expect.objectContaining({ value: 'function' }),
                 }),
               }),
             );

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/span-streaming-v4/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/span-streaming-v4/test.ts
@@ -11,7 +11,6 @@ import {
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -124,7 +123,6 @@ describe('Vercel AI integration (streaming v4)', () => {
         attributes: expect.objectContaining({
           [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: attr('call-1'),
           [GEN_AI_TOOL_NAME]: attr('getWeather'),
-          [GEN_AI_TOOL_TYPE]: attr('function'),
           [GEN_AI_OPERATION_NAME]: attr('execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: attr('gen_ai.execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: attr(expectedOrigin),
@@ -236,7 +234,6 @@ describe('Vercel AI integration (streaming v4)', () => {
           [GEN_AI_TOOL_CALL_ARGUMENTS]: expect.objectContaining({ value: expect.any(String) }),
           [GEN_AI_TOOL_NAME]: attr('getWeather'),
           [GEN_AI_TOOL_CALL_RESULT]: expect.objectContaining({ value: expect.any(String) }),
-          [GEN_AI_TOOL_TYPE]: attr('function'),
           [GEN_AI_OPERATION_NAME]: attr('execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: attr('gen_ai.execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: attr(expectedOrigin),
@@ -275,7 +272,6 @@ describe('Vercel AI integration (streaming v4)', () => {
         attributes: expect.objectContaining({
           [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: attr('call-1'),
           [GEN_AI_TOOL_NAME]: attr('getWeather'),
-          [GEN_AI_TOOL_TYPE]: attr('function'),
           [GEN_AI_OPERATION_NAME]: attr('execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: attr('gen_ai.execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: attr(expectedOrigin),

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/span-streaming-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/span-streaming-v6/test.ts
@@ -11,7 +11,6 @@ import {
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -118,7 +117,6 @@ describe('Vercel AI integration (streaming, v6)', () => {
         attributes: expect.objectContaining({
           [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: attr('call-1'),
           [GEN_AI_TOOL_NAME]: attr('getWeather'),
-          [GEN_AI_TOOL_TYPE]: attr('function'),
           [GEN_AI_OPERATION_NAME]: attr('execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: attr('gen_ai.execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: attr(origin),
@@ -230,7 +228,6 @@ describe('Vercel AI integration (streaming, v6)', () => {
           [GEN_AI_TOOL_CALL_ARGUMENTS]: expect.objectContaining({ value: expect.any(String) }),
           [GEN_AI_TOOL_NAME]: attr('getWeather'),
           [GEN_AI_TOOL_CALL_RESULT]: expect.objectContaining({ value: expect.any(String) }),
-          [GEN_AI_TOOL_TYPE]: attr('function'),
           [GEN_AI_OPERATION_NAME]: attr('execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: attr('gen_ai.execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: attr(origin),
@@ -268,7 +265,6 @@ describe('Vercel AI integration (streaming, v6)', () => {
         attributes: expect.objectContaining({
           [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: attr('call-1'),
           [GEN_AI_TOOL_NAME]: attr('getWeather'),
-          [GEN_AI_TOOL_TYPE]: attr('function'),
           [GEN_AI_OPERATION_NAME]: attr('execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: attr('gen_ai.execute_tool'),
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: attr(origin),

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/test.ts
@@ -14,7 +14,6 @@ import {
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -133,7 +132,6 @@ describe('Vercel AI integration (v4)', () => {
             expect(toolExecutionSpan!.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
             expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME].value).toBe('getWeather');
             expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
-            expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_TYPE].value).toBe('function');
           },
         })
         .start()

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v5/test.ts
@@ -11,7 +11,6 @@ import {
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -129,7 +128,6 @@ describe('Vercel AI integration (v5)', () => {
               expect(toolExecutionSpan!.attributes['sentry.origin'].value).toBe(expectedOrigin);
               expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_NAME].value).toBe('getWeather');
               expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE].value).toBe('call-1');
-              expect(toolExecutionSpan!.attributes[GEN_AI_TOOL_TYPE].value).toBe('function');
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/vercelai/v6_v7/test.ts
@@ -15,7 +15,6 @@ import {
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
@@ -277,7 +276,6 @@ describe.each(matrix)('Vercel AI integration (version %s)', (version, vercelAiVe
               expect(toolExecutionSpan.attributes['sentry.op']?.value).toBe('gen_ai.execute_tool');
               expect(toolExecutionSpan.attributes[GEN_AI_TOOL_NAME]?.value).toBe('getWeather');
               expect(toolExecutionSpan.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE]?.value).toBe('call-1');
-              expect(toolExecutionSpan.attributes[GEN_AI_TOOL_TYPE]?.value).toBe('function');
             },
           })
           .start()
@@ -444,7 +442,6 @@ describe.each(matrix)('Vercel AI integration (version %s)', (version, vercelAiVe
               expect(toolSpan.attributes['sentry.op']?.value).toBe('gen_ai.execute_tool');
               expect(toolSpan.attributes[GEN_AI_TOOL_NAME]?.value).toBe('getWeather');
               expect(toolSpan.attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE]?.value).toBe('call-1');
-              expect(toolSpan.attributes[GEN_AI_TOOL_TYPE]?.value).toBe('function');
 
               const finalGenerateContentSpan = container.items.find(
                 span => span.attributes[GEN_AI_RESPONSE_FINISH_REASONS]?.value === '["stop"]',

--- a/packages/server-utils/src/ai/langgraph/utils.ts
+++ b/packages/server-utils/src/ai/langgraph/utils.ts
@@ -18,7 +18,6 @@ import {
   GEN_AI_TOOL_CALL_RESULT,
   GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -84,7 +83,6 @@ export function wrapToolsWithSpans(tools: unknown[], options: LangGraphOptions, 
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GEN_AI_EXECUTE_TOOL_OPERATION_ATTRIBUTE,
           [GEN_AI_OPERATION_NAME]: 'execute_tool',
           [GEN_AI_TOOL_NAME]: toolName,
-          [GEN_AI_TOOL_TYPE]: 'function',
         };
 
         // Read agent name from LangChain's propagated config metadata at call time,

--- a/packages/server-utils/src/ai/vercel-ai/index.ts
+++ b/packages/server-utils/src/ai/vercel-ai/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable typescript-eslint/no-deprecated */
 /* eslint-disable max-lines */
 import {
   _INTERNAL_skipAiProviderWrapping,
@@ -25,7 +24,6 @@ import {
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
   GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
   GEN_AI_USAGE_INPUT_TOKENS,
@@ -428,10 +426,6 @@ function processToolCallSpan(span: Span, attributes: SpanAttributes): void {
     toolCallSpanContextMap.set(toolCallId, span.spanContext());
   }
 
-  // https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#gen-ai-tool-type
-  if (!attributes[GEN_AI_TOOL_TYPE]) {
-    span.setAttribute(GEN_AI_TOOL_TYPE, 'function');
-  }
   const toolName = attributes[GEN_AI_TOOL_NAME];
   if (toolName) {
     span.updateName(`execute_tool ${toolName}`);

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-/* eslint-disable typescript-eslint/no-deprecated */
 import {
   GEN_AI_EMBEDDINGS_INPUT,
   GEN_AI_FUNCTION_ID,
@@ -17,7 +16,6 @@ import {
   GEN_AI_TOOL_CALL_RESULT,
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_NAME,
-  GEN_AI_TOOL_TYPE,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -480,7 +478,6 @@ function buildToolSpan(event: Record<string, unknown>, recordInputs: boolean): S
     recordInputs && toolName ? resolveToolDescription(asString(event.callId), toolName, event.tools) : undefined;
   return startGenAiSpan(GEN_AI_EXECUTE_TOOL_SPAN_OP, toolName, {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-    [GEN_AI_TOOL_TYPE]: 'function',
     ...(toolName ? { [GEN_AI_TOOL_NAME]: toolName } : {}),
     ...(toolCallId ? { [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: toolCallId } : {}),
     ...(description ? { [GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE]: description } : {}),


### PR DESCRIPTION
Stops setting the `gen_ai.tool.type` span attribute, which `@sentry/conventions` [deprecated with no replacement](https://getsentry.github.io/sentry-conventions/attributes/gen_ai/#gen_ai-tool-type). The SDK only ever set the constant value `'function'` on tool spans, so it carried no information.

Part of https://github.com/getsentry/sentry-javascript/issues/22482