### PR TITLE
fix(profiling-node): Respect profileSessionSampleRate in trace profile lifecycle

### DIFF
--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -259,7 +259,8 @@ class ContinuousProfiler {
    */
   private _startTraceLifecycleProfiling(): void {
     if (!this._sampled) {
-      DEBUG_BUILD && debug.log('[Profiling] Profile session not sampled, trace lifecycle profiling will not be started.');
+      DEBUG_BUILD &&
+        debug.log('[Profiling] Profile session not sampled, trace lifecycle profiling will not be started.');
       return;
     }
 

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -258,6 +258,11 @@ class ContinuousProfiler {
    * Starts trace lifecycle profiling. Profiling will remain active as long as there is an active span.
    */
   private _startTraceLifecycleProfiling(): void {
+    if (!this._sampled) {
+      DEBUG_BUILD && debug.log('[Profiling] Profile session not sampled, trace lifecycle profiling will not be started.');
+      return;
+    }
+
     if (!this._client) {
       DEBUG_BUILD &&
         debug.log(

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -861,9 +861,28 @@ describe('ProfilingIntegration', () => {
       expect(stopProfilingSpy).not.toHaveBeenCalled();
     });
 
+    it('does not start profiler when profile session is not sampled', () => {
+      const [client] = makeCurrentSpanProfilingClient({
+        profileLifecycle: 'trace',
+        profileSessionSampleRate: 0,
+      });
+
+      Sentry.setCurrentClient(client);
+      client.init();
+
+      const startProfilingSpy = vi.spyOn(CpuProfilerBindings, 'startProfiling');
+
+      const span = Sentry.startInactiveSpan({ forceTransaction: true, name: 'test' });
+
+      expect(startProfilingSpy).not.toHaveBeenCalled();
+
+      span.end();
+    });
+
     it('starts profiler when first span is created', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);
@@ -884,6 +903,7 @@ describe('ProfilingIntegration', () => {
     it('waits for the tail span to end before stopping the profiler', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);
@@ -908,6 +928,7 @@ describe('ProfilingIntegration', () => {
     it('ending last span does not stop the profiler if first span is not ended', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);
@@ -930,6 +951,7 @@ describe('ProfilingIntegration', () => {
     it('multiple calls to span.end do not restart the profiler', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);


### PR DESCRIPTION
- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [x] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

Closes #22927

When using the `trace` profile lifecycle in `@sentry/profiling-node`, trace lifecycle profiling was set up without checking the session sampling decision. As a result, chunk profiling would start on span start even when `profileSessionSampleRate` resulted in an unsampled session.

This change skips trace lifecycle profiling setup when the session is not sampled, ensuring that `profileSessionSampleRate` is respected in the `trace` lifecycle as well.

A regression test was added for `profileSessionSampleRate: 0` with the `trace` profile lifecycle.