### PR TITLE
test(e2e): Fix scripts for nuxt dev server

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt-start-dev-server.bash
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/nuxt-start-dev-server.bash
@@ -25,8 +25,11 @@ if [ ! -f ".nuxt/dev/sentry.server.config.mjs" ]; then
 fi
 
 # 3.  Cleanup
+# `pkill -P` only kills direct children, so the grandchild dev server holding the
+# port survives; newer Nuxt's directory-scoped dev lock then blocks the real start.
 echo "Found .nuxt/dev/sentry.server.config.mjs, stopping 'nuxt dev' process..."
-pkill -P $DEV_PID || kill $DEV_PID
+pkill -P $DEV_PID 2>/dev/null
+kill $DEV_PID 2>/dev/null
 
 # Wait for port to be released
 echo "Waiting for port $TEMP_PORT to be released..."
@@ -38,7 +41,13 @@ while lsof -i :$TEMP_PORT > /dev/null 2>&1 && [ $COUNTER -lt 10 ]; do
 done
 
 if lsof -i :$TEMP_PORT > /dev/null 2>&1; then
-    echo "WARNING: Port $TEMP_PORT still in use after 10 seconds, proceeding anyway..."
+    echo "Port $TEMP_PORT still in use, killing remaining processes bound to it..."
+    lsof -t -i :$TEMP_PORT | xargs -r kill -9 2>/dev/null
+    sleep 1
+fi
+
+if lsof -i :$TEMP_PORT > /dev/null 2>&1; then
+    echo "WARNING: Port $TEMP_PORT still in use, proceeding anyway..."
 else
     echo "Port $TEMP_PORT released successfully"
 fi

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/nuxt-start-dev-server.bash
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/nuxt-start-dev-server.bash
@@ -25,8 +25,11 @@ if [ ! -f ".nuxt/dev/sentry.server.config.mjs" ]; then
 fi
 
 # 3.  Cleanup
+# `pkill -P` only kills direct children, so the grandchild dev server holding the
+# port survives; newer Nuxt's directory-scoped dev lock then blocks the real start.
 echo "Found .nuxt/dev/sentry.server.config.mjs, stopping 'nuxt dev' process..."
-pkill -P $DEV_PID || kill $DEV_PID
+pkill -P $DEV_PID 2>/dev/null
+kill $DEV_PID 2>/dev/null
 
 # Wait for port to be released
 echo "Waiting for port $TEMP_PORT to be released..."
@@ -38,7 +41,13 @@ while lsof -i :$TEMP_PORT > /dev/null 2>&1 && [ $COUNTER -lt 10 ]; do
 done
 
 if lsof -i :$TEMP_PORT > /dev/null 2>&1; then
-    echo "WARNING: Port $TEMP_PORT still in use after 10 seconds, proceeding anyway..."
+    echo "Port $TEMP_PORT still in use, killing remaining processes bound to it..."
+    lsof -t -i :$TEMP_PORT | xargs -r kill -9 2>/dev/null
+    sleep 1
+fi
+
+if lsof -i :$TEMP_PORT > /dev/null 2>&1; then
+    echo "WARNING: Port $TEMP_PORT still in use, proceeding anyway..."
 else
     echo "Port $TEMP_PORT released successfully"
 fi


### PR DESCRIPTION
`nuxt-start-dev-server.bash` starts a throwaway `pnpm dev` to generate `sentry.server.config.mjs`, then cleans it up with `pkill -P $DEV_PID`. That only kills the direct children of `pnpm dev`, so the actual `nuxt dev` server survives and keeps holding the port. On the canary channel, Nuxt added a directory-scoped dev lock, so the leftover process makes the real `nuxt dev` refuse to start (`Another Nuxt dev is already running`), exiting 1.

Cleanup now force-kills whatever still holds the port after the wait loop, releasing the lock so the real server can start.

Applied to nuxt-5 as well, which carries the identical script.

closes getsentry/sentry-javascript#22938