### PR TITLE
fix(v10/cloudflare): Use gen_ai.agent.name for class names

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/callable.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/callable.test.ts
@@ -181,8 +181,7 @@ test('creates an rpc span named after the @callable() method', async ({ page, ba
       description: 'greet',
       origin: 'auto.faas.cloudflare.agents',
       data: expect.objectContaining({
-        'cloudflare.agent.class': 'MyBaseAgent',
-        'cloudflare.agent.name': 'user-123',
+        'gen_ai.agent.name': 'MyBaseAgent',
       }),
     }),
   );

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/chat-rpc.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/tests/chat-rpc.test.ts
@@ -22,9 +22,6 @@ test('creates an rpc span for a @callable() invocation on an AIChatAgent', async
       op: 'rpc',
       description: 'greet',
       origin: 'auto.faas.cloudflare.agents',
-      data: expect.objectContaining({
-        'cloudflare.agent.name': AGENT_INSTANCE,
-      }),
     }),
   );
 });

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tests/autoinstrument.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/tests/autoinstrument.test.ts
@@ -74,8 +74,7 @@ for (const { title, binding, agentClass } of [
           // confirms the wrapper landed on the user's real class. Matched loosely
           // because the transform renames the class it wraps to
           // `__SENTRY_ORIGINAL_<name>__` and the bundler infers that name.
-          'cloudflare.agent.class': expect.stringContaining(agentClass),
-          'cloudflare.agent.name': instance,
+          'gen_ai.agent.name': expect.stringContaining(agentClass),
         }),
       }),
     );

--- a/packages/cloudflare/src/instrumentations/agents/types.ts
+++ b/packages/cloudflare/src/instrumentations/agents/types.ts
@@ -1,8 +1,10 @@
 import { getCurrentScope } from '@sentry/core';
 
+// v10 predates `@sentry/conventions` and doesn't expose this from `@sentry/core`, so keep the
+// standard semantic attribute name locally.
+const GEN_AI_AGENT_NAME_ATTRIBUTE = 'gen_ai.agent.name';
+
 export const AGENT_SPAN_ORIGIN = 'auto.faas.cloudflare.agents';
-export const AGENT_CLASS_ATTRIBUTE = 'cloudflare.agent.class';
-export const AGENT_NAME_ATTRIBUTE = 'cloudflare.agent.name';
 
 /**
  * The subset of the `agents` `Agent` instance internals that we instrument. These are runtime
@@ -38,12 +40,7 @@ export function getAgentAttributes(instance: AgentInternals): Record<string, str
 
   const agentClass = instance._ParentClass?.name;
   if (typeof agentClass === 'string' && agentClass) {
-    attributes[AGENT_CLASS_ATTRIBUTE] = agentClass;
-  }
-
-  const agentName = instance.name;
-  if (typeof agentName === 'string' && agentName) {
-    attributes[AGENT_NAME_ATTRIBUTE] = agentName;
+    attributes[GEN_AI_AGENT_NAME_ATTRIBUTE] = agentClass;
   }
 
   return attributes;

--- a/packages/cloudflare/test/instrumentCloudflareAgent.test.ts
+++ b/packages/cloudflare/test/instrumentCloudflareAgent.test.ts
@@ -86,8 +86,7 @@ describe('instrumentCloudflareAgent', () => {
           op: 'rpc',
           origin: 'auto.faas.cloudflare.agents',
           data: expect.objectContaining({
-            'cloudflare.agent.class': 'MyAgent',
-            'cloudflare.agent.name': 'instance-1',
+            'gen_ai.agent.name': 'MyAgent',
           }),
         }),
       );


### PR DESCRIPTION
Backport of: #22911