### PR TITLE
fix(cloudflare): Set conversation id independent of session name

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/ai-streaming.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/ai-streaming.test.ts
@@ -21,8 +21,9 @@ function assertGenAiStreamingSpan(span: SerializedStreamedSpan): void {
   expect(span.attributes['gen_ai.usage.input_tokens']?.value).toBe(15);
   expect(span.attributes['gen_ai.usage.output_tokens']?.value).toBe(8);
   expect(span.attributes['gen_ai.usage.total_tokens']?.value).toBe(23);
-  // Both agents are addressed as `.../test`, so the instance name is the conversation id.
-  expect(span.attributes['gen_ai.conversation.id']?.value).toBe('test');
+  // The conversation id is minted by the SDK and persisted per agent instance, not derived from the
+  // instance name, so only its shape is stable: `uuid4()` without dashes.
+  expect(span.attributes['gen_ai.conversation.id']?.value).toMatch(/^[0-9a-f]{32}$/);
 }
 
 test('captures Workers AI streaming output when driven via an Agent', async ({ request, baseURL }) => {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/chat-conversation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/chat-conversation.test.ts
@@ -1,10 +1,14 @@
 import { expect, test } from '@playwright/test';
 import { getSpanOp, waitForStreamedSpan, waitForTransaction } from '@sentry-internal/test-utils';
-import { sendChatMessage } from './agent-socket';
+import { callRpc, sendChatMessage } from './agent-socket';
 
-// In the Agents model one agent instance is one conversation, so the instance name is the
-// conversation id the SDK correlates the turn's gen_ai spans with.
-const CONVERSATION_ID = 'chat-conv-instance';
+const AGENT_INSTANCE = 'chat-conv-instance';
+
+// In the Agents model one agent instance is one conversation. The SDK mints the conversation id
+// itself and persists it in the instance's Durable Object storage rather than deriving it from the
+// caller-chosen instance name, so the assertion is on the shape of the id — `uuid4()` from
+// `@sentry/core`, i.e. 32 hex characters without dashes.
+const UUID_PATTERN = /^[0-9a-f]{32}$/;
 
 test('stamps the conversation id on gen_ai spans created inside a chat turn', async ({ baseURL }) => {
   const spanPromise = waitForStreamedSpan('cloudflare-agent', span => getSpanOp(span) === 'gen_ai.chat');
@@ -15,11 +19,61 @@ test('stamps the conversation id on gen_ai spans created inside a chat turn', as
 
   await sendChatMessage(baseURL!, {
     binding: 'my-chat-agent',
-    instance: CONVERSATION_ID,
+    instance: AGENT_INSTANCE,
     prompt: 'What is the capital of France?',
   });
 
   const [genAiSpan, transaction] = await Promise.all([spanPromise, transactionPromise]);
   expect(genAiSpan.trace_id).toBe(transaction.contexts?.trace?.trace_id);
-  expect(genAiSpan.attributes['gen_ai.conversation.id']?.value).toBe(CONVERSATION_ID);
+  expect(genAiSpan.attributes['gen_ai.conversation.id']?.value).toMatch(UUID_PATTERN);
+});
+
+// The agent calls `Sentry.setConversationId('conv_manual_e2e')` at the start of `onChatMessage`, the
+// recipe the docs recommend for keying a conversation on the app's own id. The manual id must win
+// over the SDK-minted uuid that the instrumentation put on the scope before the handler ran.
+test('a conversation id set manually inside onChatMessage wins over the SDK-minted one', async ({ baseURL }) => {
+  const spanPromise = waitForStreamedSpan('cloudflare-agent', span => getSpanOp(span) === 'gen_ai.chat');
+
+  await sendChatMessage(baseURL!, {
+    binding: 'my-manual-chat-agent',
+    instance: 'chat-manual-instance',
+    prompt: 'What is the capital of France?',
+  });
+
+  const genAiSpan = await spanPromise;
+  expect(genAiSpan.attributes['gen_ai.conversation.id']?.value).toBe('conv_manual_e2e');
+});
+
+// Same recipe on the other two entry points the SDK wraps: the manual id must win regardless of
+// which handler the agent uses for its AI work.
+test('a conversation id set manually inside onRequest wins over the SDK-minted one', async ({ request, baseURL }) => {
+  const spanPromise = waitForStreamedSpan('cloudflare-agent', span => getSpanOp(span) === 'gen_ai.chat');
+  const transactionPromise = waitForTransaction(
+    'cloudflare-agent',
+    transactionEvent =>
+      transactionEvent.transaction === 'GET /agents/my-manual-chat-agent/chat-manual-request-instance',
+  );
+
+  const response = await request.get(`${baseURL}/agents/my-manual-chat-agent/chat-manual-request-instance`);
+  expect(response.ok()).toBe(true);
+
+  const [genAiSpan, transaction] = await Promise.all([spanPromise, transactionPromise]);
+  expect(genAiSpan.trace_id).toBe(transaction.contexts?.trace?.trace_id);
+  expect(genAiSpan.attributes['gen_ai.conversation.id']?.value).toBe('conv_manual_e2e');
+});
+
+test('a conversation id set manually inside a callable RPC method wins over the SDK-minted one', async ({
+  baseURL,
+}) => {
+  const spanPromise = waitForStreamedSpan('cloudflare-agent', span => getSpanOp(span) === 'gen_ai.chat');
+
+  await callRpc(baseURL!, {
+    binding: 'my-manual-chat-agent',
+    instance: 'chat-manual-rpc-instance',
+    method: 'runAiTurn',
+    args: [],
+  });
+
+  const genAiSpan = await spanPromise;
+  expect(genAiSpan.attributes['gen_ai.conversation.id']?.value).toBe('conv_manual_e2e');
 });

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker-configuration.d.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker-configuration.d.ts
@@ -5,11 +5,12 @@ interface __BaseEnv_Env {
   E2E_TEST_DSN: string;
   MyAgent: DurableObjectNamespace<import('./worker/index').MyAgent>;
   MyChatAgent: DurableObjectNamespace<import('./worker/index').MyChatAgent>;
+  MyManualChatAgent: DurableObjectNamespace<import('./worker/index').MyManualChatAgent>;
 }
 declare namespace Cloudflare {
   interface GlobalProps {
     mainModule: typeof import('./worker/index');
-    durableNamespaces: 'MyAgent' | 'MyChatAgent';
+    durableNamespaces: 'MyAgent' | 'MyChatAgent' | 'MyManualChatAgent';
   }
   interface Env extends __BaseEnv_Env {}
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/worker/index.ts
@@ -75,8 +75,36 @@ class MyChatAgentBase extends AIChatAgent<Env> {
   }
 }
 
+// Not exported: the Workers runtime rejects any module export that isn't a handler/Durable Object.
+const MANUAL_CONVERSATION_ID = 'conv_manual_e2e';
+
+// Mirrors the docs recipe: the app keys conversations on its own id rather than the SDK-minted one.
+class MyManualChatAgentBase extends AIChatAgent<Env> {
+  @callable()
+  async runAiTurn(): Promise<string> {
+    Sentry.setConversationId(MANUAL_CONVERSATION_ID);
+
+    // Unlike onRequest/onChatMessage nothing consumes the returned stream here, so the gen_ai span
+    // only finishes if we drain it ourselves.
+    return streamWorkersAi().text();
+  }
+
+  async onRequest(): Promise<Response> {
+    Sentry.setConversationId(MANUAL_CONVERSATION_ID);
+
+    return streamWorkersAi();
+  }
+
+  async onChatMessage(): Promise<Response> {
+    Sentry.setConversationId(MANUAL_CONVERSATION_ID);
+
+    return streamWorkersAi();
+  }
+}
+
 export const MyAgent = Sentry.instrumentAgentWithSentry(sentryOptions, MyBaseAgent);
 export const MyChatAgent = Sentry.instrumentAgentWithSentry(sentryOptions, MyChatAgentBase);
+export const MyManualChatAgent = Sentry.instrumentAgentWithSentry(sentryOptions, MyManualChatAgentBase);
 
 export default Sentry.withSentry(sentryOptions, {
   async fetch(request: Request, env: Env): Promise<Response> {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/wrangler.jsonc
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/wrangler.jsonc
@@ -26,10 +26,11 @@
     "bindings": [
       { "name": "MyAgent", "class_name": "MyAgent" },
       { "name": "MyChatAgent", "class_name": "MyChatAgent" },
+      { "name": "MyManualChatAgent", "class_name": "MyManualChatAgent" },
     ],
   },
 
-  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MyAgent", "MyChatAgent"] }],
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["MyAgent", "MyChatAgent", "MyManualChatAgent"] }],
 
   "version_metadata": {
     "binding": "CF_VERSION_METADATA",

--- a/packages/cloudflare/src/instrumentations/agents/index.ts
+++ b/packages/cloudflare/src/instrumentations/agents/index.ts
@@ -10,8 +10,9 @@ import type { AgentInternals } from './types';
  * - **Callable RPC spans** — a span (op `rpc`) for each `@callable()` method invoked over WebSocket.
  * - **Conversation correlation** — sets the conversation id on the scope for each unit of agent
  *   work — chat turn, callable RPC call, or HTTP request — so `gen_ai` spans created within it are
- *   correlated, for chat and plain agents alike. Defaults to the instance `name` and is rotated
- *   when the chat is cleared (the `message:clear` observability event).
+ *   correlated, for chat and plain agents alike. The id is minted once per agent instance and
+ *   rotated when the chat is cleared (the `message:clear` observability event); it is persisted to
+ *   Durable Object storage so it survives hibernation.
  *
  * It only hooks the `agents` package internals and uses Sentry's tracing primitives. On Cloudflare
  * Workers, prefer `instrumentAgentWithSentry`, which additionally instruments the Durable Object

--- a/packages/cloudflare/src/instrumentations/agents/instrumentAgentCallableRpc.ts
+++ b/packages/cloudflare/src/instrumentations/agents/instrumentAgentCallableRpc.ts
@@ -8,7 +8,10 @@ import { AGENT_SPAN_ORIGIN, type AgentInternals, getAgentAttributes, setAgentCon
  * the WebSocket message (on Cloudflare, the instrumented Durable Object `webSocketMessage` hook).
  *
  * Also sets the conversation id on the scope for the duration of the call: callable methods are the
- * unit of work for plain (non-chat) agents, which run LLM calls just like chat turns do.
+ * unit of work for plain (non-chat) agents, which run LLM calls just like chat turns do. It is
+ * awaited so the id is on the scope before the method body creates any span; the `agents`
+ * `onMessage` own property this wraps is already `async`, so the promise return is nothing new to
+ * the WebSocket dispatch upstream.
  */
 export function instrumentAgentCallableRpc(obj: AgentInternals): void {
   const original = obj.onMessage;
@@ -34,8 +37,8 @@ export function instrumentAgentCallableRpc(obj: AgentInternals): void {
             ...getAgentAttributes(thisArg),
           },
         },
-        () => {
-          setAgentConversationId(thisArg);
+        async () => {
+          await setAgentConversationId(thisArg);
           return Reflect.apply(target, thisArg, args);
         },
       );

--- a/packages/cloudflare/src/instrumentations/agents/instrumentAgentRequestConversation.ts
+++ b/packages/cloudflare/src/instrumentations/agents/instrumentAgentRequestConversation.ts
@@ -9,7 +9,9 @@ import { type AgentInternals, setAgentConversationId } from './types';
  *
  * `agents` installs `onRequest` as an own property in the `Agent` constructor (as it does
  * `onMessage`), and we instrument after construction, so wrapping the own property is what the
- * router ends up calling.
+ * router ends up calling. That own property is already `async`, and partyserver's `fetch` awaits it,
+ * so returning a promise from this wrapper — to get the conversation id onto the scope before the
+ * request handler creates any span — keeps the existing contract.
  */
 export function instrumentAgentRequestConversation(obj: AgentInternals): void {
   const original = obj.onRequest;
@@ -19,8 +21,8 @@ export function instrumentAgentRequestConversation(obj: AgentInternals): void {
   }
 
   obj.onRequest = new Proxy(original, {
-    apply(target, thisArg: AgentInternals, args: unknown[]): unknown {
-      setAgentConversationId(thisArg);
+    async apply(target, thisArg: AgentInternals, args: unknown[]): Promise<unknown> {
+      await setAgentConversationId(thisArg);
 
       return Reflect.apply(target, thisArg, args);
     },

--- a/packages/cloudflare/src/instrumentations/agents/instrumentChatAgentConversation.ts
+++ b/packages/cloudflare/src/instrumentations/agents/instrumentChatAgentConversation.ts
@@ -1,20 +1,21 @@
 import { uuid4 } from '@sentry/core';
-import { type AgentInternals, setAgentConversationId } from './types';
+import { type AgentInternals, setAgentConversationId, storeAgentConversationId } from './types';
 
 /**
  * For chat agents (`AIChatAgent` from `@cloudflare/ai-chat`), correlates each chat turn's AI spans
  * with a conversation id on the active scope.
  *
- * In the Agents model one agent instance is one long-lived conversation, so the instance `name` is
- * the base conversation id. When the user clears the chat, they expect a fresh conversation — but
- * recreating the Durable Object for that would also drop the MCP/OAuth state stored per instance
- * (GitHub/Sentry sign-in). To get a fresh conversation id *without* losing that state, we rotate an
- * in-memory id on the instance when the SDK reports a cleared chat, and stamp that (falling back to
- * the instance `name` before the first clear).
+ * In the Agents model one agent instance is one long-lived conversation, so the conversation id is
+ * minted once per instance and persisted to Durable Object storage, which is what carries it across
+ * hibernation (that destroys the in-memory instance). When the user clears the chat, they expect a
+ * fresh conversation — but recreating the Durable Object for that would also drop the MCP/OAuth
+ * state stored per instance (GitHub/Sentry sign-in). To get a fresh conversation id *without*
+ * losing that state, we rotate the persisted id when the SDK reports a cleared chat.
  *
- * The id itself is not attached to spans here — the SDK's `conversationIdIntegration` reads it off
- * the scope at `spanStart` and stamps `gen_ai.conversation.id` onto the AI spans created inside the
- * turn (e.g. by the Workers AI instrumentation), which correlates a turn's model and tool calls.
+ * The id itself is not attached to spans here — `setAgentConversationId` resolves it, and the SDK's
+ * `conversationIdIntegration` picks it off the scope at `spanStart` to stamp
+ * `gen_ai.conversation.id` onto the AI spans created inside the turn (e.g. by the Workers AI
+ * instrumentation), which correlates a turn's model and tool calls.
  *
  * Plain (non-chat) `Agent`s do not define `onChatMessage`, so they are skipped here — their unit
  * of work is the callable RPC method, where `instrumentAgentCallableRpc` sets the conversation id
@@ -31,7 +32,7 @@ export function instrumentChatAgentConversation(obj: AgentInternals): void {
     obj._emit = new Proxy(originalEmit, {
       apply(target, thisArg: AgentInternals, args: [string, Record<string, unknown>?]) {
         if (args[0] === 'message:clear') {
-          thisArg.__sentryConversationId = uuid4();
+          storeAgentConversationId(thisArg, uuid4());
         }
 
         return Reflect.apply(target, thisArg, args);
@@ -46,8 +47,8 @@ export function instrumentChatAgentConversation(obj: AgentInternals): void {
   }
 
   obj.onChatMessage = new Proxy(original, {
-    apply(target, thisArg: AgentInternals, args: unknown[]): unknown {
-      setAgentConversationId(thisArg);
+    async apply(target, thisArg: AgentInternals, args: unknown[]): Promise<unknown> {
+      await setAgentConversationId(thisArg);
 
       return Reflect.apply(target, thisArg, args);
     },

--- a/packages/cloudflare/src/instrumentations/agents/types.ts
+++ b/packages/cloudflare/src/instrumentations/agents/types.ts
@@ -1,7 +1,21 @@
 import { GEN_AI_AGENT_NAME } from '@sentry/conventions/attributes';
-import { getCurrentScope } from '@sentry/core';
+import type { DurableObjectStorage } from '@cloudflare/workers-types';
+import { debug, getCurrentScope, getIsolationScope, uuid4 } from '@sentry/core';
+import { DEBUG_BUILD } from '../../debug-build';
+import type { InstrumentedDurableObjectState } from '../../wrapMethodWithSentry';
 
 export const AGENT_SPAN_ORIGIN = 'auto.faas.cloudflare.agents';
+
+/** DO storage key under which the conversation id is persisted so it survives hibernation. */
+export const AGENT_CONVERSATION_ID_STORAGE_KEY = '__SENTRY_AGENT_CONVERSATION_ID__';
+
+/**
+ * Instance keys for our conversation-id bookkeeping, keyed by symbol so the state stays invisible
+ * to anything enumerating the user-owned agent instance (`Object.keys`, `JSON.stringify`, spread).
+ * Exported because the exported `AgentInternals` interface references them.
+ */
+export const AGENT_CONVERSATION_ID_SYMBOL: unique symbol = Symbol('sentryAgentConversationId');
+export const AGENT_APPLIED_CONVERSATION_ID_SYMBOL: unique symbol = Symbol('sentryAgentAppliedConversationId');
 
 /**
  * The subset of the `agents` `Agent` instance internals that we instrument. These are runtime
@@ -22,15 +36,25 @@ export interface AgentInternals {
   onRequest?: (...args: unknown[]) => unknown;
   /** The user's Agent class (used by the SDK for the observability event `agent` field). */
   _ParentClass?: { name?: string };
-  /** The Agent instance name, which in the Agents model identifies the conversation/thread. */
+  /** The Agent instance name, reported as the `cloudflare.agent.name` span attribute. */
   name?: string;
   /**
-   * Internal: the active conversation id, rotated when the chat is cleared (the `message:clear`
-   * observability event) so a reset chat groups as a fresh conversation while the instance (and its
-   * MCP/OAuth state) stays put. Set by `instrumentChatAgentConversation`; falls back to `name`
-   * before the first clear.
+   * The Durable Object state of the instance. Present on every real Agent; guarded like the other
+   * internals so partially-mocked instances keep working.
    */
-  __sentryConversationId?: string;
+  ctx?: InstrumentedDurableObjectState;
+  /**
+   * The current conversation id for this agent instance. It is cached in memory after being loaded
+   * from Durable Object storage and updated when the conversation rotates. `undefined` means storage
+   * has not been read yet.
+   */
+  [AGENT_CONVERSATION_ID_SYMBOL]?: string;
+  /**
+   * The conversation id this instrumentation most recently applied to the isolation scope. It lets
+   * subsequent units of work distinguish an SDK-applied id, which may be replaced after rotation,
+   * from an id explicitly set by the user, which must be preserved.
+   */
+  [AGENT_APPLIED_CONVERSATION_ID_SYMBOL]?: string;
 }
 
 /** Reads best-effort agent identity attributes from the instance, tolerating missing internals. */
@@ -46,22 +70,124 @@ export function getAgentAttributes(instance: AgentInternals): Record<string, str
 }
 
 /**
- * Sets the agent instance's conversation id on the current scope for the duration of the
- * surrounding unit of work (chat turn, callable RPC call). In the Agents model one instance is one
- * conversation, so the instance `name` is the natural conversation id — for chat and plain agents
- * alike, since plain agents run LLM calls too (e.g. inside `@callable()` methods). Once the chat
- * has been cleared, the rotated `__sentryConversationId` takes precedence so LLM calls from any
- * unit of work group under the fresh conversation.
+ * Persists the conversation id to Durable Object storage, so it survives hibernation, and updates
+ * the in-memory cache synchronously so the current wake is immediately consistent even if the
+ * write fails. Uses the async storage API, which exists on KV- and SQLite-backed DOs alike.
+ * The write is fire-and-forget: DO storage writes are tracked by the runtime and land without
+ * awaiting (`waitUntil` is a no-op in Durable Objects), and the catch keeps a rejection from
+ * surfacing as unhandled — a failed write just means the next wake starts a new conversation,
+ * which must never throw into user code. Uses the original uninstrumented storage so internal
+ * bookkeeping doesn't create spans.
+ */
+export function storeAgentConversationId(instance: AgentInternals, conversationId: string): void {
+  instance[AGENT_CONVERSATION_ID_SYMBOL] = conversationId;
+
+  const storage = resolveStorage(instance);
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage
+      .put(AGENT_CONVERSATION_ID_STORAGE_KEY, conversationId)
+      .catch(error => DEBUG_BUILD && debug.log('[Sentry] Failed to persist agent conversation id', error));
+  } catch (error) {
+    DEBUG_BUILD && debug.log('[Sentry] Failed to persist agent conversation id', error);
+  }
+}
+
+/**
+ * Sets the agent instance's conversation id on the active scope for the duration of the
+ * surrounding unit of work (chat turn, callable RPC call, HTTP request). In the Agents model one
+ * instance is one long-lived conversation, so the id is minted once per instance and persisted to
+ * DO storage — for chat and plain agents alike, since plain agents run LLM calls too (e.g. inside
+ * `@callable()` methods). The instance `name` is deliberately not used: it is caller-chosen and can
+ * be a stable, guessable, or shared value, whereas a conversation id should identify exactly one
+ * conversation. Clearing the chat rotates it (see `storeAgentConversationId`) so subsequent LLM
+ * calls group under the fresh conversation.
+ *
+ * Every handler wrapper awaits this before invoking the original, so the id is on the scope before
+ * the unit of work — and any `gen_ai` span it creates — starts. Only the first unit of work per wake
+ * pays the storage read; the rest resolve from the in-memory cache. Awaiting is safe on all three
+ * paths because the `agents` `Agent` constructor already replaces `onMessage` and `onRequest` with
+ * `async` wrappers of its own, and `onChatMessage` is async by contract, so every caller upstream
+ * already handles a promise.
+ *
+ * An id the user set explicitly outranks this inferred one, in either order: a `setConversationId()`
+ * call that already happened is detected here and left alone, and one made inside the handler lands
+ * on the same scope afterwards and therefore wins. That is why the write targets the isolation scope
+ * — it is the scope the public `Sentry.setConversationId()` writes to, and `conversationIdIntegration`
+ * prefers the current scope over it, so writing there would make a user's call unoverridable.
  *
  * `conversationIdIntegration` reads the id off the scope at `spanStart` and stamps
- * `gen_ai.conversation.id` onto AI spans created within the unit of work, correlating its model
- * and tool calls. Callers run inside a per-event forked scope (`wrapMethodWithSentry`), so the id
- * does not leak into unrelated events.
+ * `gen_ai.conversation.id` onto AI spans created within the unit of work, correlating its model and
+ * tool calls.
  */
-export function setAgentConversationId(instance: AgentInternals): void {
-  const conversationId = instance.__sentryConversationId ?? instance.name;
+export async function setAgentConversationId(instance: AgentInternals): Promise<void> {
+  const isolationScope = getIsolationScope();
+  const existing = isolationScope.getScopeData().conversationId ?? getCurrentScope().getScopeData().conversationId;
 
-  if (typeof conversationId === 'string' && conversationId) {
-    getCurrentScope().setConversationId(conversationId);
+  // An id that isn't the one we put there ourselves came from the user — never override it.
+  if (existing && existing !== instance[AGENT_APPLIED_CONVERSATION_ID_SYMBOL]) {
+    return;
   }
+
+  const conversationId = instance[AGENT_CONVERSATION_ID_SYMBOL] ?? (await loadAgentConversationId(instance));
+
+  instance[AGENT_APPLIED_CONVERSATION_ID_SYMBOL] = conversationId;
+  isolationScope.setConversationId(conversationId);
+}
+
+/**
+ * Reads the persisted id into the instance cache, minting and persisting a fresh one when storage
+ * holds none, so subsequent units of work resolve from memory. The async `get` exists on KV- and
+ * SQLite-backed DOs alike, so this one path covers both.
+ *
+ * Anything already cached by the time the read lands wins over the read: that covers a rotation
+ * (cleared chat) racing the read, and a second concurrent unit of work that must not mint and
+ * persist a competing id for the same conversation.
+ */
+async function loadAgentConversationId(instance: AgentInternals): Promise<string> {
+  let stored: unknown;
+  let readFailed = false;
+
+  try {
+    stored = await resolveStorage(instance)?.get<string>(AGENT_CONVERSATION_ID_STORAGE_KEY);
+  } catch (error) {
+    readFailed = true;
+    DEBUG_BUILD && debug.log('[Sentry] Failed to read agent conversation id from storage', error);
+  }
+
+  const cached = instance[AGENT_CONVERSATION_ID_SYMBOL];
+
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (typeof stored === 'string' && stored) {
+    instance[AGENT_CONVERSATION_ID_SYMBOL] = stored;
+
+    return stored;
+  }
+
+  const conversationId = uuid4();
+
+  if (readFailed) {
+    // Cache without persisting: a read that failed may still have an id behind it, and overwriting
+    // it would split the conversation for good instead of just for this wake.
+    instance[AGENT_CONVERSATION_ID_SYMBOL] = conversationId;
+  } else {
+    storeAgentConversationId(instance, conversationId);
+  }
+
+  return conversationId;
+}
+
+/**
+ * Resolves the uninstrumented DO storage for internal reads/writes, so they don't create spans of
+ * their own. Falls back to the instance's regular storage when the uninstrumented one isn't
+ * exposed (e.g. when `instrumentCloudflareAgent` is used directly, without `instrumentContext`).
+ */
+function resolveStorage(instance: AgentInternals): DurableObjectStorage | undefined {
+  return instance.ctx?.originalStorage ?? instance.ctx?.storage;
 }

--- a/packages/cloudflare/src/wrapMethodWithSentry.ts
+++ b/packages/cloudflare/src/wrapMethodWithSentry.ts
@@ -23,7 +23,7 @@ import { extractRpcMeta } from './utils/rpcMeta';
 import { buildSpanLinks, getStoredSpanContext, storeSpanContext } from './utils/traceLinks';
 
 /** Extended DurableObjectState with originalStorage exposed by instrumentContext */
-interface InstrumentedDurableObjectState extends DurableObjectState {
+export interface InstrumentedDurableObjectState extends DurableObjectState {
   originalStorage?: DurableObjectStorage;
 }
 

--- a/packages/cloudflare/test/instrumentChatAgentConversation.test.ts
+++ b/packages/cloudflare/test/instrumentChatAgentConversation.test.ts
@@ -1,49 +1,62 @@
-import { getCurrentScope } from '@sentry/core';
+import type { DurableObjectStorage } from '@cloudflare/workers-types';
+import { getIsolationScope } from '@sentry/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { instrumentChatAgentConversation } from '../src/instrumentations/agents/instrumentChatAgentConversation';
-import type { AgentInternals } from '../src/instrumentations/agents/types';
+import {
+  AGENT_CONVERSATION_ID_STORAGE_KEY,
+  type AgentInternals,
+  setAgentConversationId,
+} from '../src/instrumentations/agents/types';
+
+/** `uuid4()` from `@sentry/core` returns 32 hex characters, without dashes. */
+const UUID_PATTERN = /^[0-9a-f]{32}$/;
+
+function mockStorage(stored?: string): {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  /** The currently persisted value, for asserting against an id the SDK minted itself. */
+  peek: () => string | undefined;
+} {
+  let value = stored;
+  return {
+    get: vi.fn(async () => value),
+    put: vi.fn(async (_key: string, newValue: string) => {
+      value = newValue;
+    }),
+    peek: () => value,
+  };
+}
+
+function mockCtx(stored?: string): {
+  ctx: NonNullable<AgentInternals['ctx']>;
+  storage: ReturnType<typeof mockStorage>;
+} {
+  const storage = mockStorage(stored);
+  const ctx = {
+    originalStorage: storage as unknown as DurableObjectStorage,
+  } as unknown as NonNullable<AgentInternals['ctx']>;
+
+  return { ctx, storage };
+}
+
+/**
+ * The conversation id is written to the isolation scope — the scope the public
+ * `Sentry.setConversationId()` targets — so that an explicit user call can override it.
+ */
+function spyOnSetConversationId(): ReturnType<typeof vi.fn> {
+  const setConversationId = vi.fn();
+  vi.spyOn(getIsolationScope(), 'setConversationId').mockImplementation(setConversationId);
+  return setConversationId;
+}
 
 describe('instrumentChatAgentConversation', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    getIsolationScope().clear();
   });
 
-  it('does not set conversation id when agent name is empty string', () => {
-    const setConversationIdSpy = vi.spyOn(getCurrentScope(), 'setConversationId').mockImplementation(() => {});
-
-    const obj: AgentInternals = {
-      name: '',
-      onChatMessage() {
-        return 'response';
-      },
-    };
-
-    instrumentChatAgentConversation(obj);
-
-    obj.onChatMessage!(() => {}, {});
-
-    expect(setConversationIdSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not set conversation id when agent name is undefined', () => {
-    const setConversationIdSpy = vi.spyOn(getCurrentScope(), 'setConversationId').mockImplementation(() => {});
-
-    const obj: AgentInternals = {
-      onChatMessage() {
-        return 'response';
-      },
-    };
-
-    instrumentChatAgentConversation(obj);
-
-    obj.onChatMessage!(() => {}, {});
-
-    expect(setConversationIdSpy).not.toHaveBeenCalled();
-  });
-
-  it('sets conversation id when agent name is present', () => {
-    const setConversationId = vi.fn();
-    vi.spyOn(getCurrentScope(), 'setConversationId').mockImplementation(setConversationId);
+  it('sets a generated conversation id during a chat turn', async () => {
+    const setConversationId = spyOnSetConversationId();
 
     const obj: AgentInternals = {
       name: 'conversation-42',
@@ -54,14 +67,100 @@ describe('instrumentChatAgentConversation', () => {
 
     instrumentChatAgentConversation(obj);
 
-    obj.onChatMessage!(() => {}, {});
+    await obj.onChatMessage!(() => {}, {});
 
-    expect(setConversationId).toHaveBeenCalledWith('conversation-42');
+    expect(setConversationId).toHaveBeenCalledTimes(1);
+    expect(setConversationId).toHaveBeenCalledWith(expect.stringMatching(UUID_PATTERN));
   });
 
-  it('forwards the return value from the original onChatMessage', () => {
+  it('keeps the same conversation id across chat turns, reading storage only once', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const { ctx, storage } = mockCtx('persisted-id');
     const obj: AgentInternals = {
-      name: 'convo-1',
+      ctx,
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await obj.onChatMessage!(() => {}, {});
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(setConversationId).toHaveBeenCalledTimes(2);
+    expect(setConversationId).toHaveBeenNthCalledWith(2, 'persisted-id');
+    expect(storage.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('mints a single conversation id when two units of work start concurrently', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const { ctx, storage } = mockCtx(undefined);
+    const obj: AgentInternals = {
+      ctx,
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await Promise.all([obj.onChatMessage!(() => {}, {}), obj.onChatMessage!(() => {}, {})]);
+
+    // The second turn must adopt the id the first one minted instead of persisting a competing one.
+    expect(storage.put).toHaveBeenCalledTimes(1);
+    expect(setConversationId).toHaveBeenCalledTimes(2);
+    expect(new Set(setConversationId.mock.calls.flat()).size).toBe(1);
+  });
+
+  it('leaves a conversation id the user set before the turn alone', async () => {
+    const { ctx, storage } = mockCtx('persisted-id');
+    const obj: AgentInternals = {
+      ctx,
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    getIsolationScope().setConversationId('user-chosen-id');
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(getIsolationScope().getScopeData().conversationId).toBe('user-chosen-id');
+    // An explicit id means the instance's own id is never needed, so storage is not touched either.
+    expect(storage.get).not.toHaveBeenCalled();
+  });
+
+  it('replaces its own id from an earlier turn, so a rotation still takes effect', async () => {
+    const { ctx } = mockCtx('persisted-id');
+    const obj: AgentInternals = {
+      ctx,
+      _emit() {
+        return undefined;
+      },
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    // The isolation scope outlives a unit of work, so the second turn finds the first turn's id
+    // already there — ours, and therefore replaceable, unlike a user's.
+    await obj.onChatMessage!(() => {}, {});
+    expect(getIsolationScope().getScopeData().conversationId).toBe('persisted-id');
+
+    obj._emit!('message:clear');
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(getIsolationScope().getScopeData().conversationId).toMatch(UUID_PATTERN);
+  });
+
+  it('forwards the return value from the original onChatMessage', async () => {
+    const obj: AgentInternals = {
       onChatMessage() {
         return { output: 'hello' };
       },
@@ -69,9 +168,7 @@ describe('instrumentChatAgentConversation', () => {
 
     instrumentChatAgentConversation(obj);
 
-    const result = obj.onChatMessage!(() => {}, {});
-
-    expect(result).toEqual({ output: 'hello' });
+    await expect(obj.onChatMessage!(() => {}, {})).resolves.toEqual({ output: 'hello' });
   });
 
   it('leaves the agent untouched when onChatMessage is not defined', () => {
@@ -82,12 +179,12 @@ describe('instrumentChatAgentConversation', () => {
     expect('onChatMessage' in obj).toBe(false);
   });
 
-  it('uses the instance name as the conversation id before any clear', () => {
-    const setConversationId = vi.fn();
-    vi.spyOn(getCurrentScope(), 'setConversationId').mockImplementation(setConversationId);
+  it('rotates the conversation id on the message:clear observability event', async () => {
+    const setConversationId = spyOnSetConversationId();
 
+    const { ctx } = mockCtx('persisted-id');
     const obj: AgentInternals = {
-      name: 'session-7',
+      ctx,
       _emit() {
         return undefined;
       },
@@ -98,43 +195,20 @@ describe('instrumentChatAgentConversation', () => {
 
     instrumentChatAgentConversation(obj);
 
-    obj.onChatMessage!(() => {}, {});
-
-    expect(setConversationId).toHaveBeenCalledWith('session-7');
-  });
-
-  it('rotates the conversation id on the message:clear observability event (fresh id, not the instance name)', () => {
-    const setConversationId = vi.fn();
-    vi.spyOn(getCurrentScope(), 'setConversationId').mockImplementation(setConversationId);
-
-    const obj: AgentInternals = {
-      name: 'session-7',
-      _emit() {
-        return undefined;
-      },
-      onChatMessage() {
-        return 'response';
-      },
-    };
-
-    instrumentChatAgentConversation(obj);
+    await obj.onChatMessage!(() => {}, {});
 
     // Simulate the SDK emitting the chat-clear observability event.
     obj._emit!('message:clear');
 
-    obj.onChatMessage!(() => {}, {});
+    await obj.onChatMessage!(() => {}, {});
 
-    expect(setConversationId).toHaveBeenCalledTimes(1);
-    const rotated = setConversationId.mock.calls[0]?.[0] as string;
-    expect(typeof rotated).toBe('string');
-    expect(rotated).not.toBe('session-7');
-    expect(obj.__sentryConversationId).toBe(rotated);
+    expect(setConversationId).toHaveBeenNthCalledWith(1, 'persisted-id');
+    expect(setConversationId).toHaveBeenNthCalledWith(2, expect.stringMatching(UUID_PATTERN));
   });
 
   it('forwards message:clear to the original _emit', () => {
     const received: Array<{ type: string; payload: unknown }> = [];
     const obj: AgentInternals = {
-      name: 'session-7',
       _emit(type: string, payload?: Record<string, unknown>) {
         received.push({ type, payload });
         return undefined;
@@ -150,9 +224,12 @@ describe('instrumentChatAgentConversation', () => {
     expect(received).toEqual([{ type: 'message:clear', payload: { source: 'user' } }]);
   });
 
-  it('does not rotate the conversation id for other observability events', () => {
+  it('does not rotate the conversation id for other observability events', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const { ctx, storage } = mockCtx('persisted-id');
     const obj: AgentInternals = {
-      name: 'session-7',
+      ctx,
       _emit() {
         return undefined;
       },
@@ -166,6 +243,244 @@ describe('instrumentChatAgentConversation', () => {
     obj._emit!('message:request');
     obj._emit!('rpc', { method: 'greet' });
 
-    expect(obj.__sentryConversationId).toBeUndefined();
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(setConversationId).toHaveBeenCalledWith('persisted-id');
+    expect(storage.put).not.toHaveBeenCalled();
+  });
+
+  it('persists the rotated conversation id to DO storage on message:clear', () => {
+    const { ctx, storage } = mockCtx('persisted-id');
+    const obj: AgentInternals = {
+      ctx,
+      _emit() {
+        return undefined;
+      },
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    obj._emit!('message:clear');
+
+    expect(storage.put).toHaveBeenCalledTimes(1);
+    expect(storage.put).toHaveBeenCalledWith(AGENT_CONVERSATION_ID_STORAGE_KEY, expect.stringMatching(UUID_PATTERN));
+    expect(storage.peek()).not.toBe('persisted-id');
+  });
+
+  it('reads a persisted conversation id from DO storage (survives hibernation)', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const { ctx, storage } = mockCtx('persisted-id');
+    const obj: AgentInternals = {
+      ctx,
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(setConversationId).toHaveBeenCalledWith('persisted-id');
+    expect(storage.put).not.toHaveBeenCalled();
+  });
+
+  it('resolves the id for an instance that was never routed through a handler wrapper', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const { ctx } = mockCtx('late-id');
+    const obj: AgentInternals = { ctx };
+
+    await setAgentConversationId(obj);
+
+    expect(setConversationId).toHaveBeenCalledWith('late-id');
+  });
+
+  it('generates and persists a conversation id when storage has none', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const { ctx, storage } = mockCtx(undefined);
+    const obj: AgentInternals = {
+      name: 'session-7',
+      ctx,
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(storage.put).toHaveBeenCalledTimes(1);
+    expect(storage.put).toHaveBeenCalledWith(AGENT_CONVERSATION_ID_STORAGE_KEY, expect.stringMatching(UUID_PATTERN));
+    expect(setConversationId).toHaveBeenCalledWith(storage.peek());
+  });
+
+  it('generates a conversation id when the instance has no DO storage at all', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const obj: AgentInternals = {
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await obj.onChatMessage!(() => {}, {});
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(setConversationId).toHaveBeenCalledTimes(2);
+    expect(setConversationId).toHaveBeenCalledWith(expect.stringMatching(UUID_PATTERN));
+    expect(new Set(setConversationId.mock.calls.flat()).size).toBe(1);
+  });
+
+  it('prefers the uninstrumented originalStorage over the instrumented storage', async () => {
+    const original = mockStorage();
+    const instrumented = mockStorage();
+    const ctx = {
+      originalStorage: original as unknown as DurableObjectStorage,
+      storage: instrumented as unknown as DurableObjectStorage,
+    } as unknown as NonNullable<AgentInternals['ctx']>;
+
+    const obj: AgentInternals = {
+      ctx,
+      _emit() {
+        return undefined;
+      },
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await obj.onChatMessage!(() => {}, {});
+    obj._emit!('message:clear');
+
+    expect(original.get).toHaveBeenCalled();
+    expect(original.put).toHaveBeenCalled();
+    expect(instrumented.get).not.toHaveBeenCalled();
+    expect(instrumented.put).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the instrumented storage when originalStorage is not exposed', () => {
+    const storage = mockStorage();
+    const ctx = {
+      storage: storage as unknown as DurableObjectStorage,
+    } as unknown as NonNullable<AgentInternals['ctx']>;
+
+    const obj: AgentInternals = {
+      ctx,
+      _emit() {
+        return undefined;
+      },
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    obj._emit!('message:clear');
+
+    expect(storage.put).toHaveBeenCalledTimes(1);
+    expect(storage.put).toHaveBeenCalledWith(AGENT_CONVERSATION_ID_STORAGE_KEY, expect.stringMatching(UUID_PATTERN));
+  });
+
+  it('swallows storage read errors and keeps an in-memory id without overwriting storage', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const storage = {
+      get: vi.fn(async () => {
+        throw new Error('storage unavailable');
+      }),
+      put: vi.fn(async () => undefined),
+    };
+    const ctx = {
+      originalStorage: storage as unknown as DurableObjectStorage,
+    } as unknown as NonNullable<AgentInternals['ctx']>;
+
+    const obj: AgentInternals = {
+      name: 'session-7',
+      ctx,
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await expect(obj.onChatMessage!(() => {}, {})).resolves.toBe('response');
+
+    expect(setConversationId).toHaveBeenCalledWith(expect.stringMatching(UUID_PATTERN));
+    // A read that failed may still have an id behind it — don't destroy it.
+    expect(storage.put).not.toHaveBeenCalled();
+  });
+
+  it('swallows a storage write that throws synchronously', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const storage = {
+      get: vi.fn(async () => undefined),
+      put: vi.fn(() => {
+        throw new Error('storage unavailable');
+      }),
+    };
+    const ctx = {
+      originalStorage: storage as unknown as DurableObjectStorage,
+    } as unknown as NonNullable<AgentInternals['ctx']>;
+
+    const obj: AgentInternals = {
+      ctx,
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    await expect(obj.onChatMessage!(() => {}, {})).resolves.toBe('response');
+
+    expect(storage.put).toHaveBeenCalledTimes(1);
+    expect(setConversationId).toHaveBeenCalledWith(expect.stringMatching(UUID_PATTERN));
+  });
+
+  it('swallows storage write errors and keeps the rotation for the current wake', async () => {
+    const setConversationId = spyOnSetConversationId();
+
+    const storage = {
+      get: vi.fn(async () => 'persisted-id'),
+      put: vi.fn(async () => {
+        throw new Error('storage unavailable');
+      }),
+    };
+    const ctx = {
+      originalStorage: storage as unknown as DurableObjectStorage,
+    } as unknown as NonNullable<AgentInternals['ctx']>;
+
+    const obj: AgentInternals = {
+      ctx,
+      _emit() {
+        return undefined;
+      },
+      onChatMessage() {
+        return 'response';
+      },
+    };
+
+    instrumentChatAgentConversation(obj);
+
+    expect(() => obj._emit!('message:clear')).not.toThrow();
+
+    await obj.onChatMessage!(() => {}, {});
+
+    expect(setConversationId).toHaveBeenCalledWith(expect.stringMatching(UUID_PATTERN));
+    expect(setConversationId).not.toHaveBeenCalledWith('persisted-id');
   });
 });

--- a/packages/cloudflare/test/instrumentCloudflareAgent.test.ts
+++ b/packages/cloudflare/test/instrumentCloudflareAgent.test.ts
@@ -1,5 +1,12 @@
-import type { Event } from '@sentry/core';
-import { getCurrentScope, setCurrentClient } from '@sentry/core';
+import type { Event, SpanJSON } from '@sentry/core';
+import {
+  conversationIdIntegration,
+  getCurrentScope,
+  getIsolationScope,
+  setConversationId,
+  setCurrentClient,
+  startSpan,
+} from '@sentry/core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';
 import { CloudflareClient, type CloudflareClientOptions } from '../src/client';
@@ -7,6 +14,11 @@ import { instrumentCloudflareAgent } from '../src/instrumentations/agents';
 import { resetSdk } from './testUtils';
 
 const dsn = 'https://123@sentry.io/42';
+
+/** Resolves the conversation id the way `conversationIdIntegration` does at `spanStart`. */
+function effectiveConversationId(): string | undefined {
+  return getCurrentScope().getScopeData().conversationId || getIsolationScope().getScopeData().conversationId;
+}
 
 /** Minimal stand-in for an `agents` Agent instance exposing the internals we hook. */
 function createFakeAgent(overrides: Record<string, unknown> = {}): Record<string, any> {
@@ -24,6 +36,7 @@ function createFakeAgent(overrides: Record<string, unknown> = {}): Record<string
 
 describe('instrumentCloudflareAgent', () => {
   let transactions: Event[];
+  let childSpans: SpanJSON[];
   let client: CloudflareClient;
 
   beforeEach(() => {
@@ -31,13 +44,16 @@ describe('instrumentCloudflareAgent', () => {
     setAsyncLocalStorageAsyncContextStrategy();
 
     transactions = [];
+    childSpans = [];
 
     const options: CloudflareClientOptions = {
       dsn,
       tracesSampleRate: 1,
       traceLifecycle: 'static',
       stackParser: () => [],
-      integrations: [],
+      // The integration that turns the scope's conversation id into `gen_ai.conversation.id`, so the
+      // tests below assert the attribute the way it actually reaches Sentry.
+      integrations: [conversationIdIntegration()],
       transport: () => ({
         send: vi.fn().mockResolvedValue({}),
         flush: vi.fn().mockResolvedValue(true),
@@ -45,6 +61,10 @@ describe('instrumentCloudflareAgent', () => {
       beforeSendTransaction: event => {
         transactions.push(event);
         return event;
+      },
+      beforeSendSpan: span => {
+        childSpans.push(span);
+        return span;
       },
     };
 
@@ -56,6 +76,15 @@ describe('instrumentCloudflareAgent', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  /**
+   * The `gen_ai.conversation.id` that reached the transport, read off the sent span rather than the
+   * enclosing transaction: a gen_ai span started inside a callable RPC method is a child of the `rpc`
+   * span, so it is only ever sent as a span.
+   */
+  function genAiConversationId(): unknown {
+    return childSpans.find(span => span.op === 'gen_ai.chat')?.data['gen_ai.conversation.id'];
+  }
 
   it('returns the same instance', () => {
     const agent = createFakeAgent();
@@ -72,7 +101,10 @@ describe('instrumentCloudflareAgent', () => {
       const agent = createFakeAgent();
       instrumentCloudflareAgent(agent);
 
-      const result = agent.onMessage({}, JSON.stringify({ type: 'rpc', id: '1', method: 'greet', args: ['World'] }));
+      const result = await agent.onMessage(
+        {},
+        JSON.stringify({ type: 'rpc', id: '1', method: 'greet', args: ['World'] }),
+      );
 
       expect(result).toBe('handled');
       expect(agent.messages).toHaveLength(1);
@@ -108,7 +140,7 @@ describe('instrumentCloudflareAgent', () => {
     it('does not set the conversation id for non-RPC messages', () => {
       const agent = createFakeAgent({
         onMessage(this: any, _connection: unknown, message: unknown) {
-          this.seenConversationId = getCurrentScope().getScopeData().conversationId;
+          this.seenConversationId = effectiveConversationId();
           this.messages.push(message);
           return 'handled';
         },
@@ -122,28 +154,31 @@ describe('instrumentCloudflareAgent', () => {
   });
 
   describe('conversation id', () => {
-    it('sets the conversation id from the instance name during a chat turn', () => {
+    /** `uuid4()` from `@sentry/core` returns 32 hex characters, without dashes. */
+    const UUID_PATTERN = /^[0-9a-f]{32}$/;
+
+    it('sets a generated conversation id during a chat turn', async () => {
       const agent = createFakeAgent({
         name: 'thread-abc',
         onChatMessage(this: any) {
           // Capture what the scope sees while the turn is running.
-          this.seenConversationId = getCurrentScope().getScopeData().conversationId;
+          this.seenConversationId = effectiveConversationId();
           return 'response';
         },
       });
       instrumentCloudflareAgent(agent);
 
-      const result = agent.onChatMessage(() => {}, {});
+      const result = await agent.onChatMessage(() => {}, {});
 
       expect(result).toBe('response');
-      expect(agent.seenConversationId).toBe('thread-abc');
+      expect(agent.seenConversationId).toMatch(UUID_PATTERN);
     });
 
-    it('sets the conversation id during callable RPC execution on plain (non-chat) agents', () => {
+    it('sets the conversation id during callable RPC execution on plain (non-chat) agents', async () => {
       const agent = createFakeAgent({
         onMessage(this: any, _connection: unknown, message: unknown) {
           // Capture what the scope sees while the RPC method is running.
-          this.seenConversationId = getCurrentScope().getScopeData().conversationId;
+          this.seenConversationId = effectiveConversationId();
           this.messages.push(message);
           return 'handled';
         },
@@ -151,41 +186,58 @@ describe('instrumentCloudflareAgent', () => {
       instrumentCloudflareAgent(agent);
 
       // A plain Agent has no `onChatMessage`; the RPC call is its unit of work.
-      agent.onMessage({}, JSON.stringify({ type: 'rpc', id: '1', method: 'greet', args: [] }));
+      await agent.onMessage({}, JSON.stringify({ type: 'rpc', id: '1', method: 'greet', args: [] }));
 
-      expect(agent.seenConversationId).toBe('instance-1');
+      expect(agent.seenConversationId).toMatch(UUID_PATTERN);
       expect('onChatMessage' in agent).toBe(false);
     });
 
-    it('sets the conversation id during an HTTP request', () => {
+    it('sets the conversation id during an HTTP request', async () => {
       const agent = createFakeAgent({
         onRequest(this: any) {
-          this.seenConversationId = getCurrentScope().getScopeData().conversationId;
+          this.seenConversationId = effectiveConversationId();
           return 'response';
         },
       });
       instrumentCloudflareAgent(agent);
 
-      const result = agent.onRequest(new Request('https://example.com/agents/my-agent/instance-1'));
+      const result = await agent.onRequest(new Request('https://example.com/agents/my-agent/instance-1'));
 
       expect(result).toBe('response');
-      expect(agent.seenConversationId).toBe('instance-1');
+      expect(agent.seenConversationId).toMatch(UUID_PATTERN);
     });
 
-    it('prefers the rotated conversation id over the instance name on the HTTP path', () => {
+    it('never uses the instance name as the conversation id', async () => {
       const agent = createFakeAgent({
+        name: 'thread-abc',
         onRequest(this: any) {
-          this.seenConversationId = getCurrentScope().getScopeData().conversationId;
+          this.seenConversationId = effectiveConversationId();
           return 'response';
         },
       });
       instrumentCloudflareAgent(agent);
 
-      agent._emit?.('message:clear');
-      agent.__sentryConversationId = 'rotated-id';
-      agent.onRequest(new Request('https://example.com/agents/my-agent/instance-1'));
+      await agent.onRequest(new Request('https://example.com/agents/my-agent/thread-abc'));
 
-      expect(agent.seenConversationId).toBe('rotated-id');
+      expect(agent.seenConversationId).not.toBe('thread-abc');
+    });
+
+    it('uses the persisted conversation id on the HTTP path', async () => {
+      const agent = createFakeAgent({
+        // Simulates a hibernation wake: only storage carries the conversation id over.
+        ctx: {
+          originalStorage: { get: async () => 'persisted-id', put: async () => undefined },
+        },
+        onRequest(this: any) {
+          this.seenConversationId = effectiveConversationId();
+          return 'response';
+        },
+      });
+      instrumentCloudflareAgent(agent);
+
+      await agent.onRequest(new Request('https://example.com/agents/my-agent/instance-1'));
+
+      expect(agent.seenConversationId).toBe('persisted-id');
     });
 
     it('does not throw when the agent has no onRequest handler', () => {
@@ -193,6 +245,79 @@ describe('instrumentCloudflareAgent', () => {
 
       expect(() => instrumentCloudflareAgent(agent)).not.toThrow();
       expect('onRequest' in agent).toBe(false);
+    });
+
+    it('stamps the agent conversation id on gen_ai spans created inside a chat turn', async () => {
+      const agent = createFakeAgent({
+        onChatMessage() {
+          return startSpan({ name: 'chat gpt-4', op: 'gen_ai.chat' }, () => 'response');
+        },
+      });
+      instrumentCloudflareAgent(agent);
+
+      await agent.onChatMessage(() => {}, {});
+      await client.flush();
+
+      expect(genAiConversationId()).toMatch(UUID_PATTERN);
+    });
+
+    it('lets a conversation id set manually inside onRequest take over the request', async () => {
+      const agent = createFakeAgent({
+        onRequest(this: any) {
+          this.seenConversationId = effectiveConversationId();
+
+          setConversationId('user-chosen-id');
+
+          return startSpan({ name: 'chat gpt-4', op: 'gen_ai.chat' }, () => 'response');
+        },
+      });
+      instrumentCloudflareAgent(agent);
+
+      await agent.onRequest(new Request('https://example.com/agents/my-agent/instance-1'));
+      await client.flush();
+
+      // The wrapper sets its id before invoking the handler, so the manual call lands afterwards.
+      expect(agent.seenConversationId).toMatch(UUID_PATTERN);
+      expect(genAiConversationId()).toBe('user-chosen-id');
+    });
+
+    it('lets a conversation id set manually inside a callable RPC method take over the call', async () => {
+      const agent = createFakeAgent({
+        onMessage(this: any) {
+          setConversationId('user-chosen-id');
+
+          return startSpan({ name: 'chat gpt-4', op: 'gen_ai.chat' }, () => 'handled');
+        },
+      });
+      instrumentCloudflareAgent(agent);
+
+      await agent.onMessage({}, JSON.stringify({ type: 'rpc', id: '1', method: 'greet', args: [] }));
+      await client.flush();
+
+      expect(genAiConversationId()).toBe('user-chosen-id');
+    });
+
+    it('lets a conversation id set manually inside onChatMessage take over the turn', async () => {
+      const agent = createFakeAgent({
+        onChatMessage(this: any) {
+          // The id we put on the scope is already there when the user's handler runs.
+          this.seenConversationId = effectiveConversationId();
+
+          // A user may prefer to key the conversation on an id from their own domain.
+          setConversationId('user-chosen-id');
+
+          return startSpan({ name: 'chat gpt-4', op: 'gen_ai.chat' }, () => 'response');
+        },
+      });
+      instrumentCloudflareAgent(agent);
+
+      const result = await agent.onChatMessage(() => {}, {});
+      await client.flush();
+
+      expect(result).toBe('response');
+      expect(agent.seenConversationId).toMatch(UUID_PATTERN);
+
+      expect(genAiConversationId()).toBe('user-chosen-id');
     });
   });
 });


### PR DESCRIPTION
The first conversation ID was always the session name of the `useAgent`. The issue was that locally, when `name: 'default'` was set, the first conversation ID was always set into `default`. After a reset with `clearHistory` a UUID v4 got assigned and then correctly set into a new bucket. 

This could potentially also happen on DO hibernations where the cached `__sentryConversationId` got reset (which is now a Symbol). To prevent this from happening on hibernations the conversation ID is now stored in the DO as `__SENTRY_AGENT_CONVERSATION_ID__`. 

Also there was an issue where a manual `Sentry.setConversationId()` within a `onChatMessage` was not properly overridden, the  `AGENT_APPLIED_CONVERSATION_ID_SYMBOL` makes sure, that the conversation ID can be overridden by the user if they wish for it.