### PR TITLE
ref(core): Make `spanStreamingIntegration` tree-shakeable via `__SENTRY_TRACING__` flag 

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -36,6 +36,31 @@ module.exports = [
     },
   },
   {
+    name: '@sentry/browser - with treeshaking flags incl. tracing',
+    path: 'packages/browser/build/npm/esm/prod/index.js',
+    import: createImport('init'),
+    gzip: true,
+    limit: '34 KB',
+    disablePlugins: ['@size-limit/esbuild'],
+    modifyWebpackConfig: function (config) {
+      const webpack = require('webpack');
+
+      config.plugins.push(
+        new webpack.DefinePlugin({
+          __SENTRY_DEBUG__: false,
+          __RRWEB_EXCLUDE_SHADOW_DOM__: true,
+          __RRWEB_EXCLUDE_IFRAME__: true,
+          __SENTRY_EXCLUDE_REPLAY_WORKER__: true,
+          __SENTRY_TRACING__: false,
+        }),
+      );
+
+      config.optimization.minimize = true;
+
+      return config;
+    },
+  },
+  {
     name: '@sentry/browser (incl. Tracing)',
     path: 'packages/browser/build/npm/esm/prod/index.js',
     import: createImport('init', 'browserTracingIntegration'),

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -36,11 +36,11 @@ module.exports = [
     },
   },
   {
-    name: '@sentry/browser - with treeshaking flags incl. tracing',
+    name: '@sentry/browser - with treeshaking flags tracing without tracing',
     path: 'packages/browser/build/npm/esm/prod/index.js',
     import: createImport('init'),
     gzip: true,
-    limit: '34 KB',
+    limit: '32 KB',
     disablePlugins: ['@size-limit/esbuild'],
     modifyWebpackConfig: function (config) {
       const webpack = require('webpack');

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -28,6 +28,8 @@ import { makeFetchTransport } from './transports/fetch';
 import { normalizeStringifyValue } from './normalizeStringifyValue';
 import { checkAndWarnIfIsEmbeddedBrowserExtension } from './utils/detectBrowserExtension';
 
+declare const __SENTRY_TRACING__: boolean;
+
 /** Get the default integrations for the browser SDK. */
 export function getDefaultIntegrations(_options: Options): Integration[] {
   /**
@@ -120,6 +122,7 @@ export function init(options: BrowserOptions = {}): Client | undefined {
   });
 
   if (
+    (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) &&
     options.traceLifecycle !== 'static' &&
     !integrations.some(integration => integration.name === SPAN_STREAMING_INTEGRATION_NAME)
   ) {

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -28,6 +28,8 @@ export interface ServerRuntimeClientOptions extends ClientOptions<BaseTransportO
   serverName?: string;
 }
 
+declare const __SENTRY_TRACING__: boolean;
+
 /**
  * The Sentry Server Runtime Client SDK.
  */
@@ -47,6 +49,7 @@ export class ServerRuntimeClient<
     // is required to flush spans. We add it here so the individual server SDKs don't have to.
     // A user-provided `spanStreamingIntegration` always takes precedence over the one we add.
     if (
+      (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) &&
       options.traceLifecycle !== 'static' &&
       !options.integrations.some(i => i.name === SPAN_STREAMING_INTEGRATION_NAME)
     ) {


### PR DESCRIPTION
Guards the automatic `spanStreamingIntegration` push behind `__SENTRY_TRACING__` so that bundlers configured to [tree-shake tracing](https://docs.sentry.io/platforms/javascript/configuration/tree-shaking/#manual-tree-shaking) can actually drop the integration. This should remove ~2KB of gzipped dead code for anyone who doesn't care about tracing.