### PR TITLE
fix(react-router): prevent unstable_sentryVitePluginOptions spread from overwriting sourcemaps

### DIFF
--- a/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
+++ b/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
@@ -19,6 +19,11 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
     release,
   } = options;
 
+  // Destructure keys that are merged explicitly below so the trailing spread
+  // cannot overwrite them with the user's raw value.
+  const { sourcemaps: userSourcemaps, ...restUnstableVitePluginOptions } =
+    unstable_sentryVitePluginOptions ?? {};
+
   const sentryVitePlugins = sentryVitePlugin({
     applicationKey,
     authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
@@ -45,9 +50,9 @@ export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuil
     // will be handled in buildEnd hook
     sourcemaps: {
       disable: true,
-      ...unstable_sentryVitePluginOptions?.sourcemaps,
+      ...userSourcemaps,
     },
-    ...unstable_sentryVitePluginOptions,
+    ...restUnstableVitePluginOptions,
   }) as Plugin[];
 
   return sentryVitePlugins;


### PR DESCRIPTION
`makeCustomSentryVitePlugins` builds a `sourcemaps: { disable: true, ...user }` object to prevent double debug-ID injection during the React Router build. However, the trailing `...unstable_sentryVitePluginOptions` spread on the next line overwrites the entire `sourcemaps` key with the user's raw value, dropping `disable: true`.

JavaScript's object spread is shallow — when both `sourcemaps: { disable: true, ...userSourcemaps }` and `...unstable_sentryVitePluginOptions` are present on the same level, the second `sourcemaps` key wins unconditionally.

**Fix:** destructure `sourcemaps` out of `unstable_sentryVitePluginOptions` before the call, then use `userSourcemaps` inside the already-merged object and spread the remainder separately. This keeps user customizations on all other keys while preserving `disable: true`.

Fixes #22929