### PR TITLE
fix(hono): Include originalException in captured exception hint

### DIFF
--- a/packages/hono/src/shared/middlewareHandlers.ts
+++ b/packages/hono/src/shared/middlewareHandlers.ts
@@ -94,6 +94,7 @@ export function responseHandler(
     if ((shouldHandleError ?? defaultShouldHandleError)(context.error)) {
       getClient()?.captureException(context.error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: context.error,
       });
     }
   }

--- a/packages/hono/test/shared/middlewareHandlers.test.ts
+++ b/packages/hono/test/shared/middlewareHandlers.test.ts
@@ -75,6 +75,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -90,6 +91,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -126,6 +128,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -167,6 +170,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
   });
@@ -185,6 +189,7 @@ describe('responseHandler', () => {
       expect(shouldHandleError).toHaveBeenCalledWith(error);
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -212,6 +217,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 


### PR DESCRIPTION
Hono is the only package that is using client interface directly. Because of that, none of default behavior applies, and `captureException` is not receiving a standard `originalException` property.
Without it, `LinkedErrors` integration and alike do not work and any data about `cause` chain is lost.