### PR TITLE
ref(remix)!: Migrate import hook to makeOrchestrionLoader

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -418,6 +418,7 @@ Sentry.init({
 - (AWS Lambda) The `@sentry/aws-serverless/loader` entry point was removed. Use `node --import @sentry/aws-serverless/import` instead.
 - (Google Cloud) The `@sentry/google-cloud-serverless/loader` entry point was removed. Use `node --import @sentry/google-cloud-serverless/import` instead.
 - (Next.js) The `@sentry/nextjs/loader` entry point was removed. Use `node --import @sentry/nextjs/import` instead.
+- (Remix) The `@sentry/remix/loader` entry point was removed. Use `node --import @sentry/remix/import` instead.
 - (Fastify) The deprecated `setShouldHandleError` method was removed.
 - (AWS Lambda) The deprecated `disableAwsContextPropagation` option was removed. It no longer had any effect.
 - (AWS Lambda) The deprecated `startTrace` option was removed. It no longer had any effect; to disable tracing, set `tracesSampleRate` to `0`.

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -46,11 +46,6 @@
       "import": {
         "default": "./build/import-hook.mjs"
       }
-    },
-    "./loader": {
-      "import": {
-        "default": "./build/loader-hook.mjs"
-      }
     }
   },
   "publishConfig": {

--- a/packages/remix/rollup.npm.config.mjs
+++ b/packages/remix/rollup.npm.config.mjs
@@ -1,4 +1,4 @@
-import { makeBaseNPMConfig, makeNPMConfigVariants, makeOtelLoaders } from '@sentry-internal/rollup-utils';
+import { makeBaseNPMConfig, makeNPMConfigVariants, makeOrchestrionLoader } from '@sentry-internal/rollup-utils';
 
 // We rely on esbuild's defaults for JSX (`jsx: 'transform'` = classic runtime, no
 // __self/__source attributes). React 19 prefers the new automatic transform, but switching
@@ -23,5 +23,5 @@ export default [
       },
     }),
   ),
-  ...makeOtelLoaders('./build', 'sentry-node'),
+  ...makeOrchestrionLoader('./build'),
 ];


### PR DESCRIPTION
## What

Part of the `@opentelemetry/instrumentation` removal stack (based on #22843).

- Switch `@sentry/remix`'s `./import` loader from the legacy `makeOtelLoaders` build util to `makeOrchestrionLoader`, so the generated `import-hook.mjs` imports `@sentry/server-utils/orchestrion/import-hook` directly.
- Drop the obsolete `./loader` export (the iitm `--loader` entry, unused on Node >= 20.19).

## Why

Orchestrion is the only instrumentation path now, so the framework's `--import` hook should register it directly instead of the removed iitm loader. `--loader` no longer applies (minimum Node is 20.19.0) and orchestrion has no `--loader` equivalent, so the `./loader` export is dead.
