### PR TITLE
chore(cloudflare): Remove restricted imports

### DIFF
--- a/packages/cloudflare/.oxlintrc.json
+++ b/packages/cloudflare/.oxlintrc.json
@@ -14,38 +14,7 @@
     {
       "files": ["**/src/**"],
       "rules": {
-        "sdk/no-class-field-initializers": "off",
-        "no-restricted-imports": [
-          "error",
-          {
-            "paths": [
-              {
-                "name": "@sentry/node",
-                "message": "Do not import from `@sentry/node` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
-              },
-              {
-                "name": "@sentry/server-utils",
-                "message": "Do not import from `@sentry/server-utils` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
-              }
-            ],
-            "patterns": [
-              {
-                "group": ["@sentry/node/**"],
-                "message": "Do not import from `@sentry/node` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
-              },
-              {
-                "group": ["@sentry/server-utils/**", "!@sentry/server-utils/no-diagnostic-channels"],
-                "message": "Do not import from `@sentry/server-utils` in the Cloudflare SDK. It relies on Node.js APIs that are only available when the `nodejs_compat` flag is set. The only allowed importers are files in `src/nodejs_compat/`, which are exposed via the `@sentry/cloudflare/nodejs_compat/*` entry points."
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
-      "files": ["**/src/nodejs_compat/**", "**/src/vite/**"],
-      "rules": {
-        "no-restricted-imports": "off"
+        "sdk/no-class-field-initializers": "off"
       }
     }
   ]


### PR DESCRIPTION
Theoretically we would still need them for `/request`, but this would get so complex in the patterns, that relying on the tests from the stack above is easier and more future proof