### PR TITLE
feat(cloudflare): Prepare for nodejs_compat entrypoint

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/basic/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/basic/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/d1/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "d1-test-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "d1_databases": [
     {
       "binding": "DB",

--- a/dev-packages/cloudflare-integration-tests/suites/double-instrumentation/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/double-instrumentation/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-disabled/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-filtered/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-ignore/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server-small/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/integrations/http-server/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/public-api/metrics/server-address/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/public-api/metrics/server-address/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/public-api/startSpan-streamed/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "start-span-streamed",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/queue/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/queue/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "queues": {
     "producers": [
       {

--- a/dev-packages/cloudflare-integration-tests/suites/r2/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/r2/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "r2_buckets": [
     {
       "binding": "MY_BUCKET",

--- a/dev-packages/cloudflare-integration-tests/suites/ratelimit/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/ratelimit/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "ratelimits": [
     {
       "name": "MY_RATE_LIMITER",

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/anthropic-ai/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "anthropic-ai-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/d1/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/d1/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "d1-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "d1_databases": [
     {
       "binding": "DB",

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/dsc-url-source/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/dsc-url-source/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links-sync/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links-sync/wrangler.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-alarm-links/wrangler.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-spans/wrangler.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sql/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sql/wrangler.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sync-kv/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject-sync-kv/wrangler.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/wrangler.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/google-genai/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "google-genai-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/headers/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/headers/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-child/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "ignore-spans-streamed-continued-trace-child",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-http-client/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "ignore-spans-streamed-continued-trace-http-client",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/ignoreSpans-streamed/continued-trace-segment/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "ignore-spans-streamed-continued-trace-segment",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/instrument-fetcher/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/instrument-fetcher/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-instrument-fetcher",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["EchoHeadersDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langchain/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "langchain-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "worker-name",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/openai/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/openai/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "openai-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/no-propagation-worker-do/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/no-propagation-worker-do/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-durable-objects",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc-disabled/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc-disabled/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-worker-do-rpc-disabled",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do-rpc/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-worker-do-rpc",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-do/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-durable-objects",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/wrangler-sub-worker.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/wrangler-sub-worker.jsonc
@@ -2,5 +2,5 @@
   "name": "cloudflare-service-binding-sub-worker",
   "main": "index-sub-worker.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-service-binding/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-worker-service-binding",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "services": [
     {
       "binding": "ANOTHER_WORKER",

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/wrangler-sub-worker.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/wrangler-sub-worker.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-worker-worker-do-rpc-sub",
   "main": "index-sub-worker.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-worker-do-rpc/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-worker-worker-do-rpc",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "services": [
     {
       "binding": "SUB_WORKER",

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/wrangler-sub-worker.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/wrangler-sub-worker.jsonc
@@ -2,5 +2,5 @@
   "name": "cloudflare-worker-workerentrypoint-rpc-sub",
   "main": "index-sub-worker.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/worker-workerentrypoint-rpc/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-worker-workerentrypoint-rpc",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als", "enable_ctx_exports"],
+  "compatibility_flags": ["nodejs_compat", "enable_ctx_exports"],
   "services": [
     {
       "binding": "SUB_WORKER",

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc-disabled/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc-disabled/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-workerentrypoint-do-rpc-disabled",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-do-rpc/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-workerentrypoint-do-rpc",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/wrangler-sub-worker.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/wrangler-sub-worker.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-workerentrypoint-workerentrypoint-do-rpc-sub",
   "main": "index-sub-worker.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workerentrypoint-workerentrypoint-do-rpc/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-workerentrypoint-workerentrypoint-do-rpc",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "services": [
     {
       "binding": "SUB_WORKER",

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workflow-do/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/propagation/workflow-do/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-durable-objects",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "migrations": [
     {
       "new_sqlite_classes": ["MyDurableObject"],

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/scheduled/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/scheduled/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "scheduled-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "triggers": {
     "crons": ["* * * * *"],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workers-ai/wrangler.jsonc
@@ -2,5 +2,5 @@
   "name": "workers-ai-worker",
   "compatibility_date": "2025-06-17",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/workflow/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/workflow/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "workflow-worker",
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "workflows": [
     {
       "name": "my-workflow",

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-chained/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-chained/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   // Self-service-binding: the worker binds to its own named `WorkerEntrypoint`
   // export, so the auto-instrument transform can identify and wrap it.
   "services": [

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-manual-mixed/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do-manual-mixed/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   // Self-service-binding: the worker binds to its own named `WorkerEntrypoint`
   // export, so the auto-instrument transform can identify and wrap it.
   "services": [

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/combination-entrypoint-do/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   // Self-service-binding: the worker binds to its own named `WorkerEntrypoint`
   // export, so the auto-instrument transform can identify and wrap it.
   "services": [

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/default-export/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/default-export/wrangler.jsonc
@@ -5,5 +5,5 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
 }

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-manual-wrap/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-manual-wrap/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-mixed/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-mixed/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [
       { "name": "MANUAL", "class_name": "Manual" },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-multiple/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-multiple/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [
       { "name": "COUNTER_A", "class_name": "CounterA" },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-reexport-instrumented/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-reexport-instrumented/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier-alias/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier-alias/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     // The binding references the *exported* alias (`Counter`), while the class
     // is declared locally as `CounterImpl` and exported via `export { ... as Counter }`.

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-specifier/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-manual-mixed/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-manual-mixed/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-specifier/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow-specifier/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject-workflow/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/durableobject/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "durable_objects": {
     "bindings": [{ "name": "COUNTER", "class_name": "Counter" }],
   },

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workerentrypoint/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workerentrypoint/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   // Self-service-binding: the worker binds to its own named `WorkerEntrypoint`
   // export, so the auto-instrument transform can identify and wrap it.
   "services": [

--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workflow/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workflow/wrangler.jsonc
@@ -5,7 +5,7 @@
   // the auto-instrument transform runs) and the runner serves the built output.
   "main": "index.ts",
   "compatibility_date": "2025-06-17",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "workflows": [
     {
       "name": "my-workflow",

--- a/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "workflow-step-context-test",
   "compatibility_date": "2026-05-01",
   "main": "index.ts",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "workflows": [
     {
       "name": "step-context-test-workflow",

--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/wrangler.jsonc
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "astro-5-cf-workers",
   "main": "dist/_worker.js/index.js",
   "compatibility_date": "2025-12-01",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "vars": {
     "SENTRY_DSN": "https://username@domain/123",
     "SENTRY_ENVIRONMENT": "qa",

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/wrangler.jsonc
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "compatibility_date": "2026-03-12",
-  "compatibility_flags": ["global_fetch_strictly_public", "nodejs_als"],
+  "compatibility_flags": ["global_fetch_strictly_public", "nodejs_compat"],
   "name": "astro-6-cf-workers",
   "main": "./sentry.server.config.js",
   "assets": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/wrangler.toml
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/wrangler.toml
@@ -2,7 +2,7 @@
 name = "cloudflare-local-workers"
 main = "src/index.ts"
 compatibility_date = "2024-07-25"
-compatibility_flags = ["nodejs_als"]
+compatibility_flags = ["nodejs_compat"]
 
 # [vars]
 # E2E_TEST_DSN = ""

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/wrangler.toml
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7-als/wrangler.toml
@@ -2,4 +2,4 @@
 name = "cloudflare-vercelai-v7-als"
 main = "src/index.ts"
 compatibility_date = "2026-04-26"
-compatibility_flags = ["nodejs_als"]
+compatibility_flags = ["nodejs_compat"]

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-streaming/wrangler.toml
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-streaming/wrangler.toml
@@ -2,7 +2,7 @@
 name = "cloudflare-workers-streaming"
 main = "src/index.ts"
 compatibility_date = "2024-07-25"
-compatibility_flags = ["nodejs_als"]
+compatibility_flags = ["nodejs_compat"]
 
 # [vars]
 # E2E_TEST_DSN = ""

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/wrangler.jsonc
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/wrangler.jsonc
@@ -2,7 +2,7 @@
   "name": "cloudflare-workers-workflow-legacy",
   "main": "src/index.ts",
   "compatibility_date": "2025-05-01",
-  "compatibility_flags": ["nodejs_als"],
+  "compatibility_flags": ["nodejs_compat"],
   "workflows": [
     {
       "name": "retry-test-workflow",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/wrangler.toml
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/wrangler.toml
@@ -2,7 +2,7 @@
 name = "cloudflare-workers"
 main = "src/index.ts"
 compatibility_date = "2024-07-25"
-compatibility_flags = ["nodejs_als"]
+compatibility_flags = ["nodejs_compat"]
 
 # [vars]
 # E2E_TEST_DSN = ""

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/wrangler.toml
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/wrangler.toml
@@ -2,7 +2,7 @@
 name = "cloudflare-workersentrypoint"
 main = "src/index.ts"
 compatibility_date = "2024-07-25"
-compatibility_flags = ["nodejs_als"]
+compatibility_flags = ["nodejs_compat"]
 
 [vars]
 E2E_TEST_DSN = ""


### PR DESCRIPTION
This changes `nodejs_als` to `nodejs_compat` in the tests, as the next PRs do require that in order to import from it. In theory `nodejs_als` would still work when building and then running the final result because of tree-shaking, but `workerd` within wrangler in dev mode does not tree-shake, that is why the `cloudflare-integration-tests` change it, but the e2e tests keep the `nodejs_als`, just to probe how far we can go with `als` support.