### PR TITLE
ref(aws-serverless)!: Migrate import hook to makeOrchestrionLoader

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -415,6 +415,7 @@ Sentry.init({
 - The `generateInstrumentOnce` export was removed (from `@sentry/node` and the framework SDKs that re-exported it). It wrapped OpenTelemetry's `registerInstrumentations` and is no longer needed now that instrumentation is channel-based.
 - The `@sentry/node/loader` entry point was removed. Use `node --import @sentry/node/import` instead.
 - (Astro) The `@sentry/astro/loader` entry point was removed. Use `node --import @sentry/astro/import` instead.
+- (AWS Lambda) The `@sentry/aws-serverless/loader` entry point was removed. Use `node --import @sentry/aws-serverless/import` instead.
 - (Fastify) The deprecated `setShouldHandleError` method was removed.
 - (AWS Lambda) The deprecated `disableAwsContextPropagation` option was removed. It no longer had any effect.
 - (AWS Lambda) The deprecated `startTrace` option was removed. It no longer had any effect; to disable tracing, set `tracesSampleRate` to `0`.

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -12,7 +12,6 @@
   "files": [
     "/build/npm",
     "/build/import-hook.mjs",
-    "/build/loader-hook.mjs",
     "/build/lambda-extension"
   ],
   "main": "build/npm/cjs/index.js",
@@ -33,11 +32,6 @@
     "./import": {
       "import": {
         "default": "./build/import-hook.mjs"
-      }
-    },
-    "./loader": {
-      "import": {
-        "default": "./build/loader-hook.mjs"
       }
     },
     "./awslambda-auto": {

--- a/packages/aws-serverless/rollup.npm.config.mjs
+++ b/packages/aws-serverless/rollup.npm.config.mjs
@@ -1,4 +1,4 @@
-import { makeBaseNPMConfig, makeNPMConfigVariants, makeOtelLoaders } from '@sentry-internal/rollup-utils';
+import { makeBaseNPMConfig, makeNPMConfigVariants, makeOrchestrionLoader } from '@sentry-internal/rollup-utils';
 
 // The handler shim (loaded by the AWS Lambda runtime via the redirected `_HANDLER`) is
 // built as a standalone, ESM-only bundle: it uses top-level await to load the user's
@@ -41,5 +41,5 @@ export default [
       },
     }),
   ),
-  ...makeOtelLoaders('./build', 'sentry-node'),
+  ...makeOrchestrionLoader('./build'),
 ];


### PR DESCRIPTION
## What

Part of the `@opentelemetry/instrumentation` removal stack (based on #22843).

- Switch `@sentry/aws-serverless`'s `./import` loader from the legacy `makeOtelLoaders` build util to `makeOrchestrionLoader`, so the generated `import-hook.mjs` imports `@sentry/server-utils/orchestrion/import-hook` directly.
- Drop the obsolete `./loader` export (the iitm `--loader` entry, unused on Node >= 20.19).

## Why

Orchestrion is the only instrumentation path now, so the framework's `--import` hook should register it directly instead of the removed iitm loader. `--loader` no longer applies (minimum Node is 20.19.0) and orchestrion has no `--loader` equivalent, so the `./loader` export is dead.
