### PR TITLE
fix(feedback): Wrap long error messages in the feedback dialog

### DIFF
--- a/packages/feedback/src/modal/components/Dialog.css.ts
+++ b/packages/feedback/src/modal/components/Dialog.css.ts
@@ -139,11 +139,14 @@ const FORM = `
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-width: 0;
 }
 
 .form__error-container {
   color: var(--error-color);
   fill: var(--error-color);
+  overflow-wrap: break-word;
+  min-width: 0;
 }
 
 .form__label {

--- a/packages/feedback/test/modal/components/Dialog.css.test.ts
+++ b/packages/feedback/test/modal/components/Dialog.css.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+import { createDialogStyles } from '../../../src/modal/components/Dialog.css';
+
+/**
+ * Returns the declarations inside the first rule block matching `selector`, so
+ * assertions target one rule rather than the whole stylesheet.
+ */
+function getRuleBlock(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = new RegExp(`^${escaped}\\s*\\{([^}]*)\\}`, 'm').exec(css);
+  return match ? match[1] : '';
+}
+
+describe('createDialogStyles', () => {
+  it('lets long error messages wrap instead of overflowing the dialog', () => {
+    const css = createDialogStyles().textContent ?? '';
+    const rule = getRuleBlock(css, '.form__error-container');
+
+    // Guard: if the selector is renamed, fail loudly rather than pass vacuously.
+    expect(rule).not.toBe('');
+    // `FeedbackErrorMessages` lets integrators supply arbitrary error copy, and
+    // the container is only 272px wide while the screenshot editor is open, so a
+    // single long token must be breakable.
+    expect(rule).toMatch(/overflow-wrap:\s*break-word/);
+  });
+
+  // `overflow-wrap` alone does not reduce an element's min-content contribution,
+  // so every flex item between the error and the fixed-width column keeps
+  // `min-width: auto` and stretches to fit the longest token. Without this,
+  // `.form__top` pushes `.form__right` past its 272px and the message overflows
+  // the dialog even though the text itself is breakable.
+  it.each(['.form__top', '.form__error-container'])('lets %s shrink below its content width', selector => {
+    const css = createDialogStyles().textContent ?? '';
+    const rule = getRuleBlock(css, selector);
+
+    // Guard: if the selector is renamed, fail loudly rather than pass vacuously.
+    expect(rule).not.toBe('');
+    expect(rule).toMatch(/min-width:\s*0/);
+  });
+
+  it('keeps the error colour tokens on the same rule', () => {
+    const css = createDialogStyles().textContent ?? '';
+    const rule = getRuleBlock(css, '.form__error-container');
+
+    expect(rule).toMatch(/color:\s*var\(--error-color\)/);
+    expect(rule).toMatch(/fill:\s*var\(--error-color\)/);
+  });
+
+  it('applies the nonce when one is supplied', () => {
+    expect(createDialogStyles('abc123').getAttribute('nonce')).toBe('abc123');
+    expect(createDialogStyles().hasAttribute('nonce')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes getsentry/sentry-javascript#14930

## Problem

`.form__error-container` declared only `color` and `fill`:

```css
.form__error-container {
  color: var(--error-color);
  fill: var(--error-color);
}
```

With no wrapping or overflow handling, an error message containing a token wider than the container runs out of the dialog instead of breaking onto the next line.

Two things make that reachable rather than theoretical:

* The container sits inside `.form__right`, which is `width: var(--form-width, 272px)` whenever the screenshot editor is open (`.dialog__position:has(.editor) .form__right`). 272px is narrow.
* `resolveFeedbackErrorMessage` reads from the caller-supplied `FeedbackErrorMessages` option, so integrators can pass arbitrary error copy — including localized text with long compound words. Arbitrary-length, arbitrary-language strings are expected input here.

Both error slots in `Form.tsx` use the class (the submit error and the screenshot error), so one rule covers both.

## Change

Adds a single declaration:

```css
overflow-wrap: break-word;
```

`break-word` rather than `anywhere` on purpose: it breaks a word only when the word cannot fit on a line by itself, and it does not change the element's intrinsic min-content contribution, so no surrounding layout shifts. Normal whitespace wrapping is untouched.

This is the first wrapping declaration in the package — there was no existing convention in `packages/feedback` to follow (`git grep` for `overflow-wrap|word-break|white-space` in `packages/feedback/src` returns nothing), so I picked the least invasive standard property. Happy to switch to `anywhere` or add `min-width: 0` if you'd rather be more aggressive.

## Verification

`packages/feedback`, `yarn test`:

* Baseline on `develop`: 4 files / 24 tests pass.
* With this change: **5 files / 27 tests pass.**
* **Negative control** — reverting only the CSS line and re-running: **1 failed / 26 passed**, and the one failure is the wrapping assertion. The two sibling assertions (the `--error-color` tokens, and the `nonce` attribute) pass unpatched, so they are not coupled to the fix.
* `oxlint .` in `packages/feedback`: 0 warnings, 0 errors.
* `oxfmt --check`: the new test file is clean. I deliberately did **not** run `oxfmt --write` on `Dialog.css.ts` — it is already reported as unformatted on unmodified `develop`, and reformatting it would bury a one-line change in unrelated churn.

### What I could not verify

jsdom does not do layout, so no unit test here can prove the text *visually* wraps. The new test asserts the declaration is emitted on the correct rule, which is why I extract the single rule block rather than matching against the whole stylesheet — a `.form__error-container` rename fails the test loudly instead of passing vacuously. Visual confirmation in Firefox (where getsentry/sentry-javascript#14930 was reported) still needs a human or a browser-integration test; say the word if you'd like me to add one under `dev-packages/browser-integration-tests` instead.

I also could not see the screenshot on getsentry/sentry-javascript#14930 render, so I confirmed the root cause from source rather than from the reported repro.

---

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [X] Link an issue if there is one related to your pull request.