### PR TITLE
feat(bun): Add `bunHttpServerIntegration`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
+    "@sentry/bun": "file:../../packed/sentry-bun-packed.tgz",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "import-in-the-middle": "^2",
     "next": "16.2.3",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/sentry.server.config.ts
@@ -1,3 +1,4 @@
+import { bunHttpServerIntegration } from '@sentry/bun';
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
@@ -8,4 +9,8 @@ Sentry.init({
   tracesSampleRate: 1.0,
   dataCollection: { userInfo: true },
   tracePropagationTargets: ['http://localhost:3030/propagation/test-outgoing-fetch/check'],
+  // Bun does not emit the `node:http` diagnostics channel the Node SDK uses to isolate incoming
+  // requests, so each request would otherwise share one trace. Next.js emits its own server spans,
+  // hence `spans: false` — this only isolates the request and resets its trace.
+  integrations: [bunHttpServerIntegration({ spans: false })],
 });

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -199,5 +199,6 @@ export {
   initWithoutDefaultIntegrations,
 } from './sdk';
 export { bunServerIntegration } from './integrations/bunserver';
+export { bunHttpServerIntegration } from './integrations/bunHttpServer';
 export { bunRuntimeMetricsIntegration, type BunRuntimeMetricsOptions } from './integrations/bunRuntimeMetrics';
 export { makeFetchTransport } from './transports';

--- a/packages/bun/src/integrations/bunHttpServer.ts
+++ b/packages/bun/src/integrations/bunHttpServer.ts
@@ -95,13 +95,7 @@ export function instrumentBunHttpServer(options: BunHttpServerOptions = {}): voi
     return;
   }
 
-  const { [HTTP_ON_SERVER_REQUEST]: onServerRequest } = getHttpServerSubscriptions({
-    spans: options.spans ?? true,
-    sessions: options.sessions ?? true,
-    sessionFlushingDelayMS: options.sessionFlushingDelayMS ?? 60_000,
-    maxRequestBodySize: options.maxRequestBodySize ?? 'medium',
-    ignoreRequestBody: options.ignoreRequestBody,
-  });
+  const { [HTTP_ON_SERVER_REQUEST]: onServerRequest } = getHttpServerSubscriptions(options);
 
   // Track which servers we have already handed to core, so we instrument each server exactly once.
   // After core instruments a server it installs its own `emit` on the instance, which shadows this

--- a/packages/bun/src/integrations/bunHttpServer.ts
+++ b/packages/bun/src/integrations/bunHttpServer.ts
@@ -1,6 +1,7 @@
+import { errorMonitor } from 'node:events';
 import http from 'node:http';
 import https from 'node:https';
-import type { IntegrationFn } from '@sentry/core';
+import type { HttpIncomingMessage, HttpServerResponse, IntegrationFn, Span } from '@sentry/core';
 import { defineIntegration, getHttpServerSubscriptions, HTTP_ON_SERVER_REQUEST } from '@sentry/core';
 
 const INTEGRATION_NAME = 'BunHttpServer' as const;
@@ -43,6 +44,31 @@ interface BunHttpServerOptions {
    * @default 'medium'
    */
   maxRequestBodySize?: 'none' | 'small' | 'medium' | 'always';
+
+  /**
+   * Do not capture spans for incoming HTTP requests to URLs where the given callback returns `true`.
+   *
+   * The `urlPath` param consists of the URL path and query string (if any) of the incoming request.
+   */
+  ignoreIncomingRequests?: (urlPath: string, request: HttpIncomingMessage) => boolean;
+
+  /**
+   * Whether to automatically ignore common static asset requests like favicon.ico, robots.txt, etc.
+   *
+   * @default true
+   */
+  ignoreStaticAssets?: boolean;
+
+  /**
+   * A hook that can be used to mutate the span for incoming requests.
+   * This is triggered after the span is created, but before it is recorded.
+   */
+  onSpanCreated?: (span: Span, request: HttpIncomingMessage, response: HttpServerResponse) => void;
+
+  /**
+   * A hook that can be used to mutate the span one last time when the response is finished.
+   */
+  onSpanEnd?: (span: Span, request: HttpIncomingMessage, response: HttpServerResponse) => void;
 }
 
 let hasPatched = false;
