### PR TITLE
feat: Streamline isolation scope handling & reset in isolation scopes

### DIFF
--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -19,7 +19,6 @@ import {
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromSpan,
-  getIsolationScope,
   getLocationHref,
   GLOBAL_OBJ,
   hasSpansEnabled,
@@ -553,12 +552,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         lastInteractionTimestamp = undefined;
 
         maybeEndActiveSpan();
-
-        getIsolationScope().setPropagationContext({
-          traceId: generateTraceId(),
-          sampleRand: Math.random(),
-          propagationSpanId: hasSpansEnabled() ? undefined : generateSpanId(),
-        });
 
         const scope = getCurrentScope();
         scope.setPropagationContext({

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -937,12 +937,10 @@ describe('browserTracingIntegration', () => {
       setCurrentClient(client);
       client.init();
 
-      const oldIsolationScopePropCtx = getIsolationScope().getPropagationContext();
       const oldCurrentScopePropCtx = getCurrentScope().getPropagationContext();
 
       startBrowserTracingNavigationSpan(client, { name: 'test navigation span' });
 
-      const newIsolationScopePropCtx = getIsolationScope().getPropagationContext();
       const newCurrentScopePropCtx = getCurrentScope().getPropagationContext();
 
       expect(oldCurrentScopePropCtx).toEqual({
@@ -950,24 +948,13 @@ describe('browserTracingIntegration', () => {
         propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
-      expect(oldIsolationScopePropCtx).toEqual({
-        traceId: expect.stringMatching(/[a-f0-9]{32}/),
-        sampleRand: expect.any(Number),
-      });
+
       expect(newCurrentScopePropCtx).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
         propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
-      expect(newIsolationScopePropCtx).toEqual({
-        traceId: expect.stringMatching(/[a-f0-9]{32}/),
-        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
-        sampleRand: expect.any(Number),
-      });
-
-      expect(newIsolationScopePropCtx.traceId).not.toEqual(oldIsolationScopePropCtx.traceId);
       expect(newCurrentScopePropCtx.traceId).not.toEqual(oldCurrentScopePropCtx.traceId);
-      expect(newIsolationScopePropCtx.propagationSpanId).not.toEqual(oldIsolationScopePropCtx.propagationSpanId);
     });
 
     it("saves the span's positive sampling decision and its DSC on the propagationContext when the span finishes", () => {

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -1,10 +1,8 @@
 import type { AttributeObject, RawAttribute, RawAttributes } from './attributes';
-import { getClient, getCurrentScope, getIsolationScope, withIsolationScope } from './currentScopes';
+import { getClient, getCurrentScope, getIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { CaptureContext } from './scope';
 import { closeSession, makeSession, updateSession } from './session';
-import { startNewTrace } from './tracing/trace';
-import type { CheckIn, FinishedCheckIn, MonitorConfig } from './types/checkin';
 import type { Event, EventHint } from './types/event';
 import type { EventProcessor } from './types/eventprocessor';
 import type { Extra, Extras } from './types/extra';
@@ -13,12 +11,9 @@ import type { Session, SessionContext } from './types/session';
 import type { SeverityLevel } from './types/severity';
 import type { User } from './types/user';
 import { debug } from './utils/debug-logger';
-import { isThenable } from './utils/is';
-import { uuid4 } from './utils/misc';
 import type { ExclusiveEventHintOrCaptureContext } from './utils/prepareEvent';
 import { parseEventHintOrCaptureContext } from './utils/prepareEvent';
 import { getCombinedScopeData } from './utils/scopeData';
-import { timestampInSeconds } from './utils/time';
 import { GLOBAL_OBJ } from './utils/worldwide';
 
 /**
@@ -180,76 +175,6 @@ export function setConversationId(conversationId: string | null | undefined): vo
  */
 export function lastEventId(): string | undefined {
   return getIsolationScope().lastEventId();
-}
-
-/**
- * Create a cron monitor check in and send it to Sentry.
- *
- * @param checkIn An object that describes a check in.
- * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
- * to create a monitor automatically when sending a check in.
- */
-export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorConfig): string {
-  const scope = getCurrentScope();
-  const client = getClient();
-  if (!client) {
-    DEBUG_BUILD && debug.warn('Cannot capture check-in. No client defined.');
-  } else if (!client.captureCheckIn) {
-    DEBUG_BUILD && debug.warn('Cannot capture check-in. Client does not support sending check-ins.');
-  } else {
-    return client.captureCheckIn(checkIn, upsertMonitorConfig, scope);
-  }
-
-  return uuid4();
-}
-
-/**
- * Wraps a callback with a cron monitor check in. The check in will be sent to Sentry when the callback finishes.
- *
- * @param monitorSlug The distinct slug of the monitor.
- * @param callback Callback to be monitored
- * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
- * to create a monitor automatically when sending a check in.
- */
-export function withMonitor<T>(
-  monitorSlug: CheckIn['monitorSlug'],
-  callback: () => T,
-  upsertMonitorConfig?: MonitorConfig,
-): T {
-  function runCallback(): T {
-    const checkInId = captureCheckIn({ monitorSlug, status: 'in_progress' }, upsertMonitorConfig);
-    const now = timestampInSeconds();
-
-    function finishCheckIn(status: FinishedCheckIn['status']): void {
-      captureCheckIn({ monitorSlug, status, checkInId, duration: timestampInSeconds() - now });
-    }
-    // Default behavior without isolateTrace
-    let maybePromiseResult: T;
-    try {
-      maybePromiseResult = callback();
-    } catch (e) {
-      finishCheckIn('error');
-      throw e;
-    }
-
-    if (isThenable(maybePromiseResult)) {
-      return maybePromiseResult.then(
-        r => {
-          finishCheckIn('ok');
-          return r;
-        },
-        e => {
-          finishCheckIn('error');
-          throw e;
-        },
-      ) as T;
-    }
-    finishCheckIn('ok');
-
-    return maybePromiseResult;
-  }
-
-  return withIsolationScope(() => (upsertMonitorConfig?.isolateTrace ? startNewTrace(runCallback) : runCallback()));
 }
 
 /**

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -1,0 +1,98 @@
+import { getClient, getCurrentScope, withIsolationScope } from './currentScopes';
+import { DEBUG_BUILD } from './debug-build';
+import { continueTrace, startNewTrace, withActiveSpan } from './tracing/trace';
+import type { CheckIn, FinishedCheckIn, MonitorConfig } from './types/checkin';
+import { debug } from './utils/debug-logger';
+import { isThenable } from './utils/is';
+import { uuid4 } from './utils/misc';
+import { getActiveSpan } from './utils/spanUtils';
+import { timestampInSeconds } from './utils/time';
+import { getTraceData } from './utils/traceData';
+
+/**
+ * Wraps a callback with a cron monitor check in. The check in will be sent to Sentry when the callback finishes.
+ *
+ * @param monitorSlug The distinct slug of the monitor.
+ * @param callback Callback to be monitored
+ * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
+ * to create a monitor automatically when sending a check in.
+ */
+export function withMonitor<T>(
+  monitorSlug: CheckIn['monitorSlug'],
+  callback: () => T,
+  upsertMonitorConfig?: MonitorConfig,
+): T {
+  function runCallback(): T {
+    const checkInId = captureCheckIn({ monitorSlug, status: 'in_progress' }, upsertMonitorConfig);
+    const now = timestampInSeconds();
+
+    function finishCheckIn(status: FinishedCheckIn['status']): void {
+      captureCheckIn({ monitorSlug, status, checkInId, duration: timestampInSeconds() - now });
+    }
+    // Default behavior without isolateTrace
+    let maybePromiseResult: T;
+    try {
+      maybePromiseResult = callback();
+    } catch (e) {
+      finishCheckIn('error');
+      throw e;
+    }
+
+    if (isThenable(maybePromiseResult)) {
+      return maybePromiseResult.then(
+        r => {
+          finishCheckIn('ok');
+          return r;
+        },
+        e => {
+          finishCheckIn('error');
+          throw e;
+        },
+      ) as T;
+    }
+    finishCheckIn('ok');
+
+    return maybePromiseResult;
+  }
+
+  // With isolation scope resets the propagation context, so if we do not pass isolateTace, we want to manually continue the trace
+  const traceData = getTraceData();
+  const activeSpan = getActiveSpan();
+
+  return withIsolationScope(() => {
+    if (upsertMonitorConfig?.isolateTrace) {
+      return startNewTrace(runCallback);
+    }
+
+    // If we are not isolating the trace, we want to keep the same trace as the parent
+    // We also need to ensure to set the same span active as before, to ensure an eventually active span is set back in continueTrace
+    return continueTrace(
+      {
+        sentryTrace: traceData['sentry-trace'],
+        baggage: traceData['baggage'],
+      },
+      () => withActiveSpan(activeSpan ?? null, runCallback),
+    );
+  });
+}
+
+/**
+ * Create a cron monitor check in and send it to Sentry.
+ *
+ * @param checkIn An object that describes a check in.
+ * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
+ * to create a monitor automatically when sending a check in.
+ */
+export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorConfig): string {
+  const scope = getCurrentScope();
+  const client = getClient();
+  if (!client) {
+    DEBUG_BUILD && debug.warn('Cannot capture check-in. No client defined.');
+  } else if (!client.captureCheckIn) {
+    DEBUG_BUILD && debug.warn('Cannot capture check-in. Client does not support sending check-ins.');
+  } else {
+    return client.captureCheckIn(checkIn, upsertMonitorConfig, scope);
+  }
+
+  return uuid4();
+}

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -6,6 +6,7 @@ import { debug } from './utils/debug-logger';
 import { isThenable } from './utils/is';
 import { uuid4 } from './utils/misc';
 import { timestampInSeconds } from './utils/time';
+import { isContinuingTrace } from './utils/tracing';
 
 /**
  * Wraps a callback with a cron monitor check in. The check in will be sent to Sentry when the callback finishes.
@@ -53,10 +54,10 @@ export function withMonitor<T>(
     return maybePromiseResult;
   }
 
-  // `withIsolationScope` resets the propagation context, so unless
-  // `isolateTrace` is set we restore the parent's trace below. Copied rather
-  // than aliased: the monitor scope must not share an object with the parent,
-  // or in-place writes inside the callback would rewrite the parent's trace
+  // `withIsolationScope` gives the fork its own trace, so unless `isolateTrace` is set we restore the
+  // parent's trace below. Copied rather than aliased: sharing the object with the parent scope would
+  // let in-place writes inside the callback (e.g. the HTTP server integration assigning
+  // `propagationSpanId`) rewrite the parent's trace.
   const oldPropagationContext = { ...getCurrentScope().getPropagationContext() };
 
   return withIsolationScope(() => {
@@ -64,11 +65,11 @@ export function withMonitor<T>(
       return startNewTrace(runCallback);
     }
 
-    // If we are not isolating the trace, in this case we want to keep the same
-    // trace as the parent
-    const newPropagationContext = getCurrentScope().getPropagationContext();
-    if (!newPropagationContext.parentSpanId) {
-      getCurrentScope().setPropagationContext(oldPropagationContext);
+    // Mirrors the reset condition in the async context strategies: only a fork that was given a fresh
+    // trace needs the parent's trace put back.
+    const scope = getCurrentScope();
+    if (!isContinuingTrace(scope.getPropagationContext())) {
+      scope.setPropagationContext(oldPropagationContext);
     }
 
     return runCallback();

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -1,13 +1,11 @@
 import { getClient, getCurrentScope, withIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
-import { continueTrace, startNewTrace, withActiveSpan } from './tracing/trace';
+import { startNewTrace } from './tracing/trace';
 import type { CheckIn, FinishedCheckIn, MonitorConfig } from './types/checkin';
 import { debug } from './utils/debug-logger';
 import { isThenable } from './utils/is';
 import { uuid4 } from './utils/misc';
-import { getActiveSpan } from './utils/spanUtils';
 import { timestampInSeconds } from './utils/time';
-import { getTraceData } from './utils/traceData';
 
 /**
  * Wraps a callback with a cron monitor check in. The check in will be sent to Sentry when the callback finishes.
@@ -56,23 +54,20 @@ export function withMonitor<T>(
   }
 
   // With isolation scope resets the propagation context, so if we do not pass isolateTace, we want to manually continue the trace
-  const traceData = getTraceData();
-  const activeSpan = getActiveSpan();
+  const oldPropagationContext = getCurrentScope().getPropagationContext();
 
   return withIsolationScope(() => {
     if (upsertMonitorConfig?.isolateTrace) {
       return startNewTrace(runCallback);
     }
 
-    // If we are not isolating the trace, we want to keep the same trace as the parent
-    // We also need to ensure to set the same span active as before, to ensure an eventually active span is set back in continueTrace
-    return continueTrace(
-      {
-        sentryTrace: traceData['sentry-trace'],
-        baggage: traceData['baggage'],
-      },
-      () => withActiveSpan(activeSpan ?? null, runCallback),
-    );
+    // If we are not isolating the trace, in this case we want to keep the same trace as the parent
+    const newPropagationContext = getCurrentScope().getPropagationContext();
+    if (!newPropagationContext.parentSpanId) {
+      getCurrentScope().setPropagationContext(oldPropagationContext);
+    }
+
+    return runCallback();
   });
 }
 

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -53,15 +53,19 @@ export function withMonitor<T>(
     return maybePromiseResult;
   }
 
-  // With isolation scope resets the propagation context, so if we do not pass isolateTace, we want to manually continue the trace
-  const oldPropagationContext = getCurrentScope().getPropagationContext();
+  // `withIsolationScope` resets the propagation context, so unless
+  // `isolateTrace` is set we restore the parent's trace below. Copied rather
+  // than aliased: the monitor scope must not share an object with the parent,
+  // or in-place writes inside the callback would rewrite the parent's trace
+  const oldPropagationContext = { ...getCurrentScope().getPropagationContext() };
 
   return withIsolationScope(() => {
     if (upsertMonitorConfig?.isolateTrace) {
       return startNewTrace(runCallback);
     }
 
-    // If we are not isolating the trace, in this case we want to keep the same trace as the parent
+    // If we are not isolating the trace, in this case we want to keep the same
+    // trace as the parent
     const newPropagationContext = getCurrentScope().getPropagationContext();
     if (!newPropagationContext.parentSpanId) {
       getCurrentScope().setPropagationContext(oldPropagationContext);

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -12,8 +12,6 @@ export * from './tracing';
 export * from './semanticAttributes';
 export { createEventEnvelope, createSessionEnvelope } from './envelope';
 export {
-  captureCheckIn,
-  withMonitor,
   captureException,
   captureEvent,
   captureMessage,
@@ -36,6 +34,7 @@ export {
   captureSession,
   addEventProcessor,
 } from './exports';
+export { withMonitor, captureCheckIn } from './monitor';
 export {
   getCurrentScope,
   getIsolationScope,

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -276,6 +276,7 @@ export {
   TRACEPARENT_REGEXP,
   extractTraceparentData,
   generateSentryTraceHeader,
+  isContinuingTrace,
   propagationContextFromHeaders,
   shouldContinueTrace,
   generateTraceparentHeader,

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -432,15 +432,7 @@ function createChildOrRootSpan({
 
     freezeDscOnSpan(span, dsc);
   } else {
-    const {
-      traceId,
-      dsc,
-      parentSpanId,
-      sampled: parentSampled,
-    } = {
-      ...isolationScope.getPropagationContext(),
-      ...scope.getPropagationContext(),
-    };
+    const { traceId, dsc, parentSpanId, sampled: parentSampled } = scope.getPropagationContext();
 
     span = _startRootSpan(
       {

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -367,7 +367,7 @@ function createChildOrRootSpan({
   const isolationScope = getIsolationScope();
 
   if (!hasSpansEnabled()) {
-    const scopePropagationContext = { ...isolationScope.getPropagationContext(), ...scope.getPropagationContext() };
+    const scopePropagationContext = scope.getPropagationContext();
     const traceId = parentSpan ? parentSpan.spanContext().traceId : scopePropagationContext.traceId;
 
     // The placeholder is a thin marker; it carries no sampling decision or DSC. Both are read from

--- a/packages/core/src/utils/tracing.ts
+++ b/packages/core/src/utils/tracing.ts
@@ -53,6 +53,17 @@ export function extractTraceparentData(traceparent?: string): TraceparentData | 
 }
 
 /**
+ * Whether a propagation context continues an incoming trace, rather than being the head of a new one.
+ *
+ * Both fields have to be checked. `parentSpanId` is unset when the incoming `sentry-trace` header
+ * carried no span id, which the header format allows. `dsc` is unset when a remote parent arrived
+ * without any incoming baggage. Either one on its own therefore misses a continued trace.
+ */
+export function isContinuingTrace(propagationContext: PropagationContext): boolean {
+  return !!propagationContext.parentSpanId || !!propagationContext.dsc;
+}
+
+/**
  * Create a propagation context from incoming headers or
  * creates a minimal new one if the headers are undefined.
  */

--- a/packages/core/test/lib/monitor.test.ts
+++ b/packages/core/test/lib/monitor.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getCurrentScope, getGlobalScope, getIsolationScope } from '../../src/currentScopes';
+import { withMonitor } from '../../src/monitor';
+import { setCurrentClient } from '../../src/sdk';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('withMonitor', () => {
+  beforeEach(() => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    const client = new TestClient(getDefaultTestClientOptions({ dsn: 'https://username@domain/123' }));
+    setCurrentClient(client);
+    client.init();
+  });
+
+  it('keeps the parent trace when not isolating the trace', () => {
+    const parentTraceId = getCurrentScope().getPropagationContext().traceId;
+
+    withMonitor('cron-job', () => {
+      expect(getCurrentScope().getPropagationContext().traceId).toBe(parentTraceId);
+    });
+  });
+
+  it('starts a separate trace when isolateTrace is set', () => {
+    const parentTraceId = getCurrentScope().getPropagationContext().traceId;
+
+    withMonitor(
+      'cron-job',
+      () => {
+        expect(getCurrentScope().getPropagationContext().traceId).not.toBe(parentTraceId);
+      },
+      { schedule: { type: 'crontab', value: '* * * * *' }, isolateTrace: true },
+    );
+  });
+
+  // The parent's propagation context is restored onto the monitor scope, so it
+  // must be copied rather than aliased. Several call sites mutate the
+  // propagation context in place (e.g. the Node HTTP server integration
+  // assigns `propagationSpanId`), which would otherwise rewrite the parent's
+  // trace from inside the callback.
+  it('does not let the callback mutate the parent propagation context', () => {
+    const parentScope = getCurrentScope();
+    const parentPropagationContext = parentScope.getPropagationContext();
+
+    withMonitor('cron-job', () => {
+      const propagationContext = getCurrentScope().getPropagationContext();
+
+      expect(propagationContext).not.toBe(parentPropagationContext);
+      expect(propagationContext).toEqual(parentPropagationContext);
+
+      propagationContext.propagationSpanId = 'deadbeefdeadbeef';
+      propagationContext.traceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    });
+
+    expect(parentScope.getPropagationContext()).toEqual(parentPropagationContext);
+    expect(parentPropagationContext.propagationSpanId).toBeUndefined();
+  });
+});

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, type Mock, test, vi } from 'vitest';
 import type { Client } from '../../src/client';
 import { getCurrentScope } from '../../src/currentScopes';
-import { captureCheckIn } from '../../src/exports';
+import { captureCheckIn } from '../../src/monitor';
 import { installedIntegrations } from '../../src/integration';
 import { initAndBind, setCurrentClient } from '../../src/sdk';
 import type { Integration } from '../../src/types/integration';

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1471,6 +1471,30 @@ describe('startInactiveSpan', () => {
     expect(getActiveSpan()).toBeUndefined();
   });
 
+  // A root span reads its trace from the current scope only. The isolation
+  // scope's propagation context must not contribute: mixing the two yields
+  // a span whose `parent_span_id` and frozen DSC describe a different trace
+  // than its own `trace_id`.
+  it('ignores the propagation context on the isolation scope', () => {
+    const isolationTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    getIsolationScope().setPropagationContext({
+      traceId: isolationTraceId,
+      sampleRand: 0.1,
+      parentSpanId: 'bbbbbbbbbbbbbbbb',
+      sampled: true,
+      dsc: { trace_id: isolationTraceId, transaction: 'from-isolation-scope' },
+    });
+
+    const currentTraceId = getCurrentScope().getPropagationContext().traceId;
+    const span = startInactiveSpan({ name: 'GET users/[id]' });
+
+    expect(spanToJSON(span).trace_id).toBe(currentTraceId);
+    expect(spanToJSON(span).parent_span_id).toBeUndefined();
+    expect(getDynamicSamplingContextFromSpan(span)).toEqual(
+      expect.objectContaining({ trace_id: currentTraceId, transaction: 'GET users/[id]' }),
+    );
+  });
+
   it('allows to pass a scope', () => {
     const initialScope = getCurrentScope();
 

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -88,14 +88,15 @@ export function setOpenTelemetryContextAsyncContextStrategy(): AsyncLocalStorage
     // the OTEL context manager, which uses the presence of this key to determine if it should
     // fork the isolation scope, or not
     return api.context.with(ctx.setValue(SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY, true), () => {
-      // When forking an isolation scope, unless we are continuing an incoming trace (identified by a `parentSpanId`),
-      // we give the freshly forked scope its own trace.
-      // This way, new root spans in an isolation scope will get separate traces
+      // When forking an isolation scope, unless we are continuing an
+      // incoming trace (identified by a `parentSpanId`), we give the freshly
+      // forked scope its own trace. This way, new root spans in an isolation
+      // scope will get separate traces. The previous trace's `dsc`, `sampled`
+      // and `propagationSpanId` are dropped on purpose. Carrying them over
+      // would tie the new trace to the old one's DSC and sampling decision.
       const scope = getCurrentScope();
-      const propagationContext = scope.getPropagationContext();
-      if (!propagationContext.parentSpanId) {
+      if (!scope.getPropagationContext().parentSpanId) {
         scope.setPropagationContext({
-          ...propagationContext,
           traceId: generateTraceId(),
           sampleRand: _INTERNAL_safeMathRandom(),
         });

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -8,6 +8,7 @@ import {
   getDefaultIsolationScope,
   getMainCarrier,
   getRootSpan,
+  isContinuingTrace,
   setAsyncContextStrategy,
   spanIsIgnored,
 } from '@sentry/core';
@@ -88,14 +89,14 @@ export function setOpenTelemetryContextAsyncContextStrategy(): AsyncLocalStorage
     // the OTEL context manager, which uses the presence of this key to determine if it should
     // fork the isolation scope, or not
     return api.context.with(ctx.setValue(SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY, true), () => {
-      // When forking an isolation scope, unless we are continuing an
-      // incoming trace (identified by a `parentSpanId`), we give the freshly
-      // forked scope its own trace. This way, new root spans in an isolation
-      // scope will get separate traces. The previous trace's `dsc`, `sampled`
-      // and `propagationSpanId` are dropped on purpose. Carrying them over
-      // would tie the new trace to the old one's DSC and sampling decision.
+      // When forking an isolation scope, unless we are continuing an incoming
+      // trace, we give the freshly forked scope its own trace. This way, new
+      // root spans in an isolation scope will get separate traces. The
+      // previous trace's `sampled` and `propagationSpanId` are dropped on
+      // purpose. Carrying them over would apply the old trace's sampling
+      // decision to the new one and propagate a span id from a different trace.
       const scope = getCurrentScope();
-      if (!scope.getPropagationContext().parentSpanId) {
+      if (!isContinuingTrace(scope.getPropagationContext())) {
         scope.setPropagationContext({
           traceId: generateTraceId(),
           sampleRand: _INTERNAL_safeMathRandom(),

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -2,6 +2,8 @@ import * as api from '@opentelemetry/api';
 import type { Scope, TracingChannelBinding } from '@sentry/core';
 import {
   getAsyncContextStrategy,
+  _INTERNAL_safeMathRandom,
+  generateTraceId,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
   getMainCarrier,
@@ -86,6 +88,18 @@ export function setOpenTelemetryContextAsyncContextStrategy(): AsyncLocalStorage
     // the OTEL context manager, which uses the presence of this key to determine if it should
     // fork the isolation scope, or not
     return api.context.with(ctx.setValue(SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY, true), () => {
+      // When forking an isolation scope, unless we are continuing an incoming trace (identified by a `parentSpanId`),
+      // we give the freshly forked scope its own trace.
+      // This way, new root spans in an isolation scope will get separate traces
+      const scope = getCurrentScope();
+      const propagationContext = scope.getPropagationContext();
+      if (!propagationContext.parentSpanId) {
+        scope.setPropagationContext({
+          ...propagationContext,
+          traceId: generateTraceId(),
+          sampleRand: _INTERNAL_safeMathRandom(),
+        });
+      }
       return callback(getIsolationScope());
     });
   }

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -540,5 +540,31 @@ describe('asyncContextStrategy', () => {
           done();
         });
       }));
+
+    // A new trace must not inherit the previous trace's frozen DSC, sampling
+    // decision or propagation span id. Keeping them makes the outgoing
+    // `baggage` advertise the old trace id, marks the fresh trace as not
+    // head-of-trace, and propagates a span id from a different trace.
+    it('drops the previous trace data when giving a forked isolation scope its own trace', () => {
+      const oldTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      getCurrentScope().setPropagationContext({
+        traceId: oldTraceId,
+        sampleRand: 0.1,
+        sampled: true,
+        propagationSpanId: 'bbbbbbbbbbbbbbbb',
+        dsc: { trace_id: oldTraceId, sampled: 'true' },
+      });
+
+      withIsolationScope(() => {
+        const propagationContext = getCurrentScope().getPropagationContext();
+
+        expect(propagationContext.traceId).toMatch(/^[a-f0-9]{32}$/);
+        expect(propagationContext.traceId).not.toBe(oldTraceId);
+        expect(propagationContext.sampleRand).toEqual(expect.any(Number));
+        expect(propagationContext.sampled).toBeUndefined();
+        expect(propagationContext.propagationSpanId).toBeUndefined();
+        expect(propagationContext.dsc).toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -541,10 +541,30 @@ describe('asyncContextStrategy', () => {
         });
       }));
 
-    // A new trace must not inherit the previous trace's frozen DSC, sampling
-    // decision or propagation span id. Keeping them makes the outgoing
-    // `baggage` advertise the old trace id, marks the fresh trace as not
-    // head-of-trace, and propagates a span id from a different trace.
+    // A trace-id-only `sentry-trace` header yields a propagation context with
+    // a `dsc` but no `parentSpanId`, because the span id is optional in the
+    // header. Such a trace is still being continued, so its trace id must
+    // survive the fork.
+    it('keeps the trace id when continuing an incoming trace without a span id (dsc set)', () => {
+      const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+      getCurrentScope().setPropagationContext({
+        traceId: incomingTraceId,
+        sampleRand: 0.42,
+        dsc: { trace_id: incomingTraceId, sample_rate: '1' },
+      });
+
+      withIsolationScope(() => {
+        const propagationContext = getCurrentScope().getPropagationContext();
+
+        expect(propagationContext.traceId).toBe(incomingTraceId);
+        expect(propagationContext.dsc).toEqual({ trace_id: incomingTraceId, sample_rate: '1' });
+      });
+    });
+
+    // A new trace must not inherit the previous trace's sampling decision or
+    // propagation span id. Keeping them would apply the old trace's sampling
+    // decision to the new one and propagate a span id belonging to a
+    // different trace.
     it('drops the previous trace data when giving a forked isolation scope its own trace', () => {
       const oldTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
       getCurrentScope().setPropagationContext({
@@ -552,7 +572,6 @@ describe('asyncContextStrategy', () => {
         sampleRand: 0.1,
         sampled: true,
         propagationSpanId: 'bbbbbbbbbbbbbbbb',
-        dsc: { trace_id: oldTraceId, sampled: 'true' },
       });
 
       withIsolationScope(() => {

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -19,6 +19,15 @@ import { TraceState } from '../src/utils/TraceState';
 import { mockSdkInit } from './helpers/mockSdkInit';
 
 describe('asyncContextStrategy', () => {
+  // `withIsolationScope` gives the forked current scope a fresh propagation context (unless it is
+  // continuing an incoming trace), so scope data is expected to match apart from that context.
+  function scopeDataWithoutPropagationContext(
+    scope: Scope,
+  ): Omit<ReturnType<Scope['getScopeData']>, 'propagationContext'> {
+    const { propagationContext: _propagationContext, ...rest } = scope.getScopeData();
+    return rest;
+  }
+
   beforeEach(() => {
     getCurrentScope().clear();
     getIsolationScope().clear();
@@ -45,7 +54,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b', 'b');
@@ -162,7 +172,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       await asyncSetExtra(scope1, 'b', 'b');
@@ -207,7 +218,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b', 'b');
@@ -244,7 +256,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b2', 'b');
@@ -294,7 +307,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       await asyncSetExtra(scope1, 'b', 'b');
@@ -331,7 +345,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b2', 'b');

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -541,8 +541,7 @@ class ContinuousProfiler {
       return;
     }
 
-    const traceId =
-      getCurrentScope().getPropagationContext().traceId || getIsolationScope().getPropagationContext().traceId;
+    const traceId = getCurrentScope().getPropagationContext().traceId;
     const chunk = this._initializeChunk(traceId);
 
     CpuProfilerBindings.startProfiling(chunk.id);

--- a/packages/server-utils/src/async-context.ts
+++ b/packages/server-utils/src/async-context.ts
@@ -8,6 +8,7 @@ import {
   getDefaultCurrentScope,
   getDefaultIsolationScope,
   getMainCarrier,
+  isContinuingTrace,
   setAsyncContextStrategy,
 } from '@sentry/core';
 
@@ -66,13 +67,13 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     const scope = getScopes().scope.clone();
     const isolationScope = getScopes().isolationScope.clone();
 
-    // When forking an isolation scope, unless we are continuing an incoming trace (identified by a `parentSpanId`),
-    // we give the freshly forked scope its own trace.
-    // This way, new root spans in an isolation scope will get separate traces.
-    // The previous trace's `dsc`, `sampled` and `propagationSpanId` are
-    // dropped on purpose. Carrying them over would tie the new trace to the
-    // old one's DSC and sampling decision.
-    if (!scope.getPropagationContext().parentSpanId) {
+    // When forking an isolation scope, unless we are continuing an incoming
+    // trace, we give the freshly forked scope its own trace. This way, new
+    // root spans in an isolation scope will get separate traces. The previous
+    // trace's `sampled` and `propagationSpanId` are dropped on purpose.
+    // Carrying them over would apply the old trace's sampling decision to the
+    // new one and propagate a span id from a different trace.
+    if (!isContinuingTrace(scope.getPropagationContext())) {
       scope.setPropagationContext({
         traceId: generateTraceId(),
         sampleRand: _INTERNAL_safeMathRandom(),

--- a/packages/server-utils/src/async-context.ts
+++ b/packages/server-utils/src/async-context.ts
@@ -69,10 +69,11 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     // When forking an isolation scope, unless we are continuing an incoming trace (identified by a `parentSpanId`),
     // we give the freshly forked scope its own trace.
     // This way, new root spans in an isolation scope will get separate traces.
-    const propagationContext = scope.getPropagationContext();
-    if (!propagationContext.parentSpanId) {
+    // The previous trace's `dsc`, `sampled` and `propagationSpanId` are
+    // dropped on purpose. Carrying them over would tie the new trace to the
+    // old one's DSC and sampling decision.
+    if (!scope.getPropagationContext().parentSpanId) {
       scope.setPropagationContext({
-        ...propagationContext,
         traceId: generateTraceId(),
         sampleRand: _INTERNAL_safeMathRandom(),
       });

--- a/packages/server-utils/src/async-context.ts
+++ b/packages/server-utils/src/async-context.ts
@@ -3,6 +3,8 @@ import type { Scope } from '@sentry/core';
 import {
   _INTERNAL_createTracingChannelBinding,
   getAsyncContextStrategy,
+  _INTERNAL_safeMathRandom,
+  generateTraceId,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
   getMainCarrier,
@@ -63,6 +65,18 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
   function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T {
     const scope = getScopes().scope.clone();
     const isolationScope = getScopes().isolationScope.clone();
+
+    // When forking an isolation scope, unless we are continuing an incoming trace (identified by a `parentSpanId`),
+    // we give the freshly forked scope its own trace.
+    // This way, new root spans in an isolation scope will get separate traces.
+    const propagationContext = scope.getPropagationContext();
+    if (!propagationContext.parentSpanId) {
+      scope.setPropagationContext({
+        ...propagationContext,
+        traceId: generateTraceId(),
+        sampleRand: _INTERNAL_safeMathRandom(),
+      });
+    }
 
     return asyncStorage.run({ scope, isolationScope }, () => {
       return callback(isolationScope);

--- a/packages/server-utils/test/async-context.test.ts
+++ b/packages/server-utils/test/async-context.test.ts
@@ -241,6 +241,32 @@ describe('withIsolationScope()', () => {
       expect(getCurrentScope().getPropagationContext().traceId).toBe(incomingTraceId);
     });
   });
+
+  // A new trace must not inherit the previous trace's frozen DSC, sampling
+  // decision or propagation span id. Keeping them makes the outgoing
+  // `baggage` advertise the old trace id, marks the fresh trace as not
+  // head-of-trace, and propagates a span id from a different trace.
+  it('drops the previous trace data when giving a forked isolation scope its own trace', () => {
+    const oldTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    getCurrentScope().setPropagationContext({
+      traceId: oldTraceId,
+      sampleRand: 0.1,
+      sampled: true,
+      propagationSpanId: 'bbbbbbbbbbbbbbbb',
+      dsc: { trace_id: oldTraceId, sampled: 'true' },
+    });
+
+    withIsolationScope(() => {
+      const propagationContext = getCurrentScope().getPropagationContext();
+
+      expect(propagationContext.traceId).toMatch(/^[a-f0-9]{32}$/);
+      expect(propagationContext.traceId).not.toBe(oldTraceId);
+      expect(propagationContext.sampleRand).toEqual(expect.any(Number));
+      expect(propagationContext.sampled).toBeUndefined();
+      expect(propagationContext.propagationSpanId).toBeUndefined();
+      expect(propagationContext.dsc).toBeUndefined();
+    });
+  });
 });
 
 describe('AsyncLocalStorage re-use', () => {

--- a/packages/server-utils/test/async-context.test.ts
+++ b/packages/server-utils/test/async-context.test.ts
@@ -242,10 +242,28 @@ describe('withIsolationScope()', () => {
     });
   });
 
-  // A new trace must not inherit the previous trace's frozen DSC, sampling
-  // decision or propagation span id. Keeping them makes the outgoing
-  // `baggage` advertise the old trace id, marks the fresh trace as not
-  // head-of-trace, and propagates a span id from a different trace.
+  // A trace-id-only `sentry-trace` header yields a propagation context with a `dsc` but no
+  // `parentSpanId`, because the span id is optional in the header. Such a trace is still being
+  // continued, so its trace id must survive the fork.
+  it('keeps the trace id when continuing an incoming trace without a span id (dsc set)', () => {
+    const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+    getCurrentScope().setPropagationContext({
+      traceId: incomingTraceId,
+      sampleRand: 0.42,
+      dsc: { trace_id: incomingTraceId, sample_rate: '1' },
+    });
+
+    withIsolationScope(() => {
+      const propagationContext = getCurrentScope().getPropagationContext();
+
+      expect(propagationContext.traceId).toBe(incomingTraceId);
+      expect(propagationContext.dsc).toEqual({ trace_id: incomingTraceId, sample_rate: '1' });
+    });
+  });
+
+  // A new trace must not inherit the previous trace's sampling decision or propagation span id.
+  // Keeping them would apply the old trace's sampling decision to the new one and propagate a
+  // span id belonging to a different trace.
   it('drops the previous trace data when giving a forked isolation scope its own trace', () => {
     const oldTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
     getCurrentScope().setPropagationContext({
@@ -253,7 +271,6 @@ describe('withIsolationScope()', () => {
       sampleRand: 0.1,
       sampled: true,
       propagationSpanId: 'bbbbbbbbbbbbbbbb',
-      dsc: { trace_id: oldTraceId, sampled: 'true' },
     });
 
     withIsolationScope(() => {

--- a/packages/server-utils/test/async-context.test.ts
+++ b/packages/server-utils/test/async-context.test.ts
@@ -213,6 +213,34 @@ describe('withIsolationScope()', () => {
 
       expect(initialScope.getScopeData().tags).toEqual({ aa: 'aa' });
     }));
+
+  it('gives each forked isolation scope its own trace id when not continuing an incoming trace', () => {
+    const traceIds: string[] = [];
+
+    withIsolationScope(() => {
+      traceIds.push(getCurrentScope().getPropagationContext().traceId);
+    });
+    withIsolationScope(() => {
+      traceIds.push(getCurrentScope().getPropagationContext().traceId);
+    });
+
+    expect(traceIds[0]).toMatch(/^[a-f0-9]{32}$/);
+    expect(traceIds[1]).toMatch(/^[a-f0-9]{32}$/);
+    expect(traceIds[0]).not.toBe(traceIds[1]);
+  });
+
+  it('keeps the trace id when continuing an incoming trace (parentSpanId set)', () => {
+    const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+    getCurrentScope().setPropagationContext({
+      traceId: incomingTraceId,
+      parentSpanId: '1234567890abcdef',
+      sampleRand: 0.42,
+    });
+
+    withIsolationScope(() => {
+      expect(getCurrentScope().getPropagationContext().traceId).toBe(incomingTraceId);
+    });
+  });
 });
 
 describe('AsyncLocalStorage re-use', () => {

--- a/packages/vercel-edge/test/middlewareTraceIsolation.test.ts
+++ b/packages/vercel-edge/test/middlewareTraceIsolation.test.ts
@@ -1,5 +1,12 @@
 import { context, propagation, ROOT_CONTEXT, trace } from '@opentelemetry/api';
-import { getCurrentScope, getGlobalScope, getIsolationScope, GLOBAL_OBJ, spanToJSON } from '@sentry/core';
+import {
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  GLOBAL_OBJ,
+  spanToJSON,
+  withIsolationScope,
+} from '@sentry/core';
 import { setOpenTelemetryContextAsyncContextStrategy } from '@sentry/opentelemetry';
 import { AsyncLocalStorage } from 'async_hooks';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -59,24 +66,28 @@ async function runMiddlewareRequest(
   delay = 0,
 ): Promise<{ traceId: string; childTraceId: string }> {
   const request = new Request(url, { method: 'GET', headers });
-  return withPropagatedContext(request.headers, () =>
-    nextMiddlewareTrace(new URL(url).pathname, async () => {
-      const rootSpan = trace.getActiveSpan()!;
-      const traceId = spanToJSON(rootSpan).trace_id!;
+  // Mirror `wrapMiddlewareWithSentry`: fork an isolation scope per request, then run Next's
+  // `withPropagatedContext` + `Middleware.execute` trace inside it.
+  return withIsolationScope(() =>
+    withPropagatedContext(request.headers, () =>
+      nextMiddlewareTrace(new URL(url).pathname, async () => {
+        const rootSpan = trace.getActiveSpan()!;
+        const traceId = spanToJSON(rootSpan).trace_id!;
 
-      await new Promise(resolve => setTimeout(resolve, delay));
+        await new Promise(resolve => setTimeout(resolve, delay));
 
-      // A child span started within the request must parent onto this request's root span (same trace id), not onto a
-      // concurrent request's span.
-      const childTracer = trace.getTracer('user');
-      const childSpan = childTracer.startSpan('user-work');
-      const childTraceId = spanToJSON(childSpan as unknown as Parameters<typeof spanToJSON>[0]).trace_id!;
-      childSpan.end();
+        // A child span started within the request must parent onto this request's root span (same trace id), not onto a
+        // concurrent request's span.
+        const childTracer = trace.getTracer('user');
+        const childSpan = childTracer.startSpan('user-work');
+        const childTraceId = spanToJSON(childSpan as unknown as Parameters<typeof spanToJSON>[0]).trace_id!;
+        childSpan.end();
 
-      await new Promise(resolve => setTimeout(resolve, delay));
+        await new Promise(resolve => setTimeout(resolve, delay));
 
-      return { traceId, childTraceId };
-    }),
+        return { traceId, childTraceId };
+      }),
+    ),
   );
 }
 


### PR DESCRIPTION
This PR does two things:

1. Removes any usage of propagation context on isolation scope. We never really need/read this, as the current scope one will always overwrite this. Generally we should only ever set/read propagation context on current scope.
2. Adjust server-side withIsolationScope to reset the propagation context unless it is continuing a trace. Today, this kind of works in otel-based places because we wrap root spans in `startNewTrace`. But this does not align with core/browser handling, so going forward this will be removed. instead, we want this logic to be applied in an isolation scope, so the following code will result in separate traces:

```js
Sentry.withIsolationScope(() => {
  Sentry.startSpan({ name: 'process 1' }, () => ...);
});

Sentry.withIsolationScope(() => {
  Sentry.startSpan({ name: 'process 2' }, () => ...);
});
```

without this change, both of these spans would be part of the same trace, which is not what we want in server.

note: In browser, we do not actually fork the isolation scope, there is just a single one, so this does not apply.