### PR TITLE
ref(cloudflare)!: Remove wrapRequestHandler from main entrypoint

### DIFF
--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -121,8 +121,6 @@ export { defineCloudflareOptions } from './defineCloudflareOptions';
 export { instrumentAgentWithSentry, instrumentDurableObjectWithSentry } from './durableobject';
 export { sentryPagesPlugin } from './pages-plugin';
 
-export { wrapRequestHandler } from './request';
-
 export { CloudflareClient } from './client';
 export { getDefaultIntegrations } from './sdk';
 

--- a/packages/nuxt/src/runtime/plugins/sentry-cloudflare.server.ts
+++ b/packages/nuxt/src/runtime/plugins/sentry-cloudflare.server.ts
@@ -1,5 +1,6 @@
 import type { CloudflareOptions } from '@sentry/cloudflare';
-import { setAsyncLocalStorageAsyncContextStrategy, wrapRequestHandler } from '@sentry/cloudflare';
+import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/cloudflare';
+import { wrapRequestHandler } from '@sentry/cloudflare/request';
 import { debug, getDefaultIsolationScope, getIsolationScope, getTraceData } from '@sentry/core';
 import type { H3Event } from 'h3';
 import type { NitroApp, NitroAppPlugin } from 'nitropack';

--- a/packages/sveltekit/src/worker/cloudflare.ts
+++ b/packages/sveltekit/src/worker/cloudflare.ts
@@ -2,8 +2,8 @@ import {
   type CloudflareOptions,
   getDefaultIntegrations as getDefaultCloudflareIntegrations,
   setAsyncLocalStorageAsyncContextStrategy,
-  wrapRequestHandler,
 } from '@sentry/cloudflare';
+import { wrapRequestHandler } from '@sentry/cloudflare/request';
 import { addNonEnumerableProperty } from '@sentry/core';
 import type { Handle } from '@sveltejs/kit';
 import { rewriteFramesIntegration } from '../server-common/integrations/rewriteFramesIntegration';

--- a/packages/sveltekit/test/worker/cloudflare.test.ts
+++ b/packages/sveltekit/test/worker/cloudflare.test.ts
@@ -1,8 +1,14 @@
-import { beforeEach } from 'node:test';
 import * as SentryCloudflare from '@sentry/cloudflare';
+import { wrapRequestHandler } from '@sentry/cloudflare/request';
+import type * as SentryCloudflareRequest from '@sentry/cloudflare/request';
 import type { Carrier, GLOBAL_OBJ } from '@sentry/core';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { initCloudflareSentryHandle } from '../../src/worker';
+
+vi.mock('@sentry/cloudflare/request', async importOriginal => {
+  const actual = await importOriginal<typeof SentryCloudflareRequest>();
+  return { ...actual, wrapRequestHandler: vi.fn(actual.wrapRequestHandler) };
+});
 
 const globalWithSentry = globalThis as typeof GLOBAL_OBJ & Carrier;
 
@@ -19,6 +25,7 @@ function getHandlerInput() {
 describe('initCloudflareSentryHandle', () => {
   beforeEach(() => {
     delete globalWithSentry.__SENTRY__;
+    vi.mocked(wrapRequestHandler).mockClear();
   });
 
   it('sets the async context strategy when called', () => {
@@ -36,15 +43,15 @@ describe('initCloudflareSentryHandle', () => {
     const { options, event, resolve, request, context } = getHandlerInput();
 
     // @ts-expect-error - resolving an empty object is enough for this test
-    vi.spyOn(SentryCloudflare, 'wrapRequestHandler').mockImplementationOnce((_, cb) => cb());
+    vi.mocked(wrapRequestHandler).mockImplementationOnce((_, cb) => cb());
 
     const handle = initCloudflareSentryHandle(options);
 
     // @ts-expect-error - only passing a partial event object
     await handle({ event, resolve });
 
-    expect(SentryCloudflare.wrapRequestHandler).toHaveBeenCalledTimes(1);
-    expect(SentryCloudflare.wrapRequestHandler).toHaveBeenCalledWith(
+    expect(wrapRequestHandler).toHaveBeenCalledTimes(1);
+    expect(wrapRequestHandler).toHaveBeenCalledWith(
       { options: expect.objectContaining({ dsn: options.dsn }), request, context, captureErrors: false },
       expect.any(Function),
     );
@@ -57,7 +64,7 @@ describe('initCloudflareSentryHandle', () => {
     const locals = {};
 
     // @ts-expect-error - resolving an empty object is enough for this test
-    vi.spyOn(SentryCloudflare, 'wrapRequestHandler').mockImplementationOnce((_, cb) => cb());
+    vi.mocked(wrapRequestHandler).mockImplementationOnce((_, cb) => cb());
 
     const handle = initCloudflareSentryHandle(options);
 
@@ -74,14 +81,14 @@ describe('initCloudflareSentryHandle', () => {
     delete event.platform;
 
     // @ts-expect-error - resolving an empty object is enough for this test
-    vi.spyOn(SentryCloudflare, 'wrapRequestHandler').mockImplementationOnce((_, cb) => cb());
+    vi.mocked(wrapRequestHandler).mockImplementationOnce((_, cb) => cb());
 
     const handle = initCloudflareSentryHandle(options);
 
     // @ts-expect-error - only passing a partial event object
     await handle({ event, resolve });
 
-    expect(SentryCloudflare.wrapRequestHandler).not.toHaveBeenCalled();
+    expect(wrapRequestHandler).not.toHaveBeenCalled();
     expect(resolve).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
closes getsentry/sentry-javascript#22367

This export from the main entrypoint only leads to confusion - the `wrapRequestHandler` is/was exported here and has a dedicated entrypoint in `@sentry/cloudflare/request`. The only reason for this export is for Oxygen runtimes, or internal use cases. For internal use cases it is ok to also import from the other entrypoint.