### PR TITLE
fix(v10/hono): Include originalException in captured exception hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by @Jxxunnn. Thank you for your contribution!
+Work in this release was contributed by @Jxxunnn and @kamilogorek. Thank you for your contributions!
 
 ## 10.69.0
 

--- a/packages/hono/src/shared/middlewareHandlers.ts
+++ b/packages/hono/src/shared/middlewareHandlers.ts
@@ -94,6 +94,7 @@ export function responseHandler(
     if ((shouldHandleError ?? defaultShouldHandleError)(context.error)) {
       getClient()?.captureException(context.error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: context.error,
       });
     }
   }

--- a/packages/hono/test/shared/middlewareHandlers.test.ts
+++ b/packages/hono/test/shared/middlewareHandlers.test.ts
@@ -75,6 +75,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -90,6 +91,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -126,6 +128,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -167,6 +170,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
   });
@@ -185,6 +189,7 @@ describe('responseHandler', () => {
       expect(shouldHandleError).toHaveBeenCalledWith(error);
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 
@@ -212,6 +217,7 @@ describe('responseHandler', () => {
 
       expect(mockCaptureException).toHaveBeenCalledWith(error, {
         mechanism: { handled: false, type: 'auto.http.hono.context_error' },
+        originalException: error,
       });
     });
 


### PR DESCRIPTION
Backport of: #22979