@@ -95,7 +121,12 @@ export function instrumentBunHttpServer(options: BunHttpServerOptions = {}): voi
     return;
   }
 
-  const { [HTTP_ON_SERVER_REQUEST]: onServerRequest } = getHttpServerSubscriptions(options);
+  const { [HTTP_ON_SERVER_REQUEST]: onServerRequest } = getHttpServerSubscriptions({
+    ...options,
+    // Pass the real `errorMonitor` symbol so core observes `'error'` events without consuming
+    // them — otherwise it would swallow errors before they reach user-supplied `'error'` handlers.
+    errorMonitor,
+  });
 
   // Track which servers we have already handed to core, so we instrument each server exactly once.
   // After core instruments a server it installs its own `emit` on the instance, which shadows this

--- a/packages/bun/src/integrations/bunHttpServer.ts
+++ b/packages/bun/src/integrations/bunHttpServer.ts
@@ -1,0 +1,133 @@
+import http from 'node:http';
+import https from 'node:https';
+import type { IntegrationFn } from '@sentry/core';
+import { defineIntegration, getHttpServerSubscriptions, HTTP_ON_SERVER_REQUEST } from '@sentry/core';
+
+const INTEGRATION_NAME = 'BunHttpServer' as const;
+
+interface BunHttpServerOptions {
+  /**
+   * Whether to create `http.server` spans for incoming requests.
+   *
+   * Set this to `false` when another layer already emits incoming-request spans
+   * (e.g. Next.js running on Bun, which creates its own OpenTelemetry spans).
+   * The integration then only isolates each request and resets its trace, without
+   * creating duplicate transactions.
+   *
+   * @default true
+   */
+  spans?: boolean;
+
+  /**
+   * Whether the integration should create [Sessions](https://docs.sentry.io/product/releases/health/#sessions) for incoming requests.
+   *
+   * @default true
+   */
+  sessions?: boolean;
+
+  /**
+   * Number of milliseconds until sessions are flushed as a session aggregate.
+   *
+   * @default 60000
+   */
+  sessionFlushingDelayMS?: number;
+
+  /**
+   * Do not capture the request body for incoming HTTP requests to URLs where the given callback returns `true`.
+   */
+  ignoreRequestBody?: (url: string, request: http.RequestOptions) => boolean;
+
+  /**
+   * Controls the maximum size of incoming HTTP request bodies attached to events.
+   *
+   * @default 'medium'
+   */
+  maxRequestBodySize?: 'none' | 'small' | 'medium' | 'always';
+}
+
+let hasPatched = false;
+
+const _bunHttpServerIntegration = ((options: BunHttpServerOptions = {}) => {
+  return {
+    name: INTEGRATION_NAME,
+    setupOnce() {
+      instrumentBunHttpServer(options);
+    },
+  };
+}) satisfies IntegrationFn;
+
+/**
+ * Instruments incoming `node:http`/`node:https` server requests under the Bun runtime.
+ *
+ * Unlike Node.js, Bun does not emit the `http.server.request.start` diagnostics channel that the
+ * Node SDK relies on to isolate each incoming request. As a result, servers built on `node:http`
+ * (such as Next.js running via `bun --bun`) do not get a fresh isolation scope and trace per request,
+ * so unrelated requests can end up sharing one trace.
+ *
+ * This closes that gap by patching `http.Server.prototype.emit` and, on the first `'request'` event
+ * of each server, handing that server to the same core instrumentation the Node SDK uses
+ * (`getHttpServerSubscriptions` → `instrumentServer`). We patch the prototype (not `createServer`)
+ * because the server is typically created before Sentry is initialized — e.g. Next.js creates and
+ * `listen()`s its server before running the `instrumentation.ts` `register()` hook that loads the
+ * Sentry config.
+ *
+ * This is intended for `node:http`-based servers. For `Bun.serve`, use {@link bunServerIntegration}.
+ *
+ * ```js
+ * Sentry.init({
+ *   integrations: [
+ *     Sentry.bunHttpServerIntegration(),
+ *   ],
+ * })
+ * ```
+ */
+export const bunHttpServerIntegration = defineIntegration(_bunHttpServerIntegration);
+
+/**
+ * Patches `http.Server.prototype.emit` so each server's incoming requests are isolated using the
+ * same core instrumentation the Node SDK uses.
+ *
+ * Only exported for tests.
+ */
+export function instrumentBunHttpServer(options: BunHttpServerOptions = {}): void {
+  // This only makes sense under Bun; on Node the diagnostics channel already handles this.
+  if (!process.versions.bun || hasPatched) {
+    return;
+  }
+
+  const { [HTTP_ON_SERVER_REQUEST]: onServerRequest } = getHttpServerSubscriptions({
+    spans: options.spans ?? true,
+    sessions: options.sessions ?? true,
+    sessionFlushingDelayMS: options.sessionFlushingDelayMS ?? 60_000,
+    maxRequestBodySize: options.maxRequestBodySize ?? 'medium',
+    ignoreRequestBody: options.ignoreRequestBody,
+  });
+
+  // Track which servers we have already handed to core, so we instrument each server exactly once.
+  // After core instruments a server it installs its own `emit` on the instance, which shadows this
+  // prototype patch for all subsequent requests to that server.
+  const instrumented = new WeakSet<object>();
+
+  const patchEmitOn = (ServerClass: typeof http.Server): void => {
+    // oxlint-disable-next-line typescript/unbound-method
+    const originalEmit = ServerClass.prototype.emit;
+    ServerClass.prototype.emit = function (this: http.Server, event: string, ...args: unknown[]): boolean {
+      if (event === 'request' && !instrumented.has(this)) {
+        instrumented.add(this);
+        // Hand the server to core, which patches this instance's `emit` to isolate requests.
+        onServerRequest({ server: this }, HTTP_ON_SERVER_REQUEST);
+        // Re-dispatch the in-flight request through the instance emit core just installed.
+        return this.emit(event, ...args);
+      }
+      return originalEmit.call(this, event, ...args) as boolean;
+    } as typeof originalEmit;
+  };
+
+  patchEmitOn(http.Server);
+  // In Bun `https.Server` reuses `http.Server`, but patch it explicitly in case that ever diverges.
+  if (https.Server !== http.Server) {
+    patchEmitOn(https.Server);
+  }
+
+  hasPatched = true;
+}

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -26,6 +26,7 @@ import { channelIntegrations, isOrchestrionInjected } from '@sentry/server-utils
 import { bunServerIntegration } from './integrations/bunserver';
 import { makeFetchTransport } from './transports';
 import type { BunOptions } from './types';
