### PR TITLE
ref(react-router): Remove stale @opentelemetry/instrumentation dependency

### DIFF
--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/instrumentation": "^0.220.0",
     "@sentry/browser": "10.67.0",
     "@sentry/cli": "^2.58.6",
     "@sentry/conventions": "^0.16.0",


### PR DESCRIPTION
## What

Remove the unused `@opentelemetry/instrumentation` dependency from `@sentry/react-router`.

## Why

Nothing in the package imports it. React Router server spans come from the framework's own instrumentation API, and the server-side OTel `InstrumentationBase` was already removed. `@opentelemetry/api` stays (still used by `createServerInstrumentation`).

Closes: getsentry/sentry-javascript#22776