### PR TITLE
ref(core): Use `stringify` helper for AI span attribute serialization

### DIFF
--- a/packages/server-utils/src/ai/google-genai/index.ts
+++ b/packages/server-utils/src/ai/google-genai/index.ts
@@ -152,7 +152,7 @@ export function addPrivateRequestAttributes(
   if (operationName === 'embeddings') {
     const contents = params.contents;
     if (contents != null) {
-      span.setAttribute(GEN_AI_EMBEDDINGS_INPUT, typeof contents === 'string' ? contents : JSON.stringify(contents));
+      span.setAttribute(GEN_AI_EMBEDDINGS_INPUT, stringify(contents, String));
     }
     return;
   }

--- a/packages/server-utils/src/ai/langchain/embeddings.ts
+++ b/packages/server-utils/src/ai/langchain/embeddings.ts
@@ -3,6 +3,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startSpan,
+  stringify,
 } from '@sentry/core';
 import type { SpanAttributeValue } from '@sentry/core';
 import {
@@ -76,7 +77,7 @@ export function _INTERNAL_getLangChainEmbeddingsSpanOptions(
   const modelName = attributes[GEN_AI_REQUEST_MODEL] || 'unknown';
 
   if (recordInputs && input != null) {
-    attributes[GEN_AI_EMBEDDINGS_INPUT] = typeof input === 'string' ? input : JSON.stringify(input);
+    attributes[GEN_AI_EMBEDDINGS_INPUT] = stringify(input, String);
   }
 
   return {

--- a/packages/server-utils/src/ai/langchain/index.ts
+++ b/packages/server-utils/src/ai/langchain/index.ts
@@ -5,6 +5,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   startSpanManual,
+  stringify,
 } from '@sentry/core';
 import type { Span, SpanAttributeValue } from '@sentry/core';
 import {
@@ -330,7 +331,7 @@ export function createLangChainCallbackHandler(options: LangChainOptions = {}): 
           const content =
             outputObj && typeof outputObj === 'object' && 'content' in outputObj ? outputObj.content : output;
           span.setAttributes({
-            [GEN_AI_TOOL_CALL_RESULT]: typeof content === 'string' ? content : JSON.stringify(content),
+            [GEN_AI_TOOL_CALL_RESULT]: stringify(content, String),
           });
         }
         exitSpan(runId);

--- a/packages/server-utils/src/ai/openai/index.ts
+++ b/packages/server-utils/src/ai/openai/index.ts
@@ -108,8 +108,7 @@ export function addRequestAttributes(
       return;
     }
 
-    // Store strings as-is, arrays/objects as JSON
-    span.setAttribute(GEN_AI_EMBEDDINGS_INPUT, typeof input === 'string' ? input : JSON.stringify(input));
+    span.setAttribute(GEN_AI_EMBEDDINGS_INPUT, stringify(input, String));
     return;
   }
 

--- a/packages/server-utils/src/ai/workers-ai/utils.ts
+++ b/packages/server-utils/src/ai/workers-ai/utils.ts
@@ -107,7 +107,7 @@ export function addRequestAttributes(
       return;
     }
 
-    span.setAttribute(GEN_AI_EMBEDDINGS_INPUT, typeof text === 'string' ? text : JSON.stringify(text));
+    span.setAttribute(GEN_AI_EMBEDDINGS_INPUT, stringify(text, String));
     return;
   }
 
@@ -168,7 +168,7 @@ export function setOutputMessagesAttribute(
         type: 'tool_call',
         id: call.id,
         name,
-        arguments: typeof args === 'string' ? args : JSON.stringify(args ?? {}),
+        arguments: stringify(args ?? {}, String),
       });
     }
   }


### PR DESCRIPTION
Replaces the manual `typeof x === 'string' ? x : JSON.stringify(x)` pattern in the AI integrations with the defensive `stringify` helper so non-serializable values no longer throw and drop span attributes.