### PR TITLE
feat: split childProcess integration into childProcess and worker integrations

### DIFF
--- a/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/app.mjs
+++ b/dev-packages/node-integration-tests/suites/breadcrumbs/process-thread/app.mjs
@@ -10,7 +10,7 @@ Sentry.init({
   traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  integrations: [Sentry.childProcessIntegration({ captureWorkerErrors: false })],
+  integrations: [Sentry.childProcessIntegration(), Sentry.workerIntegration({ captureWorkerErrors: false })],
   transport: loggingTransport,
 });
 

--- a/dev-packages/node-integration-tests/suites/child-process/test.ts
+++ b/dev-packages/node-integration-tests/suites/child-process/test.ts
@@ -10,7 +10,7 @@ const WORKER_EVENT: Event = {
         type: 'Error',
         value: 'Test error',
         mechanism: {
-          type: 'auto.child_process.worker_thread',
+          type: 'auto.worker_thread',
           handled: false,
           data: {
             threadId: expect.any(String),

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -120,6 +120,7 @@ export {
   processSessionIntegration,
   prismaIntegration,
   childProcessIntegration,
+  workerIntegration,
   createSentryWinstonTransport,
   hapiIntegration,
   setupHapiErrorHandler,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -142,6 +142,7 @@ export {
   anthropicAIIntegration,
   googleGenAIIntegration,
   childProcessIntegration,
+  workerIntegration,
   createSentryWinstonTransport,
   vercelAIIntegration,
   logger,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -178,6 +178,7 @@ export { metrics, withStreamedSpan } from '@sentry/core';
 export * as logger from './logs/exports';
 
 export { childProcessIntegration } from './integrations/childProcess';
+export { workerIntegration } from './integrations/workerIntegration';
 export { consoleIntegration } from './integrations/console';
 export { nodeContextIntegration } from './integrations/context';
 export { contextLinesIntegration } from './integrations/contextlines';

--- a/packages/node/src/integrations/childProcess.ts
+++ b/packages/node/src/integrations/childProcess.ts
@@ -1,7 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
-import type { Worker } from 'node:worker_threads';
-import { addBreadcrumb, captureException, defineIntegration, isObjectLike } from '@sentry/core';
+import { addBreadcrumb, defineIntegration, isObjectLike } from '@sentry/core';
 
 interface Options {
   /**
@@ -12,9 +11,9 @@ interface Options {
   includeChildProcessArgs?: boolean;
 
   /**
-   * Whether to capture errors from worker threads.
-   *
-   * @default true
+   * @deprecated This option has been moved to `workerIntegration()`.
+   * Use `workerIntegration({ captureWorkerErrors: false })` instead.
+   * This option is now a no-op and will be removed in a future version.
    */
   captureWorkerErrors?: boolean;
 }
@@ -22,7 +21,9 @@ interface Options {
 const INTEGRATION_NAME = 'ChildProcess' as const;
 
 /**
- * Capture breadcrumbs and events for child processes and worker threads.
+ * Capture breadcrumbs and events for child processes.
+ *
+ * For worker thread events, use `workerIntegration()` instead.
  */
 export const childProcessIntegration = defineIntegration((options: Options = {}) => {
   return {
@@ -31,12 +32,6 @@ export const childProcessIntegration = defineIntegration((options: Options = {})
       diagnosticsChannel.channel('child_process').subscribe((event: unknown) => {
         if (isObjectLike(event) && 'process' in event) {
           captureChildProcessEvents(event.process as ChildProcess, options);
-        }
-      });
-
-      diagnosticsChannel.channel('worker_threads').subscribe((event: unknown) => {
-        if (isObjectLike(event) && 'worker' in event) {
-          captureWorkerThreadEvents(event.worker as Worker, options);
         }
       });
     },
@@ -69,7 +64,7 @@ function captureChildProcessEvents(child: ChildProcess, options: Options): void 
           addBreadcrumb({
             category: 'child_process',
             message: `Child process exited with code '${code}'`,
-            level: code === 0 ? 'info' : 'warning',
+            level: 'warning',
             data,
           });
         }
@@ -89,25 +84,3 @@ function captureChildProcessEvents(child: ChildProcess, options: Options): void 
     });
 }
 
-function captureWorkerThreadEvents(worker: Worker, options: Options): void {
-  let threadId: number | undefined;
-
-  worker
-    .on('online', () => {
-      threadId = worker.threadId;
-    })
-    .on('error', error => {
-      if (options.captureWorkerErrors !== false) {
-        captureException(error, {
-          mechanism: { type: 'auto.child_process.worker_thread', handled: false, data: { threadId: String(threadId) } },
-        });
-      } else {
-        addBreadcrumb({
-          category: 'worker_thread',
-          message: `Worker thread errored with '${error.message}'`,
-          level: 'error',
-          data: { threadId },
-        });
-      }
-    });
-}

--- a/packages/node/src/integrations/workerIntegration.ts
+++ b/packages/node/src/integrations/workerIntegration.ts
@@ -1,0 +1,53 @@
+import type { Worker } from 'node:worker_threads';
+import * as diagnosticsChannel from 'node:diagnostics_channel';
+import { addBreadcrumb, captureException, defineIntegration, isObjectLike } from '@sentry/core';
+
+interface Options {
+  /**
+   * Whether to capture errors from worker threads.
+   *
+   * @default true
+   */
+  captureWorkerErrors?: boolean;
+}
+
+const INTEGRATION_NAME = 'Worker' as const;
+
+/**
+ * Capture breadcrumbs and events for worker threads.
+ */
+export const workerIntegration = defineIntegration((options: Options = {}) => {
+  return {
+    name: INTEGRATION_NAME,
+    setup() {
+      diagnosticsChannel.channel('worker_threads').subscribe((event: unknown) => {
+        if (isObjectLike(event) && 'worker' in event) {
+          captureWorkerThreadEvents(event.worker as Worker, options);
+        }
+      });
+    },
+  };
+});
+
+function captureWorkerThreadEvents(worker: Worker, options: Options): void {
+  let threadId: number | undefined;
+
+  worker
+    .on('online', () => {
+      threadId = worker.threadId;
+    })
+    .on('error', error => {
+      if (options.captureWorkerErrors !== false) {
+        captureException(error, {
+          mechanism: { type: 'auto.worker_thread', handled: false, data: { threadId: threadId !== undefined ? String(threadId) : undefined } },
+        });
+      } else {
+        addBreadcrumb({
+          category: 'worker_thread',
+          message: `Worker thread errored with '${error.message}'`,
+          level: 'error',
+          data: { threadId },
+        });
+      }
+    });
+}

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -21,6 +21,7 @@ import { detectOrchestrionSetup } from '@sentry/server-utils/orchestrion';
 import { registerDiagnosticsChannelInjection } from '@sentry/server-utils/orchestrion/register';
 import { DEBUG_BUILD } from '../debug-build';
 import { childProcessIntegration } from '../integrations/childProcess';
+import { workerIntegration } from '../integrations/workerIntegration';
 import { consoleIntegration } from '../integrations/console';
 import { nodeContextIntegration } from '../integrations/context';
 import { contextLinesIntegration } from '../integrations/contextlines';
@@ -68,6 +69,7 @@ function getBaseDefaultIntegrations(): Integration[] {
     localVariablesIntegration(),
     nodeContextIntegration(),
     childProcessIntegration(),
+    workerIntegration(),
     processSessionIntegration(),
     modulesIntegration(),
   ];


### PR DESCRIPTION
The childProcess integration handled both child process and worker thread events under one integration. This splits it into two separate integrations:

- childProcessIntegration: handles child process events only
- workerIntegration: handles worker thread events only (new)

The old childProcessIntegration's captureWorkerErrors option is deprecated. Users should use workerIntegration() instead.

Fixes #18698