### PR TITLE
feat(core)!: Use `rpc` span op for tRPC spans

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-express-streaming/tests/trpc.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-streaming/tests/trpc.test.ts
@@ -5,7 +5,7 @@ import type { AppRouter } from '../src/app';
 
 test('Should record streamed span for trpc query', async ({ baseURL }) => {
   const trpcSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-    return span.name === 'trpc/getSomething' && getSpanOp(span) === 'rpc.server';
+    return span.name === 'trpc/getSomething' && getSpanOp(span) === 'rpc';
   });
 
   const trpcClient = createTRPCProxyClient<AppRouter>({
@@ -21,13 +21,13 @@ test('Should record streamed span for trpc query', async ({ baseURL }) => {
   const trpcSpan = await trpcSpanPromise;
   expect(trpcSpan).toBeDefined();
   expect(trpcSpan.name).toBe('trpc/getSomething');
-  expect(getSpanOp(trpcSpan)).toBe('rpc.server');
+  expect(getSpanOp(trpcSpan)).toBe('rpc');
   expect(trpcSpan.attributes['sentry.origin']?.value).toBe('auto.rpc.trpc');
 });
 
 test('Should record streamed span for trpc mutation', async ({ baseURL }) => {
   const trpcSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-    return span.name === 'trpc/createSomething' && getSpanOp(span) === 'rpc.server';
+    return span.name === 'trpc/createSomething' && getSpanOp(span) === 'rpc';
   });
 
   const trpcClient = createTRPCProxyClient<AppRouter>({
@@ -43,13 +43,13 @@ test('Should record streamed span for trpc mutation', async ({ baseURL }) => {
   const trpcSpan = await trpcSpanPromise;
   expect(trpcSpan).toBeDefined();
   expect(trpcSpan.name).toBe('trpc/createSomething');
-  expect(getSpanOp(trpcSpan)).toBe('rpc.server');
+  expect(getSpanOp(trpcSpan)).toBe('rpc');
   expect(trpcSpan.attributes['sentry.origin']?.value).toBe('auto.rpc.trpc');
 });
 
 test('Should record streamed span and error for a crashing trpc handler', async ({ baseURL }) => {
   const trpcSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-    return span.name === 'trpc/crashSomething' && getSpanOp(span) === 'rpc.server';
+    return span.name === 'trpc/crashSomething' && getSpanOp(span) === 'rpc';
   });
 
   const errorEventPromise = waitForError('node-express-streaming', errorEvent => {
@@ -83,7 +83,7 @@ test('Should record streamed span and error for a crashing trpc handler', async 
 
 test('Should record streamed span and error for a trpc handler that returns a status code', async ({ baseURL }) => {
   const trpcSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-    return span.name === 'trpc/badRequest' && getSpanOp(span) === 'rpc.server';
+    return span.name === 'trpc/badRequest' && getSpanOp(span) === 'rpc';
   });
 
   const errorEventPromise = waitForError('node-express-streaming', errorEvent => {

--- a/dev-packages/e2e-tests/test-applications/node-express-v5/tests/trpc.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/tests/trpc.test.ts
@@ -27,7 +27,7 @@ test('Should record span for trpc query', async ({ baseURL }) => {
   expect(transaction.spans).toContainEqual(
     expect.objectContaining({
       data: expect.objectContaining({
-        'sentry.op': 'rpc.server',
+        'sentry.op': 'rpc',
         'sentry.origin': 'auto.rpc.trpc',
       }),
       description: `trpc/getSomething`,
@@ -59,7 +59,7 @@ test('Should record transaction for trpc mutation', async ({ baseURL }) => {
   expect(transaction.spans).toContainEqual(
     expect.objectContaining({
       data: expect.objectContaining({
-        'sentry.op': 'rpc.server',
+        'sentry.op': 'rpc',
         'sentry.origin': 'auto.rpc.trpc',
       }),
       description: `trpc/createSomething`,

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/trpc.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/trpc.test.ts
@@ -27,7 +27,7 @@ test('Should record span for trpc query', async ({ baseURL }) => {
   expect(transaction.spans).toContainEqual(
     expect.objectContaining({
       data: expect.objectContaining({
-        'sentry.op': 'rpc.server',
+        'sentry.op': 'rpc',
         'sentry.origin': 'auto.rpc.trpc',
       }),
       description: `trpc/getSomething`,
@@ -59,7 +59,7 @@ test('Should record transaction for trpc mutation', async ({ baseURL }) => {
   expect(transaction.spans).toContainEqual(
     expect.objectContaining({
       data: expect.objectContaining({
-        'sentry.op': 'rpc.server',
+        'sentry.op': 'rpc',
         'sentry.origin': 'auto.rpc.trpc',
       }),
       description: `trpc/createSomething`,

--- a/dev-packages/e2e-tests/test-applications/tsx-express/tests/trpc.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/tests/trpc.test.ts
@@ -27,7 +27,7 @@ test('Records span for trpc query', async ({ baseURL }) => {
   expect(transaction.spans).toContainEqual(
     expect.objectContaining({
       data: expect.objectContaining({
-        'sentry.op': 'rpc.server',
+        'sentry.op': 'rpc',
         'sentry.origin': 'auto.rpc.trpc',
       }),
       description: `trpc/getSomething`,
@@ -59,7 +59,7 @@ test('Records transaction for trpc mutation', async ({ baseURL }) => {
   expect(transaction.spans).toContainEqual(
     expect.objectContaining({
       data: expect.objectContaining({
-        'sentry.op': 'rpc.server',
+        'sentry.op': 'rpc',
         'sentry.origin': 'auto.rpc.trpc',
       }),
       description: `trpc/createSomething`,

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -1,3 +1,11 @@
+import {
+  RPC_METHOD,
+  RPC_SYSTEM_NAME,
+  SENTRY_OP,
+  TRPC_PROCEDURE_PATH,
+  TRPC_PROCEDURE_TYPE,
+} from '@sentry/conventions/attributes';
+import { WEB_SERVER_RPC_SPAN_OP } from '@sentry/conventions/op';
 import { getClient, withIsolationScope } from './currentScopes';
 import { captureException } from './exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from './semanticAttributes';
@@ -85,10 +93,14 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
       return startSpanManual(
         {
           name: `trpc/${path}`,
-          op: 'rpc.server',
           attributes: {
+            [SENTRY_OP]: WEB_SERVER_RPC_SPAN_OP,
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.rpc.trpc',
+            [RPC_SYSTEM_NAME]: 'trpc',
+            [RPC_METHOD]: String(path),
+            [TRPC_PROCEDURE_PATH]: String(path),
+            [TRPC_PROCEDURE_TYPE]: String(type),
           },
           forceTransaction: !!options.forceTransaction,
         },

--- a/packages/core/test/lib/trpc.test.ts
+++ b/packages/core/test/lib/trpc.test.ts
@@ -59,10 +59,14 @@ describe('trpcMiddleware', () => {
     expect(tracing.startSpanManual).toHaveBeenCalledWith(
       {
         name: 'trpc/test.procedure',
-        op: 'rpc.server',
         attributes: {
+          'sentry.op': 'rpc',
           'sentry.origin': 'auto.rpc.trpc',
           'sentry.source': 'route',
+          'rpc.system.name': 'trpc',
+          'rpc.method': 'test.procedure',
+          'trpc.procedure_path': 'test.procedure',
+          'trpc.procedure_type': 'query',
         },
         forceTransaction: false,
       },


### PR DESCRIPTION
Replace `rpc.server` with `rpc` from conventions for trpc spans

Part of getsentry/sentry-javascript#22446