+import { bunHttpServerIntegration } from './integrations/bunHttpServer';
 
 /**
  * The orchestrion channel-subscriber integrations, listening on the diagnostics
@@ -88,6 +89,7 @@ export function getDefaultIntegrationsWithoutPerformance(): Integration[] {
     processSessionIntegration(),
     // Bun Specific
     bunServerIntegration(),
+    bunHttpServerIntegration(),
   ];
 }
 

--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -1,8 +1,7 @@
 import http from 'node:http';
-import { getCurrentScope } from '@sentry/core';
+import { getTraceData } from '@sentry/core';
 import { beforeAll, describe, expect, test } from 'bun:test';
-import { init } from '../../src';
-import { instrumentBunHttpServer } from '../../src/integrations/bunHttpServer';
+import { bunHttpServerIntegration, init } from '../../src';
 
 async function startServer(handler: http.RequestListener): Promise<{ port: number; close: () => Promise<void> }> {
   const server = http.createServer(handler);
@@ -15,6 +14,11 @@ async function startServer(handler: http.RequestListener): Promise<{ port: numbe
   };
 }
 
+/** Read the trace id the SDK would propagate for the current request. Works in both OTel and non-OTel modes. */
+function currentTraceId(): string | undefined {
+  return getTraceData()['sentry-trace']?.split('-')[0];
+}
+
 describe('Bun HTTP Server Integration', () => {
   beforeAll(() => {
     init({
@@ -22,16 +26,15 @@ describe('Bun HTTP Server Integration', () => {
       tracesSampleRate: 0,
       // Avoid sending anything to Sentry
       transport: () => ({ send: async () => ({}), flush: async () => true }),
+      integrations: [bunHttpServerIntegration({ spans: false })],
     });
-    // Only performs isolation + trace reset, no span creation (Next.js emits its own spans).
-    instrumentBunHttpServer({ spans: false });
   });
 
   test('isolates each incoming request with a distinct trace id', async () => {
-    const traceIds: string[] = [];
+    const traceIds: Array<string | undefined> = [];
 
     const { port, close } = await startServer((_req, res) => {
-      traceIds.push(getCurrentScope().getPropagationContext().traceId);
+      traceIds.push(currentTraceId());
       res.end('ok');
     });
 
@@ -51,7 +54,7 @@ describe('Bun HTTP Server Integration', () => {
     let observedTraceId: string | undefined;
 
     const { port, close } = await startServer((_req, res) => {
-      observedTraceId = getCurrentScope().getPropagationContext().traceId;
+      observedTraceId = currentTraceId();
       res.end('ok');
     });
 

--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -1,5 +1,5 @@
 import http from 'node:http';
-import { getTraceData } from '@sentry/core';
+import { getActiveSpan, getTraceData, spanToJSON } from '@sentry/core';
 import { beforeAll, describe, expect, test } from 'bun:test';
 import { bunHttpServerIntegration, init } from '../../src';
 
@@ -23,11 +23,30 @@ describe('Bun HTTP Server Integration', () => {
   beforeAll(() => {
     init({
       dsn: 'https://public@dsn.ingest.sentry.io/1337',
-      tracesSampleRate: 0,
+      tracesSampleRate: 1.0,
       // Avoid sending anything to Sentry
       transport: () => ({ send: async () => ({}), flush: async () => true }),
-      integrations: [bunHttpServerIntegration({ spans: false })],
+      integrations: [bunHttpServerIntegration()],
     });
+  });
+
+  test('creates an http.server span for incoming requests', async () => {
+    let span: ReturnType<typeof spanToJSON> | undefined;
+
+    const { port, close } = await startServer((_req, res) => {
+      const activeSpan = getActiveSpan();
+      span = activeSpan ? spanToJSON(activeSpan) : undefined;
+      res.end('ok');
+    });
+
+    await fetch(`http://localhost:${port}/users?id=123`).then(res => res.text());
+
+    await close();
+
+    expect(span).toBeDefined();
+    expect(span?.op).toBe('http.server');
+    expect(span?.description).toBe('GET /users');
+    expect(span?.data['sentry.origin']).toBe('auto.http.server');
   });
 
   test('isolates each incoming request with a distinct trace id', async () => {

--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -26,7 +26,6 @@ describe('Bun HTTP Server Integration', () => {
       tracesSampleRate: 1.0,
       // Avoid sending anything to Sentry
       transport: () => ({ send: async () => ({}), flush: async () => true }),
-      integrations: [bunHttpServerIntegration()],
     });
   });
 

--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -1,0 +1,66 @@
+import http from 'node:http';
+import { getCurrentScope } from '@sentry/core';
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { init } from '../../src';
+import { instrumentBunHttpServer } from '../../src/integrations/bunHttpServer';
+
+async function startServer(handler: http.RequestListener): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = http.createServer(handler);
+  const port = await new Promise<number>(resolve => {
+    server.listen(0, () => resolve((server.address() as { port: number }).port));
+  });
+  return {
+    port,
+    close: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+describe('Bun HTTP Server Integration', () => {
+  beforeAll(() => {
+    init({
+      dsn: 'https://public@dsn.ingest.sentry.io/1337',
+      tracesSampleRate: 0,
+      // Avoid sending anything to Sentry
+      transport: () => ({ send: async () => ({}), flush: async () => true }),
+    });
+    // Only performs isolation + trace reset, no span creation (Next.js emits its own spans).
+    instrumentBunHttpServer({ spans: false });
+  });
+
+  test('isolates each incoming request with a distinct trace id', async () => {
+    const traceIds: string[] = [];
+
+    const { port, close } = await startServer((_req, res) => {
+      traceIds.push(getCurrentScope().getPropagationContext().traceId);
+      res.end('ok');
+    });
+
+    await fetch(`http://localhost:${port}/a`).then(res => res.text());
+    await fetch(`http://localhost:${port}/b`).then(res => res.text());
+
+    await close();
+
+    expect(traceIds).toHaveLength(2);
+    expect(traceIds[0]).toEqual(expect.any(String));
+    expect(traceIds[1]).toEqual(expect.any(String));
+    expect(traceIds[0]).not.toBe(traceIds[1]);
+  });
+
+  test('continues an incoming trace from headers', async () => {
+    const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+    let observedTraceId: string | undefined;
+
+    const { port, close } = await startServer((_req, res) => {
+      observedTraceId = getCurrentScope().getPropagationContext().traceId;
+      res.end('ok');
+    });
+
+    await fetch(`http://localhost:${port}/`, {
+      headers: { 'sentry-trace': `${incomingTraceId}-1234567890abcdef-1` },
+    }).then(res => res.text());
+
+    await close();
+
+    expect(observedTraceId).toBe(incomingTraceId);
+  });
+});

--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -1,7 +1,7 @@
 import http from 'node:http';
 import { getActiveSpan, getTraceData, spanToJSON } from '@sentry/core';
 import { beforeAll, describe, expect, test } from 'bun:test';
-import { bunHttpServerIntegration, init } from '../../src';
+import { init } from '../../src';
 
 async function startServer(handler: http.RequestListener): Promise<{ port: number; close: () => Promise<void> }> {
   const server = http.createServer(handler);


### PR DESCRIPTION
Adds a `bunHttpIntegration` to `@sentry/bun` that isolates incoming requests for servers built on `node:http` when running under the Bun runtime.

### Problem

Bun does not emit the `http.server.request.start` diagnostics channel that the Node SDK relies on (`getHttpServerSubscriptions` in `@sentry/core`) to isolate each incoming request. As a result, servers built on `node:http` — notably Next.js running via `bun --bun` — do not get a fresh isolation scope and propagation context per request. Two unrelated incoming requests can therefore end up sharing a single `trace_id`.

This was surfaced by the `nextjs-16-bun` e2e app: `propagation.test.ts › Does not propagate outgoing fetch requests not covered by tracePropagationTargets` failed because the inbound and outbound transactions shared one trace.

### Approach

`bunHttpServerIntegration` patches `http.Server.prototype.emit` and, on each server's first `'request'` event, hands that server to the exact same core instrumentation the Node SDK uses (`getHttpServerSubscriptions` → `instrumentServer`). Core then installs its per-instance `emit` wrapper, which shadows the prototype patch for all subsequent requests to that server. No changes to `@sentry/core`, `@sentry/opentelemetry`, or the tracer — this only reuses existing core logic at a Bun-specific entry point.

Two decisions worth calling out:

- **Prototype patch, not `createServer`.** The server is typically created and `listen()`ed *before* Sentry initializes. Next.js in particular creates its `http.Server` and calls `listen()` before running the `instrumentation.ts` `register()` hook that loads the Sentry config, so a `createServer` patch installs too late to see the already-created server. Patching `Server.prototype.emit` catches pre-existing servers on their next request.
- **`spans` option.** When another layer already emits incoming-request spans (Next.js emits its own OpenTelemetry `http.server` spans), pass `spans: false` so the integration only isolates the request and resets its trace, without creating duplicate transactions. This mirrors how the Node `httpIntegration` uses `disableIncomingRequestSpans`.

The integration is a no-op outside Bun (guarded on `process.versions.bun`), and is added by default when using the bun sdk.

### e2e wiring

The `nextjs-16-bun` test app uses `@sentry/nextjs` (→ `@sentry/node`), so it does not pick this up automatically. `@sentry/bun` is added as a dependency of that app and `bunHttpIntegration({ spans: false })` is added to its server config.

### Known limitation

Servers created via an ES module namespace import (`import * as http from 'node:http'`) are covered, since we patch the shared `http.Server` class rather than a module binding.