### PR TITLE
feat(core)!: Return `StreamedSpanJSON` from `spanToJSON`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -463,7 +463,7 @@ In Node, Bun, Vercel Edge and Cloudflare you can also set the `SENTRY_TRACE_LIFE
 
 The `spanToJSON` helper previously returned a `SpanJSON` object. In v11, the return type was changed to `StreamedSpanJSON`, meaning the object shape is now the [same as in `beforeSendSpan`](#beforeSendSpan-receives-the-streamed-span-format).
 
-If you're [opting out of span streaming](#opting-out-of-span-streaming), you can replace your `spanToJSON` calls with `spanToStaticJSON`, which still returns the static `SpanJSON` object format.
+If you're [opting out of span streaming](#opting-out-of-span-streaming), you can replace your `spanToJSON` calls with `spanToStaticSpanJSON`, which still returns the static `SpanJSON` object format.
 
 ### Logs are enabled by default
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -346,7 +346,7 @@ Sentry.init({
 // After
 Sentry.init({
   beforeSendSpan: span => {
-    if (span.attributes?.['sentry.op'] === 'db.query') {
+    if (span.attributes['sentry.op'] === 'db.query') {
       span.name = scrub(span.name);
       span.attributes['db.statement'] = scrub(span.attributes['db.statement']);
     }
@@ -458,6 +458,12 @@ Sentry.init({
 ```
 
 In Node, Bun, Vercel Edge and Cloudflare you can also set the `SENTRY_TRACE_LIFECYCLE=static` environment variable instead. The static lifecycle only exists for backwards compatibility and is planned for removal in a future major version, so treat this as a temporary measure.
