### PR TITLE
ref(tanstackstart-react)!: Migrate import hook to makeOrchestrionLoader

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -419,6 +419,7 @@ Sentry.init({
 - (Google Cloud) The `@sentry/google-cloud-serverless/loader` entry point was removed. Use `node --import @sentry/google-cloud-serverless/import` instead.
 - (Next.js) The `@sentry/nextjs/loader` entry point was removed. Use `node --import @sentry/nextjs/import` instead.
 - (Remix) The `@sentry/remix/loader` entry point was removed. Use `node --import @sentry/remix/import` instead.
+- (TanStack Start) The `@sentry/tanstackstart-react/loader` entry point was removed. Use `node --import @sentry/tanstackstart-react/import` instead.
 - (Fastify) The deprecated `setShouldHandleError` method was removed.
 - (AWS Lambda) The deprecated `disableAwsContextPropagation` option was removed. It no longer had any effect.
 - (AWS Lambda) The deprecated `startTrace` option was removed. It no longer had any effect; to disable tracing, set `tracesSampleRate` to `0`.

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -41,11 +41,6 @@
         "default": "./build/import-hook.mjs"
       }
     },
-    "./loader": {
-      "import": {
-        "default": "./build/loader-hook.mjs"
-      }
-    },
     "./vite": {
       "types": "./build/types/vite/index.d.ts",
       "import": "./build/esm/vite/index.js",

--- a/packages/tanstackstart-react/rollup.npm.config.mjs
+++ b/packages/tanstackstart-react/rollup.npm.config.mjs
@@ -1,4 +1,4 @@
-import { makeBaseNPMConfig, makeNPMConfigVariants, makeOtelLoaders } from '@sentry-internal/rollup-utils';
+import { makeBaseNPMConfig, makeNPMConfigVariants, makeOrchestrionLoader } from '@sentry-internal/rollup-utils';
 
 export default [
   ...makeNPMConfigVariants(
@@ -12,5 +12,5 @@ export default [
       ],
     }),
   ),
-  ...makeOtelLoaders('./build', 'sentry-node'),
+  ...makeOrchestrionLoader('./build'),
 ];


### PR DESCRIPTION
## What

Part of the `@opentelemetry/instrumentation` removal stack (based on #22843).

- Switch `@sentry/tanstackstart-react`'s `./import` loader from the legacy `makeOtelLoaders` build util to `makeOrchestrionLoader`, so the generated `import-hook.mjs` imports `@sentry/server-utils/orchestrion/import-hook` directly.
- Drop the obsolete `./loader` export (the iitm `--loader` entry, unused on Node >= 20.19).

## Why

Orchestrion is the only instrumentation path now, so the framework's `--import` hook should register it directly instead of the removed iitm loader. `--loader` no longer applies (minimum Node is 20.19.0) and orchestrion has no `--loader` equivalent, so the `./loader` export is dead.
