### PR TITLE
ref(node)!: Remove deprecated `prismaInstrumentation` option

### DIFF
--- a/packages/server-utils/src/prisma/index.ts
+++ b/packages/server-utils/src/prisma/index.ts
@@ -15,10 +15,6 @@ export interface PrismaInstrumentationConfig {
 
 export interface PrismaOptions {
   /**
-   * @deprecated This is no longer used, v5 works out of the box.
-   */
-  prismaInstrumentation?: unknown;
-  /**
    * Configuration for the Prisma tracing helper.
    */
   instrumentationConfig?: PrismaInstrumentationConfig;


### PR DESCRIPTION
Removes the deprecated `prismaInstrumentation` option. Already documented in the v11 migration guide.

Fixes getsentry/sentry-javascript#21838