+
+#### `Sentry.spanToJSON` returns streamed span format
+
+The `spanToJSON` helper previously returned a `SpanJSON` object. In v11, the return type was changed to `StreamedSpanJSON`, meaning the object shape is now the [same as in `beforeSendSpan`](#beforeSendSpan-receives-the-streamed-span-format).
+
+If you're [opting out of span streaming](#opting-out-of-span-streaming), you can replace your `spanToJSON` calls with `spanToStaticJSON`, which still returns the static `SpanJSON` object format.
 
 ### Logs are enabled by default
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/async-spans/test.ts
@@ -23,14 +23,12 @@ sentryTest(
     expect(envelope).toBeDefined();
 
     const firstWaitingSpanValue = await page.evaluate(
-      () => (window as unknown as WindowWithSpan).firstWaitingSpan.description,
+      () => (window as unknown as WindowWithSpan).firstWaitingSpan.name,
     );
     const secondWaitingSpanName = await page.evaluate(
-      () => (window as unknown as WindowWithSpan).secondWaitingSpan.description,
+      () => (window as unknown as WindowWithSpan).secondWaitingSpan.name,
     );
-    const thirdWaitingSpanName = await page.evaluate(
-      () => (window as unknown as WindowWithSpan).thirdWaitingSpan.description,
-    );
+    const thirdWaitingSpanName = await page.evaluate(() => (window as unknown as WindowWithSpan).thirdWaitingSpan.name);
 
     expect(firstWaitingSpanValue).toBe('span 2');
     expect(secondWaitingSpanName).toBe('span 1');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/backgroundtab-custom/test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import type { SpanJSON } from '@sentry/core';
+import type { StreamedSpanJSON } from '@sentry/core';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
 
@@ -12,25 +12,26 @@ sentryTest('should finish a custom transaction when the page goes background', a
   await page.goto(url);
 
   await page.locator('#start-span').click();
-  const spanJsonBefore: SpanJSON = await page.evaluate('window.getSpanJson()');
+  const spanJsonBefore: StreamedSpanJSON = await page.evaluate('window.getSpanJson()');
 
   const id_before = spanJsonBefore.span_id;
-  const description_before = spanJsonBefore.description;
+  const name_before = spanJsonBefore.name;
   const status_before = spanJsonBefore.status;
 
-  expect(description_before).toBe('test-span');
+  expect(name_before).toBe('test-span');
   expect(status_before).toBe('ok');
 
   await page.locator('#go-background').click();
-  const spanJsonAfter: SpanJSON = await page.evaluate('window.getSpanJson()');
+  const spanJsonAfter: StreamedSpanJSON = await page.evaluate('window.getSpanJson()');
 
   const id_after = spanJsonAfter.span_id;
-  const description_after = spanJsonAfter.description;
-  const status_after = spanJsonAfter.status;
-  const data_after = spanJsonAfter.data;
+  const name_after = spanJsonAfter.name;
+  const attributes_after = spanJsonAfter.attributes;
 
   expect(id_before).toBe(id_after);
-  expect(description_after).toBe(description_before);
-  expect(status_after).toBe('cancelled');
-  expect(data_after?.['sentry.cancellation_reason']).toBe('document.hidden');
+  expect(name_after).toBe(name_before);
+  // a cancelled span is reported as `ok`, with the raw status kept as an attribute
+  expect(spanJsonAfter.status).toBe('ok');
+  expect(attributes_after['sentry.status.message']).toBeUndefined();
+  expect(attributes_after['sentry.cancellation_reason']).toBe('document.hidden');
 });

--- a/dev-packages/deno-integration-tests/suites/orchestrion-aws/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-aws/test.ts
@@ -8,6 +8,7 @@ import { assert } from 'https://deno.land/std@0.212.0/assert/assert.ts';
 import { assertExists } from 'https://deno.land/std@0.212.0/assert/assert_exists.ts';
 import { assertEquals } from 'https://deno.land/std@0.212.0/assert/assert_equals.ts';
 import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 Deno.test('aws-sdk instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
@@ -37,7 +38,7 @@ Deno.test('aws-sdk instrumentation: orchestrion @smithy/smithy-client:send chann
   // child has actually ended and can be captured on the transaction.
   const rpcSpanEnded = new Promise<void>(resolve => {
     client.on('spanEnd', (span: Span) => {
-      if (spanToJSON(span).op === 'rpc') {
+      if (spanToJSON(span).attributes[SENTRY_OP] === 'rpc') {
         resolve();
       }
     });

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -68,7 +68,7 @@ export function _updateSpanAttributesForParametrizedUrl(route: string, url: stri
     return;
   }
 
-  const { data: attributes, op } = spanToJSON(span);
+  const attributes = spanToJSON(span).attributes;
 
   if (!attributes || attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'url') {
     span.updateName(route);
@@ -76,7 +76,7 @@ export function _updateSpanAttributesForParametrizedUrl(route: string, url: stri
     const absoluteUrl = getAbsoluteUrl(url);
 
     span.setAttributes({
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.${op}.angular`,
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.${attributes[SENTRY_OP]}.angular`,
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
       [URL_FULL]: filterCollectedUrl(absoluteUrl),
       [URL_PATH]: parseStringToURLObject(absoluteUrl)?.pathname,
@@ -259,7 +259,7 @@ export class TraceService implements OnDestroy {
 
     const rootSpan = getRootSpan(activeSpan);
 
-    this._pageloadOngoing = spanToJSON(rootSpan).op === 'pageload';
+    this._pageloadOngoing = spanToJSON(rootSpan).attributes[SENTRY_OP] === 'pageload';
     return this._pageloadOngoing;
   }
 }

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -84,7 +84,7 @@ describe('Angular Tracing', () => {
 
       expect(spanToJSON(span)).toEqual(
         expect.objectContaining({
-          data: expect.objectContaining({
+          attributes: expect.objectContaining({
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.undefined.angular',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
             [URL_TEMPLATE]: route,
@@ -92,7 +92,7 @@ describe('Angular Tracing', () => {
             [URL_FULL]: expect.stringContaining('/users/123/'),
             [URL_PATH]: '/users/123/',
           }),
-          description: route,
+          name: route,
         }),
       );
     });
@@ -109,11 +109,11 @@ describe('Angular Tracing', () => {
 
       expect(spanToJSON(span)).toEqual(
         expect.objectContaining({
-          data: {
+          attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'sample-source',
           },
-          description: 'initial-span-name',
+          name: 'initial-span-name',
         }),
       );
     });

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { HTTP_ROUTE, URL_FRAGMENT, URL_FULL, URL_PATH, URL_QUERY } from '@sentry/conventions/attributes';
+import { HTTP_ROUTE, SENTRY_OP, URL_FRAGMENT, URL_FULL, URL_PATH, URL_QUERY } from '@sentry/conventions/attributes';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   addNonEnumerableProperty,
@@ -98,7 +98,7 @@ export const handleRequest: (options?: MiddlewareOptions) => MiddlewareHandler =
     const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 
     // if there is an active span, we just want to enhance it with routing data etc.
-    if (rootSpan && spanToJSON(rootSpan).op === 'http.server') {
+    if (rootSpan && spanToJSON(rootSpan).attributes[SENTRY_OP] === 'http.server') {
       return enhanceHttpServerSpan(ctx, next, rootSpan);
     }
 

--- a/packages/browser-utils/src/performance/entries.ts
+++ b/packages/browser-utils/src/performance/entries.ts
@@ -73,13 +73,13 @@ export function startTrackingLongTasks(): void {
       return;
     }
 
-    const { op: parentOp, start_timestamp: parentStartTimestamp } = spanToJSON(parent);
+    const { attributes: parentAttributes, start_timestamp: parentStartTimestamp } = spanToJSON(parent);
 
     for (const entry of entries) {
       const startTime = msToSec((browserPerformanceTimeOrigin() as number) + entry.startTime);
       const duration = msToSec(entry.duration);
 
-      if (parentOp === 'navigation' && parentStartTimestamp && startTime < parentStartTimestamp) {
+      if (parentAttributes[SENTRY_OP] === 'navigation' && parentStartTimestamp && startTime < parentStartTimestamp) {
         // Skip adding a span if the long task started before the navigation started.
         // `startAndEndSpan` will otherwise adjust the parent's start time to the span's start
         // time, potentially skewing the duration of the actual navigation as reported via our
@@ -117,7 +117,10 @@ export function startTrackingLongAnimationFrames(): void {
 
       const startTime = msToSec((browserPerformanceTimeOrigin() as number) + entry.startTime);
 
-      const { start_timestamp: parentStartTimestamp, op: parentOp } = spanToJSON(parent);
+      const {
+        start_timestamp: parentStartTimestamp,
+        attributes: { [SENTRY_OP]: parentOp },
+      } = spanToJSON(parent);
 
       if (parentOp === 'navigation' && parentStartTimestamp && startTime < parentStartTimestamp) {
         // Skip adding the span if the long animation frame started before the navigation started.
@@ -220,7 +223,7 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
 
   const performanceEntries = performance.getEntries();
 
-  const { op, start_timestamp: transactionStartTime } = spanToJSON(span);
+  const { attributes, start_timestamp: transactionStartTime } = spanToJSON(span);
 
   performanceEntries.slice(_performanceCursor).forEach(entry => {
     const startTime = msToSec(entry.startTime);
@@ -232,7 +235,11 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
       Math.max(0, entry.duration),
     );
 
-    if (op === 'navigation' && transactionStartTime && timeOrigin + startTime < transactionStartTime) {
+    if (
+      attributes[SENTRY_OP] === 'navigation' &&
+      transactionStartTime &&
+      timeOrigin + startTime < transactionStartTime
+    ) {
       return;
     }
 
@@ -479,7 +486,7 @@ function _trackNavigator(span: Span, spanStreamingEnabled: boolean | undefined):
     if (isMeasurementValue(connection.rtt)) {
       if (spanStreamingEnabled) {
         span.setAttribute('network.connection.rtt', connection.rtt);
-      } else if (spanToJSON(span).op === 'pageload') {
+      } else if (spanToJSON(span).attributes[SENTRY_OP] === 'pageload') {
         // Measurements are only recorded on the pageload span, matching the historical
         // behavior where `connection.rtt` was only flushed for pageload transactions.
         setMeasurement('connection.rtt', connection.rtt, 'millisecond');

--- a/packages/browser-utils/src/performance/userTiming.ts
+++ b/packages/browser-utils/src/performance/userTiming.ts
@@ -1,4 +1,4 @@
-import { SENTRY_ORIGIN } from '@sentry/conventions/attributes';
+import { SENTRY_OP, SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 import type { IntegrationFn, Span, SpanAttributes, SpanAttributeValue } from '@sentry/core';
 import {
   browserPerformanceTimeOrigin,
@@ -34,7 +34,9 @@ const _userTimingIntegration = ((options: UserTimingOptions = {}) => {
       let performanceCursor = 0;
 
       client.on('beforeIdleSpanEnd', idleSpan => {
-        const { op: parentOp, start_timestamp: parentStartTimestamp } = spanToJSON(idleSpan);
+        const { attributes, start_timestamp: parentStartTimestamp } = spanToJSON(idleSpan);
+        const parentOp = attributes[SENTRY_OP];
+
         if (parentOp !== 'pageload' && parentOp !== 'navigation') {
           return;
         }

--- a/packages/browser-utils/src/web-vitals/spans.ts
+++ b/packages/browser-utils/src/web-vitals/spans.ts
@@ -10,7 +10,7 @@ import {
   SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  spanToStreamedSpanJSON,
+  spanToJSON,
   startInactiveSpan,
   timestampInSeconds,
 } from '@sentry/core';
@@ -105,7 +105,7 @@ export function _emitWebVitalSpan(options: WebVitalSpanOptions): void {
     ...passedAttributes,
   };
 
-  if (parentSpan && spanToStreamedSpanJSON(parentSpan).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'pageload') {
+  if (parentSpan && spanToJSON(parentSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'pageload') {
     // for LCP and CLS, we collect the pageload span id as an attribute
     attributes['sentry.pageload.span_id'] = parentSpan.spanContext().spanId;
   }
@@ -343,9 +343,7 @@ export function _sendInpSpan(inpValue: number, entry: PerformanceEventTiming, st
   const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 
   const spanToUse = cachedContext?.span || rootSpan;
-  const routeName = spanToUse
-    ? spanToStreamedSpanJSON(spanToUse).name
-    : getCurrentScope().getScopeData().transactionName;
+  const routeName = spanToUse ? spanToJSON(spanToUse).name : getCurrentScope().getScopeData().transactionName;
   const name = cachedContext?.elementName || htmlTreeAsString(entry.target);
 
   _emitWebVitalSpan({

--- a/packages/browser-utils/src/web-vitals/tracking.ts
+++ b/packages/browser-utils/src/web-vitals/tracking.ts
@@ -1,5 +1,6 @@
 import type { Client, Measurements, Span } from '@sentry/core';
 import { browserPerformanceTimeOrigin, debug, setMeasurement, spanToJSON } from '@sentry/core';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 import { DEBUG_BUILD } from '../debug-build';
 import { htmlTreeAsString } from '../htmlTreeAsString';
 import {
@@ -150,7 +151,7 @@ export function addWebVitalsToSpan(span: Span, options: AddWebVitalsToSpanOption
   const timeOrigin = msToSec(origin);
 
   // Measurements are only available for pageload transactions
-  if (spanToJSON(span).op === 'pageload') {
+  if (spanToJSON(span).attributes[SENTRY_OP] === 'pageload') {
     _addTtfbRequestTimeToMeasurements(_measurements);
 
     if (spanStreamingEnabled) {

--- a/packages/browser-utils/test/browser/utils.test.ts
+++ b/packages/browser-utils/test/browser/utils.test.ts
@@ -26,9 +26,9 @@ describe('startAndEndSpan()', () => {
 
     expect(span).toBeDefined();
     expect(span).toBeInstanceOf(SentrySpan);
-    expect(spanToJSON(span).description).toBe('evaluation');
-    expect(spanToJSON(span).op).toBe('script');
-    expect(spanToJSON(span).op).toBe('script');
+    expect(spanToJSON(span).name).toBe('evaluation');
+    expect(spanToJSON(span).attributes['sentry.op']).toBe('script');
+    expect(spanToJSON(span).attributes['sentry.op']).toBe('script');
   });
 
   it('adjusts the start timestamp if child span starts before transaction', () => {

--- a/packages/browser-utils/test/performance/browserMetrics.test.ts
+++ b/packages/browser-utils/test/performance/browserMetrics.test.ts
@@ -134,8 +134,8 @@ describe('addWebVitalsToSpan', () => {
       spanStreamingEnabled: true,
     });
 
-    expect(spanToJSON(nextPageloadSpan).data['browser.web_vital.fp.value']).toBeUndefined();
-    expect(spanToJSON(nextPageloadSpan).data['browser.web_vital.fcp.value']).toBeUndefined();
+    expect(spanToJSON(nextPageloadSpan).attributes['browser.web_vital.fp.value']).toBeUndefined();
+    expect(spanToJSON(nextPageloadSpan).attributes['browser.web_vital.fcp.value']).toBeUndefined();
   });
 });
 
@@ -240,12 +240,10 @@ describe('_addResourceSpans', () => {
     expect(spans).toHaveLength(1);
     expect(spanToJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        description: '/assets/to/css',
+        name: '/assets/to/css',
         start_timestamp: timeOrigin + startTime,
-        timestamp: timeOrigin + startTime + duration,
-        op: 'resource.css',
-        origin: 'auto.resource.browser.metrics',
-        data: {
+        end_timestamp: timeOrigin + startTime + duration,
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           ['http.decoded_response_content_length']: entry.decodedBodySize,
@@ -292,8 +290,8 @@ describe('_addResourceSpans', () => {
 
     expect(spans).toHaveLength(1);
     const json = spanToJSON(spans[0]!);
-    expect(json.description).toBe('/assets/app.js?v=42#main');
-    expect(json.data['url.full']).toBe('https://example.com/assets/app.js?v=42#main');
+    expect(json.name).toBe('/assets/app.js?v=42#main');
+    expect(json.attributes['url.full']).toBe('https://example.com/assets/app.js?v=42#main');
   });
 
   it('sets url.full to the full cross-origin URL', () => {
@@ -312,9 +310,9 @@ describe('_addResourceSpans', () => {
 
     expect(spans).toHaveLength(1);
     const json = spanToJSON(spans[0]!);
-    expect(json.description).toBe('https://cdn.example.org/static/logo.png');
-    expect(json.data['url.full']).toBe('https://cdn.example.org/static/logo.png');
-    expect(json.data['url.same_origin']).toBe(false);
+    expect(json.name).toBe('https://cdn.example.org/static/logo.png');
+    expect(json.attributes['url.full']).toBe('https://cdn.example.org/static/logo.png');
+    expect(json.attributes['url.same_origin']).toBe(false);
   });
 
   it('creates a variety of resource spans', () => {
@@ -355,7 +353,7 @@ describe('_addResourceSpans', () => {
       _addResourceSpans(span, entry, 'https://example.com/assets/to/me', 123, 234, 465);
 
       expect(spans).toHaveLength(i + 1);
-      expect(spanToJSON(spans[i]!)).toEqual(expect.objectContaining({ op }));
+      expect(spanToJSON(spans[i]!).attributes).toEqual(expect.objectContaining({ [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op }));
     }
   });
 
@@ -400,7 +398,7 @@ describe('_addResourceSpans', () => {
     expect(spans).toHaveLength(table.length - ignoredResourceSpans.length);
     const spanOps = new Set(
       spans.map(s => {
-        return spanToJSON(s).op;
+        return spanToJSON(s).attributes['sentry.op'];
       }),
     );
     expect(spanOps).toEqual(new Set(['resource.css', 'resource.image']));
@@ -427,7 +425,7 @@ describe('_addResourceSpans', () => {
     expect(spans).toHaveLength(1);
     expect(spanToJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        data: expect.objectContaining({
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           ['http.decoded_response_content_length']: entry.decodedBodySize,
@@ -465,7 +463,7 @@ describe('_addResourceSpans', () => {
     expect(spans).toHaveLength(1);
     expect(spanToJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        data: expect.objectContaining({
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           'server.address': 'example.com',
@@ -475,10 +473,8 @@ describe('_addResourceSpans', () => {
           ['network.protocol.name']: 'http',
           ['network.protocol.version']: '3',
         }),
-        description: '/assets/to/css',
-        timestamp: 468,
-        op: 'resource.css',
-        origin: 'auto.resource.browser.metrics',
+        name: '/assets/to/css',
+        end_timestamp: 468,
         start_timestamp: 445,
       }),
     );
@@ -518,7 +514,7 @@ describe('_addResourceSpans', () => {
     expect(spans).toHaveLength(1);
     expect(spanToJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           'server.address': 'example.com',
@@ -541,10 +537,8 @@ describe('_addResourceSpans', () => {
           'http.request.time_to_first_byte': 1.008,
           'http.request.worker_start': expect.any(Number),
         },
-        description: '/assets/to/css',
-        timestamp: 468,
-        op: 'resource.css',
-        origin: 'auto.resource.browser.metrics',
+        name: '/assets/to/css',
+        end_timestamp: 468,
         start_timestamp: 445,
       }),
     );
@@ -573,7 +567,7 @@ describe('_addResourceSpans', () => {
       _addResourceSpans(span, entry, resourceEntryName, 100, 23, 345);
 
       expect(spans).toHaveLength(1);
-      expect(spanToJSON(spans[0]!).data).toMatchObject({ 'http.response_delivery_type': deliveryType });
+      expect(spanToJSON(spans[0]!).attributes).toMatchObject({ 'http.response_delivery_type': deliveryType });
     },
   );
 });
@@ -656,102 +650,84 @@ describe('_addNavigationSpans', () => {
     expect(spans.map(spanToJSON)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.dom_content_loaded_event',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.dom_content_loaded_event',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.load_event',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.load_event',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.connect',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.connect',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.tls_ssl',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.tls_ssl',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.cache',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.cache',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.dns',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.dns',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.request',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.request',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.response',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.response',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'http.redirect_count': 2,
             'sentry.op': 'browser.redirect',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.redirect',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),

--- a/packages/browser-utils/test/performance/userTiming.test.ts
+++ b/packages/browser-utils/test/performance/userTiming.test.ts
@@ -42,10 +42,10 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(2);
-    expect(spans.map(span => spanToJSON(span).description)).toEqual(['app-ready', 'hydrate']);
-    expect(spans.map(span => spanToJSON(span).op)).toEqual(['mark', 'measure']);
-    expect(spanToJSON(spans[0]!).timestamp).toBe(spanToJSON(spans[0]!).start_timestamp);
-    expect(spanToJSON(spans[1]!).timestamp! - spanToJSON(spans[1]!).start_timestamp).toBeCloseTo(0.025);
+    expect(spans.map(span => spanToJSON(span).name)).toEqual(['app-ready', 'hydrate']);
+    expect(spans.map(span => spanToJSON(span).attributes['sentry.op'])).toEqual(['mark', 'measure']);
+    expect(spanToJSON(spans[0]!).end_timestamp).toBe(spanToJSON(spans[0]!).start_timestamp);
+    expect(spanToJSON(spans[1]!).end_timestamp - spanToJSON(spans[1]!).start_timestamp).toBeCloseTo(0.025);
     expect(spanToJSON(spans[1]!).parent_span_id).toBe(parentSpan.spanContext().spanId);
   });
 
@@ -66,7 +66,7 @@ describe('userTimingIntegration', () => {
     );
 
     expect(spans).toHaveLength(2);
-    expect(spans.map(span => spanToJSON(span).description)).toEqual(['initial-render', 'route-render']);
+    expect(spans.map(span => spanToJSON(span).name)).toEqual(['initial-render', 'route-render']);
   });
 
   it('reads the latest entries immediately before the segment ends', () => {
@@ -77,7 +77,7 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!).description).toBe('last-moment-work');
+    expect(spanToJSON(spans[0]!).name).toBe('last-moment-work');
   });
 
   it('does not capture entries for unrelated idle spans', () => {
@@ -103,7 +103,7 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(2);
-    expect(spans.map(span => spanToJSON(span).description)).toEqual(['application-mark', 'application-render']);
+    expect(spans.map(span => spanToJSON(span).name)).toEqual(['application-mark', 'application-render']);
   });
 
   it('does not attach entries preceding a navigation span', () => {
@@ -123,7 +123,7 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!).description).toBe('current-route');
+    expect(spanToJSON(spans[0]!).name).toBe('current-route');
   });
 });
 
@@ -159,7 +159,7 @@ describe('_addUserTimingSpan', () => {
     _addUserTimingSpan(parentSpan, entry, 0.012, 0.01, 100, 0, []);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!).data).toEqual({
+    expect(spanToJSON(spans[0]!).attributes).toEqual({
       'sentry.browser.measure.detail.phase': 'client',
       'sentry.browser.measure.detail.counts': '{"components":4}',
       'sentry.op': 'measure',

--- a/packages/browser-utils/test/web-vitals/spans.test.ts
+++ b/packages/browser-utils/test/web-vitals/spans.test.ts
@@ -24,7 +24,6 @@ vi.mock('@sentry/core', async () => {
     getActiveSpan: vi.fn(),
     getRootSpan: vi.fn(),
     spanToJSON: vi.fn(),
-    spanToStreamedSpanJSON: vi.fn(),
   };
 });
 
@@ -64,7 +63,7 @@ describe('_emitWebVitalSpan', () => {
   beforeEach(() => {
     vi.mocked(SentryCore.getCurrentScope).mockReturnValue(mockScope as any);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({ attributes: {} } as any);
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
     vi.mocked(SentryCore.getClient).mockReturnValue({ getIntegrationByName: () => undefined } as any);
   });
 
@@ -187,7 +186,7 @@ describe('_emitWebVitalSpan', () => {
 
   it('includes pageload span id when parentSpan is a pageload span', () => {
     const mockPageloadSpan = createMockPageloadSpan('abc123');
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({
       attributes: { 'sentry.op': 'pageload' },
     } as any);
 
@@ -213,7 +212,7 @@ describe('_emitWebVitalSpan', () => {
 
   it('does not include pageload span id when parentSpan is not a pageload span', () => {
     const mockNonPageloadSpan = createMockPageloadSpan('xyz789');
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({
       attributes: { 'sentry.op': 'ui.interaction.click' },
     } as any);
 
@@ -308,7 +307,7 @@ describe('_sendLcpSpan', () => {
     vi.mocked(SentryCore.browserPerformanceTimeOrigin).mockReturnValue(1000);
     vi.mocked(htmlTreeAsString).mockImplementation((node: any) => `<${node?.tagName || 'div'}>`);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({
       attributes: { 'sentry.op': 'pageload' },
     } as any);
   });
@@ -395,7 +394,7 @@ describe('_sendClsSpan', () => {
     vi.mocked(SentryCore.timestampInSeconds).mockReturnValue(1.5);
     vi.mocked(htmlTreeAsString).mockImplementation((node: any) => `<${node?.tagName || 'div'}>`);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({
       attributes: { 'sentry.op': 'pageload' },
     } as any);
   });
@@ -478,7 +477,7 @@ describe('_sendInpSpan', () => {
     vi.mocked(htmlTreeAsString).mockReturnValue('<button>');
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.getActiveSpan).mockReturnValue(undefined);
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({ attributes: {} } as any);
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
   });
 
   afterEach(() => {
@@ -541,7 +540,7 @@ describe('_sendInpSpan', () => {
 
   it('uses cached element name and span from registerInpInteractionListener', () => {
     const mockRootSpan = createMockPageloadSpan('span-42');
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({
       name: 'cached-route',
       attributes: { 'sentry.op': 'navigation' },
     } as any);
@@ -595,7 +594,7 @@ describe('trackInpAsSpan', () => {
     vi.mocked(SentryCore.getCurrentScope).mockReturnValue(mockScope as any);
     vi.mocked(SentryCore.getActiveSpan).mockReturnValue(undefined);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue({ end: vi.fn() } as any);
-    vi.mocked(SentryCore.spanToStreamedSpanJSON).mockReturnValue({ attributes: {} } as any);
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
     vi.mocked(htmlTreeAsString).mockReturnValue('<button>');
     vi.spyOn(inpModule, 'getCachedInteractionContext').mockReturnValue(undefined);
     vi.spyOn(instrument, 'addInpInstrumentationHandler').mockImplementation((cb: any) => {

--- a/packages/browser/src/integrations/graphqlClient.ts
+++ b/packages/browser/src/integrations/graphqlClient.ts
@@ -4,13 +4,12 @@ import {
   isObjectLike,
   isString,
   SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   spanToJSON,
   stringMatchesSomePattern,
 } from '@sentry/core/browser';
 import type { FetchHint, XhrHint } from '@sentry/browser-utils';
 import { getBodyString, getFetchRequestArgBody, SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
-import { GRAPHQL_DOCUMENT, URL_FULL } from '@sentry/conventions/attributes';
+import { GRAPHQL_DOCUMENT, HTTP_METHOD, SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
 
 interface GraphQLClientOptions {
   endpoints: Array<string | RegExp>;
@@ -59,8 +58,8 @@ function _updateSpanWithGraphQLData(client: Client, options: GraphQLClientOption
   client.on('beforeOutgoingRequestSpan', (span, hint) => {
     const spanJSON = spanToJSON(span);
 
-    const spanAttributes = spanJSON.data || {};
-    const spanOp = spanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_OP];
+    const spanAttributes = spanJSON.attributes;
+    const spanOp = spanAttributes[SENTRY_OP];
 
     const isHttpClientSpan = spanOp === 'http.client';
 
@@ -69,7 +68,8 @@ function _updateSpanWithGraphQLData(client: Client, options: GraphQLClientOption
     }
 
     const httpUrl = spanAttributes[URL_FULL];
-    const httpMethod = spanAttributes[SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD] || spanAttributes['http.method'];
+    // oxlint-disable-next-line typescript/no-deprecated
+    const httpMethod = spanAttributes[SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD] || spanAttributes[HTTP_METHOD];
 
     if (!isString(httpUrl) || !isString(httpMethod)) {
       return;

--- a/packages/browser/src/profiling/startProfileForSpan.ts
+++ b/packages/browser/src/profiling/startProfileForSpan.ts
@@ -24,6 +24,7 @@ export function startProfileForSpan(span: Span): void {
     startTimestamp = timestampInSeconds() * 1000;
   }
 
+  const spanName = spanToJSON(span).name;
   const profiler = startJSSelfProfile();
 
   // We failed to construct the profiler, so we skip.
@@ -33,7 +34,7 @@ export function startProfileForSpan(span: Span): void {
   }
 
   if (DEBUG_BUILD) {
-    debug.log(`[Profiling] started profiling span: ${spanToJSON(span).description}`);
+    debug.log(`[Profiling] started profiling span: ${spanName}`);
   }
 
   // We create "unique" span names to avoid concurrent spans with same names
@@ -72,7 +73,7 @@ export function startProfileForSpan(span: Span): void {
     }
     if (processedProfile) {
       if (DEBUG_BUILD) {
-        debug.log('[Profiling] profile for:', spanToJSON(span).description, 'already exists, returning early');
+        debug.log('[Profiling] profile for:', spanName, 'already exists, returning early');
       }
       return;
     }
@@ -86,14 +87,14 @@ export function startProfileForSpan(span: Span): void {
         }
 
         if (DEBUG_BUILD) {
-          debug.log(`[Profiling] stopped profiling of span: ${spanToJSON(span).description}`);
+          debug.log(`[Profiling] stopped profiling of span: ${spanName}`);
         }
 
         // In case of an overlapping span, stopProfiling may return null and silently ignore the overlapping profile.
         if (!profile) {
           if (DEBUG_BUILD) {
             debug.log(
-              `[Profiling] profiler returned null profile for: ${spanToJSON(span).description}`,
+              `[Profiling] profiler returned null profile for: ${spanName}`,
               'this may indicate an overlapping span or a call to stopProfiling with a profile title that was never started',
             );
           }
@@ -113,7 +114,7 @@ export function startProfileForSpan(span: Span): void {
   // Enqueue a timeout to prevent profiles from running over max duration.
   let maxDurationTimeoutID: number | undefined = WINDOW.setTimeout(() => {
     if (DEBUG_BUILD) {
-      debug.log('[Profiling] max profile duration elapsed, stopping profiling for:', spanToJSON(span).description);
+      debug.log('[Profiling] max profile duration elapsed, stopping profiling for:', spanName);
     }
     // If the timeout exceeds, we want to stop profiling, but not finish the span
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -27,6 +27,7 @@ import type { BrowserOptions } from '../client';
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
 import type { JSSelfProfile, JSSelfProfiler, JSSelfProfilerConstructor, JSSelfProfileStack } from './jsSelfProfiling';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 const MS_TO_NS = 1e6;
 
@@ -380,7 +381,7 @@ export function isProfiledTransactionEvent(event: Event): event is ProfiledEvent
  *
  */
 export function isAutomatedPageLoadSpan(span: Span): boolean {
-  return spanToJSON(span).op === 'pageload';
+  return spanToJSON(span).attributes[SENTRY_OP] === 'pageload';
 }
 
 /**

--- a/packages/browser/src/tracing/backgroundtab.ts
+++ b/packages/browser/src/tracing/backgroundtab.ts
@@ -1,6 +1,7 @@
 import { debug, getActiveSpan, getRootSpan, SPAN_STATUS_ERROR, spanToJSON } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 /**
  * Add a listener that cancels and finishes a transaction when the global
@@ -19,7 +20,10 @@ export function registerBackgroundTabDetection(): void {
       if (WINDOW.document.hidden && rootSpan) {
         const cancelledStatus = 'cancelled';
 
-        const { op, status } = spanToJSON(rootSpan);
+        const {
+          attributes: { [SENTRY_OP]: op },
+          status,
+        } = spanToJSON(rootSpan);
 
         if (DEBUG_BUILD) {
           debug.log(`[Tracing] Transaction: ${cancelledStatus} -> since tab moved to the background, op: ${op}`);

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -51,7 +51,7 @@ import { WEB_VITALS_INTEGRATION_NAME, webVitalsIntegration } from '../integratio
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
-import { URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
 
 export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 
@@ -472,8 +472,11 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       function maybeEndActiveSpan(): void {
         const activeSpan = getActiveIdleSpan(client);
 
-        if (activeSpan && !spanToJSON(activeSpan).timestamp) {
-          DEBUG_BUILD && debug.log(`[Tracing] Finishing current active span with op: ${spanToJSON(activeSpan).op}`);
+        if (activeSpan && !spanToJSON(activeSpan).end_timestamp) {
+          DEBUG_BUILD &&
+            debug.log(
+              `[Tracing] Finishing current active span with op: ${spanToJSON(activeSpan).attributes[SENTRY_OP]}`,
+            );
           // If there's an open active span, we need to finish it before creating an new one.
           activeSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON, 'cancelled');
           activeSpan.end();
@@ -799,7 +802,7 @@ function registerInteractionListener(
 
     const activeIdleSpan = getActiveIdleSpan(client);
     if (activeIdleSpan) {
-      const currentRootSpanOp = spanToJSON(activeIdleSpan).op;
+      const currentRootSpanOp = spanToJSON(activeIdleSpan).attributes[SENTRY_OP];
       if (['navigation', 'pageload'].includes(currentRootSpanOp as string)) {
         DEBUG_BUILD &&
           debug.warn(`[Tracing] Did not create ${op} span because a pageload or navigation span is in progress.`);

--- a/packages/browser/src/tracing/linkedTraces.ts
+++ b/packages/browser/src/tracing/linkedTraces.ts
@@ -10,6 +10,7 @@ import {
 } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../exports';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 export interface PreviousTraceInfo {
   /**
@@ -142,7 +143,7 @@ export function addPreviousTraceSpanLink(
   function getSampleRate(): number {
     try {
       const oldSampleRate = Number(
-        spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] ?? oldPropagationContext.dsc?.sample_rate,
+        spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] ?? oldPropagationContext.dsc?.sample_rate,
       );
       return Number.isNaN(oldSampleRate) ? 0 : oldSampleRate;
     } catch {
@@ -178,7 +179,7 @@ export function addPreviousTraceSpanLink(
     if (DEBUG_BUILD) {
       debug.log(
         `Adding previous_trace \`${JSON.stringify(previousTraceSpanCtx)}\` link to span \`${JSON.stringify({
-          op: spanJson.op,
+          op: spanJson.attributes[SENTRY_OP],
           ...span.spanContext(),
         })}\``,
       );

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -212,7 +212,7 @@ const HTTP_TIMING_WAIT_MS = 300;
  * @param span A span that has yet to be finished, must contain `url.full` on data.
  */
 function addHTTPTimings(span: Span, client: Client): void {
-  const url = spanToJSON(span).data[URL_FULL];
+  const url = spanToJSON(span).attributes[URL_FULL];
 
   if (!url || typeof url !== 'string') {
     return;

--- a/packages/browser/test/integrations/graphqlClient.test.ts
+++ b/packages/browser/test/integrations/graphqlClient.test.ts
@@ -368,8 +368,8 @@ describe('GraphqlClient', () => {
       handler(span, makeFetchHint('http://localhost:4000/graphql', requestBody));
 
       const json = spanToJSON(span);
-      expect(json.description).toBe('POST http://localhost:4000/graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBe(requestBody.query);
+      expect(json.name).toBe('POST http://localhost:4000/graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBe(requestBody.query);
     });
 
     test('enriches http.client span when only url.full is present', () => {
@@ -386,8 +386,8 @@ describe('GraphqlClient', () => {
       handler(span, makeFetchHint('http://localhost:4000/graphql', requestBody));
 
       const json = spanToJSON(span);
-      expect(json.description).toBe('POST http://localhost:4000/graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBe(requestBody.query);
+      expect(json.name).toBe('POST http://localhost:4000/graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBe(requestBody.query);
     });
 
     test('enriches http.client span for relative URLs', () => {
@@ -404,8 +404,8 @@ describe('GraphqlClient', () => {
       handler(span, makeFetchHint('/graphql', requestBody));
 
       const json = spanToJSON(span);
-      expect(json.description).toBe('POST /graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBe(requestBody.query);
+      expect(json.name).toBe('POST /graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBe(requestBody.query);
     });
 
     test('does nothing when no URL attribute is present', () => {
@@ -421,8 +421,8 @@ describe('GraphqlClient', () => {
       handler(span, makeFetchHint('/graphql', requestBody));
 
       const json = spanToJSON(span);
-      expect(json.description).toBe('POST');
-      expect(json.data['graphql.document']).toBeUndefined();
+      expect(json.name).toBe('POST');
+      expect(json.attributes['graphql.document']).toBeUndefined();
     });
 
     test('does nothing when span op is not http.client', () => {
@@ -439,8 +439,8 @@ describe('GraphqlClient', () => {
       handler(span, makeFetchHint('/graphql', requestBody));
 
       const json = spanToJSON(span);
-      expect(json.description).toBe('custom span');
-      expect(json.data['graphql.document']).toBeUndefined();
+      expect(json.name).toBe('custom span');
+      expect(json.attributes['graphql.document']).toBeUndefined();
     });
 
     test('omits graphql.document when dataCollection.graphQL.document is false', () => {
@@ -459,8 +459,8 @@ describe('GraphqlClient', () => {
 
       const json = spanToJSON(span);
       // The span is still renamed with the operation, but the document is not attached.
-      expect(json.description).toBe('POST http://localhost:4000/graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBeUndefined();
+      expect(json.name).toBe('POST http://localhost:4000/graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBeUndefined();
     });
   });
 });

--- a/packages/browser/test/profiling/integration.test.ts
+++ b/packages/browser/test/profiling/integration.test.ts
@@ -54,7 +54,7 @@ describe('BrowserProfilingIntegration', () => {
 
     const currentTransaction = Sentry.getActiveSpan();
     expect(currentTransaction).toBeDefined();
-    expect(Sentry.spanToJSON(currentTransaction!).op).toBe('pageload');
+    expect(Sentry.spanToJSON(currentTransaction!).attributes['sentry.op']).toBe('pageload');
     currentTransaction?.end();
     await client!.flush(1000);
 

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -173,11 +173,9 @@ describe('browserTracingIntegration', () => {
     expect(span).toBeDefined();
     expect(spanIsSampled(span!)).toBe(true);
     expect(spanToJSON(span!)).toEqual({
-      description: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.browser',
+      name: '/',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -188,6 +186,10 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
+      links: undefined,
     });
   });
 
@@ -260,11 +262,9 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span)).toBe(true);
     expect(span.isRecording()).toBe(true);
     expect(spanToJSON(span)).toEqual({
-      description: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.browser',
+      name: '/',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -275,6 +275,10 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
+      links: undefined,
     });
 
     // this is what is used to get the span name - JSDOM does not update this on it's own!
@@ -291,11 +295,9 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span2)).toBe(true);
     expect(span2.isRecording()).toBe(true);
     expect(spanToJSON(span2)).toEqual({
-      description: '/test',
-      op: 'navigation',
-      origin: 'auto.navigation.browser',
+      name: '/test',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -317,6 +319,9 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
     });
 
     // this is what is used to get the span name - JSDOM does not update this on it's own!
@@ -333,11 +338,9 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span3)).toBe(true);
     expect(span3.isRecording()).toBe(true);
     expect(spanToJSON(span3)).toEqual({
-      description: '/test2',
-      op: 'navigation',
-      origin: 'auto.navigation.browser',
+      name: '/test2',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -359,6 +362,9 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
     });
   });
 
@@ -377,11 +383,9 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span)).toBe(true);
     expect(span.isRecording()).toBe(true);
     expect(spanToJSON(span)).toEqual({
-      description: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.browser',
+      name: '/',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -392,6 +396,10 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
+      links: undefined,
     });
 
     // this is what is used to get the span name - JSDOM does not update this on it's own!
@@ -412,16 +420,14 @@ describe('browserTracingIntegration', () => {
     // span has connected redirect span
     expect(getSpanDescendants(span).map(span => spanToJSON(span))).toContainEqual(
       expect.objectContaining({
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation.redirect',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [URL_FULL]: 'https://example.com/test',
           [URL_PATH]: '/test',
         },
-        description: '/test',
-        op: 'navigation.redirect',
-        origin: 'auto.navigation.browser',
+        name: '/test',
         parent_span_id: span.spanContext().spanId,
       }),
     );
@@ -472,11 +478,9 @@ describe('browserTracingIntegration', () => {
 
       expect(span).toBeDefined();
       expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'pageload',
-        origin: 'manual',
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -487,6 +491,10 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
+        links: undefined,
       });
       expect(spanIsSampled(span!)).toBe(true);
     });
@@ -511,11 +519,9 @@ describe('browserTracingIntegration', () => {
 
       expect(span).toBeDefined();
       expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'pageload',
-        origin: 'auto.test',
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -527,6 +533,10 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
+        links: undefined,
       });
     });
 
@@ -579,7 +589,7 @@ describe('browserTracingIntegration', () => {
 
       const pageloadSpan = getActiveSpan();
 
-      expect(spanToJSON(pageloadSpan!).op).toBe('test op');
+      expect(spanToJSON(pageloadSpan!).attributes['sentry.op']).toBe('test op');
     });
 
     it('sets the pageload span name on `scope.transactionName`', () => {
@@ -673,8 +683,8 @@ describe('browserTracingIntegration', () => {
 
     const pageloadSpan = getActiveSpan();
 
-    expect(spanToJSON(pageloadSpan!).description).toBe('changed');
-    expect(spanToJSON(pageloadSpan!).data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+    expect(spanToJSON(pageloadSpan!).name).toBe('changed');
+    expect(spanToJSON(pageloadSpan!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
   });
 
   it('sets source to "custom" if name is changed in-place in beforeStartSpan', () => {
@@ -705,8 +715,8 @@ describe('browserTracingIntegration', () => {
 
     const pageloadSpan = getActiveSpan();
 
-    expect(spanToJSON(pageloadSpan!).description).toBe('changed');
-    expect(spanToJSON(pageloadSpan!).data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+    expect(spanToJSON(pageloadSpan!).name).toBe('changed');
+    expect(spanToJSON(pageloadSpan!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
   });
 
   describe('startBrowserTracingNavigationSpan', () => {
@@ -754,11 +764,9 @@ describe('browserTracingIntegration', () => {
 
       expect(span).toBeDefined();
       expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'navigation',
-        origin: 'manual',
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -780,6 +788,9 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
       });
       expect(spanIsSampled(span!)).toBe(true);
     });
@@ -810,11 +821,9 @@ describe('browserTracingIntegration', () => {
 
       expect(span).toBeDefined();
       expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'navigation',
-        origin: 'auto.test',
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -826,6 +835,10 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
+        links: undefined,
       });
     });
 
@@ -882,7 +895,7 @@ describe('browserTracingIntegration', () => {
 
       const navigationSpan = getActiveSpan();
 
-      expect(spanToJSON(navigationSpan!).op).toBe('test op');
+      expect(spanToJSON(navigationSpan!).attributes['sentry.op']).toBe('test op');
     });
 
     it('sets source to "custom" if name is changed in beforeStartSpan', () => {
@@ -910,8 +923,8 @@ describe('browserTracingIntegration', () => {
 
       const pageloadSpan = getActiveSpan();
 
-      expect(spanToJSON(pageloadSpan!).description).toBe('changed');
-      expect(spanToJSON(pageloadSpan!).data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+      expect(spanToJSON(pageloadSpan!).name).toBe('changed');
+      expect(spanToJSON(pageloadSpan!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
     });
 
     it('sets the navigation span name on `scope.transactionName`', () => {
@@ -1088,7 +1101,7 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
+      expect(spanToJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
       expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
       expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(false);
@@ -1126,7 +1139,7 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
+      expect(spanToJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
       expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
       expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(false);
@@ -1170,7 +1183,7 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('navigation');
+      expect(spanToJSON(idleSpan).attributes['sentry.op']).toBe('navigation');
       expect(spanToJSON(idleSpan).trace_id).not.toEqual('12312012123120121231201212312012');
       expect(spanToJSON(idleSpan).parent_span_id).not.toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(true);
@@ -1227,7 +1240,7 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
+      expect(spanToJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
       expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312011');
       expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212011');
       expect(spanIsSampled(idleSpan)).toBe(true);
@@ -1336,7 +1349,7 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
+      expect(spanToJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
       expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
       expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(false);

--- a/packages/browser/test/tracing/linkedTraces.test.ts
+++ b/packages/browser/test/tracing/linkedTraces.test.ts
@@ -196,7 +196,7 @@ describe('addPreviousTraceSpanLink', () => {
       },
     ]);
 
-    expect(spanJson.data).toMatchObject({
+    expect(spanJson.attributes).toMatchObject({
       [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: '123-456-1',
     });
 
@@ -398,7 +398,7 @@ describe('addPreviousTraceSpanLink', () => {
 
     expect(spanJson.links).toBeUndefined();
 
-    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
+    expect(Object.keys(spanJson.attributes)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     // but still updates the previousTraceInfo to the current span
     expect(updatedPreviousTraceInfo).toEqual({
@@ -491,7 +491,7 @@ describe('addPreviousTraceSpanLink', () => {
 
     const spanJson = spanToJSON(currentSpan);
     expect(spanJson.links).toBeUndefined();
-    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
+    expect(Object.keys(spanJson.attributes)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     expect(updatedPreviousTraceInfo).toEqual({
       sampleRand: 0.0126,
@@ -532,7 +532,7 @@ describe('addPreviousTraceSpanLink', () => {
 
     const spanJson = spanToJSON(currentSpan);
     expect(spanJson.links).toBeUndefined();
-    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
+    expect(Object.keys(spanJson.attributes)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     expect(updatedPreviousTraceInfo).toBe(previousTraceInfo);
   });

--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -50,9 +50,9 @@ describe('Bun HTTP Server Integration', () => {
     await close();
 
     expect(span).toBeDefined();
-    expect(span?.op).toBe('http.server');
-    expect(span?.description).toBe('GET /users');
-    expect(span?.data['sentry.origin']).toBe('auto.http.server');
+    expect(span?.attributes['sentry.op']).toBe('http.server');
+    expect(span?.name).toBe('GET /users');
+    expect(span?.attributes['sentry.origin']).toBe('auto.http.server');
   });
 
   test('isolates each incoming request with a distinct trace id', async () => {

--- a/packages/core/src/integrations/conversationId.ts
+++ b/packages/core/src/integrations/conversationId.ts
@@ -4,7 +4,7 @@ import { defineIntegration } from '../integration';
 import { GEN_AI_CONVERSATION_ID_ATTRIBUTE } from '../semanticAttributes';
 import type { IntegrationFn } from '../types/integration';
 import type { Span } from '../types/span';
-import { spanToJSON } from '../utils/spanUtils';
+import { spanToStaticSpanJSON } from '../utils/spanUtils';
 
 const INTEGRATION_NAME = 'ConversationId' as const;
 
@@ -19,7 +19,7 @@ const _conversationIdIntegration = (() => {
         const conversationId = scopeData.conversationId || isolationScopeData.conversationId;
 
         if (conversationId) {
-          const { op, data: attributes, description: name } = spanToJSON(span);
+          const { op, data: attributes, description: name } = spanToStaticSpanJSON(span);
 
           // Only apply conversation ID to gen_ai spans.
           // We also check for Vercel AI spans (ai.operationId attribute or ai.* span name)

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -10,6 +10,7 @@ export type { OfflineStore, OfflineTransportOptions } from './transports/offline
 export type { IntegrationIndex } from './integration';
 export * from './tracing';
 export * from './semanticAttributes';
+export type { RawAttributes } from './attributes';
 export { createEventEnvelope, createSessionEnvelope } from './envelope';
 export {
   captureException,
@@ -98,8 +99,8 @@ export { addAutoIpAddressToSession } from './utils/ipAddress';
 export {
   convertSpanLinksForEnvelope,
   spanToTraceHeader,
+  spanToStaticSpanJSON,
   spanToJSON,
-  spanToStreamedSpanJSON,
   spanIsSampled,
   spanIsSentrySpan,
   spanToTraceContext,

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -13,7 +13,7 @@ import { baggageHeaderToDynamicSamplingContext, dynamicSamplingContextToSentryBa
 import { extractOrgIdFromClient } from '../utils/dsn';
 import { hasSpansEnabled } from '../utils/hasSpansEnabled';
 import { addNonEnumerableProperty } from '../utils/object';
-import { getRootSpan, spanIsSampled, spanToJSON } from '../utils/spanUtils';
+import { getRootSpan, spanIsSampled, spanToStaticSpanJSON } from '../utils/spanUtils';
 import { spanIsNonRecordingSpan } from './sentryNonRecordingSpan';
 import { getCapturedScopesOnSpan } from './utils';
 
@@ -93,7 +93,7 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
   }
 
   const rootSpan = getRootSpan(span);
-  const rootSpanJson = spanToJSON(rootSpan);
+  const rootSpanJson = spanToStaticSpanJSON(rootSpan);
   const rootSpanAttributes = rootSpanJson.data;
   const traceState = rootSpan.spanContext().traceState;
 

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -13,6 +13,7 @@ import {
   removeChildSpanFromSpan,
   spanTimeInputToSeconds,
   spanToJSON,
+  spanToStaticSpanJSON,
 } from '../utils/spanUtils';
 import { timestampInSeconds } from '../utils/time';
 import { SentryNonRecordingSpan, spanIsNonRecordingSpan } from './sentryNonRecordingSpan';
@@ -152,7 +153,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       // Ensure we end with the last span timestamp, if possible
       const spans = getSpanDescendants(span).filter(child => child !== span);
 
-      const spanJson = spanToJSON(span);
+      const spanJson = spanToStaticSpanJSON(span);
 
       // If we have no spans, we just end, nothing else to do here
       // Likewise, if users explicitly ended the span, we simply end the span without timestamp adjustment
@@ -164,7 +165,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       const ignoreSpans = client.getOptions().ignoreSpans;
 
       const latestSpanEndTimestamp = spans?.reduce((acc: number | undefined, current) => {
-        const currentSpanJson = spanToJSON(current);
+        const currentSpanJson = spanToStaticSpanJSON(current);
         if (!currentSpanJson.timestamp) {
           return acc;
         }
@@ -287,7 +288,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
 
     _setSpanForScope(scope, previousActiveSpan);
 
-    const spanJSON = spanToJSON(span);
+    const spanJSON = spanToStaticSpanJSON(span);
 
     const { start_timestamp: startTimestamp } = spanJSON;
     // This should never happen, but to make TS happy...
@@ -320,7 +321,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
           debug.log('[Tracing] Cancelling span since span ended early', JSON.stringify(childSpan, undefined, 2));
       }
 
-      const childSpanJSON = spanToJSON(childSpan);
+      const childSpanJSON = spanToStaticSpanJSON(childSpan);
       const { timestamp: childEndTimestamp = 0, start_timestamp: childStartTimestamp = 0 } = childSpanJSON;
 
       const spanStartedBeforeIdleSpanEnd = childStartTimestamp <= endTimestamp;
@@ -359,7 +360,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       if (
         _finished ||
         startedSpan === span ||
-        !!spanToJSON(startedSpan).timestamp ||
+        !!spanToJSON(startedSpan).end_timestamp ||
         (startedSpan instanceof SentrySpan && startedSpan.isStandaloneSpan())
       ) {
         return;

--- a/packages/core/src/tracing/logSpans.ts
+++ b/packages/core/src/tracing/logSpans.ts
@@ -1,7 +1,7 @@
 import { DEBUG_BUILD } from '../debug-build';
 import type { Span } from '../types/span';
 import { debug } from '../utils/debug-logger';
-import { getRootSpan, spanIsSampled, spanToJSON } from '../utils/spanUtils';
+import { getRootSpan, spanIsSampled, spanToStaticSpanJSON } from '../utils/spanUtils';
 
 /**
  * Print a log message for a started span.
@@ -9,7 +9,11 @@ import { getRootSpan, spanIsSampled, spanToJSON } from '../utils/spanUtils';
 export function logSpanStart(span: Span): void {
   if (!DEBUG_BUILD) return;
 
-  const { description = '< unknown name >', op = '< unknown op >', parent_span_id: parentSpanId } = spanToJSON(span);
+  const {
+    description = '< unknown name >',
+    op = '< unknown op >',
+    parent_span_id: parentSpanId,
+  } = spanToStaticSpanJSON(span);
   const { spanId } = span.spanContext();
 
   const sampled = spanIsSampled(span);
@@ -25,7 +29,7 @@ export function logSpanStart(span: Span): void {
   }
 
   if (!isRootSpan) {
-    const { op, description } = spanToJSON(rootSpan);
+    const { op, description } = spanToStaticSpanJSON(rootSpan);
     infoParts.push(`root ID: ${rootSpan.spanContext().spanId}`);
     if (op) {
       infoParts.push(`root op: ${op}`);
@@ -45,7 +49,7 @@ export function logSpanStart(span: Span): void {
 export function logSpanEnd(span: Span): void {
   if (!DEBUG_BUILD) return;
 
-  const { description = '< unknown name >', op = '< unknown op >' } = spanToJSON(span);
+  const { description = '< unknown name >', op = '< unknown op >' } = spanToStaticSpanJSON(span);
   const { spanId } = span.spanContext();
   const rootSpan = getRootSpan(span);
   const isRootSpan = rootSpan === span;

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -36,7 +36,7 @@ import {
   getStatusMessage,
   getStreamedSpanLinks,
   spanTimeInputToSeconds,
-  spanToJSON,
+  spanToStaticSpanJSON,
   spanToTransactionTraceContext,
   TRACE_FLAG_NONE,
   TRACE_FLAG_SAMPLED,
@@ -315,7 +315,7 @@ export class SentrySpan implements Span {
    * @hidden
    * @internal This method is purely for internal purposes and should not be used outside
    * of SDK code. If you need to get a JSON representation of a span,
-   * use `spanToStreamedSpanJSON(span)` instead.
+   * use `spanToJSON(span)` instead.
    */
   public getStreamedSpanJSON(): StreamedSpanJSON {
     return {
@@ -324,8 +324,7 @@ export class SentrySpan implements Span {
       trace_id: this._traceId,
       parent_span_id: this._parentSpanId,
       start_timestamp: this._startTime,
-      // just in case _endTime is not set, we use the start time (i.e. duration 0)
-      end_timestamp: this._endTime ?? this._startTime,
+      end_timestamp: this._endTime,
       is_segment: this === getRootSpan(this),
       status: getSimpleStatus(this._status),
       attributes: addStatusMessageAttribute(this._attributes, this._status),
@@ -436,7 +435,7 @@ export class SentrySpan implements Span {
    */
   private _convertSpanToTransaction(options: SegmentSpanCaptureConvertOptions = {}): TransactionEvent | undefined {
     // We can only convert finished spans
-    if (!isFullFinishedSpan(spanToJSON(this))) {
+    if (!isFullFinishedSpan(spanToStaticSpanJSON(this))) {
       return undefined;
     }
 
@@ -463,7 +462,7 @@ export class SentrySpan implements Span {
       if (descendant === this || isStandaloneSpan(descendant) || options.isSpanAlreadyCaptured?.(descendant)) {
         continue;
       }
-      const spanJSON = spanToJSON(descendant);
+      const spanJSON = spanToStaticSpanJSON(descendant);
       if (!isFullFinishedSpan(spanJSON)) {
         continue;
       }

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -15,8 +15,8 @@ import type { SerializedStreamedSpan, Span, SpanAttributeValue, SpanJSON, Stream
 import { getCombinedScopeData } from '../../utils/scopeData';
 import {
   INTERNAL_getSegmentSpan,
+  spanToStaticSpanJSON,
   spanToJSON,
-  spanToStreamedSpanJSON,
   streamedSpanJsonToSerializedSpan,
 } from '../../utils/spanUtils';
 import { getCapturedScopesOnSpan } from '../utils';
@@ -47,10 +47,10 @@ export type SerializedStreamedSpanWithSegmentSpan = SerializedStreamedSpan & {
  */
 export function captureSpan(span: Span, client: Client): SerializedStreamedSpanWithSegmentSpan {
   // Convert to JSON FIRST - we cannot write to an already-ended span
-  const spanJSON = spanToStreamedSpanJSON(span);
+  const spanJSON = spanToJSON(span);
 
   const segmentSpan = INTERNAL_getSegmentSpan(span);
-  const serializedSegmentSpan = spanToStreamedSpanJSON(segmentSpan);
+  const serializedSegmentSpan = spanToJSON(segmentSpan);
 
   const { isolationScope: spanIsolationScope, scope: spanScope } = getCapturedScopesOnSpan(span);
 
@@ -83,7 +83,7 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
       ? applyBeforeSendSpanCallback(spanJSON, beforeSendSpan)
       : spanJSON;
 
-  const spanNameSource = processedSpan.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+  const spanNameSource = processedSpan.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
   if (spanJSON.is_segment && spanNameSource) {
     // Backfill sentry.segment.name.source from sentry.source.
     // TODO(v11): Remove this backfill once we removed setting SEMANTIC_ATTRIBUTE_SENTRY_SOURCE in favour of
@@ -181,10 +181,10 @@ export function captureStandaloneSpanWithStaticCallback(
   client: Client,
   beforeSendSpan: (span: SpanJSON) => SpanJSON,
 ): SerializedStreamedSpan {
-  const spanJSON = spanToJSON(span);
+  const spanJSON = spanToStaticSpanJSON(span);
 
   const segmentSpan = INTERNAL_getSegmentSpan(span);
-  const serializedSegmentSpan = spanToStreamedSpanJSON(segmentSpan);
+  const serializedSegmentSpan = spanToJSON(segmentSpan);
 
   const { isolationScope: spanIsolationScope, scope: spanScope } = getCapturedScopesOnSpan(span);
   const finalScopeData = getCombinedScopeData(spanIsolationScope, spanScope);

--- a/packages/core/src/tracing/spans/spanJsonToStreamedSpan.ts
+++ b/packages/core/src/tracing/spans/spanJsonToStreamedSpan.ts
@@ -12,7 +12,7 @@ export function spanJsonToSerializedStreamedSpan(span: SpanJSON): SerializedStre
     parent_span_id: span.parent_span_id,
     name: span.description || '',
     start_timestamp: span.start_timestamp,
-    end_timestamp: span.timestamp || span.start_timestamp,
+    end_timestamp: span.timestamp,
     status: !span.status || span.status === 'ok' || span.status === 'cancelled' ? 'ok' : 'error',
     is_segment: false,
     attributes: { ...(span.data as RawAttributes<Record<string, unknown>>) },

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -24,7 +24,13 @@ import { parseSampleRate } from '../utils/parseSampleRate';
 import { generateTraceId } from '../utils/propagationContext';
 import { safeMathRandom } from '../utils/randomSafeContext';
 import { _getSpanForScope, _setSpanForScope } from '../utils/spanOnScope';
-import { addChildSpanToSpan, getRootSpan, spanIsSampled, spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';
+import {
+  addChildSpanToSpan,
+  getRootSpan,
+  spanIsSampled,
+  spanTimeInputToSeconds,
+  spanToStaticSpanJSON,
+} from '../utils/spanUtils';
 import { propagationContextFromHeaders, shouldContinueTrace } from '../utils/tracing';
 import { freezeDscOnSpan, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { logSpanStart } from './logSpans';
@@ -89,7 +95,7 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
         () => callback(activeSpan),
         () => {
           // Only update the span status if it hasn't been changed yet, and the span is not yet finished
-          const { status } = spanToJSON(activeSpan);
+          const { status } = spanToStaticSpanJSON(activeSpan);
           if (activeSpan.isRecording() && status === 'ok') {
             activeSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
           }
@@ -155,7 +161,7 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
         () => callback(activeSpan, () => activeSpan.end()),
         () => {
           // Only update the span status if it hasn't been changed yet, and the span is not yet finished
-          const { status } = spanToJSON(activeSpan);
+          const { status } = spanToStaticSpanJSON(activeSpan);
           if (activeSpan.isRecording() && status === 'ok') {
             activeSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
           }

--- a/packages/core/src/types/samplingcontext.ts
+++ b/packages/core/src/types/samplingcontext.ts
@@ -1,6 +1,6 @@
+import type { RawAttributes } from '../attributes';
 import type { RequestEventData } from '../types/request';
 import type { WorkerLocation } from './misc';
-import type { SpanAttributes } from './span';
 
 /**
  * Context data passed by the user when starting a transaction, to be used by the tracesSampler method.
@@ -38,7 +38,7 @@ export interface SamplingContext extends CustomSamplingContext {
   name: string;
 
   /** Initial attributes that have been passed to the span being sampled. */
-  attributes?: SpanAttributes;
+  attributes?: RawAttributes<Record<string, unknown>>;
 }
 
 /**

--- a/packages/core/src/types/span.ts
+++ b/packages/core/src/types/span.ts
@@ -49,10 +49,11 @@ export interface StreamedSpanJSON {
   span_id: string;
   name: string;
   start_timestamp: number;
-  end_timestamp: number;
+  /** Only set once the span has ended. */
+  end_timestamp?: number;
   status: 'ok' | 'error';
   is_segment: boolean;
-  attributes?: RawAttributes<Record<string, unknown>>;
+  attributes: RawAttributes<Record<string, unknown>>;
   links?: SpanLinkJSON<RawAttributes<Record<string, unknown>>>[];
 }
 
@@ -60,9 +61,11 @@ export interface StreamedSpanJSON {
  * Serialized span item.
  * This is the final, serialized span format that is sent to Sentry.
  * The intermediate representation is {@link StreamedSpanJSON}.
- * Main difference: Attributes are converted to {@link Attributes}, thus including the `type` annotation.
+ * Main differences: Attributes are converted to {@link Attributes}, thus including the `type`
+ * annotation, and `end_timestamp` is guaranteed to be set (we only ever send ended spans).
  */
-export type SerializedStreamedSpan = Omit<StreamedSpanJSON, 'attributes' | 'links'> & {
+export type SerializedStreamedSpan = Omit<StreamedSpanJSON, 'attributes' | 'links' | 'end_timestamp'> & {
+  end_timestamp: number;
   attributes: Attributes;
   links?: SpanLinkJSON<Attributes>[];
 };

--- a/packages/core/src/utils/featureFlags.ts
+++ b/packages/core/src/utils/featureFlags.ts
@@ -2,7 +2,7 @@ import { getCurrentScope } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { type Event } from '../types/event';
 import { debug } from './debug-logger';
-import { getActiveSpan, spanToJSON } from './spanUtils';
+import { getActiveSpan, spanToStaticSpanJSON } from './spanUtils';
 
 /**
  * Ordered LRU cache for storing feature flags in the scope context. The name
@@ -143,7 +143,7 @@ export function _INTERNAL_addFeatureFlagToActiveSpan(
     return;
   }
 
-  const attributes = spanToJSON(span).data;
+  const attributes = spanToStaticSpanJSON(span).data;
 
   // If the flag already exists, always update it
   if (`${SPAN_FLAG_ATTRIBUTE_PREFIX}${name}` in attributes) {

--- a/packages/core/src/utils/scopeData.ts
+++ b/packages/core/src/utils/scopeData.ts
@@ -5,7 +5,7 @@ import type { Breadcrumb } from '../types/breadcrumb';
 import type { Event } from '../types/event';
 import type { Span } from '../types/span';
 import { merge } from './merge';
-import { getRootSpan, spanToJSON, spanToTraceContext } from './spanUtils';
+import { getRootSpan, spanToStaticSpanJSON, spanToTraceContext } from './spanUtils';
 
 /**
  * Applies data from the scope to the event and runs all event processors on it.
@@ -181,7 +181,7 @@ function applySpanToEvent(event: Event, span: Span): void {
   };
 
   const rootSpan = getRootSpan(span);
-  const transactionName = spanToJSON(rootSpan).description;
+  const transactionName = spanToStaticSpanJSON(rootSpan).description;
   if (transactionName && !event.transaction && event.type === 'transaction') {
     event.transaction = transactionName;
   }

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -43,7 +43,7 @@ export const TRACE_FLAG_SAMPLED = 0x1;
  */
 export function spanToTransactionTraceContext(span: Span): TraceContext {
   const { spanId: span_id, traceId: trace_id } = span.spanContext();
-  const { data, op, parent_span_id, status, origin, links } = spanToJSON(span);
+  const { data, op, parent_span_id, status, origin, links } = spanToStaticSpanJSON(span);
 
   return {
     parent_span_id,
@@ -65,7 +65,7 @@ export function spanToTraceContext(span: Span): TraceContext {
 
   // If the span is remote, we use a random/virtual span as span_id to the trace context,
   // and the remote span as parent_span_id
-  const parent_span_id = isRemote ? spanId : spanToJSON(span).parent_span_id;
+  const parent_span_id = isRemote ? spanId : spanToStaticSpanJSON(span).parent_span_id;
   const scope = getCapturedScopesOnSpan(span).scope;
 
   const span_id = isRemote ? scope?.getPropagationContext().propagationSpanId || generateSpanId() : spanId;
@@ -168,7 +168,7 @@ function ensureTimestampInSeconds(timestamp: number): number {
 // Note: Because of this, we currently have a circular type dependency (which we opted out of in package.json).
 // This is not avoidable as we need `spanToJSON` in `spanUtils.ts`, which in turn is needed by `span.ts` for backwards compatibility.
 // And `spanToJSON` needs the Span class from `span.ts` to check here.
-export function spanToJSON(span: Span): SpanJSON {
+export function spanToStaticSpanJSON(span: Span): SpanJSON {
   if (spanIsSentrySpan(span)) {
     return span.getSpanJSON();
   }
@@ -209,7 +209,7 @@ export function spanToJSON(span: Span): SpanJSON {
 /**
  * Convert a span to the intermediate {@link StreamedSpanJSON} representation.
  */
-export function spanToStreamedSpanJSON(span: Span): StreamedSpanJSON {
+export function spanToJSON(span: Span): StreamedSpanJSON {
   if (spanIsSentrySpan(span)) {
     return span.getStreamedSpanJSON();
   }
@@ -226,7 +226,8 @@ export function spanToStreamedSpanJSON(span: Span): StreamedSpanJSON {
       trace_id,
       parent_span_id: getOtelParentSpanId(span),
       start_timestamp: spanTimeInputToSeconds(startTime),
-      end_timestamp: spanTimeInputToSeconds(endTime),
+      // This is [0,0] by default in OTEL, in which case we want to interpret this as no end time
+      end_timestamp: spanTimeInputToSeconds(endTime) || undefined,
       is_segment: span === INTERNAL_getSegmentSpan(span),
       status: getSimpleStatus(status),
       attributes: addStatusMessageAttribute(attributes, status),
@@ -241,9 +242,9 @@ export function spanToStreamedSpanJSON(span: Span): StreamedSpanJSON {
     trace_id,
     start_timestamp: 0,
     name: '',
-    end_timestamp: 0,
     status: 'ok',
     is_segment: span === INTERNAL_getSegmentSpan(span),
+    attributes: {},
   };
 }
 
@@ -269,6 +270,9 @@ function getOtelParentSpanId(span: OpenTelemetrySdkTraceBaseSpan): string | unde
 export function streamedSpanJsonToSerializedSpan(spanJson: StreamedSpanJSON): SerializedStreamedSpan {
   return {
     ...spanJson,
+    // We only ever send ended spans, but fall back to the start time (i.e. duration 0) so that
+    // sent spans always carry an end timestamp.
+    end_timestamp: spanJson.end_timestamp ?? spanJson.start_timestamp,
     attributes: serializeAttributes(spanJson.attributes),
     links: spanJson.links?.map(link => ({
       ...link,

--- a/packages/core/test/lib/integrations/conversationId.test.ts
+++ b/packages/core/test/lib/integrations/conversationId.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getCurrentScope, getIsolationScope, setCurrentClient, startSpan } from '../../../src';
 import { conversationIdIntegration } from '../../../src/integrations/conversationId';
 import { GEN_AI_CONVERSATION_ID_ATTRIBUTE } from '../../../src/semanticAttributes';
-import { spanToJSON } from '../../../src/utils/spanUtils';
+import { spanToStaticSpanJSON } from '../../../src/utils/spanUtils';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
 
 describe('ConversationId', () => {
@@ -27,7 +27,7 @@ describe('ConversationId', () => {
     getCurrentScope().setConversationId('conv_test_123');
 
     startSpan({ name: 'test-span', op: 'gen_ai.chat' }, span => {
-      const spanJSON = spanToJSON(span);
+      const spanJSON = spanToStaticSpanJSON(span);
       expect(spanJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBe('conv_test_123');
     });
   });
@@ -36,7 +36,7 @@ describe('ConversationId', () => {
     getIsolationScope().setConversationId('conv_isolation_456');
 
     startSpan({ name: 'test-span', op: 'gen_ai.chat' }, span => {
-      const spanJSON = spanToJSON(span);
+      const spanJSON = spanToStaticSpanJSON(span);
       expect(spanJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBe('conv_isolation_456');
     });
   });
@@ -46,14 +46,14 @@ describe('ConversationId', () => {
     getIsolationScope().setConversationId('conv_isolation_999');
 
     startSpan({ name: 'test-span', op: 'gen_ai.chat' }, span => {
-      const spanJSON = spanToJSON(span);
+      const spanJSON = spanToStaticSpanJSON(span);
       expect(spanJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBe('conv_current_789');
     });
   });
 
   it('does not apply conversation ID when not set in scope', () => {
     startSpan({ name: 'test-span', op: 'gen_ai.chat' }, span => {
-      const spanJSON = spanToJSON(span);
+      const spanJSON = spanToStaticSpanJSON(span);
       expect(spanJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBeUndefined();
     });
   });
@@ -63,7 +63,7 @@ describe('ConversationId', () => {
     getCurrentScope().setConversationId(null);
 
     startSpan({ name: 'test-span', op: 'gen_ai.chat' }, span => {
-      const spanJSON = spanToJSON(span);
+      const spanJSON = spanToStaticSpanJSON(span);
       expect(spanJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBeUndefined();
     });
   });
@@ -73,7 +73,7 @@ describe('ConversationId', () => {
 
     startSpan({ name: 'parent-span', op: 'gen_ai.invoke_agent' }, () => {
       startSpan({ name: 'child-span', op: 'gen_ai.chat' }, childSpan => {
-        const childJSON = spanToJSON(childSpan);
+        const childJSON = spanToStaticSpanJSON(childSpan);
         expect(childJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBe('conv_nested_abc');
       });
     });
@@ -91,7 +91,7 @@ describe('ConversationId', () => {
         },
       },
       span => {
-        const spanJSON = spanToJSON(span);
+        const spanJSON = spanToStaticSpanJSON(span);
         expect(spanJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBe('conv_from_scope');
       },
     );
@@ -101,7 +101,7 @@ describe('ConversationId', () => {
     getCurrentScope().setConversationId('conv_test_123');
 
     startSpan({ name: 'db-query', op: 'db.query' }, span => {
-      const spanJSON = spanToJSON(span);
+      const spanJSON = spanToStaticSpanJSON(span);
       expect(spanJSON.data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]).toBeUndefined();
     });
   });

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { setCurrentClient, spanToJSON, startInactiveSpan, startSpan } from '../../../src';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
+  setCurrentClient,
+  spanToJSON,
+  startInactiveSpan,
+  startSpan,
+} from '../../../src';
 import * as globalErrorModule from '../../../src/instrument/globalError';
 import * as globalUnhandledRejectionModule from '../../../src/instrument/globalUnhandledRejection';
 import { _resetErrorsInstrumented, registerSpanErrorInstrumentation } from '../../../src/tracing/errors';
@@ -59,7 +65,9 @@ describe('registerErrorHandlers()', () => {
 
     startSpan({ name: 'test' }, span => {
       mockErrorCallback({} as HandlerDataError);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      const { status, attributes } = spanToJSON(span);
+      expect(status).toBe('error');
+      expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('internal_error');
     });
   });
 
@@ -68,7 +76,9 @@ describe('registerErrorHandlers()', () => {
 
     startSpan({ name: 'test' }, span => {
       mockUnhandledRejectionCallback({});
-      expect(spanToJSON(span).status).toBe('internal_error');
+      const { status, attributes } = spanToJSON(span);
+      expect(status).toBe('error');
+      expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('internal_error');
     });
   });
 });

--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -10,6 +10,7 @@ import {
   getTraceData,
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
   SentryNonRecordingSpan,
   SentrySpan,
   setCurrentClient,
@@ -264,7 +265,7 @@ describe('startIdleSpan', () => {
     vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout + 1);
     vi.runOnlyPendingTimers();
 
-    expect(spanToJSON(idleSpan).data).toEqual(
+    expect(spanToJSON(idleSpan).attributes).toEqual(
       expect.objectContaining({
         foo: 'bar',
       }),
@@ -289,7 +290,7 @@ describe('startIdleSpan', () => {
   it('runs beforeIdleSpanEnd before trimming the idle span', () => {
     const baseTimeInSeconds = Math.floor(Date.now() / 1000) - 9999;
     const beforeIdleSpanEnd = vi.fn((span: Span) => {
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToJSON(span).end_timestamp).toBeUndefined();
       const childSpan = startInactiveSpan({ name: 'last-moment child', startTime: baseTimeInSeconds });
       childSpan.end(baseTimeInSeconds + 1);
     });
@@ -301,7 +302,7 @@ describe('startIdleSpan', () => {
 
     expect(beforeIdleSpanEnd).toHaveBeenCalledOnce();
     expect(beforeIdleSpanEnd).toHaveBeenCalledWith(idleSpan);
-    expect(spanToJSON(idleSpan).timestamp).toBe(baseTimeInSeconds + 1);
+    expect(spanToJSON(idleSpan).end_timestamp).toBe(baseTimeInSeconds + 1);
   });
 
   it('filters spans on end', () => {
@@ -476,7 +477,7 @@ describe('startIdleSpan', () => {
     expect(hookSpans).toEqual([{ span: idleSpan, hook: 'spanStart' }]);
 
     vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-    expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+    expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
 
     expect(hookSpans).toEqual([
       { span: idleSpan, hook: 'spanStart' },
@@ -624,7 +625,7 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('does not finish if a activity is started', () => {
@@ -634,7 +635,7 @@ describe('startIdleSpan', () => {
       startInactiveSpan({ name: 'span' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
     });
 
     it('does not finish when idleTimeout is not exceed after last activity finished', () => {
@@ -650,7 +651,7 @@ describe('startIdleSpan', () => {
 
       vi.advanceTimersByTime(8);
 
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
     });
 
     it('finish when idleTimeout is exceeded after last activity finished', () => {
@@ -666,7 +667,7 @@ describe('startIdleSpan', () => {
 
       vi.advanceTimersByTime(10);
 
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
   });
 
@@ -678,18 +679,24 @@ describe('startIdleSpan', () => {
       // Start any span to cancel idle timeout
       startInactiveSpan({ name: 'span' });
 
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait some time
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait for timeout to exceed
       vi.advanceTimersByTime(1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('resets after new activities are added', () => {
@@ -699,32 +706,42 @@ describe('startIdleSpan', () => {
       // Start any span to cancel idle timeout
       startInactiveSpan({ name: 'span' });
 
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait some time
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // New span resets the timeout
       startInactiveSpan({ name: 'span' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // New span resets the timeout
       startInactiveSpan({ name: 'span' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait for timeout to exceed
       vi.advanceTimersByTime(1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it("doesn't reset the timeout for standalone spans", () => {
@@ -736,8 +753,10 @@ describe('startIdleSpan', () => {
 
       // Wait some time
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // new standalone span should not reset the timeout
       const standaloneSpan = startInactiveSpan({ name: 'standalone span', experimental: { standalone: true } });
@@ -745,8 +764,10 @@ describe('startIdleSpan', () => {
 
       // Wait for timeout to exceed
       vi.advanceTimersByTime(1001);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
   });
 
@@ -756,16 +777,16 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Now emit a signal
       getClient()!.emit('idleSpanEnableAutoFinish', idleSpan);
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('skips span timeout if disableAutoFinish=true', () => {
@@ -775,16 +796,16 @@ describe('startIdleSpan', () => {
       startInactiveSpan({ name: 'inner' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Now emit a signal
       getClient()!.emit('idleSpanEnableAutoFinish', idleSpan);
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('times out at final timeout if disableAutoFinish=true', () => {
@@ -792,7 +813,7 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.finalTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('ignores it if hook is emitted with other span', () => {
@@ -801,17 +822,17 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Now emit a signal, but with a different span
       getClient()!.emit('idleSpanEnableAutoFinish', span);
 
       // This doesn't affect us!
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToJSON(idleSpan).end_timestamp).toBeUndefined();
     });
   });
 
@@ -833,7 +854,7 @@ describe('startIdleSpan', () => {
 
       vi.runAllTimers();
 
-      expect(spanToJSON(idleSpan).timestamp).toBe(1100);
+      expect(spanToJSON(idleSpan).end_timestamp).toBe(1100);
     });
 
     it('trims end to final timeout', () => {
@@ -853,7 +874,7 @@ describe('startIdleSpan', () => {
 
       vi.runAllTimers();
 
-      expect(spanToJSON(idleSpan).timestamp).toBe(1030);
+      expect(spanToJSON(idleSpan).end_timestamp).toBe(1030);
     });
 
     it('keeps lower span endTime than highest child span end', () => {
@@ -873,8 +894,8 @@ describe('startIdleSpan', () => {
 
       vi.runAllTimers();
 
-      expect(spanToJSON(idleSpan).timestamp).toBeLessThan(999_999_999);
-      expect(spanToJSON(idleSpan).timestamp).toBeGreaterThan(1060);
+      expect(spanToJSON(idleSpan).end_timestamp).toBeLessThan(999_999_999);
+      expect(spanToJSON(idleSpan).end_timestamp).toBeGreaterThan(1060);
     });
   });
 });

--- a/packages/core/test/lib/tracing/sentryNonRecordingSpan.test.ts
+++ b/packages/core/test/lib/tracing/sentryNonRecordingSpan.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { SPAN_STATUS_ERROR } from '../../../src/tracing';
 import { SentryNonRecordingSpan } from '../../../src/tracing/sentryNonRecordingSpan';
 import type { Span } from '../../../src/types/span';
-import { spanIsSampled, spanToJSON, TRACE_FLAG_NONE } from '../../../src/utils/spanUtils';
+import { spanIsSampled, spanToStaticSpanJSON, TRACE_FLAG_NONE } from '../../../src/utils/spanUtils';
 
 describe('SentryNonRecordingSpan', () => {
   it('satisfies the Span interface', () => {
@@ -16,7 +16,7 @@ describe('SentryNonRecordingSpan', () => {
 
     expect(spanIsSampled(span)).toBe(false);
     expect(span.isRecording()).toBe(false);
-    expect(spanToJSON(span)).toEqual({
+    expect(spanToStaticSpanJSON(span)).toEqual({
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
       data: {},
@@ -33,7 +33,7 @@ describe('SentryNonRecordingSpan', () => {
     span.setStatus({ code: SPAN_STATUS_ERROR });
 
     // but nothing is actually set/readable
-    expect(spanToJSON(span)).toEqual({
+    expect(spanToStaticSpanJSON(span)).toEqual({
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
       data: {},

--- a/packages/core/test/lib/tracing/sentrySpan.test.ts
+++ b/packages/core/test/lib/tracing/sentrySpan.test.ts
@@ -17,7 +17,7 @@ import {
 import { withStaticSpan } from '../../../src/tracing/spans/beforeSendSpan';
 import type { Envelope } from '../../../src/types/envelope';
 import type { SpanJSON } from '../../../src/types/span';
-import { spanToJSON, TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED } from '../../../src/utils/spanUtils';
+import { spanToStaticSpanJSON, TRACE_FLAG_NONE, TRACE_FLAG_SAMPLED } from '../../../src/utils/spanUtils';
 import { timestampInSeconds } from '../../../src/utils/time';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
 
@@ -25,16 +25,16 @@ describe('SentrySpan', () => {
   describe('name', () => {
     it('works with name', () => {
       const span = new SentrySpan({ name: 'span name' });
-      expect(spanToJSON(span).description).toEqual('span name');
+      expect(spanToStaticSpanJSON(span).description).toEqual('span name');
     });
 
     it('allows to update the name via updateName', () => {
       const span = new SentrySpan({ name: 'span name' });
-      expect(spanToJSON(span).description).toEqual('span name');
+      expect(spanToStaticSpanJSON(span).description).toEqual('span name');
 
       span.updateName('new name');
 
-      expect(spanToJSON(span).description).toEqual('new name');
+      expect(spanToStaticSpanJSON(span).description).toEqual('new name');
     });
 
     it('sets the source to custom when calling updateName', () => {
@@ -45,7 +45,7 @@ describe('SentrySpan', () => {
 
       span.updateName('new name');
 
-      const spanJson = spanToJSON(span);
+      const spanJson = spanToStaticSpanJSON(span);
       expect(spanJson.description).toEqual('new name');
       expect(spanJson.data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
     });
@@ -55,7 +55,7 @@ describe('SentrySpan', () => {
 
       span.updateName('new name');
 
-      const spanJson = spanToJSON(span);
+      const spanJson = spanToStaticSpanJSON(span);
       expect(spanJson.description).toEqual('new name');
       expect(spanJson.data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('custom');
     });
@@ -66,7 +66,7 @@ describe('SentrySpan', () => {
 
       span.updateName('new name');
 
-      const spanJson = spanToJSON(span);
+      const spanJson = spanToStaticSpanJSON(span);
       expect(spanJson.description).toEqual('new name');
       expect(spanJson.data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBeUndefined();
     });
@@ -105,9 +105,9 @@ describe('SentrySpan', () => {
   describe('setters', () => {
     test('setName', () => {
       const span = new SentrySpan({});
-      expect(spanToJSON(span).description).toBeUndefined();
+      expect(spanToStaticSpanJSON(span).description).toBeUndefined();
       span.updateName('foo');
-      expect(spanToJSON(span).description).toBe('foo');
+      expect(spanToStaticSpanJSON(span).description).toBe('foo');
     });
   });
 
@@ -115,13 +115,13 @@ describe('SentrySpan', () => {
     test('setStatus', () => {
       const span = new SentrySpan({});
       span.setStatus({ code: SPAN_STATUS_ERROR, message: 'permission_denied' });
-      expect(spanToJSON(span).status).toBe('permission_denied');
+      expect(spanToStaticSpanJSON(span).status).toBe('permission_denied');
     });
   });
 
   describe('toJSON', () => {
     test('simple', () => {
-      const span = spanToJSON(
+      const span = spanToStaticSpanJSON(
         new SentrySpan({ traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', spanId: 'bbbbbbbbbbbbbbbb' }),
       );
       expect(span).toHaveProperty('span_id', 'bbbbbbbbbbbbbbbb');
@@ -136,7 +136,7 @@ describe('SentrySpan', () => {
         sampled: false,
         parentSpanId: spanA.spanContext().spanId,
       });
-      const serialized = spanToJSON(spanB);
+      const serialized = spanToStaticSpanJSON(spanB);
       expect(serialized).toHaveProperty('parent_span_id', 'b');
       expect(serialized).toHaveProperty('span_id', 'd');
       expect(serialized).toHaveProperty('trace_id', 'c');
@@ -169,7 +169,7 @@ describe('SentrySpan', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_MEASUREMENT_UNIT]: 'millisecond',
       });
 
-      const json = spanToJSON(span);
+      const json = spanToStaticSpanJSON(span);
       expect(json.data?.['key']).toBe('before');
       expect(json.data?.['key2']).toBeUndefined();
       expect(json.status).toBe('permission_denied');
@@ -190,7 +190,7 @@ describe('SentrySpan', () => {
       span.updateStartTime(999);
       span.addLink({ context: linked.spanContext() });
 
-      const json = spanToJSON(span);
+      const json = spanToStaticSpanJSON(span);
       expect(json.data?.['key']).toBe('after');
       expect(json.description).toBe('after');
       expect(json.start_timestamp).toBe(999);
@@ -211,32 +211,32 @@ describe('SentrySpan', () => {
       span.end();
 
       span.setAttribute('key', 'after');
-      expect(spanToJSON(span).data?.['key']).toBe('before');
+      expect(spanToStaticSpanJSON(span).data?.['key']).toBe('before');
     });
   });
 
   describe('end', () => {
     test('simple', () => {
       const span = new SentrySpan({});
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToStaticSpanJSON(span).timestamp).toBeUndefined();
       span.end();
-      expect(spanToJSON(span).timestamp).toBeGreaterThan(1);
+      expect(spanToStaticSpanJSON(span).timestamp).toBeGreaterThan(1);
     });
 
     test('with endTime in seconds', () => {
       const span = new SentrySpan({});
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToStaticSpanJSON(span).timestamp).toBeUndefined();
       const endTime = Date.now() / 1000;
       span.end(endTime);
-      expect(spanToJSON(span).timestamp).toBe(endTime);
+      expect(spanToStaticSpanJSON(span).timestamp).toBe(endTime);
     });
 
     test('with endTime in milliseconds', () => {
       const span = new SentrySpan({});
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToStaticSpanJSON(span).timestamp).toBeUndefined();
       const endTime = Date.now();
       span.end(endTime);
-      expect(spanToJSON(span).timestamp).toBe(endTime / 1000);
+      expect(spanToStaticSpanJSON(span).timestamp).toBe(endTime / 1000);
     });
 
     test('uses sampled config for standalone span', () => {
@@ -591,7 +591,7 @@ describe('SentrySpan', () => {
       const now = timestampInSeconds();
       span.end();
 
-      expect(spanToJSON(span).timestamp).toBeGreaterThanOrEqual(now);
+      expect(spanToStaticSpanJSON(span).timestamp).toBeGreaterThanOrEqual(now);
     });
 
     it('works with endTimestamp in seconds', () => {
@@ -599,7 +599,7 @@ describe('SentrySpan', () => {
       const timestamp = timestampInSeconds() - 1;
       span.end(timestamp);
 
-      expect(spanToJSON(span).timestamp).toEqual(timestamp);
+      expect(spanToStaticSpanJSON(span).timestamp).toEqual(timestamp);
     });
 
     it('works with endTimestamp in milliseconds', () => {
@@ -607,7 +607,7 @@ describe('SentrySpan', () => {
       const timestamp = Date.now() - 1000;
       span.end(timestamp);
 
-      expect(spanToJSON(span).timestamp).toEqual(timestamp / 1000);
+      expect(spanToStaticSpanJSON(span).timestamp).toEqual(timestamp / 1000);
     });
 
     it('works with endTimestamp in array form', () => {
@@ -615,7 +615,7 @@ describe('SentrySpan', () => {
       const seconds = Math.floor(timestampInSeconds() - 1);
       span.end([seconds, 0]);
 
-      expect(spanToJSON(span).timestamp).toEqual(seconds);
+      expect(spanToStaticSpanJSON(span).timestamp).toEqual(seconds);
     });
 
     it('skips if span is already ended', () => {
@@ -625,7 +625,7 @@ describe('SentrySpan', () => {
 
       span.end();
 
-      expect(spanToJSON(span).timestamp).toBe(endTimestamp);
+      expect(spanToStaticSpanJSON(span).timestamp).toBe(endTimestamp);
     });
   });
 

--- a/packages/core/test/lib/tracing/spanstatus.test.ts
+++ b/packages/core/test/lib/tracing/spanstatus.test.ts
@@ -1,30 +1,31 @@
 import { describe, expect, it } from 'vitest';
-import { SentrySpan, setHttpStatus, spanToJSON } from '../../../src/index';
+import { SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE, SentrySpan, setHttpStatus, spanToJSON } from '../../../src/index';
 
 describe('setHttpStatus', () => {
   it.each([
-    [200, 'ok'],
-    [300, 'ok'],
-    [401, 'unauthenticated'],
-    [403, 'permission_denied'],
-    [404, 'not_found'],
-    [409, 'already_exists'],
-    [413, 'failed_precondition'],
-    [429, 'resource_exhausted'],
-    [455, 'invalid_argument'],
-    [501, 'unimplemented'],
-    [503, 'unavailable'],
-    [504, 'deadline_exceeded'],
-    [520, 'internal_error'],
-  ])('applies the correct span status and http status code to the span (%s - $%s)', (code, status) => {
+    [200, 'ok', undefined],
+    [300, 'ok', undefined],
+    [401, 'error', 'unauthenticated'],
+    [403, 'error', 'permission_denied'],
+    [404, 'error', 'not_found'],
+    [409, 'error', 'already_exists'],
+    [413, 'error', 'failed_precondition'],
+    [429, 'error', 'resource_exhausted'],
+    [455, 'error', 'invalid_argument'],
+    [501, 'error', 'unimplemented'],
+    [503, 'error', 'unavailable'],
+    [504, 'error', 'deadline_exceeded'],
+    [520, 'error', 'internal_error'],
+  ])('applies the correct span status and http status code to the span (%s - $%s)', (code, status, statusMessage) => {
     const span = new SentrySpan({ name: 'test' });
 
-    setHttpStatus(span, code);
+    setHttpStatus(span, code as number);
 
-    const { status: spanStatus, data } = spanToJSON(span);
+    const { status: spanStatus, attributes } = spanToJSON(span);
 
     expect(spanStatus).toBe(status);
-    expect(data).toMatchObject({ 'http.response.status_code': code });
+    expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe(statusMessage);
+    expect(attributes).toMatchObject({ 'http.response.status_code': code });
   });
 
   it('defaults to internal_error', () => {
@@ -32,9 +33,10 @@ describe('setHttpStatus', () => {
 
     setHttpStatus(span, 600);
 
-    const { status: spanStatus, data } = spanToJSON(span);
+    const { status: spanStatus, attributes } = spanToJSON(span);
 
-    expect(spanStatus).toBe('internal_error');
-    expect(data).toMatchObject({ 'http.response.status_code': 600 });
+    expect(spanStatus).toBe('error');
+    expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('internal_error');
+    expect(attributes).toMatchObject({ 'http.response.status_code': 600 });
   });
 });

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -104,8 +104,8 @@ describe('startSpan', () => {
       }
       expect(_span).toBeDefined();
 
-      expect(spanToJSON(_span!).description).toEqual('GET users/[id]');
-      expect(spanToJSON(_span!).status).toEqual(isError ? 'internal_error' : 'ok');
+      expect(spanToJSON(_span!).name).toEqual('GET users/[id]');
+      expect(spanToJSON(_span!).status).toEqual(isError ? 'error' : 'ok');
     });
 
     it('allows for transaction to be mutated', async () => {
@@ -122,7 +122,7 @@ describe('startSpan', () => {
         //
       }
 
-      expect(spanToJSON(_span!).op).toEqual('http.server');
+      expect(spanToJSON(_span!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual('http.server');
     });
 
     it('creates a span with correct description', async () => {
@@ -146,9 +146,9 @@ describe('startSpan', () => {
       const spans = getSpanDescendants(_span!);
 
       expect(spans).toHaveLength(2);
-      expect(spanToJSON(spans[1]!).description).toEqual('SELECT * from users');
+      expect(spanToJSON(spans[1]!).name).toEqual('SELECT * from users');
       expect(spanToJSON(spans[1]!).parent_span_id).toEqual(_span!.spanContext().spanId);
-      expect(spanToJSON(spans[1]!).status).toEqual(isError ? 'internal_error' : 'ok');
+      expect(spanToJSON(spans[1]!).status).toEqual(isError ? 'error' : 'ok');
     });
 
     it('allows for span to be mutated', async () => {
@@ -173,7 +173,7 @@ describe('startSpan', () => {
       const spans = getSpanDescendants(_span!);
 
       expect(spans).toHaveLength(2);
-      expect(spanToJSON(spans[1]!).op).toEqual('db.query');
+      expect(spanToJSON(spans[1]!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual('db.query');
     });
 
     it('correctly sets the span origin', async () => {
@@ -198,17 +198,20 @@ describe('startSpan', () => {
       expect(_span).toBeDefined();
       const jsonSpan = spanToJSON(_span!);
       expect(jsonSpan).toEqual({
-        data: {
+        attributes: {
           'sentry.origin': 'auto.http.browser',
           'sentry.sample_rate': 1,
           'sentry.source': 'custom',
+          ...(isError && { 'sentry.status.message': 'internal_error' }),
         },
-        origin: 'auto.http.browser',
-        description: 'GET users/[id]',
+        name: 'GET users/[id]',
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
+        parent_span_id: undefined,
         start_timestamp: expect.any(Number),
-        status: isError ? 'internal_error' : 'ok',
-        timestamp: expect.any(Number),
+        end_timestamp: expect.any(Number),
+        is_segment: true,
+        status: isError ? 'error' : 'ok',
+        links: undefined,
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
       });
     });
@@ -308,12 +311,12 @@ describe('startSpan', () => {
     const span = startSpan({ name: 'GET users/[id]' }, span => {
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToJSON(span).end_timestamp).toBeUndefined();
       return span;
     });
 
     expect(span).toBeDefined();
-    expect(spanToJSON(span).timestamp).toBeDefined();
+    expect(spanToJSON(span).end_timestamp).toBeDefined();
   });
 
   it('allows to pass a `startTime`', () => {
@@ -937,9 +940,9 @@ describe('startSpanManual', () => {
     startSpanManual({ name: 'GET users/[id]' }, (span, finish) => {
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToJSON(span).end_timestamp).toBeUndefined();
       finish();
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
     });
   });
 
@@ -1453,11 +1456,11 @@ describe('startInactiveSpan', () => {
 
     expect(span).toBeDefined();
     expect(span).toBeInstanceOf(SentrySpan);
-    expect(spanToJSON(span).timestamp).toBeUndefined();
+    expect(spanToJSON(span).end_timestamp).toBeUndefined();
 
     span.end();
 
-    expect(spanToJSON(span).timestamp).toBeDefined();
+    expect(spanToJSON(span).end_timestamp).toBeDefined();
   });
 
   it('does not set span on scope', () => {
@@ -1569,7 +1572,7 @@ describe('startInactiveSpan', () => {
     expect(span2LinkJSON?.span_id).toBe(span1JSON.span_id);
 
     // sampling decision is inherited
-    expect(span2LinkJSON?.sampled).toBe(Boolean(spanToJSON(rawSpan1).data['sentry.sample_rate']));
+    expect(span2LinkJSON?.sampled).toBe(Boolean(spanToJSON(rawSpan1).attributes['sentry.sample_rate']));
   });
 
   it('allows to force a transaction with forceTransaction=true', async () => {
@@ -2383,11 +2386,11 @@ describe('span hooks', () => {
     const endedSpans: string[] = [];
 
     client.on('spanStart', span => {
-      startedSpans.push(spanToJSON(span).description || '');
+      startedSpans.push(spanToJSON(span).name);
     });
 
     client.on('spanEnd', span => {
-      endedSpans.push(spanToJSON(span).description || '');
+      endedSpans.push(spanToJSON(span).name);
     });
 
     startSpan({ name: 'span1' }, () => {

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -6,6 +6,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
   SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE,
+  SentryNonRecordingSpan,
   SentrySpan,
   setCurrentClient,
   SPAN_STATUS_ERROR,
@@ -25,8 +26,8 @@ import {
   getRootSpan,
   spanIsSampled,
   spanTimeInputToSeconds,
+  spanToStaticSpanJSON,
   spanToJSON,
-  spanToStreamedSpanJSON,
   spanToTraceContext,
   streamedSpanJsonToSerializedSpan,
   TRACE_FLAG_NONE,
@@ -316,7 +317,7 @@ describe('spanToJSON', () => {
   describe('SentrySpan', () => {
     it('works with a simple span', () => {
       const span = new SentrySpan();
-      expect(spanToJSON(span)).toEqual({
+      expect(spanToStaticSpanJSON(span)).toEqual({
         span_id: span.spanContext().spanId,
         trace_id: span.spanContext().traceId,
         origin: 'manual',
@@ -343,7 +344,7 @@ describe('spanToJSON', () => {
       });
       span.setStatus({ code: SPAN_STATUS_OK });
 
-      expect(spanToJSON(span)).toEqual({
+      expect(spanToStaticSpanJSON(span)).toEqual({
         description: 'test name',
         op: 'test op',
         parent_span_id: '1234',
@@ -373,7 +374,7 @@ describe('spanToJSON', () => {
         status: { code: SPAN_STATUS_UNSET },
       });
 
-      expect(spanToJSON(span)).toEqual({
+      expect(spanToStaticSpanJSON(span)).toEqual({
         span_id: 'SPAN-1',
         trace_id: 'TRACE-1',
         start_timestamp: 123,
@@ -399,7 +400,7 @@ describe('spanToJSON', () => {
         status: { code: SPAN_STATUS_ERROR, message: 'unknown_error' },
       });
 
-      expect(spanToJSON(span)).toEqual({
+      expect(spanToStaticSpanJSON(span)).toEqual({
         span_id: 'SPAN-1',
         trace_id: 'TRACE-1',
         start_timestamp: 123,
@@ -418,16 +419,16 @@ describe('spanToJSON', () => {
     });
   });
 
-  describe('spanToStreamedSpanJSON', () => {
+  describe('spanToJSON', () => {
     describe('SentrySpan', () => {
       it('converts a minimal span', () => {
         const span = new SentrySpan();
-        expect(spanToStreamedSpanJSON(span)).toEqual({
+        expect(spanToJSON(span)).toEqual({
           span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
           trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
           name: '',
           start_timestamp: expect.any(Number),
-          end_timestamp: expect.any(Number),
+          end_timestamp: undefined,
           status: 'ok',
           is_segment: true,
           attributes: {
@@ -467,7 +468,7 @@ describe('spanToJSON', () => {
         span.setStatus({ code: SPAN_STATUS_OK });
         span.setAttribute('attr4', [1, 2, 3]);
 
-        expect(spanToStreamedSpanJSON(span)).toEqual({
+        expect(spanToJSON(span)).toEqual({
           name: 'test name',
           parent_span_id: '1234',
           span_id: '5678',
@@ -500,7 +501,7 @@ describe('spanToJSON', () => {
         const span = new SentrySpan({ name: 'test name' });
         span.setStatus({ code: SPAN_STATUS_ERROR, message: 'Connection Refused' });
 
-        const json = spanToStreamedSpanJSON(span);
+        const json = spanToJSON(span);
         expect(json.status).toBe('error');
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('Connection Refused');
       });
@@ -509,7 +510,7 @@ describe('spanToJSON', () => {
         const span = new SentrySpan({ name: 'test name' });
         span.setStatus({ code: SPAN_STATUS_OK });
 
-        const json = spanToStreamedSpanJSON(span);
+        const json = spanToJSON(span);
         expect(json.status).toBe('ok');
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBeUndefined();
       });
@@ -518,7 +519,7 @@ describe('spanToJSON', () => {
         const span = new SentrySpan({ name: 'test name' });
         span.setStatus({ code: SPAN_STATUS_ERROR });
 
-        const json = spanToStreamedSpanJSON(span);
+        const json = spanToJSON(span);
         expect(json.status).toBe('error');
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBeUndefined();
       });
@@ -527,7 +528,7 @@ describe('spanToJSON', () => {
         const span = new SentrySpan({ name: 'test name' });
         span.setStatus({ code: SPAN_STATUS_ERROR, message: 'cancelled' });
 
-        const json = spanToStreamedSpanJSON(span);
+        const json = spanToJSON(span);
         expect(json.status).toBe('ok');
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBeUndefined();
       });
@@ -539,7 +540,7 @@ describe('spanToJSON', () => {
         });
         span.setStatus({ code: SPAN_STATUS_ERROR, message: 'Connection Refused' });
 
-        const json = spanToStreamedSpanJSON(span);
+        const json = spanToJSON(span);
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('explicit message');
       });
     });
@@ -555,12 +556,12 @@ describe('spanToJSON', () => {
           status: { code: SPAN_STATUS_UNSET },
         });
 
-        expect(spanToStreamedSpanJSON(span)).toEqual({
+        expect(spanToJSON(span)).toEqual({
           span_id: 'SPAN-1',
           trace_id: 'TRACE-1',
           parent_span_id: undefined,
           start_timestamp: 123,
-          end_timestamp: 0,
+          end_timestamp: undefined,
           name: 'test span',
           is_segment: true,
           status: 'ok',
@@ -597,7 +598,7 @@ describe('spanToJSON', () => {
           status: { code: SPAN_STATUS_ERROR, message: 'unknown_error' },
         });
 
-        expect(spanToStreamedSpanJSON(span)).toEqual({
+        expect(spanToJSON(span)).toEqual({
           span_id: 'SPAN-1',
           trace_id: 'TRACE-1',
           parent_span_id: 'PARENT-1',
@@ -637,7 +638,7 @@ describe('spanToJSON', () => {
           status: { code: SPAN_STATUS_ERROR, message: 'Connection Refused' },
         });
 
-        const json = spanToStreamedSpanJSON(span);
+        const json = spanToJSON(span);
         expect(json.status).toBe('error');
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('Connection Refused');
       });
@@ -653,7 +654,7 @@ describe('spanToJSON', () => {
           status: { code: SPAN_STATUS_UNSET },
         });
 
-        const json = spanToStreamedSpanJSON(span);
+        const json = spanToJSON(span);
         expect(json.status).toBe('ok');
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBeUndefined();
       });
@@ -731,7 +732,7 @@ describe('spanToJSON', () => {
       }),
     };
 
-    expect(spanToJSON(span as unknown as Span)).toEqual({
+    expect(spanToStaticSpanJSON(span as unknown as Span)).toEqual({
       status: 'ok',
       span_id: 'SPAN-1',
       trace_id: 'TRACE-1',
@@ -750,6 +751,38 @@ describe('spanIsSampled', () => {
   test('not sampled', () => {
     const span = new SentrySpan({ sampled: false });
     expect(spanIsSampled(span)).toBe(false);
+  });
+});
+
+// `end_timestamp` is what call sites use to tell an open span from an ended one, so it must stay
+// unset until the span actually ends — across all span implementations.
+describe('spanToJSON end_timestamp', () => {
+  test('SentrySpan', () => {
+    const span = new SentrySpan({ name: 'test' });
+    expect(spanToJSON(span).end_timestamp).toBeUndefined();
+
+    span.end();
+    expect(spanToJSON(span).end_timestamp).toBeDefined();
+  });
+
+  test('unsampled SentrySpan', () => {
+    const span = new SentrySpan({ name: 'test', sampled: false });
+    expect(spanToJSON(span).end_timestamp).toBeUndefined();
+
+    span.end();
+    expect(spanToJSON(span).end_timestamp).toBeDefined();
+  });
+
+  test('OpenTelemetry span', () => {
+    const openSpan = createMockedOtelSpan({ spanId: 'SPAN-1', traceId: 'TRACE-1', endTime: [0, 0] });
+    expect(spanToJSON(openSpan).end_timestamp).toBeUndefined();
+
+    const endedSpan = createMockedOtelSpan({ spanId: 'SPAN-1', traceId: 'TRACE-1', endTime: 456 });
+    expect(spanToJSON(endedSpan).end_timestamp).toBe(456);
+  });
+
+  test('SentryNonRecordingSpan', () => {
+    expect(spanToJSON(new SentryNonRecordingSpan()).end_timestamp).toBeUndefined();
   });
 });
 
@@ -784,7 +817,7 @@ describe('updateSpanName', () => {
   it('updates the span name and source', () => {
     const span = new SentrySpan({ name: 'old-name', attributes: { [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url' } });
     updateSpanName(span, 'new-name');
-    const spanJSON = spanToJSON(span);
+    const spanJSON = spanToStaticSpanJSON(span);
     expect(spanJSON.description).toBe('new-name');
     expect(spanJSON.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
   });

--- a/packages/nestjs/test/integrations/orchestrion-subscriber.test.ts
+++ b/packages/nestjs/test/integrations/orchestrion-subscriber.test.ts
@@ -146,17 +146,17 @@ describe('NestJS orchestrion subscriber: app_creation', () => {
     const span = getSpan();
     expect(span).toBeDefined();
     const json = spanToJSON(span!);
-    expect(json.description).toBe('Create Nest App');
-    expect(json.op).toBe('function');
-    expect(json.origin).toBe('auto.http.nestjs');
-    expect(json.data).toMatchObject({
+    expect(json.name).toBe('Create Nest App');
+    expect(json.attributes['sentry.op']).toBe('function');
+    expect(json.attributes['sentry.origin']).toBe('auto.http.nestjs');
+    expect(json.attributes).toMatchObject({
       component: '@nestjs/core',
       'nestjs.type': 'app_creation',
       'nestjs.version': '10.4.1',
       'nestjs.module': 'AppModule',
     });
     // Span was ended on `asyncEnd`.
-    expect(json.timestamp).toBeDefined();
+    expect(json.end_timestamp).toBeDefined();
   });
 
   it('omits optional attributes when version/module are absent', async () => {
@@ -170,9 +170,9 @@ describe('NestJS orchestrion subscriber: app_creation', () => {
     await channel.tracePromise(async () => ({ app: true }), { arguments: [] });
 
     const json = spanToJSON(getSpan()!);
-    expect(json.data['nestjs.version']).toBeUndefined();
-    expect(json.data['nestjs.module']).toBeUndefined();
-    expect(json.data['nestjs.type']).toBe('app_creation');
+    expect(json.attributes['nestjs.version']).toBeUndefined();
+    expect(json.attributes['nestjs.module']).toBeUndefined();
+    expect(json.attributes['nestjs.type']).toBe('app_creation');
   });
 });
 
@@ -240,10 +240,10 @@ describe('NestJS orchestrion subscriber: request_context / request_handler', () 
     });
 
     expect(contextSpanJson).toBeDefined();
-    expect(contextSpanJson!.description).toBe('CatsController.getCats');
-    expect(contextSpanJson!.op).toBe('function');
-    expect(contextSpanJson!.origin).toBe('auto.http.nestjs');
-    expect(contextSpanJson!.data).toMatchObject({
+    expect(contextSpanJson!.name).toBe('CatsController.getCats');
+    expect(contextSpanJson!.attributes['sentry.op']).toBe('function');
+    expect(contextSpanJson!.attributes['sentry.origin']).toBe('auto.http.nestjs');
+    expect(contextSpanJson!.attributes).toMatchObject({
       component: '@nestjs/core',
       'nestjs.type': 'request_context',
       'nestjs.controller': 'CatsController',
@@ -277,10 +277,10 @@ describe('NestJS orchestrion subscriber: request_context / request_handler', () 
     wrappedCallback.call(instance);
 
     expect(handlerSpanJson).toBeDefined();
-    expect(handlerSpanJson!.description).toBe('getCats');
-    expect(handlerSpanJson!.op).toBe('handler');
-    expect(handlerSpanJson!.origin).toBe('auto.http.nestjs');
-    expect(handlerSpanJson!.data).toMatchObject({
+    expect(handlerSpanJson!.name).toBe('getCats');
+    expect(handlerSpanJson!.attributes['sentry.op']).toBe('handler');
+    expect(handlerSpanJson!.attributes['sentry.origin']).toBe('auto.http.nestjs');
+    expect(handlerSpanJson!.attributes).toMatchObject({
       component: '@nestjs/core',
       'nestjs.type': 'handler',
       'nestjs.callback': 'getCats',
@@ -353,11 +353,11 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
 
     expect(next).toHaveBeenCalledTimes(1);
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('LoggerMiddleware');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs');
+    expect(json.name).toBe('LoggerMiddleware');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs');
     // startSpanManual span ends when the proxied `next` is called.
-    expect(json.timestamp).toBeDefined();
+    expect(json.end_timestamp).toBeDefined();
   });
 
   it('guard: wraps `canActivate` in a span and preserves its return value', () => {
@@ -376,9 +376,9 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
 
     expect(new AuthGuard().canActivate({ ctx: true })).toBe(true);
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('AuthGuard');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.guard');
+    expect(json.name).toBe('AuthGuard');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.guard');
   });
 
   it('pipe: wraps `transform` in a span and preserves its return value', () => {
@@ -397,9 +397,9 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
 
     expect(new ParseIntPipe().transform('42', { type: 'param' })).toBe(42);
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('ParseIntPipe');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.pipe');
+    expect(json.name).toBe('ParseIntPipe');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.pipe');
   });
 
   it('interceptor: opens a before-span (ended at next.handle) and instruments the returned observable', () => {
@@ -431,11 +431,11 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     expect(returned).toBe(observable);
 
     const beforeJson = spanToJSON(beforeSpan!);
-    expect(beforeJson.description).toBe('LoggingInterceptor');
-    expect(beforeJson.op).toBe('middleware');
-    expect(beforeJson.origin).toBe('auto.middleware.nestjs.interceptor');
+    expect(beforeJson.name).toBe('LoggingInterceptor');
+    expect(beforeJson.attributes['sentry.op']).toBe('middleware');
+    expect(beforeJson.attributes['sentry.origin']).toBe('auto.middleware.nestjs.interceptor');
     // before-span ends when `next.handle()` is called.
-    expect(beforeJson.timestamp).toBeDefined();
+    expect(beforeJson.end_timestamp).toBeDefined();
 
     // The returned observable was instrumented: subscribing registers an
     // after-span teardown (proving the after-span was created).
@@ -473,7 +473,7 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
 
     expect(returned).toBe(observable);
     // before-span ended (when `next.handle()` ran, post-await)
-    expect(spanToJSON(beforeSpan!).timestamp).toBeDefined();
+    expect(spanToJSON(beforeSpan!).end_timestamp).toBeDefined();
     // after-span was created AND the observable instrumented despite the await
     returned.subscribe();
     expect(teardowns).toHaveLength(1);
@@ -509,7 +509,7 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     expect(next.handle).not.toHaveBeenCalled();
     // before-span is closed even though `next.handle()` (which normally
     // ends it) never ran
-    expect(spanToJSON(beforeSpan!).timestamp).toBeDefined();
+    expect(spanToJSON(beforeSpan!).end_timestamp).toBeDefined();
     // no after-span, so the observable is left un-instrumented
     returned.subscribe();
     expect(teardowns).toHaveLength(0);
@@ -545,7 +545,7 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     expect(next.handle).not.toHaveBeenCalled();
     // before-span is closed even though `next.handle()` (which normally
     // ends it) never ran
-    expect(spanToJSON(beforeSpan!).timestamp).toBeDefined();
+    expect(spanToJSON(beforeSpan!).end_timestamp).toBeDefined();
     // no after-span, so the observable is left un-instrumented
     returned.subscribe();
     expect(teardowns).toHaveLength(0);
@@ -597,8 +597,8 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     expect(returned).toBe(observable);
     // Each interceptor opened and ended its own distinct before-span.
     expect(outerBefore).not.toBe(innerBefore);
-    expect(spanToJSON(outerBefore!).timestamp).toBeDefined();
-    expect(spanToJSON(innerBefore!).timestamp).toBeDefined();
+    expect(spanToJSON(outerBefore!).end_timestamp).toBeDefined();
+    expect(spanToJSON(innerBefore!).end_timestamp).toBeDefined();
     // Exactly one "Interceptors - After Route" span was created for the
     // shared context.
     returned.subscribe();
@@ -658,9 +658,9 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
     expect(ret).toBe('handled:boom');
 
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('HttpExceptionFilter');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.exception_filter');
+    expect(json.name).toBe('HttpExceptionFilter');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.exception_filter');
   });
 
   it('does not open a span when exception or host is absent', () => {
@@ -713,9 +713,9 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
     expect(ret).toBe('handled:boom');
 
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('HttpExceptionFilter');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.exception_filter');
+    expect(json.name).toBe('HttpExceptionFilter');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.exception_filter');
   });
 
   it('still wraps `catch` when the @Catch channel fired first (dual @Injectable @Catch filter)', () => {
@@ -737,9 +737,9 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
     expect(ret).toBe('handled:boom');
 
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('HttpExceptionFilter');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.exception_filter');
+    expect(json.name).toBe('HttpExceptionFilter');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.exception_filter');
   });
 
   // A (contrived) class that is BOTH a guard (`canActivate`) and an
@@ -776,8 +776,8 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
       expect(new GuardAndFilter().canActivate({ ctx: true })).toBe(true);
       expect(new GuardAndFilter().catch('boom', { switchToHttp: () => ({}) })).toBe('handled:boom');
 
-      expect(spanToJSON(guardSpan!).origin).toBe('auto.middleware.nestjs.guard');
-      expect(spanToJSON(filterSpan!).origin).toBe('auto.middleware.nestjs.exception_filter');
+      expect(spanToJSON(guardSpan!).attributes['sentry.origin']).toBe('auto.middleware.nestjs.guard');
+      expect(spanToJSON(filterSpan!).attributes['sentry.origin']).toBe('auto.middleware.nestjs.exception_filter');
     });
   }
 });
@@ -871,9 +871,9 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
     await (descriptor.value as AnyFn)();
 
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('event user.created');
-    expect(json.op).toBe('function');
-    expect(json.origin).toBe('auto.event.nestjs');
+    expect(json.name).toBe('event user.created');
+    expect(json.attributes['sentry.op']).toBe('function');
+    expect(json.attributes['sentry.origin']).toBe('auto.event.nestjs');
   });
 
   it('bullmq @Processor: patches `process` into a queue.process transaction (string queue name)', async () => {
@@ -901,10 +901,10 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
 
     await new EmailProcessor().process({});
     const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('emails process');
-    expect(json.op).toBe('queue.process');
-    expect(json.origin).toBe('auto.queue.nestjs.bullmq');
-    expect(json.data).toMatchObject({
+    expect(json.name).toBe('emails process');
+    expect(json.attributes['sentry.op']).toBe('queue.process');
+    expect(json.attributes['sentry.origin']).toBe('auto.queue.nestjs.bullmq');
+    expect(json.attributes).toMatchObject({
       'messaging.system': 'bullmq',
       'messaging.destination.name': 'emails',
     });
@@ -925,7 +925,7 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
     }
     wrappedDecorator(ReportsProcessor);
     return new ReportsProcessor().process().then(() => {
-      expect(spanToJSON(spanInside!).description).toBe('reports process');
+      expect(spanToJSON(spanInside!).name).toBe('reports process');
     });
   });
 
@@ -990,7 +990,7 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
 
     await (descriptor.value as AnyFn)();
 
-    expect(spanToJSON(spanInside!).description).toBe(expected);
+    expect(spanToJSON(spanInside!).name).toBe(expected);
   });
 
   it('bullmq @Processor: skips wrapping when the class is flagged __SENTRY_INTERNAL__', () => {

--- a/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
+++ b/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
@@ -1,12 +1,6 @@
 import { HTTP_TARGET, URL_FULL } from '@sentry/conventions/attributes';
-import {
-  getClient,
-  GLOBAL_OBJ,
-  isSentryRequestUrl,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  type Span,
-  type SpanAttributes,
-} from '@sentry/core';
+import type { RawAttributes } from '@sentry/core';
+import { getClient, GLOBAL_OBJ, isSentryRequestUrl, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, type Span } from '@sentry/core';
 import { ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
 import { isPathnameUnderSentryTunnelRoute } from './tunnelPathnameMatch';
 import { TRANSACTION_ATTR_SHOULD_DROP_TRANSACTION } from '../span-attributes-with-logic-attached';
@@ -21,7 +15,10 @@ const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
  * 1. Requests to the local tunnel route (before rewrite) via middleware or BaseServer.handleRequest
  * 2. Requests to Sentry ingest (after rewrite) via fetch spans
  */
-export function dropMiddlewareTunnelRequests(span: Span, attrs: SpanAttributes | undefined): void {
+export function dropMiddlewareTunnelRequests(
+  span: Span,
+  attrs: RawAttributes<Record<string, unknown>> | undefined,
+): void {
   // When the user brings their own OTel setup (enableOpenTelemetrySetup: false), we should not
   // mutate their spans with Sentry-internal attributes as it pollutes their tracing backends.
   if (
@@ -53,7 +50,7 @@ export function dropMiddlewareTunnelRequests(span: Span, attrs: SpanAttributes |
   }
 }
 
-function isSentryRequestSpan(attrs: SpanAttributes): boolean {
+function isSentryRequestSpan(attrs: RawAttributes<Record<string, unknown>>): boolean {
   const httpUrl = attrs[URL_FULL];
 
   if (!httpUrl) {

--- a/packages/nextjs/src/common/utils/forkIsolationScopeForRootSpan.ts
+++ b/packages/nextjs/src/common/utils/forkIsolationScopeForRootSpan.ts
@@ -1,5 +1,5 @@
 import { context } from '@opentelemetry/api';
-import type { Span, SpanAttributes } from '@sentry/core';
+import type { RawAttributes, Span } from '@sentry/core';
 import {
   getCapturedScopesOnSpan,
   getCurrentScope,
@@ -14,7 +14,10 @@ import { ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
  * Forks the isolation scope for `BaseServer.handleRequest` / `Middleware.execute` root spans so that request-scoped
  * data (e.g. `normalizedRequest`) stays isolated per request.
  */
-export function maybeForkIsolationScopeForRootSpan(span: Span, spanAttributes: SpanAttributes | undefined): void {
+export function maybeForkIsolationScopeForRootSpan(
+  span: Span,
+  spanAttributes: RawAttributes<Record<string, unknown>> | undefined,
+): void {
   const spanType = spanAttributes?.[ATTR_NEXT_SPAN_TYPE];
   if (spanType !== 'BaseServer.handleRequest' && spanType !== 'Middleware.execute') {
     return;

--- a/packages/nextjs/src/common/utils/tracingUtils.ts
+++ b/packages/nextjs/src/common/utils/tracingUtils.ts
@@ -1,6 +1,6 @@
 import { HTTP_ROUTE, SENTRY_OP } from '@sentry/conventions/attributes';
 import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
-import type { PropagationContext, Span, SpanAttributes } from '@sentry/core';
+import type { PropagationContext, RawAttributes, Span } from '@sentry/core';
 import { isObjectLike, Scope, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { ATTR_NEXT_SEGMENT, ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
 
@@ -61,7 +61,7 @@ export function commonObjectToIsolationScope(commonObject: unknown): Scope {
  * @param spanAttributes The attributes of the span to check.
  * @returns True if the span is a resolve segment span, false otherwise.
  */
-export function isResolveSegmentSpan(spanAttributes: SpanAttributes): boolean {
+export function isResolveSegmentSpan(spanAttributes: RawAttributes<Record<string, unknown>>): boolean {
   return (
     spanAttributes[ATTR_NEXT_SPAN_TYPE] === 'NextNodeServer.getLayoutOrPageModule' &&
     spanAttributes[ATTR_NEXT_SPAN_NAME] === 'resolve segment modules' &&
@@ -96,8 +96,8 @@ export function getEnhancedResolveSegmentSpanName({ segment, route }: { segment:
  */
 export function maybeEnhanceServerComponentSpanName(
   activeSpan: Span,
-  spanAttributes: SpanAttributes,
-  rootSpanAttributes: SpanAttributes,
+  spanAttributes: RawAttributes<Record<string, unknown>>,
+  rootSpanAttributes: RawAttributes<Record<string, unknown>>,
 ): void {
   if (!isResolveSegmentSpan(spanAttributes)) {
     return;
@@ -109,7 +109,7 @@ export function maybeEnhanceServerComponentSpanName(
   activeSpan.updateName(enhancedName);
   activeSpan.setAttributes({
     'sentry.nextjs.ssr.function.type': segment === PAGE_SEGMENT ? 'Page' : 'Layout',
-    'sentry.nextjs.ssr.function.route': route,
+    'sentry.nextjs.ssr.function.route': route as string | undefined,
     [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
     [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
   });

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -126,7 +126,7 @@ export function init(options: VercelEdgeOptions = {}): void {
   });
 
   client.on('spanStart', span => {
-    const spanAttributes = spanToJSON(span).data;
+    const spanAttributes = spanToJSON(span).attributes;
     const rootSpan = getRootSpan(span);
     const isRootSpan = span === rootSpan;
 

--- a/packages/nextjs/src/server/handleOnSpanStart.ts
+++ b/packages/nextjs/src/server/handleOnSpanStart.ts
@@ -22,9 +22,9 @@ import { maybeEnrichQueueConsumerSpan, maybeEnrichQueueProducerSpan } from './ve
  * @param span The span that is starting.
  */
 export function handleOnSpanStart(span: Span): void {
-  const spanAttributes = spanToJSON(span).data;
+  const spanAttributes = spanToJSON(span).attributes;
   const rootSpan = getRootSpan(span);
-  const rootSpanAttributes = spanToJSON(rootSpan).data;
+  const rootSpanAttributes = spanToJSON(rootSpan).attributes;
   const isRootSpan = span === rootSpan;
 
   dropMiddlewareTunnelRequests(span, spanAttributes);

--- a/packages/nextjs/src/server/vercelCronsMonitoring.ts
+++ b/packages/nextjs/src/server/vercelCronsMonitoring.ts
@@ -86,7 +86,7 @@ export function maybeStartCronCheckIn(span: Span, route: string | undefined): vo
  * Should be called from the spanEnd event handler.
  */
 export function maybeCompleteCronCheckIn(span: Span): void {
-  const spanData = spanToJSON(span).data;
+  const spanData = spanToJSON(span).attributes;
   const checkInId = spanData?.[ATTR_SENTRY_CRON_CHECK_IN_ID];
   const monitorSlug = spanData?.[ATTR_SENTRY_CRON_MONITOR_SLUG];
   const startTime = spanData?.[ATTR_SENTRY_CRON_START_TIME];

--- a/packages/nextjs/src/server/vercelQueuesMonitoring.ts
+++ b/packages/nextjs/src/server/vercelQueuesMonitoring.ts
@@ -74,7 +74,7 @@ export function maybeEnrichQueueConsumerSpan(span: Span): void {
  * We use domain-based detection to avoid false positives from user routes.
  */
 export function maybeEnrichQueueProducerSpan(span: Span): void {
-  const spanData = spanToJSON(span).data;
+  const spanData = spanToJSON(span).attributes;
 
   // http.client spans have url.full attribute
   const urlFull = spanData?.[URL_FULL] as string | undefined;
@@ -113,7 +113,7 @@ export function maybeEnrichQueueProducerSpan(span: Span): void {
  * Cleans up the internal marker attribute from enriched queue spans on end.
  */
 export function maybeCleanupQueueSpan(span: Span): void {
-  const spanData = spanToJSON(span).data;
+  const spanData = spanToJSON(span).attributes;
   if (spanData?.[ATTR_SENTRY_QUEUE_ENRICHED]) {
     span.setAttribute(ATTR_SENTRY_QUEUE_ENRICHED, undefined);
   }

--- a/packages/nextjs/test/server/vercelQueuesMonitoring.test.ts
+++ b/packages/nextjs/test/server/vercelQueuesMonitoring.test.ts
@@ -11,7 +11,7 @@ vi.mock('@sentry/core', () => ({
     }),
   }),
   spanToJSON: (span: { _data: Record<string, unknown> }) => ({
-    data: span._data,
+    attributes: span._data,
   }),
 }));
 

--- a/packages/node/src/integrations/tracing/redis/cache.ts
+++ b/packages/node/src/integrations/tracing/redis/cache.ts
@@ -19,6 +19,14 @@ import {
   shouldConsiderForCache,
 } from '../../../utils/redisCache';
 import type { IORedisResponseCustomAttributeFunction } from './vendored/types';
+import {
+  NET_PEER_NAME,
+  NET_PEER_PORT,
+  NETWORK_PEER_ADDRESS,
+  NETWORK_PEER_PORT,
+  SERVER_ADDRESS,
+  SERVER_PORT,
+} from '@sentry/conventions/attributes';
 
 // This module deliberately does NOT import the vendored OTel `IORedisInstrumentation`/
 // `RedisInstrumentation`, so the orchestrion opt-in can pull `cacheResponseHook`
@@ -74,11 +82,14 @@ export const cacheResponseHook: IORedisResponseCustomAttributeFunction = (
   // Fall back to stable semconv attributes (server.address/server.port) when
   // old-semconv ones are absent, eg OTEL_SEMCONV_STABILITY_OPT_IN=database
   // set for node-redis v4/v5.
-  const spanData = spanToJSON(span).data;
-  const networkPeerAddress = spanData['net.peer.name'] ?? spanData['server.address'];
-  const networkPeerPort = spanData['net.peer.port'] ?? spanData['server.port'];
+  const attributes = spanToJSON(span).attributes;
+  // oxlint-disable-next-line typescript/no-deprecated
+  const networkPeerAddress = (attributes[NET_PEER_NAME] ?? attributes[SERVER_ADDRESS]) as string | undefined;
+  // oxlint-disable-next-line typescript/no-deprecated
+  const networkPeerPort = (attributes[NET_PEER_PORT] ?? attributes[SERVER_PORT]) as number | undefined;
+
   if (networkPeerPort && networkPeerAddress) {
-    span.setAttributes({ 'network.peer.address': networkPeerAddress, 'network.peer.port': networkPeerPort });
+    span.setAttributes({ [NETWORK_PEER_ADDRESS]: networkPeerAddress, [NETWORK_PEER_PORT]: networkPeerPort });
   }
 
   // A remove response is a delete-count, not a cached value, so its size is meaningless.

--- a/packages/opentelemetry/src/applyOtelSpanData.ts
+++ b/packages/opentelemetry/src/applyOtelSpanData.ts
@@ -2,6 +2,7 @@ import {
   getClient,
   hasSpanStreamingEnabled,
   spanToJSON,
+  spanToStaticSpanJSON,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
   isStatusErrorMessageValid,
@@ -19,7 +20,14 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
 
   if (options.finalizeStatus) {
     const client = getClient();
-    applyOtelSpanStatus(span, attributes, spanJSON.status, !!client && hasSpanStreamingEnabled(client));
+    // The status message (`not_found`, `internal_error`, …) is what we branch on here, so read it from
+    // the static representation — `spanToJSON` only narrows to `'ok' | 'error'`.
+    applyOtelSpanStatus(
+      span,
+      attributes,
+      spanToStaticSpanJSON(span).status,
+      !!client && hasSpanStreamingEnabled(client),
+    );
   }
 }
 

--- a/packages/opentelemetry/src/applyOtelSpanData.ts
+++ b/packages/opentelemetry/src/applyOtelSpanData.ts
@@ -6,7 +6,7 @@ import {
   SPAN_STATUS_OK,
   isStatusErrorMessageValid,
 } from '@sentry/core';
-import type { Span, SpanAttributes } from '@sentry/core';
+import type { RawAttributes, Span } from '@sentry/core';
 import { inferStatusFromAttributes } from './utils/mapStatus';
 
 /**
@@ -15,7 +15,7 @@ import { inferStatusFromAttributes } from './utils/mapStatus';
  */
 export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolean } = {}): void {
   const spanJSON = spanToJSON(span);
-  const attributes = spanJSON.data;
+  const attributes = spanJSON.attributes;
 
   if (options.finalizeStatus) {
     const client = getClient();
@@ -25,7 +25,7 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
 
 function applyOtelSpanStatus(
   span: Span,
-  attributes: SpanAttributes,
+  attributes: RawAttributes<Record<string, unknown>>,
   status: string,
   spanStreamingEnabled: boolean,
 ): void {

--- a/packages/opentelemetry/src/utils/mapStatus.ts
+++ b/packages/opentelemetry/src/utils/mapStatus.ts
@@ -1,5 +1,5 @@
 import { HTTP_RESPONSE_STATUS_CODE, HTTP_STATUS_CODE, RPC_GRPC_STATUS_CODE } from '@sentry/conventions/attributes';
-import type { SpanAttributes, SpanStatus } from '@sentry/core';
+import type { RawAttributes, SpanStatus } from '@sentry/core';
 import { getSpanStatusFromHttpCode, SPAN_STATUS_ERROR } from '@sentry/core';
 
 // canonicalCodesGrpcMap maps some GRPC codes to Sentry's span statuses. See description in grpc documentation.
@@ -22,7 +22,7 @@ const canonicalGrpcErrorCodesMap: Record<string, SpanStatus['message']> = {
   '16': 'unauthenticated',
 } as const;
 
-export function inferStatusFromAttributes(attributes: SpanAttributes): SpanStatus | undefined {
+export function inferStatusFromAttributes(attributes: RawAttributes<Record<string, unknown>>): SpanStatus | undefined {
   // If the span status is UNSET, we try to infer it from HTTP or GRPC status codes.
 
   // eslint-disable-next-line typescript/no-deprecated

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -733,7 +733,7 @@ describe('trace', () => {
       expect(span2LinkJSON?.span_id).toBe(span1JSON.span_id);
 
       // sampling decision is inherited
-      expect(span2LinkJSON?.sampled).toBe(Boolean(spanToJSON(rawSpan1).data['sentry.sample_rate']));
+      expect(span2LinkJSON?.sampled).toBe(Boolean(spanToJSON(rawSpan1).attributes['sentry.sample_rate']));
     });
 
     it('allows to force a transaction with forceTransaction=true', async () => {
@@ -1904,7 +1904,7 @@ describe('span.end() timestamp conversion', () => {
 });
 
 function getSpanName(span: Span): string | undefined {
-  return spanToJSON(span).description;
+  return spanToJSON(span).name;
 }
 
 // Native Sentry spans store timestamps in seconds; the tests assert HrTime `[seconds, nanoseconds]`.
@@ -1917,8 +1917,8 @@ function hrTimeFromSeconds(seconds: number): [number, number] {
 }
 
 function getSpanEndTime(span: Span): [number, number] | undefined {
-  const timestamp = spanToJSON(span).timestamp;
-  return typeof timestamp === 'number' ? hrTimeFromSeconds(timestamp) : [0, 0];
+  const endTimestamp = spanToJSON(span).end_timestamp;
+  return typeof endTimestamp === 'number' ? hrTimeFromSeconds(endTimestamp) : [0, 0];
 }
 
 function getSpanStartTime(span: Span): [number, number] | undefined {
@@ -1927,7 +1927,7 @@ function getSpanStartTime(span: Span): [number, number] | undefined {
 }
 
 function getSpanAttributes(span: Span): Record<string, unknown> | undefined {
-  return spanToJSON(span).data;
+  return spanToJSON(span).attributes;
 }
 
 function getSpanParentSpanId(span: Span): string | undefined {

--- a/packages/opentelemetry/test/tracerProvider.test.ts
+++ b/packages/opentelemetry/test/tracerProvider.test.ts
@@ -4,8 +4,8 @@ import {
   getActiveSpan,
   getCapturedScopesOnSpan,
   getRootSpan,
+  SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
   spanToJSON,
-  spanToStreamedSpanJSON,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
   startSpanManual,
@@ -31,26 +31,21 @@ describe('SentryTracerProvider', () => {
     });
 
     expect(spanToJSON(span as Span)).toEqual({
-      data: {
+      attributes: {
         'sentry.origin': 'manual',
         'sentry.sample_rate': 1,
         'db.system.name': 'postgresql',
         'db.statement': 'SELECT * FROM users',
         'sentry.source': 'custom',
       },
-      description: 'SELECT users',
-      origin: 'manual',
+      name: 'SELECT users',
       parent_span_id: undefined,
       span_id: span.spanContext().spanId,
       start_timestamp: expect.any(Number),
+      end_timestamp: undefined,
+      is_segment: true,
       status: 'ok',
-      timestamp: undefined,
       trace_id: span.spanContext().traceId,
-      profile_id: undefined,
-      exclusive_time: undefined,
-      measurements: undefined,
-      is_segment: undefined,
-      segment_id: undefined,
       links: undefined,
     });
   });
@@ -134,7 +129,7 @@ describe('SentryTracerProvider', () => {
 
     expect(json.trace_id).toBe('12312012123120121231201212312012');
     expect(json.parent_span_id).toBe('1121201211212012');
-    expect(json.data?.['sentry.kind']).toBe('server');
+    expect(json.attributes['sentry.kind']).toBe('server');
   });
 
   it('finalizes span statuses like the OpenTelemetry exporter', () => {
@@ -145,12 +140,16 @@ describe('SentryTracerProvider', () => {
     const httpErrorSpan = trace.getTracer('test').startSpan('http-error');
     httpErrorSpan.setAttribute('http.response.status_code', 500);
     applyOtelSpanData(httpErrorSpan as Span, { finalizeStatus: true });
-    expect(spanToJSON(httpErrorSpan as Span).status).toBe('internal_error');
+    expect(spanToJSON(httpErrorSpan as Span).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe(
+      'internal_error',
+    );
 
     const customErrorSpan = trace.getTracer('test').startSpan('custom-error');
     customErrorSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'This is a custom error' });
     applyOtelSpanData(customErrorSpan as Span, { finalizeStatus: true });
-    expect(spanToJSON(customErrorSpan as Span).status).toBe('internal_error');
+    expect(spanToJSON(customErrorSpan as Span).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe(
+      'internal_error',
+    );
   });
 
   it('preserves an explicit OK status when finalizing', () => {
@@ -168,7 +167,7 @@ describe('SentryTracerProvider', () => {
 
     applyOtelSpanData(span as Span, { finalizeStatus: true });
 
-    expect(spanToJSON(span as Span).data?.['sentry.source']).toBe('custom');
+    expect(spanToJSON(span as Span).attributes['sentry.source']).toBe('custom');
   });
 
   it('preserves a non-canonical error status message under span streaming', () => {
@@ -181,7 +180,7 @@ describe('SentryTracerProvider', () => {
 
     applyOtelSpanData(span as Span, { finalizeStatus: true });
 
-    const streamed = spanToStreamedSpanJSON(span as Span);
+    const streamed = spanToJSON(span as Span);
     expect(streamed.status).toBe('error');
     expect(streamed.attributes?.['sentry.status.message']).toBe('Cannot enqueue Query after fatal error.');
   });

--- a/packages/opentelemetry/test/tracerProvider.test.ts
+++ b/packages/opentelemetry/test/tracerProvider.test.ts
@@ -4,8 +4,8 @@ import {
   getActiveSpan,
   getCapturedScopesOnSpan,
   getRootSpan,
-  SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
   spanToJSON,
+  spanToStaticSpanJSON,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
   startSpanManual,
@@ -135,21 +135,23 @@ describe('SentryTracerProvider', () => {
   it('finalizes span statuses like the OpenTelemetry exporter', () => {
     const okSpan = trace.getTracer('test').startSpan('ok');
     applyOtelSpanData(okSpan as Span, { finalizeStatus: true });
+    expect(spanToStaticSpanJSON(okSpan as Span).status).toBe('ok');
     expect(spanToJSON(okSpan as Span).status).toBe('ok');
+    expect(spanToJSON(okSpan as Span).attributes).not.toHaveProperty('sentry.status.message');
 
     const httpErrorSpan = trace.getTracer('test').startSpan('http-error');
     httpErrorSpan.setAttribute('http.response.status_code', 500);
     applyOtelSpanData(httpErrorSpan as Span, { finalizeStatus: true });
-    expect(spanToJSON(httpErrorSpan as Span).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe(
-      'internal_error',
-    );
+    expect(spanToStaticSpanJSON(httpErrorSpan as Span).status).toBe('internal_error');
+    expect(spanToJSON(httpErrorSpan as Span).status).toBe('error');
+    expect(spanToJSON(httpErrorSpan as Span).attributes).toMatchObject({
+      'sentry.status.message': 'internal_error',
+    });
 
     const customErrorSpan = trace.getTracer('test').startSpan('custom-error');
     customErrorSpan.setStatus({ code: SPAN_STATUS_ERROR, message: 'This is a custom error' });
     applyOtelSpanData(customErrorSpan as Span, { finalizeStatus: true });
-    expect(spanToJSON(customErrorSpan as Span).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe(
-      'internal_error',
-    );
+    expect(spanToStaticSpanJSON(customErrorSpan as Span).status).toBe('internal_error');
   });
 
   it('preserves an explicit OK status when finalizing', () => {

--- a/packages/react-router/src/client/createClientInstrumentation.ts
+++ b/packages/react-router/src/client/createClientInstrumentation.ts
@@ -378,7 +378,8 @@ function updateRootSpanRoute(routeName: string, hasPattern: boolean): void {
     return;
   }
 
-  const { op } = spanToJSON(rootSpan);
+  const { attributes } = spanToJSON(rootSpan);
+  const op = attributes[SENTRY_OP];
   if (op !== 'navigation' && op !== 'pageload') {
     return;
   }

--- a/packages/react-router/src/client/hydratedRouter.ts
+++ b/packages/react-router/src/client/hydratedRouter.ts
@@ -22,7 +22,7 @@ import {
   resolveNavigateAbsoluteUrl,
   resolveNavigateArg,
 } from './utils';
-import { URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 const GLOBAL_OBJ_WITH_DATA_ROUTER = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __reactRouterDataRouter?: DataRouter;
@@ -49,7 +49,7 @@ export function instrumentHydratedRouter(): void {
       const pageloadSpan = getActiveRootSpan();
 
       if (pageloadSpan) {
-        const pageloadName = spanToJSON(pageloadSpan).description;
+        const pageloadName = spanToJSON(pageloadSpan).name;
         const parameterizePageloadRoute = getParameterizedRoute(router.state);
         if (
           pageloadName &&
@@ -126,20 +126,21 @@ export function instrumentHydratedRouter(): void {
         }
 
         const rootSpanJson = spanToJSON(rootSpan);
+        const rootSpanAttributes = rootSpanJson.attributes;
 
         // When the instrumentation API is active, navigation roots are parameterized
         // by the native route hooks
         if (
-          rootSpanJson.op === 'navigation' &&
+          rootSpanAttributes[SENTRY_OP] === 'navigation' &&
           isClientInstrumentationApiUsed() &&
-          rootSpanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'route'
+          rootSpanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'route'
         ) {
           return;
         }
 
-        const rootSpanName = rootSpanJson.description;
+        const rootSpanName = rootSpanJson.name;
         const parameterizedRoute = getParameterizedRoute(newState);
-        const spanPathname = rootSpanJson.data?.[URL_PATH] as string | undefined;
+        const spanPathname = rootSpanAttributes[URL_PATH] as string | undefined;
         const destinationPathname = normalizePathname(newState.location.pathname);
 
         if (
@@ -207,7 +208,7 @@ function getActiveRootSpan(): Span | undefined {
 
   const rootSpan = getRootSpan(activeSpan);
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToJSON(rootSpan).attributes[SENTRY_OP];
 
   // Only use this root span if it is a pageload or navigation span
   return op === 'navigation' || op === 'pageload' ? rootSpan : undefined;

--- a/packages/react-router/test/client/createClientInstrumentation.test.ts
+++ b/packages/react-router/test/client/createClientInstrumentation.test.ts
@@ -901,7 +901,7 @@ describe('navigation root parameterization', () => {
     const mockRootSpan = { setAttributes: vi.fn() };
     (core.getActiveSpan as any).mockReturnValue({});
     (core.getRootSpan as any).mockReturnValue(mockRootSpan);
-    (core.spanToJSON as any).mockReturnValue({ op: 'navigation' });
+    (core.spanToJSON as any).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } });
 
     const mockInstrument = vi.fn();
     const instrumentation = createSentryClientInstrumentation();
@@ -923,7 +923,7 @@ describe('navigation root parameterization', () => {
     const mockRootSpan = { setAttributes: vi.fn() };
     (core.getActiveSpan as any).mockReturnValue({});
     (core.getRootSpan as any).mockReturnValue(mockRootSpan);
-    (core.spanToJSON as any).mockReturnValue({ op: 'navigation' });
+    (core.spanToJSON as any).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } });
 
     const mockInstrument = vi.fn();
     const instrumentation = createSentryClientInstrumentation();
@@ -942,7 +942,7 @@ describe('navigation root parameterization', () => {
   it('does not rename root spans that are not pageload/navigation', async () => {
     (core.getActiveSpan as any).mockReturnValue({});
     (core.getRootSpan as any).mockReturnValue({ setAttribute: vi.fn() });
-    (core.spanToJSON as any).mockReturnValue({ op: 'http.server' });
+    (core.spanToJSON as any).mockReturnValue({ attributes: { 'sentry.op': 'http.server' } });
 
     const mockInstrument = vi.fn();
     const instrumentation = createSentryClientInstrumentation();

--- a/packages/react-router/test/client/hydratedRouter.test.ts
+++ b/packages/react-router/test/client/hydratedRouter.test.ts
@@ -63,9 +63,9 @@ describe('instrumentHydratedRouter', () => {
     (core.getActiveSpan as any).mockReturnValue(mockPageloadSpan);
     (core.getRootSpan as any).mockImplementation((span: any) => span);
     (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: '/foo/bar',
+      name: '/foo/bar',
       // Distinguish so the subscribe callback can branch on op (pageload vs. navigation).
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
+      attributes: { 'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload' },
     }));
     (core.getClient as any).mockReturnValue({});
     (browser.startBrowserTracingNavigationSpan as any).mockReturnValue(mockNavigationSpan);
@@ -144,9 +144,8 @@ describe('instrumentHydratedRouter', () => {
     // source:url. The heuristic must still parameterize it instead of leaving the raw URL.
     (globalThis as any).__sentryReactRouterClientInstrumentationUsed = true;
     (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: '/foo/bar',
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
-      data: { source: 'url' },
+      name: '/foo/bar',
+      attributes: { 'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload', source: 'url' },
     }));
 
     instrumentHydratedRouter();
@@ -231,9 +230,11 @@ describe('instrumentHydratedRouter', () => {
 
     (core.getActiveSpan as any).mockReturnValue(mockNavigationSpan);
     (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: 'settings',
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
-      data: { 'url.path': '/foo/bar/settings' },
+      name: 'settings',
+      attributes: {
+        'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload',
+        'url.path': '/foo/bar/settings',
+      },
     }));
 
     const callback = mockRouter.subscribe.mock.calls[0][0];
@@ -340,9 +341,8 @@ describe('instrumentHydratedRouter', () => {
 
     (core.getActiveSpan as any).mockReturnValue(mockNavigationSpan);
     (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: '/foo/bar',
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
-      data: { 'url.path': '/foo' },
+      name: '/foo/bar',
+      attributes: { 'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload', 'url.path': '/foo' },
     }));
 
     const callback = mockRouter.subscribe.mock.calls[0][0];

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -110,7 +110,7 @@ class Profiler extends React.Component<ProfilerProps> {
     const { name, includeRender = true } = this.props;
 
     if (this._mountSpan && includeRender) {
-      const startTime = spanToJSON(this._mountSpan).timestamp;
+      const startTime = spanToJSON(this._mountSpan).end_timestamp;
       withActiveSpan(this._mountSpan, () => {
         const renderSpan = startInactiveSpan({
           onlyIfParent: true,
@@ -213,7 +213,7 @@ function useProfiler(
 
     return (): void => {
       if (mountSpan && options.hasRenderSpan) {
-        const startTime = spanToJSON(mountSpan).timestamp;
+        const startTime = spanToJSON(mountSpan).end_timestamp;
         const endTimestamp = timestampInSeconds();
 
         const renderSpan = startInactiveSpan({

--- a/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
+++ b/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
@@ -47,7 +47,7 @@ import {
   setNavigationContext,
   transactionNameHasWildcard,
 } from './utils';
-import { URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 let _useEffect: UseEffect;
 let _useLocation: UseLocation;
@@ -320,15 +320,15 @@ export function processResolvedRoutes(
   // Use captured span if provided, otherwise fall back to current active span
   const targetSpan = capturedSpan ?? getActiveRootSpan();
   if (targetSpan) {
-    const spanJson = spanToJSON(targetSpan);
+    const { end_timestamp, attributes } = spanToJSON(targetSpan);
 
-    // Skip update if span has already ended (timestamp is set when span.end() is called)
-    if (spanJson.timestamp) {
+    // Skip update if span has already ended (end_timestamp is set when span.end() is called)
+    if (end_timestamp) {
       DEBUG_BUILD && debug.warn('[React Router] Lazy handler resolved after span ended - skipping update');
       return;
     }
 
-    const spanOp = spanJson.op;
+    const spanOp = attributes[SENTRY_OP];
 
     // Use captured location for route matching (ensures we match against the correct route)
     // Fall back to window.location only if no captured location and no captured span
@@ -370,14 +370,13 @@ export function updateNavigationSpan(
   forceUpdate = false,
   matchRoutes: MatchRoutes,
 ): void {
-  const spanJson = spanToJSON(activeRootSpan);
-  const currentName = spanJson.description;
+  const { name: currentName, end_timestamp, attributes } = spanToJSON(activeRootSpan);
 
   const hasBeenNamed = (activeRootSpan as { __sentry_navigation_name_set__?: boolean })?.__sentry_navigation_name_set__;
   const currentNameHasWildcard = currentName && transactionNameHasWildcard(currentName);
   const shouldUpdate = !hasBeenNamed || forceUpdate || currentNameHasWildcard;
 
-  if (shouldUpdate && !spanJson.timestamp) {
+  if (shouldUpdate && !end_timestamp) {
     const currentBranches = matchRoutes(allRoutes, location);
     const [name, source] = resolveRouteNameAndSource(
       location,
@@ -389,7 +388,7 @@ export function updateNavigationSpan(
       _enableAsyncRouteHandlers,
     );
 
-    const currentSource = spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+    const currentSource = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
     const isImprovement =
       name &&
       (!currentName || // No current name - always set
@@ -419,7 +418,7 @@ function setupRouterSubscription(
   activeRootSpan: Span | undefined,
 ): void {
   let isInitialPageloadComplete = false;
-  let hasSeenPageloadSpan = !!activeRootSpan && spanToJSON(activeRootSpan).op === 'pageload';
+  let hasSeenPageloadSpan = !!activeRootSpan && spanToJSON(activeRootSpan).attributes[SENTRY_OP] === 'pageload';
   let hasSeenPopAfterPageload = false;
   let scheduledNavigationHandler: number | null = null;
   let lastHandledPathname: string | null = null;
@@ -427,7 +426,7 @@ function setupRouterSubscription(
   router.subscribe((state: RouterState) => {
     if (!isInitialPageloadComplete) {
       const currentRootSpan = getActiveRootSpan();
-      const isCurrentlyInPageload = currentRootSpan && spanToJSON(currentRootSpan).op === 'pageload';
+      const isCurrentlyInPageload = currentRootSpan && spanToJSON(currentRootSpan).attributes[SENTRY_OP] === 'pageload';
 
       if (isCurrentlyInPageload) {
         hasSeenPageloadSpan = true;
@@ -872,8 +871,8 @@ function wrapPatchRoutesOnNavigation(
               targetPath &&
               activeRootSpan &&
               spanJson &&
-              !spanJson.timestamp && // Span hasn't ended yet
-              spanJson.op === 'navigation'
+              !spanJson.end_timestamp && // Span hasn't ended yet
+              spanJson.attributes[SENTRY_OP] === 'navigation'
             ) {
               updateNavigationSpan(
                 activeRootSpan,
@@ -909,8 +908,8 @@ function wrapPatchRoutesOnNavigation(
         if (
           activeRootSpan &&
           spanJson &&
-          !spanJson.timestamp && // Span hasn't ended yet
-          spanJson.op === 'navigation'
+          !spanJson.end_timestamp && // Span hasn't ended yet
+          spanJson.attributes[SENTRY_OP] === 'navigation'
         ) {
           // Use targetPath consistently - don't fall back to WINDOW.location which may have changed
           // if the user navigated away during async loading
@@ -958,7 +957,7 @@ export function handleNavigation(opts: {
   }
 
   const activeRootSpan = getActiveRootSpan();
-  if (activeRootSpan && spanToJSON(activeRootSpan).op === 'pageload' && navigationType === 'POP') {
+  if (activeRootSpan && spanToJSON(activeRootSpan).attributes[SENTRY_OP] === 'pageload' && navigationType === 'POP') {
     return;
   }
 
@@ -978,7 +977,7 @@ export function handleNavigation(opts: {
 
     // Determine if this navigation should be skipped as a duplicate
     const trackedSpanHasEnded =
-      trackedNav && !trackedNav.isPlaceholder ? !!spanToJSON(trackedNav.span).timestamp : false;
+      trackedNav && !trackedNav.isPlaceholder ? !!spanToJSON(trackedNav.span).end_timestamp : false;
     const { skip, shouldUpdate } = shouldSkipNavigation(trackedNav, locationKey, name, trackedSpanHasEnded);
 
     if (skip) {
@@ -1203,7 +1202,7 @@ function tryUpdateSpanNameBeforeEnd(
   allRoutes: Set<RouteObject>,
 ): void {
   try {
-    const currentSource = spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+    const currentSource = spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as string | undefined;
 
     if (currentSource === 'route' && currentName && !transactionNameHasWildcard(currentName)) {
       return;
@@ -1228,7 +1227,7 @@ function tryUpdateSpanNameBeforeEnd(
     );
 
     const isImprovement = shouldUpdateWildcardSpanName(currentName, currentSource, name, source, true);
-    const spanNotEnded = spanType === 'pageload' || !spanJson.timestamp;
+    const spanNotEnded = spanType === 'pageload' || !spanJson.end_timestamp;
 
     if (isImprovement && spanNotEnded) {
       span.updateName(name);
@@ -1276,8 +1275,8 @@ function patchSpanEnd(
     const endTimestamp = args.length > 0 ? args[0] : Date.now() / 1000;
 
     const spanJson = spanToJSON(span);
-    const currentName = spanJson.description;
-    const currentSource = spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+    const currentName = spanJson.name;
+    const currentSource = spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
 
     // Helper to clean up activeNavigationSpans after span ends
     const cleanupNavigationSpan = (): void => {
@@ -1332,7 +1331,7 @@ function patchSpanEnd(
           tryUpdateSpanNameBeforeEnd(
             span,
             updatedSpanJson,
-            updatedSpanJson.description,
+            updatedSpanJson.name,
             location,
             routes,
             basename,

--- a/packages/react/src/reactrouter-compat-utils/utils.ts
+++ b/packages/react/src/reactrouter-compat-utils/utils.ts
@@ -3,6 +3,7 @@ import { debug, getActiveSpan, getRootSpan, spanToJSON } from '@sentry/core/brow
 import { DEBUG_BUILD } from '../debug-build';
 import type { Location, MatchRoutes, RouteMatch, RouteObject } from '../types';
 import { matchRouteManifest, stripBasenameFromPathname } from './route-manifest';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 // Global variables that these utilities depend on
 let _matchRoutes: MatchRoutes;
@@ -375,7 +376,7 @@ export function getActiveRootSpan(): Span | undefined {
     return undefined;
   }
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToJSON(rootSpan).attributes[SENTRY_OP];
 
   // Only use this root span if it is a pageload or navigation span
   return op === 'navigation' || op === 'pageload' ? rootSpan : undefined;

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -266,7 +266,7 @@ function getActiveRootSpan(): Span | undefined {
     return undefined;
   }
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToJSON(rootSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP];
 
   // Only use this root span if it is a pageload or navigation span
   return op === 'navigation' || op === 'pageload' ? rootSpan : undefined;

--- a/packages/react/test/reactrouter-compat-utils/instrumentation.test.tsx
+++ b/packages/react/test/reactrouter-compat-utils/instrumentation.test.tsx
@@ -32,7 +32,7 @@ vi.mock('@sentry/core', async requireActual => {
     getActiveSpan: vi.fn(() => mockSpan),
     getClient: vi.fn(() => mockClient),
     getRootSpan: vi.fn(() => mockSpan),
-    spanToJSON: vi.fn(() => ({ op: 'navigation' })),
+    spanToJSON: vi.fn(() => ({ attributes: { 'sentry.op': 'navigation' } })),
   };
 });
 
@@ -427,9 +427,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
   it('should upgrade from URL source to route source (regression fix)', async () => {
     // Setup: Current span has URL source and non-parameterized name
     vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/123',
-      data: { 'sentry.source': 'url' },
+      name: '/users/123',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'url' },
     } as any);
 
     // Target: Resolves to route source with parameterized name
@@ -461,9 +460,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
   it('should not downgrade from route source to URL source', async () => {
     // Setup: Current span has route source with parameterized name (no wildcard)
     vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/:id',
-      data: { 'sentry.source': 'route' },
+      name: '/users/:id',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
     } as any);
 
     // Target: Would resolve to URL source (downgrade attempt)
@@ -496,9 +494,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
   it('should upgrade wildcard names to specific routes', async () => {
     // Setup: Current span has route source with wildcard
     vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/*',
-      data: { 'sentry.source': 'route' },
+      name: '/users/*',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
     } as any);
 
     // Mock wildcard detection: current name has wildcard, new name doesn't
@@ -533,9 +530,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
   it('should not downgrade from wildcard route to URL', async () => {
     // Setup: Current span has route source with wildcard
     vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/*',
-      data: { 'sentry.source': 'route' },
+      name: '/users/*',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
     } as any);
 
     // Mock wildcard detection: current name has wildcard, new name doesn't
@@ -572,8 +568,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
   it('should set name when no current name exists', async () => {
     // Setup: Current span has no name (undefined)
     vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: undefined,
+      name: undefined,
+      attributes: { 'sentry.op': 'navigation' },
     } as any);
 
     // Target: Resolves to route
@@ -603,9 +599,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
   it('should not update when same source and no improvement', async () => {
     // Setup: Current span has URL source
     vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/123',
-      data: { 'sentry.source': 'url' },
+      name: '/users/123',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'url' },
     } as any);
 
     // Target: Resolves to same URL source (no improvement)
@@ -900,7 +895,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       vi.mocked(browserModule.startBrowserTracingNavigationSpan).mockReturnValue(mockNavigationSpan);
 
       // Mock spanToJSON to return different values for different calls
-      vi.mocked(coreModule.spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      vi.mocked(coreModule.spanToJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Mock getActiveRootSpan to return undefined (no pageload span)
       vi.mocked(coreModule.getActiveSpan).mockReturnValue(undefined);
@@ -985,7 +980,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       });
 
       // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      vi.mocked(spanToJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second navigation - exact same location, should be blocked
       handleNavigation({
@@ -1032,7 +1027,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       });
 
       // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      vi.mocked(spanToJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second navigation - same pathname, different query
       const location2: Location = {
@@ -1087,7 +1082,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       });
 
       // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      vi.mocked(spanToJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second navigation - same pathname, different hash
       const location2: Location = {
@@ -1154,9 +1149,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
       // Mock spanToJSON to indicate span hasn't ended yet and has wildcard name
       vi.mocked(spanToJSON).mockReturnValue({
-        op: 'navigation',
-        description: '/users/*',
-        data: { 'sentry.source': 'route' },
+        name: '/users/*',
+        attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
       } as any);
 
       // Second navigation - same location but better parameterized name available
@@ -1219,7 +1213,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       expect(startBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1);
 
       // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      vi.mocked(spanToJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second call: Full location (from router.state)
       // React Router provides location with empty string search and hash
@@ -1399,12 +1393,10 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   describe('wrapPatchRoutesOnNavigation race condition fix', () => {
     it('should use captured span instead of current active span in args.patch callback', () => {
-      const endedSpanJson = {
-        op: 'navigation',
-        timestamp: 1234567890, // Span has ended
-      };
-
-      vi.mocked(spanToJSON).mockReturnValue(endedSpanJson as any);
+      vi.mocked(spanToJSON).mockReturnValue({
+        attributes: { 'sentry.op': 'navigation' },
+        end_timestamp: 1234567890, // Span has ended
+      } as any);
 
       const endedSpan = {
         updateName: vi.fn(),
@@ -1424,12 +1416,10 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
     });
 
     it('should not fall back to WINDOW.location.pathname after async operations', () => {
-      const validSpanJson = {
-        op: 'navigation',
-        timestamp: undefined, // Span hasn't ended
-      };
-
-      vi.mocked(spanToJSON).mockReturnValue(validSpanJson as any);
+      vi.mocked(spanToJSON).mockReturnValue({
+        attributes: { 'sentry.op': 'navigation' },
+        end_timestamp: undefined, // Span hasn't ended
+      } as any);
 
       const validSpan = {
         updateName: vi.fn(),

--- a/packages/react/test/reactrouter-cross-usage.test.tsx
+++ b/packages/react/test/reactrouter-cross-usage.test.tsx
@@ -47,6 +47,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouter-descendant-routes.test.tsx
+++ b/packages/react/test/reactrouter-descendant-routes.test.tsx
@@ -42,6 +42,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -26,6 +26,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv4.test.tsx
+++ b/packages/react/test/reactrouterv4.test.tsx
@@ -29,6 +29,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv5.test.tsx
+++ b/packages/react/test/reactrouterv5.test.tsx
@@ -29,6 +29,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv6.test.tsx
+++ b/packages/react/test/reactrouterv6.test.tsx
@@ -47,6 +47,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -125,7 +125,7 @@ function makeWrappedDocumentRequestFunction(instrumentTracing?: boolean) {
       if (instrumentTracing) {
         const activeSpan = getActiveSpan();
         const rootSpan = activeSpan && getRootSpan(activeSpan);
-        const name = rootSpan ? spanToJSON(rootSpan).description : undefined;
+        const name = rootSpan ? spanToJSON(rootSpan).name : undefined;
 
         response = await startSpan(
           {
@@ -177,7 +177,7 @@ function updateSpanWithRoute(args: DataFunctionArgs, build: ServerBuild): void {
 
     // Preserve the HTTP method prefix if the span already has one
     const method = args.request.method.toUpperCase();
-    const currentSpanName = spanToJSON(rootSpan).description;
+    const currentSpanName = spanToJSON(rootSpan).name;
     const newSpanName = currentSpanName?.startsWith(method) ? `${method} ${transactionName}` : transactionName;
 
     rootSpan.updateName(newSpanName);

--- a/packages/remix/src/server/integrations/tracing-channel.ts
+++ b/packages/remix/src/server/integrations/tracing-channel.ts
@@ -127,7 +127,7 @@ function enrichActiveSpanWithRoute(result: unknown): void {
     // oxlint-disable-next-line typescript/no-deprecated
     span.setAttribute(HTTP_ROUTE, route.path);
     // oxlint-disable-next-line typescript/no-deprecated
-    const method = spanToJSON(span).data[HTTP_METHOD];
+    const method = spanToJSON(span).attributes[HTTP_METHOD];
     span.updateName(typeof method === 'string' ? `${method} ${route.path}` : route.path);
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
   }

--- a/packages/remix/test/server/tracing-channel-test-utils.ts
+++ b/packages/remix/test/server/tracing-channel-test-utils.ts
@@ -73,6 +73,7 @@ export function makeSpan(data: Record<string, unknown> = {}): Span {
     setAttribute: vi.fn(),
     updateName: vi.fn(),
     getSpanJSON: () => ({ data }),
+    getStreamedSpanJSON: () => ({ attributes: data }),
   } as unknown as Span;
 }
 

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -839,14 +839,17 @@ export class ReplayContainer implements ReplayContainerInterface {
   public getCurrentRoute(): string | undefined {
     const lastActiveSpan = this.lastActiveSpan || getActiveSpan();
     const lastRootSpan = lastActiveSpan && getRootSpan(lastActiveSpan);
-
-    const attributes = (lastRootSpan && spanToJSON(lastRootSpan).data) || {};
-    const source = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
-    if (!lastRootSpan || !source || !['route', 'custom'].includes(source)) {
+    if (!lastRootSpan) {
       return undefined;
     }
 
-    return spanToJSON(lastRootSpan).description;
+    const spanJson = spanToJSON(lastRootSpan);
+    const source = spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as string | undefined;
+    if (!source || !['route', 'custom'].includes(source)) {
+      return undefined;
+    }
+
+    return spanJson.name;
   }
 
   /**

--- a/packages/server-utils/src/ai/vercel-ai/index.ts
+++ b/packages/server-utils/src/ai/vercel-ai/index.ts
@@ -5,7 +5,7 @@ import {
   hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  spanToJSON,
+  spanToStaticSpanJSON,
 } from '@sentry/core';
 import type { Client, Event, Span, SpanAttributes, SpanAttributeValue, SpanJSON, StreamedSpanJSON } from '@sentry/core';
 import { WORKERS_AI_INTEGRATION_NAME } from '../workers-ai/constants';
@@ -73,7 +73,7 @@ import {
  * This is supposed to be used in `client.on('spanStart', ...)
  */
 function onVercelAiSpanStart(span: Span): void {
-  const { data: attributes, description: name } = spanToJSON(span);
+  const { data: attributes, description: name } = spanToStaticSpanJSON(span);
 
   if (!name) {
     return;
@@ -499,7 +499,7 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
     if (descriptions.size > 0) {
       // Tool call spans are siblings of doGenerate (both children of invoke_agent),
       // so we key by the parent span ID (the invoke_agent span).
-      const parentSpanId = spanToJSON(span).parent_span_id;
+      const parentSpanId = spanToStaticSpanJSON(span).parent_span_id;
       if (parentSpanId) {
         toolDescriptionMap.set(parentSpanId, descriptions);
       }

--- a/packages/server-utils/src/graphql/utils.ts
+++ b/packages/server-utils/src/graphql/utils.ts
@@ -1,5 +1,5 @@
 import { SENTRY_GRAPHQL_OPERATION } from '@sentry/conventions/attributes';
-import type { Span } from '@sentry/core';
+import type { Span, SpanAttributeValue } from '@sentry/core';
 import { getClient, isObjectLike, getRootSpan, spanToJSON, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 
 // Same key the OTel path uses, so renames stay consistent across both.
@@ -41,7 +41,7 @@ export function renameRootSpanWithOperation(span: Span, operationType: string, o
   const newOperation = operationName ? `${operationType} ${operationName}` : operationType;
 
   // A single operation is stored as a string, multiple as an array.
-  const existingOperations = rootSpanJson.data[SENTRY_GRAPHQL_OPERATION];
+  const existingOperations = rootSpanJson.attributes[SENTRY_GRAPHQL_OPERATION];
   let operations: string | string[];
   if (Array.isArray(existingOperations)) {
     operations = [...(existingOperations as string[]), newOperation];
@@ -54,15 +54,15 @@ export function renameRootSpanWithOperation(span: Span, operationType: string, o
 
   // Keep the pre-rename name so repeated renames don't compound.
   const originalDescription =
-    (rootSpanJson.data[ORIGINAL_DESCRIPTION_ATTRIBUTE] as string | undefined) ?? rootSpanJson.description;
-  if (!rootSpanJson.data[ORIGINAL_DESCRIPTION_ATTRIBUTE]) {
+    (rootSpanJson.attributes[ORIGINAL_DESCRIPTION_ATTRIBUTE] as string | undefined) ?? rootSpanJson.name;
+  if (!rootSpanJson.attributes[ORIGINAL_DESCRIPTION_ATTRIBUTE]) {
     rootSpan.setAttribute(ORIGINAL_DESCRIPTION_ATTRIBUTE, originalDescription);
   }
 
   // `updateName` stamps `source: 'custom'`, so re-set the original source afterwards to preserve it.
-  const source = rootSpanJson.data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+  const source = rootSpanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
   rootSpan.updateName(`${originalDescription} (${getGraphqlOperationNamesFromAttribute(operations)})`);
-  rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
+  rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source as SpanAttributeValue);
 }
 
 /** Format the accumulated operations for the root span name: up to 5 sorted names, then `+N`. */

--- a/packages/server-utils/src/integrations/tracing-channel/google-genai.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/google-genai.ts
@@ -1,4 +1,4 @@
-import { GEN_AI_REQUEST_MODEL } from '@sentry/conventions/attributes';
+import { GEN_AI_REQUEST_MODEL, SENTRY_OP, SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Span } from '@sentry/core';
 import {
@@ -91,7 +91,9 @@ function createGenAiSpan(
   if (operation !== 'chat') {
     const activeSpan = getActiveSpan();
     if (activeSpan) {
-      const { op, origin } = spanToJSON(activeSpan);
+      const {
+        attributes: { [SENTRY_OP]: op, [SENTRY_ORIGIN]: origin },
+      } = spanToJSON(activeSpan);
       if (origin === ORIGIN && op === 'gen_ai.chat') {
         return undefined;
       }

--- a/packages/server-utils/src/utils/setHttpServerSpanRouteAttribute.ts
+++ b/packages/server-utils/src/utils/setHttpServerSpanRouteAttribute.ts
@@ -1,11 +1,5 @@
-import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_ROUTE } from '@sentry/conventions/attributes';
-import {
-  getActiveSpan,
-  getRootSpan,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
-} from '@sentry/core';
+import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_ROUTE, SENTRY_OP } from '@sentry/conventions/attributes';
+import { getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
 
 /**
  * Set the `http.route` attribute on the root HTTP server span for the current trace.
@@ -24,8 +18,8 @@ export function setHttpServerSpanRouteAttribute(route: string): void {
     return;
   }
 
-  const attributes = spanToJSON(rootSpan).data;
-  if (attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] !== 'http.server') {
+  const attributes = spanToJSON(rootSpan).attributes;
+  if (attributes[SENTRY_OP] !== 'http.server') {
     return;
   }
 

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import {
+  GEN_AI_CONVERSATION_ID,
   GEN_AI_EMBEDDINGS_INPUT,
   GEN_AI_FUNCTION_ID,
   GEN_AI_INPUT_MESSAGES,
@@ -25,7 +26,6 @@ import type { Span, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_skipAiProviderWrapping,
   captureException,
-  GEN_AI_CONVERSATION_ID_ATTRIBUTE,
   getClient,
   isObjectLike,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -337,7 +337,7 @@ function addTokensToSpan(span: Span, attribute: string, value: number | undefine
   if (value === undefined) {
     return;
   }
-  const current = spanToJSON(span).data[attribute];
+  const current = spanToJSON(span).attributes[attribute];
   span.setAttribute(attribute, (typeof current === 'number' ? current : 0) + value);
 }
 
@@ -555,12 +555,9 @@ export function enrichSpanOnEnd(
   const providerAttributes = getProviderMetadataAttributes(providerMetadata);
   // Don't overwrite a conversation id already set on span start (e.g. by `conversationIdIntegration`
   // from a user-set scope value); the provider-derived id is only a fallback. Matches the OTel path.
-  if (
-    GEN_AI_CONVERSATION_ID_ATTRIBUTE in providerAttributes &&
-    spanToJSON(span).data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]
-  ) {
+  if (GEN_AI_CONVERSATION_ID in providerAttributes && spanToJSON(span).attributes[GEN_AI_CONVERSATION_ID]) {
     // oxlint-disable-next-line typescript/no-dynamic-delete
-    delete providerAttributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE];
+    delete providerAttributes[GEN_AI_CONVERSATION_ID];
   }
   span.setAttributes(providerAttributes);
 

--- a/packages/server-utils/test/ai/lib/tracing/workers-ai.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/workers-ai.test.ts
@@ -18,7 +18,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCurrentClient,
-  spanToJSON,
+  spanToStaticSpanJSON,
   startSpan,
 } from '@sentry/core';
 import type { DataCollection, Span } from '@sentry/core';
@@ -167,7 +167,7 @@ describe('instrumentWorkersAiClient', () => {
       });
 
       expect(endedSpans).toHaveLength(1);
-      expect(spanToJSON(endedSpans[0]!).data).toEqual(expected);
+      expect(spanToStaticSpanJSON(endedSpans[0]!).data).toEqual(expected);
     });
   });
 
@@ -183,7 +183,7 @@ describe('instrumentWorkersAiClient', () => {
       spans = [];
       const client = new TestClient(getDefaultTestClientOptions({ tracesSampleRate: 1 }));
       client.on('spanEnd', span => {
-        spans.push(spanToJSON(span).description ?? '');
+        spans.push(spanToStaticSpanJSON(span).description ?? '');
       });
       setCurrentClient(client);
       addVercelAiProcessors(client);

--- a/packages/server-utils/test/mysql2/mysql2-dc-subscriber.test.ts
+++ b/packages/server-utils/test/mysql2/mysql2-dc-subscriber.test.ts
@@ -191,15 +191,15 @@ describe('subscribeMysql2DiagnosticChannels', () => {
 
       expect(span).toBeDefined();
       const json = spanToJSON(span!);
-      expect(json.description).toBe('SELECT solution FROM maths');
-      expect(json.op).toBe('db');
-      expect(json.origin).toBe('auto.db.mysql2.diagnostic_channel');
-      expect(json.data['db.system.name']).toBe('mysql');
-      expect(json.data['db.operation.name']).toBe('SELECT');
-      expect(json.data['db.namespace']).toBe('test');
-      expect(json.data['server.address']).toBe('127.0.0.1');
-      expect(json.data['server.port']).toBe(3306);
-      expect(json.timestamp).toBeDefined();
+      expect(json.name).toBe('SELECT solution FROM maths');
+      expect(json.attributes['sentry.op']).toBe('db');
+      expect(json.attributes['sentry.origin']).toBe('auto.db.mysql2.diagnostic_channel');
+      expect(json.attributes['db.system.name']).toBe('mysql');
+      expect(json.attributes['db.operation.name']).toBe('SELECT');
+      expect(json.attributes['db.namespace']).toBe('test');
+      expect(json.attributes['server.address']).toBe('127.0.0.1');
+      expect(json.attributes['server.port']).toBe(3306);
+      expect(spanToJSON(span!).end_timestamp).toBeDefined();
     });
 
     it('sanitizes inlined values out of db.query.text and the span name', async () => {
@@ -211,12 +211,12 @@ describe('subscribeMysql2DiagnosticChannels', () => {
       );
 
       const json = spanToJSON(span!);
-      const queryText = json.data['db.query.text'] as string;
+      const queryText = json.attributes['db.query.text'] as string;
       expect(queryText).toBe('SELECT * FROM users WHERE email = ? AND age = ?');
       expect(queryText).not.toContain('a@b.com');
       expect(queryText).not.toContain('21');
       // the span name is the sanitized statement too — no raw values leak there either
-      expect(json.description).toBe('SELECT * FROM users WHERE email = ? AND age = ?');
+      expect(json.name).toBe('SELECT * FROM users WHERE email = ? AND age = ?');
     });
 
     it('does not attach raw values to the span', async () => {
@@ -226,7 +226,7 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: [] },
       );
 
-      expect(JSON.stringify(spanToJSON(span!).data)).not.toContain('secret');
+      expect(JSON.stringify(spanToJSON(span!).attributes)).not.toContain('secret');
     });
 
     it('sets error status and does NOT capture an exception on failure', async () => {
@@ -236,8 +236,8 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { error: new Error('table missing') },
       );
 
-      expect(spanToJSON(span!).status).toBe('internal_error');
-      expect(spanToJSON(span!).timestamp).toBeDefined();
+      expect(spanToJSON(span!).status).toBe('error');
+      expect(spanToJSON(span!).end_timestamp).toBeDefined();
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -262,8 +262,8 @@ describe('subscribeMysql2DiagnosticChannels', () => {
       );
 
       const json = spanToJSON(span!);
-      expect(json.data['db.query.text']).toBe('SELECT * FROM users WHERE id = ?');
-      expect(json.data['db.operation.name']).toBe('SELECT');
+      expect(json.attributes['db.query.text']).toBe('SELECT * FROM users WHERE id = ?');
+      expect(json.attributes['db.operation.name']).toBe('SELECT');
     });
   });
 
@@ -276,14 +276,14 @@ describe('subscribeMysql2DiagnosticChannels', () => {
       );
 
       const json = spanToJSON(span!);
-      expect(json.description).toBe('mysql2.connect');
-      expect(json.op).toBe('db');
-      expect(json.origin).toBe('auto.db.mysql2.diagnostic_channel');
-      expect(json.data['db.system.name']).toBe('mysql');
-      expect(json.data['db.namespace']).toBe('test');
-      expect(json.data['server.address']).toBe('127.0.0.1');
-      expect(json.data['server.port']).toBe(3306);
-      expect(json.data['db.query.text']).toBeUndefined();
+      expect(json.name).toBe('mysql2.connect');
+      expect(json.attributes['sentry.op']).toBe('db');
+      expect(json.attributes['sentry.origin']).toBe('auto.db.mysql2.diagnostic_channel');
+      expect(json.attributes['db.system.name']).toBe('mysql');
+      expect(json.attributes['db.namespace']).toBe('test');
+      expect(json.attributes['server.address']).toBe('127.0.0.1');
+      expect(json.attributes['server.port']).toBe(3306);
+      expect(json.attributes['db.query.text']).toBeUndefined();
     });
 
     it('names the pool connect span distinctly', async () => {
@@ -293,7 +293,7 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: undefined },
       );
 
-      expect(spanToJSON(span!).description).toBe('mysql2.pool.connect');
+      expect(spanToJSON(span!).name).toBe('mysql2.pool.connect');
     });
 
     it('omits server.port for unix-socket connections', async () => {
@@ -304,8 +304,8 @@ describe('subscribeMysql2DiagnosticChannels', () => {
       );
 
       const json = spanToJSON(span!);
-      expect(json.data['server.address']).toBe('/var/run/mysqld/mysqld.sock');
-      expect(json.data['server.port']).toBeUndefined();
+      expect(json.attributes['server.address']).toBe('/var/run/mysqld/mysqld.sock');
+      expect(json.attributes['server.port']).toBeUndefined();
     });
   });
 });

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -16,7 +16,6 @@ import {
   resolvedSyncPromise,
   setAsyncContextStrategy,
   spanToJSON,
-  spanToStreamedSpanJSON,
   startInactiveSpan,
   startSpan,
 } from '@sentry/core';
@@ -274,7 +273,7 @@ describe('bindTracingChannelToSpan', () => {
       channel.traceSync(() => undefined, { operation: 'read' });
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
       expect(spanToJSON(span).status).toBe('ok');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
@@ -293,7 +292,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -338,7 +337,7 @@ describe('bindTracingChannelToSpan', () => {
       await promise;
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
       expect(spanToJSON(span).status).toBe('ok');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
@@ -362,7 +361,7 @@ describe('bindTracingChannelToSpan', () => {
       await expect(promise).rejects.toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -380,7 +379,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -400,7 +399,7 @@ describe('bindTracingChannelToSpan', () => {
       });
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
       expect(spanToJSON(span).status).toBe('ok');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
@@ -422,7 +421,7 @@ describe('bindTracingChannelToSpan', () => {
       });
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -443,7 +442,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -462,10 +461,10 @@ describe('bindTracingChannelToSpan', () => {
 
         // The transaction status field is normalized to a valid value; the raw message survives on
         // the streamed span as `sentry.status.message`.
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(spanToStreamedSpanJSON(span).attributes?.['sentry.status.message']).toBe('bad input');
-        expect(data['error.type']).toBe('TypeError');
+        const { status, attributes } = spanToJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['sentry.status.message']).toBe('bad input');
+        expect(attributes['error.type']).toBe('TypeError');
       });
 
       it('stringifies a thrown primitive and marks the type unknown', () => {
@@ -480,10 +479,10 @@ describe('bindTracingChannelToSpan', () => {
           ),
         ).toThrow('plain failure');
 
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(spanToStreamedSpanJSON(span).attributes?.['sentry.status.message']).toBe('plain failure');
-        expect(data['error.type']).toBe('unknown');
+        const { status, attributes } = spanToJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['sentry.status.message']).toBe('plain failure');
+        expect(attributes['error.type']).toBe('unknown');
       });
 
       it('falls back to internal_error for an error-like object without `name` or `message`', () => {
@@ -499,9 +498,9 @@ describe('bindTracingChannelToSpan', () => {
         ).toThrow();
 
         // No usable message → no status message set → `getStatusMessage` defaults to `internal_error`.
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(data['error.type']).toBe('unknown');
+        const { status, attributes } = spanToJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['error.type']).toBe('unknown');
       });
 
       it('falls back to internal_error when a falsy value is thrown', () => {
@@ -520,9 +519,9 @@ describe('bindTracingChannelToSpan', () => {
         }
 
         expect(threw).toBe(true);
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(data['error.type']).toBe('unknown');
+        const { status, attributes } = spanToJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['error.type']).toBe('unknown');
       });
     });
   });
@@ -551,8 +550,8 @@ describe('bindTracingChannelToSpan', () => {
       ).rejects.toThrow(error);
 
       expect(captureExceptionSpy).not.toHaveBeenCalled();
-      expect(spanToJSON(span).status).toBe('internal_error');
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).status).toBe('error');
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
     });
 
     it('captures the exception with the default mechanism when `captureError` is true', async () => {
@@ -581,7 +580,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
     });
 
     it('captures the exception on the synchronous error path when `captureError` is true', () => {
@@ -610,7 +609,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
     });
 
     it('captures the exception on the callback error path when `captureError` is true', async () => {
@@ -642,7 +641,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
     });
 
     it('captures the exception with the hint returned by a `captureError` function, passing it the thrown error', async () => {
@@ -674,7 +673,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.http.custom', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToJSON(span).status).toBe('error');
     });
 
     it('uses the default mechanism when `captureError` is a function on the synchronous error path', () => {
@@ -719,7 +718,7 @@ describe('bindTracingChannelToSpan', () => {
         {
           beforeSpanEnd(s, data) {
             receivedSpan = s;
-            openWhenCalled = spanToJSON(s).timestamp === undefined;
+            openWhenCalled = spanToJSON(s).end_timestamp === undefined;
             expect(data._sentrySpan).toBe(s);
             expect('result' in data).toBe(true);
             s.setAttribute('enriched', true);
@@ -731,8 +730,8 @@ describe('bindTracingChannelToSpan', () => {
 
       expect(receivedSpan).toBe(span);
       expect(openWhenCalled).toBe(true);
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).data.enriched).toBe(true);
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
+      expect(spanToJSON(span).attributes.enriched).toBe(true);
     });
 
     it('runs before the span is ended on async completion', async () => {
@@ -745,7 +744,7 @@ describe('bindTracingChannelToSpan', () => {
         () => span,
         {
           beforeSpanEnd(s) {
-            expect(spanToJSON(s).timestamp).toBeUndefined();
+            expect(spanToJSON(s).end_timestamp).toBeUndefined();
             s.setAttribute('enriched', true);
           },
         },
@@ -753,8 +752,8 @@ describe('bindTracingChannelToSpan', () => {
 
       await channel.tracePromise(async () => 'ok', { operation: 'read' });
 
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).data.enriched).toBe(true);
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
+      expect(spanToJSON(span).attributes.enriched).toBe(true);
     });
 
     it('runs on the error path with the error on the context object', async () => {
@@ -785,7 +784,7 @@ describe('bindTracingChannelToSpan', () => {
       ).rejects.toThrow(error);
 
       expect(sawError).toBe(error);
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
     });
   });
 
@@ -817,22 +816,22 @@ describe('bindTracingChannelToSpan', () => {
     it('does not end the span while deferred', () => {
       const { span, endSpy } = setupDeferred('test:defer:open');
       expect(endSpy).not.toHaveBeenCalled();
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToJSON(span).end_timestamp).toBeUndefined();
     });
 
     it('`end()` ends the span once with no error status', () => {
       const { span, endSpy, end } = setupDeferred('test:defer:ok');
       end();
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToJSON(span).end_timestamp).toBeDefined();
       expect(spanToJSON(span).status).toBe('ok');
     });
 
     it('`end(error)` sets error status and the `error.type` attribute, then ends', () => {
       const { span, endSpy, end } = setupDeferred('test:defer:error');
       end(new TypeError('stream blew up'));
-      expect(spanToJSON(span).status).toBe('internal_error');
-      expect(spanToJSON(span).data['error.type']).toBe('TypeError');
+      expect(spanToJSON(span).status).toBe('error');
+      expect(spanToJSON(span).attributes['error.type']).toBe('TypeError');
       expect(endSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -145,8 +145,8 @@ function withSentryRouterRoot(Root: Component<RouteSectionProps>): Component<Rou
         }
       } else {
         // No matched route - update back-button navigations and set source to url
-        const { op, description } = spanToJSON(rootSpan);
-        if (op === 'navigation' && description === '-1') {
+        const { attributes, name: spanName } = spanToJSON(rootSpan);
+        if (attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'navigation' && spanName === '-1') {
           rootSpan.updateName(name);
         }
         rootSpan.setAttributes({ [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url', ...urlAttributes });

--- a/packages/solid/test/solidrouter.test.tsx
+++ b/packages/solid/test/solidrouter.test.tsx
@@ -71,9 +71,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -103,9 +102,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -145,20 +143,20 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
       // Wait for the router transition to complete (Navigate redirects are async)
       await waitFor(() => {
-        const navSpan = spans.find(s => spanToJSON(s).op === 'navigation');
+        const navSpan = spans.find(s => spanToJSON(s).attributes['sentry.op'] === 'navigation');
         expect(navSpan).toBeDefined();
 
         const span = spanToJSON(navSpan!);
-        expect(span.description).toBe(parametrizedRoute);
-        expect(span.data).toMatchObject({
+        expect(span.name).toBe(parametrizedRoute);
+        expect(span.attributes).toMatchObject({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.solidrouter',
         });
 
         for (const [key, value] of Object.entries(expectedParams as Record<string, string>)) {
-          expect(span.data![`url.path.parameter.${key}`]).toBe(value);
-          expect(span.data![`params.${key}`]).toBe(value);
+          expect(span.attributes![`url.path.parameter.${key}`]).toBe(value);
+          expect(span.attributes![`params.${key}`]).toBe(value);
         }
       });
     },
@@ -185,9 +183,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'navigation',
-        description: '/about',
-        data: expect.objectContaining({
+        name: '/about',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.solidrouter',

--- a/packages/solidstart/src/server/withServerActionInstrumentation.ts
+++ b/packages/solidstart/src/server/withServerActionInstrumentation.ts
@@ -21,7 +21,7 @@ export async function withServerActionInstrumentation<A extends (...args: unknow
   const activeSpan = getActiveSpan();
 
   if (activeSpan) {
-    const spanData = spanToJSON(activeSpan).data;
+    const spanData = spanToJSON(activeSpan).attributes;
 
     // In solid start, server function calls are made to `/_server` which doesn't tell us
     // a lot. We rewrite the span's route to be that of the sever action name but only

--- a/packages/solidstart/test/client/solidrouter.test.tsx
+++ b/packages/solidstart/test/client/solidrouter.test.tsx
@@ -71,9 +71,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -103,9 +102,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -145,20 +143,20 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
       // Wait for the router transition to complete (Navigate redirects are async)
       await waitFor(() => {
-        const navSpan = spans.find(s => spanToJSON(s).op === 'navigation');
+        const navSpan = spans.find(s => spanToJSON(s).attributes['sentry.op'] === 'navigation');
         expect(navSpan).toBeDefined();
 
         const span = spanToJSON(navSpan!);
-        expect(span.description).toBe(parametrizedRoute);
-        expect(span.data).toMatchObject({
+        expect(span.name).toBe(parametrizedRoute);
+        expect(span.attributes).toMatchObject({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solidstart.solidrouter',
         });
 
         for (const [key, value] of Object.entries(expectedParams as Record<string, string>)) {
-          expect(span.data![`url.path.parameter.${key}`]).toBe(value);
-          expect(span.data![`params.${key}`]).toBe(value);
+          expect(span.attributes![`url.path.parameter.${key}`]).toBe(value);
+          expect(span.attributes![`params.${key}`]).toBe(value);
         }
       });
     },
@@ -185,9 +183,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'navigation',
-        description: '/about',
-        data: expect.objectContaining({
+        name: '/about',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solidstart.solidrouter',

--- a/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
+++ b/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
@@ -102,9 +102,8 @@ describe('withServerActionInstrumentation', () => {
     await serverActionGetPrefecture();
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'function',
-        description: 'getPrefecture',
-        data: expect.objectContaining({
+        name: 'getPrefecture',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.solidstart',

--- a/packages/sveltekit/src/server-common/handle.ts
+++ b/packages/sveltekit/src/server-common/handle.ts
@@ -168,10 +168,10 @@ async function instrumentHandle(
         // span name as early as possible (for dynamic sampling, et al.)
         // Other spans are enhanced in the `processKitSpans` integration.
         const spanJson = spanToJSON(kitRootSpan);
-        const kitRootSpanAttributes = spanJson.data;
-        const originalName = spanJson.description;
+        const kitRootSpanAttributes = spanJson.attributes;
+        const originalName = spanJson.name;
 
-        const kitRoute = kitRootSpanAttributes[HTTP_ROUTE];
+        const kitRoute = kitRootSpanAttributes[HTTP_ROUTE] as string | undefined;
         const routeName = typeof kitRoute === 'string' ? kitRoute : routeId;
         if (routeName && typeof routeName === 'string') {
           updateSpanName(kitRootSpan, `${event.request.method ?? 'GET'} ${routeName}`);
@@ -182,8 +182,8 @@ async function instrumentHandle(
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.sveltekit',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeName ? 'route' : 'url',
           'sveltekit.tracing.original_name': originalName,
-          [URL_FULL]: kitRootSpanAttributes[URL_FULL] ?? filterCollectedUrl(event.url.href),
-          [URL_PATH]: kitRootSpanAttributes[URL_PATH] ?? event.url.pathname,
+          [URL_FULL]: (kitRootSpanAttributes[URL_FULL] as string | undefined) ?? filterCollectedUrl(event.url.href),
+          [URL_PATH]: (kitRootSpanAttributes[URL_PATH] as string | undefined) ?? event.url.pathname,
           ...(routeName && {
             [HTTP_ROUTE]: routeName,
           }),

--- a/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
+++ b/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
@@ -62,13 +62,13 @@ export function _enhanceKitSpanStreamed(span: StreamedSpanJSON): void {
     return;
   }
 
-  const previousOrigin = span.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined;
+  const previousOrigin = span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined;
 
   safeSetSpanJSONAttributes(span, { [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP });
 
   if (previousOrigin === 'manual') {
     // `safeSetSpanJSONAttributes` skips existing keys, so overwrite the 'manual' sentinel directly.
-    span.attributes![SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] = origin;
+    span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] = origin;
   } else {
     safeSetSpanJSONAttributes(span, { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: origin });
   }

--- a/packages/sveltekit/test/server-common/handle.test.ts
+++ b/packages/sveltekit/test/server-common/handle.test.ts
@@ -141,13 +141,13 @@ describe('sentryHandle', () => {
 
       expect(_span!).toBeDefined();
 
-      expect(spanToJSON(_span!).description).toEqual('GET /users/[id]');
-      expect(spanToJSON(_span!).op).toEqual('http.server');
-      expect(spanToJSON(_span!).status).toEqual(isError ? 'internal_error' : 'ok');
-      expect(spanToJSON(_span!).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
-      expect(spanToJSON(_span!).data?.[HTTP_ROUTE]).toEqual('/users/[id]');
+      expect(spanToJSON(_span!).name).toEqual('GET /users/[id]');
+      expect(spanToJSON(_span!).attributes['sentry.op']).toEqual('http.server');
+      expect(spanToJSON(_span!).status).toEqual(isError ? 'error' : 'ok');
+      expect(spanToJSON(_span!).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+      expect(spanToJSON(_span!).attributes?.[HTTP_ROUTE]).toEqual('/users/[id]');
 
-      expect(spanToJSON(_span!).timestamp).toBeDefined();
+      expect(spanToJSON(_span!).end_timestamp).toBeDefined();
 
       const spans = getSpanDescendants(_span!);
       expect(spans).toHaveLength(1);
@@ -172,9 +172,9 @@ describe('sentryHandle', () => {
       }
 
       expect(_span).toBeUndefined();
-      expect(spanToJSON(kitRootSpan).description).toEqual('GET /users/[id]');
-      expect(spanToJSON(kitRootSpan).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
-      expect(spanToJSON(kitRootSpan).data?.[HTTP_ROUTE]).toEqual('/users/[id]');
+      expect(spanToJSON(kitRootSpan).name).toEqual('GET /users/[id]');
+      expect(spanToJSON(kitRootSpan).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+      expect(spanToJSON(kitRootSpan).attributes?.[HTTP_ROUTE]).toEqual('/users/[id]');
       kitRootSpan.end();
     });
 
@@ -207,20 +207,26 @@ describe('sentryHandle', () => {
       expect(txnCount).toEqual(1);
       expect(_span!).toBeDefined();
 
-      expect(spanToJSON(_span!).description).toEqual('GET /users/[id]');
-      expect(spanToJSON(_span!).op).toEqual('http.server');
-      expect(spanToJSON(_span!).status).toEqual(isError ? 'internal_error' : 'ok');
-      expect(spanToJSON(_span!).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+      expect(spanToJSON(_span!).name).toEqual('GET /users/[id]');
+      expect(spanToJSON(_span!).attributes['sentry.op']).toEqual('http.server');
+      expect(spanToJSON(_span!).status).toEqual(isError ? 'error' : 'ok');
+      expect(spanToJSON(_span!).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
 
-      expect(spanToJSON(_span!).timestamp).toBeDefined();
+      expect(spanToJSON(_span!).end_timestamp).toBeDefined();
 
       const spans = getSpanDescendants(_span!).map(spanToJSON);
 
       expect(spans).toHaveLength(2);
       expect(spans).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ op: 'http.server', description: 'GET /users/[id]' }),
-          expect.objectContaining({ op: 'http.server', description: 'GET api/users/details/[id]' }),
+          expect.objectContaining({
+            name: 'GET /users/[id]',
+            attributes: expect.objectContaining({ 'sentry.op': 'http.server' }),
+          }),
+          expect.objectContaining({
+            name: 'GET api/users/details/[id]',
+            attributes: expect.objectContaining({ 'sentry.op': 'http.server' }),
+          }),
         ]),
       );
     });

--- a/packages/tanstackstart-react/src/server/globalMiddleware.ts
+++ b/packages/tanstackstart-react/src/server/globalMiddleware.ts
@@ -8,6 +8,7 @@ import {
 } from '@sentry/core';
 import type { SentryGlobalFunctionMiddleware, SentryGlobalRequestMiddleware } from '../common/types';
 import { SENTRY_INTERNAL } from './middleware';
+import { SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 
 type ServerFnMeta = {
   id?: string;
@@ -38,9 +39,9 @@ function createSentryFunctionMiddlewareHandler(mechanismType: string) {
   }): Promise<unknown> {
     const activeSpan = getActiveSpan();
     const spanData = activeSpan ? spanToJSON(activeSpan) : undefined;
-    if (activeSpan && spanData?.origin === 'auto.function.tanstackstart.server') {
+    if (activeSpan && spanData?.attributes[SENTRY_ORIGIN] === 'auto.function.tanstackstart.server') {
       if (serverFnMeta?.name) {
-        const method = spanData.description?.split(' ')[0] || 'GET';
+        const method = spanData.name.split(' ')[0] || 'GET';
         updateSpanName(activeSpan, `${method} /_serverFn/${serverFnMeta.name}`);
         activeSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
       }

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -53,7 +53,7 @@ export function updateSpanWithRouteParametrization(method: string, pathname: str
   }
 
   const rootSpan = getRootSpan(activeSpan);
-  const rootSpanData = spanToJSON(rootSpan).data;
+  const rootSpanData = spanToJSON(rootSpan).attributes;
   if (rootSpanData?.[HTTP_ROUTE]) {
     return;
   }

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -2,6 +2,7 @@ import { captureException, getAbsoluteUrl } from '@sentry/browser';
 import {
   NAVIGATION_ROUTE_ID,
   PARAMS_KEY_BASE,
+  SENTRY_OP,
   URL_PATH_PARAMETER_KEY_BASE,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
@@ -114,7 +115,7 @@ export function instrumentVueRouter(
 
     // Update the existing page load span with parametrized route information
     if (options.instrumentPageLoad && activePageLoadSpan) {
-      const existingAttributes = spanToJSON(activePageLoadSpan).data;
+      const existingAttributes = spanToJSON(activePageLoadSpan).attributes;
       if (existingAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom') {
         activePageLoadSpan.updateName(spanName);
         activePageLoadSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, transactionSource);
@@ -167,7 +168,7 @@ function getActivePageLoadSpan(): Span | undefined {
     return undefined;
   }
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToJSON(rootSpan).attributes[SENTRY_OP];
 
   return op === 'pageload' ? rootSpan : undefined;
 }

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -146,7 +146,8 @@ describe('instrumentVueRouter()', () => {
     (fromKey, toKey, transactionName, transactionSource) => {
       const mockRootSpan = {
         ...MOCK_SPAN,
-        getSpanJSON: vi.fn().mockReturnValue({ op: 'pageload', data: {} }),
+        getSpanJSON: () => ({}),
+        getStreamedSpanJSON: () => ({ attributes: { 'sentry.op': 'pageload' } }),
         updateName: vi.fn(),
         setAttribute: vi.fn(),
         setAttributes: vi.fn(),
@@ -252,9 +253,10 @@ describe('instrumentVueRouter()', () => {
       setAttribute: vi.fn(),
       setAttributes: vi.fn(),
       name: '',
-      getSpanJSON: () => ({
-        op: 'pageload',
-        data: {
+      getSpanJSON: () => ({}),
+      getStreamedSpanJSON: () => ({
+        attributes: {
+          'sentry.op': 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         },
       }),
@@ -276,9 +278,9 @@ describe('instrumentVueRouter()', () => {
     // now we give the transaction a custom name, thereby simulating what would
     // happen when users use the `beforeNavigate` hook
     mockRootSpan.name = 'customTxnName';
-    mockRootSpan.getSpanJSON = () => ({
-      op: 'pageload',
-      data: {
+    mockRootSpan.getStreamedSpanJSON = () => ({
+      attributes: {
+        'sentry.op': 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
       },
     });
@@ -341,9 +343,10 @@ describe('instrumentVueRouter()', () => {
         setAttribute: vi.fn(),
         setAttributes: vi.fn(),
         name: '',
-        getSpanJSON: () => ({
-          op: 'pageload',
-          data: {
+        getSpanJSON: () => ({}),
+        getStreamedSpanJSON: () => ({
+          attributes: {
+            'sentry.op': 'pageload',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           },
         }),


### PR DESCRIPTION
This PR:

- (breaking) changes the return type of `spanToJSON` from `SpanJSON` to `StreamedSpanJSON`
- (breaking) removes `spanToStreamedSpanJSON` (which IMHO is fine, it was only added for opt-in span streaming and never publicly documented)
- adds `spanToStaticSpanJSON` for any transaction code paths
- adjusts every internal `spanToJSON` usage to work with the new return type

Because we should also use the new span format in our SDK, this PR also adjusts every usage of `spanToJSON` to the new format.