### PR TITLE
test(e2e): Fix type error in nextjs ai-error tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-15/tests/ai-error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/tests/ai-error.test.ts
@@ -16,7 +16,7 @@ test.fixme('should create AI spans with correct attributes and error linking', a
   );
 
   const errorEventPromise = waitForError('nextjs-15', async errorEvent => {
-    return errorEvent.exception?.values?.[0]?.value?.includes('Tool call failed');
+    return !!errorEvent.exception?.values?.[0]?.value?.includes('Tool call failed');
   });
 
   await page.goto('/ai-error-test');

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/tests/ai-error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/tests/ai-error.test.ts
@@ -16,7 +16,7 @@ test.fixme('should create AI spans with correct attributes and error linking', a
   );
 
   const errorEventPromise = waitForError('nextjs-16', async errorEvent => {
-    return errorEvent.exception?.values?.[0]?.value?.includes('Tool call failed');
+    return !!errorEvent.exception?.values?.[0]?.value?.includes('Tool call failed');
   });
 
   await page.goto('/ai-error-test');


### PR DESCRIPTION
Fixes a build-time type error that breaks the nextjs-16 canary and latest E2E jobs.

Next 16.3 flipped `experimental.useTypeScriptCli` to `true` by default, and unlike the previous TypeScript-API path it does not filter diagnostics in `*.(spec|test).*` files, so this pre-existing error now fails `next build`.

closes getsentry/sentry-javascript#22973<br>closes getsentry/sentry-javascript#22974