### PR TITLE
ref(google-cloud-serverless)!: Migrate import hook to makeOrchestrionLoader

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -416,6 +416,7 @@ Sentry.init({
 - The `@sentry/node/loader` entry point was removed. Use `node --import @sentry/node/import` instead.
 - (Astro) The `@sentry/astro/loader` entry point was removed. Use `node --import @sentry/astro/import` instead.
 - (AWS Lambda) The `@sentry/aws-serverless/loader` entry point was removed. Use `node --import @sentry/aws-serverless/import` instead.
+- (Google Cloud) The `@sentry/google-cloud-serverless/loader` entry point was removed. Use `node --import @sentry/google-cloud-serverless/import` instead.
 - (Fastify) The deprecated `setShouldHandleError` method was removed.
 - (AWS Lambda) The deprecated `disableAwsContextPropagation` option was removed. It no longer had any effect.
 - (AWS Lambda) The deprecated `startTrace` option was removed. It no longer had any effect; to disable tracing, set `tracesSampleRate` to `0`.

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -30,11 +30,6 @@
       "import": {
         "default": "./build/import-hook.mjs"
       }
-    },
-    "./loader": {
-      "import": {
-        "default": "./build/loader-hook.mjs"
-      }
     }
   },
   "publishConfig": {
@@ -43,7 +38,8 @@
   "dependencies": {
     "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.67.0",
-    "@sentry/node": "10.67.0"
+    "@sentry/node": "10.67.0",
+    "@sentry/server-utils": "10.67.0"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.3.0",

--- a/packages/google-cloud-serverless/rollup.npm.config.mjs
+++ b/packages/google-cloud-serverless/rollup.npm.config.mjs
@@ -1,3 +1,3 @@
-import { makeBaseNPMConfig, makeNPMConfigVariants, makeOtelLoaders } from '@sentry-internal/rollup-utils';
+import { makeBaseNPMConfig, makeNPMConfigVariants, makeOrchestrionLoader } from '@sentry-internal/rollup-utils';
 
-export default [...makeNPMConfigVariants(makeBaseNPMConfig()), ...makeOtelLoaders('./build', 'sentry-node')];
+export default [...makeNPMConfigVariants(makeBaseNPMConfig()), ...makeOrchestrionLoader('./build')];


### PR DESCRIPTION
## What

Part of the `@opentelemetry/instrumentation` removal stack (based on #22843).

- Switch `@sentry/google-cloud-serverless`'s `./import` loader from the legacy `makeOtelLoaders` build util to `makeOrchestrionLoader`, so the generated `import-hook.mjs` imports `@sentry/server-utils/orchestrion/import-hook` directly.
- Drop the obsolete `./loader` export (the iitm `--loader` entry, unused on Node >= 20.19).

## Why

Orchestrion is the only instrumentation path now, so the framework's `--import` hook should register it directly instead of the removed iitm loader. `--loader` no longer applies (minimum Node is 20.19.0) and orchestrion has no `--loader` equivalent, so the `./loader` export is dead.
