### PR TITLE
fix(v10/profiling-node): Respect profileSessionSampleRate in trace profile lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+Work in this release was contributed by @Jxxunnn. Thank you for your contribution!
+
 ## 10.69.0
 
 ### Important Changes

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -258,6 +258,12 @@ class ContinuousProfiler {
    * Starts trace lifecycle profiling. Profiling will remain active as long as there is an active span.
    */
   private _startTraceLifecycleProfiling(): void {
+    if (!this._sampled) {
+      DEBUG_BUILD &&
+        debug.log('[Profiling] Profile session not sampled, trace lifecycle profiling will not be started.');
+      return;
+    }
+
     if (!this._client) {
       DEBUG_BUILD &&
         debug.log(

--- a/packages/profiling-node/test/integration.test.ts
+++ b/packages/profiling-node/test/integration.test.ts
@@ -859,9 +859,28 @@ describe('ProfilingIntegration', () => {
       expect(stopProfilingSpy).not.toHaveBeenCalled();
     });
 
+    it('does not start profiler when profile session is not sampled', () => {
+      const [client] = makeCurrentSpanProfilingClient({
+        profileLifecycle: 'trace',
+        profileSessionSampleRate: 0,
+      });
+
+      Sentry.setCurrentClient(client);
+      client.init();
+
+      const startProfilingSpy = vi.spyOn(CpuProfilerBindings, 'startProfiling');
+
+      const span = Sentry.startInactiveSpan({ forceTransaction: true, name: 'test' });
+
+      expect(startProfilingSpy).not.toHaveBeenCalled();
+
+      span.end();
+    });
+
     it('starts profiler when first span is created', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);
@@ -882,6 +901,7 @@ describe('ProfilingIntegration', () => {
     it('waits for the tail span to end before stopping the profiler', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);
@@ -906,6 +926,7 @@ describe('ProfilingIntegration', () => {
     it('ending last span does not stop the profiler if first span is not ended', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);
@@ -928,6 +949,7 @@ describe('ProfilingIntegration', () => {
     it('multiple calls to span.end do not restart the profiler', () => {
       const [client] = makeCurrentSpanProfilingClient({
         profileLifecycle: 'trace',
+        profileSessionSampleRate: 1,
       });
 
       Sentry.setCurrentClient(client);


### PR DESCRIPTION
Backport of: #22928

Also adds credits in the next v10 changelog to @Jxxunnn who contributed the fix to `develop`