### PR TITLE
feat(core)!: Remove deprecated `inboundFiltersIntegration`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -821,6 +821,24 @@ import { inboundFiltersIntegration } from '@sentry/browser';
 import { eventFiltersIntegration } from '@sentry/browser';
 ```
 
+All SDKs now also set up `eventFiltersIntegration` instead of `inboundFiltersIntegration` as a default
+integration, so the integration reports itself as `EventFilters` (e.g. in the `sdk.integrations` payload of
+events). If you disable the integration by its previous name, update the reference:
+
+```js
+// before
+Sentry.init({
+  integrations: integrations => integrations.filter(integration => integration.name !== 'InboundFilters'),
+});
+
+// after
+Sentry.init({
+  integrations: integrations => integrations.filter(integration => integration.name !== 'EventFilters'),
+});
+```
+
+The same applies when looking the integration up by name, e.g. via `client.getIntegrationByName('InboundFilters')`.
+
 ### `instrumentLangGraph` renamed to `instrumentStateGraph`
 
 Affected SDKs: SDKs with LangGraph instrumentation.

--- a/dev-packages/browser-integration-tests/suites/integrations/ContextLines/inline/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/ContextLines/inline/test.ts
@@ -7,8 +7,8 @@ sentryTest(
   async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // The error we're throwing in this test is thrown as "Script error." in Webkit.
-      // We filter "Script error." out by default in `InboundFilters`.
-      // I don't think there's much value to disable InboundFilters defaults for this test,
+      // We filter "Script error." out by default in `EventFilters`.
+      // I don't think there's much value to disable EventFilters defaults for this test,
       // given that most of our users won't do that either.
       // Let's skip it instead for Webkit.
       sentryTest.skip();

--- a/dev-packages/browser-integration-tests/suites/integrations/ContextLines/scriptTag/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/ContextLines/scriptTag/test.ts
@@ -7,8 +7,8 @@ sentryTest(
   async ({ getLocalTestUrl, page, browserName }) => {
     if (browserName === 'webkit') {
       // The error we're throwing in this test is thrown as "Script error." in Webkit.
-      // We filter "Script error." out by default in `InboundFilters`.
-      // I don't think there's much value to disable InboundFilters defaults for this test,
+      // We filter "Script error." out by default in `EventFilters`.
+      // I don't think there's much value to disable EventFilters defaults for this test,
       // given that most of our users won't do that either.
       // Let's skip it instead for Webkit.
       sentryTest.skip();

--- a/dev-packages/browser-integration-tests/suites/public-api/debug/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/debug/test.ts
@@ -31,7 +31,7 @@ sentryTest('logs debug messages correctly', async ({ getLocalTestUrl, page }) =>
   expect(consoleMessages).toEqual(
     hasDebug
       ? [
-          'Sentry Logger [log]: Integration installed: InboundFilters',
+          'Sentry Logger [log]: Integration installed: EventFilters',
           'Sentry Logger [log]: Integration installed: FunctionToString',
           'Sentry Logger [log]: Integration installed: ConversationId',
           'Sentry Logger [log]: Integration installed: BrowserApiErrors',

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -42,7 +42,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
     },
     sdk: {
       integrations: expect.arrayContaining([
-        'InboundFilters',
+        'EventFilters',
         'FunctionToString',
         'BrowserApiErrors',
         'Breadcrumbs',
@@ -91,7 +91,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
     },
     sdk: {
       integrations: expect.arrayContaining([
-        'InboundFilters',
+        'EventFilters',
         'FunctionToString',
         'BrowserApiErrors',
         'Breadcrumbs',

--- a/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -42,7 +42,7 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
     },
     sdk: {
       integrations: expect.arrayContaining([
-        'InboundFilters',
+        'EventFilters',
         'FunctionToString',
         'BrowserApiErrors',
         'Breadcrumbs',
@@ -91,7 +91,7 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
     },
     sdk: {
       integrations: expect.arrayContaining([
-        'InboundFilters',
+        'EventFilters',
         'FunctionToString',
         'BrowserApiErrors',
         'Breadcrumbs',

--- a/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
+++ b/dev-packages/browser-integration-tests/utils/replayEventTemplates.ts
@@ -25,7 +25,7 @@ const DEFAULT_REPLAY_EVENT = {
   },
   sdk: {
     integrations: expect.arrayContaining([
-      'InboundFilters',
+      'EventFilters',
       'FunctionToString',
       'BrowserApiErrors',
       'Breadcrumbs',

--- a/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/tests/errors.client.test.ts
@@ -51,7 +51,7 @@ test.describe('client-side errors', () => {
       timestamp: expect.any(Number),
       sdk: {
         integrations: expect.arrayContaining([
-          'InboundFilters',
+          'EventFilters',
           'FunctionToString',
           'BrowserApiErrors',
           'Breadcrumbs',

--- a/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-5/tests/errors.client.test.ts
@@ -51,7 +51,7 @@ test.describe('client-side errors', () => {
       timestamp: expect.any(Number),
       sdk: {
         integrations: expect.arrayContaining([
-          'InboundFilters',
+          'EventFilters',
           'FunctionToString',
           'BrowserApiErrors',
           'Breadcrumbs',

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/tests/errors.client.test.ts
@@ -51,7 +51,7 @@ test.describe('client-side errors', () => {
       timestamp: expect.any(Number),
       sdk: {
         integrations: expect.arrayContaining([
-          'InboundFilters',
+          'EventFilters',
           'FunctionToString',
           'BrowserApiErrors',
           'Breadcrumbs',

--- a/dev-packages/e2e-tests/test-applications/astro-6/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-6/tests/errors.client.test.ts
@@ -51,7 +51,7 @@ test.describe('client-side errors', () => {
       timestamp: expect.any(Number),
       sdk: {
         integrations: expect.arrayContaining([
-          'InboundFilters',
+          'EventFilters',
           'FunctionToString',
           'BrowserApiErrors',
           'Breadcrumbs',

--- a/dev-packages/e2e-tests/test-applications/astro-7/tests/errors.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-7/tests/errors.client.test.ts
@@ -51,7 +51,7 @@ test.describe('client-side errors', () => {
       timestamp: expect.any(Number),
       sdk: {
         integrations: expect.arrayContaining([
-          'InboundFilters',
+          'EventFilters',
           'FunctionToString',
           'BrowserApiErrors',
           'Breadcrumbs',

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -16,8 +16,8 @@ import {
   conversationIdIntegration,
   debug,
   dedupeIntegration,
+  eventFiltersIntegration,
   functionToStringIntegration,
-  inboundFiltersIntegration,
 } from '@sentry/core';
 import { IS_DEBUG_BUILD } from './flags';
 
@@ -34,9 +34,7 @@ export function getDefaultIntegrations(_options: BrowserOptions = {}): Integrati
   //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
   //  - https://github.com/getsentry/sentry-javascript/issues/2744
   return [
-    // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line typescript/no-deprecated
-    inboundFiltersIntegration(),
+    eventFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),
     breadcrumbsIntegration(),

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -66,8 +66,6 @@ export {
   httpIntegration,
   httpServerIntegration,
   httpServerSpansIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -70,8 +70,6 @@ export {
   localVariablesIntegration,
   requestDataIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   setMeasurement,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -60,8 +60,6 @@ export {
   withScope,
   withIsolationScope,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   dedupeIntegration,
   parameterize,

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -2,9 +2,9 @@ import type { Client, Integration, Options } from '@sentry/core/browser';
 import {
   conversationIdIntegration,
   dedupeIntegration,
+  eventFiltersIntegration,
   functionToStringIntegration,
   getIntegrationsToSetup,
-  inboundFiltersIntegration,
   initAndBind,
   setNormalizeStringifier,
   stackParserFromStackParserOptions,
@@ -35,9 +35,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
    * `getDefaultIntegrations` but with an adjusted set of integrations.
    */
   return [
-    // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line typescript/no-deprecated
-    inboundFiltersIntegration(),
+    eventFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),
     browserApiErrorsIntegration(),

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -91,8 +91,6 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   setMeasurement,

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -2,9 +2,9 @@ import * as os from 'node:os';
 import type { Integration, Options } from '@sentry/core';
 import {
   applySdkMetadata,
+  eventFiltersIntegration,
   functionToStringIntegration,
   hasSpansEnabled,
-  inboundFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,
 } from '@sentry/core';
@@ -69,9 +69,7 @@ export function getDefaultIntegrationsWithoutPerformance(): Integration[] {
   // Return a fresh array on each call so callers can safely mutate the result.
   return [
     // Common
-    // TODO(v11): Replace with eventFiltersIntegration once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line typescript/no-deprecated
-    inboundFiltersIntegration(),
+    eventFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),
     requestDataIntegration(),

--- a/packages/cloudflare/src/baseSdk.ts
+++ b/packages/cloudflare/src/baseSdk.ts
@@ -3,10 +3,10 @@ import {
   consoleIntegration,
   conversationIdIntegration,
   dedupeIntegration,
+  eventFiltersIntegration,
   functionToStringIntegration,
   getIntegrationsToSetup,
   GLOBAL_OBJ,
-  inboundFiltersIntegration,
   initAndBind,
   linkedErrorsIntegration,
   requestDataIntegration,
@@ -52,9 +52,7 @@ export function getBaseDefaultIntegrations(options: CloudflareOptions): Integrat
     // The Dedupe integration should not be used in workflows because we want to
     // capture all step failures, even if they are the same error.
     ...(options.enableDedupe === false ? [] : [dedupeIntegration()]),
-    // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line typescript/no-deprecated
-    inboundFiltersIntegration(),
+    eventFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),
     linkedErrorsIntegration(),

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -74,8 +74,6 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,

--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -1,7 +1,6 @@
 import { DEBUG_BUILD } from '../debug-build';
 import { defineIntegration } from '../integration';
 import type { Event } from '../types/event';
-import type { IntegrationFn } from '../types/integration';
 import type { StackFrame } from '../types/stackframe';
 import { debug } from '../utils/debug-logger';
 import { getPossibleEventMessages } from '../utils/eventUtils';
@@ -66,29 +65,6 @@ export const eventFiltersIntegration = defineIntegration((options: Partial<Event
     },
   };
 });
-
-/**
- * An integration that filters out events (errors and transactions) based on:
- *
- * - (Errors) A curated list of known low-value or irrelevant errors (see {@link DEFAULT_IGNORE_ERRORS})
- * - (Errors) A list of error messages or urls/filenames passed in via
- *   - Top level Sentry.init options (`ignoreErrors`, `denyUrls`, `allowUrls`)
- *   - The same options passed to the integration directly via @param options
- * - (Transactions/Spans) A list of root span (transaction) names passed in via
- *   - Top level Sentry.init option (`ignoreTransactions`)
- *   - The same option passed to the integration directly via @param options
- *
- * Events filtered by this integration will not be sent to Sentry.
- *
- * @deprecated this integration was renamed and will be removed in a future major version.
- * Use `eventFiltersIntegration` instead.
- */
-export const inboundFiltersIntegration = defineIntegration(((options: Partial<EventFiltersOptions> = {}) => {
-  return {
-    ...eventFiltersIntegration(options),
-    name: 'InboundFilters' as const,
-  };
-}) satisfies IntegrationFn);
 
 function _mergeOptions(
   internalOptions: Partial<EventFiltersOptions> = {},

--- a/packages/core/src/semanticAttributes.ts
+++ b/packages/core/src/semanticAttributes.ts
@@ -74,7 +74,7 @@ export const SEMANTIC_ATTRIBUTE_SENTRY_SDK_NAME = 'sentry.sdk.name';
  * @deprecated Use `SENTRY_SDK_VERSION` `@sentry/conventions/attributes` instead.
  */
 export const SEMANTIC_ATTRIBUTE_SENTRY_SDK_VERSION = 'sentry.sdk.version';
-/** The list of integrations enabled in the Sentry SDK (e.g., ["InboundFilters", "BrowserTracing"]) */
+/** The list of integrations enabled in the Sentry SDK (e.g., ["EventFilters", "BrowserTracing"]) */
 export const SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS = 'sentry.sdk.integrations';
 
 /** The user ID */

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -144,8 +144,6 @@ export { spanKindToName } from './spanKind';
 export type { SpanKind, SpanKindNumber } from './spanKind';
 export { addBreadcrumb } from './breadcrumbs';
 export { functionToStringIntegration } from './integrations/functiontostring';
-// eslint-disable-next-line typescript/no-deprecated
-export { inboundFiltersIntegration } from './integrations/eventFilters';
 export { eventFiltersIntegration } from './integrations/eventFilters';
 export { linkedErrorsIntegration } from './integrations/linkederrors';
 export { moduleMetadataIntegration } from './integrations/moduleMetadata';

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { EventFiltersOptions } from '../../../src/integrations/eventFilters';
-import { eventFiltersIntegration, inboundFiltersIntegration } from '../../../src/integrations/eventFilters';
+import { eventFiltersIntegration } from '../../../src/integrations/eventFilters';
 import type { Event } from '../../../src/types/event';
 import type { EventProcessor } from '../../../src/types/eventprocessor';
 import type { Integration } from '../../../src/types/integration';
@@ -23,7 +23,7 @@ const PUBLIC_DSN = 'https://username@domain/123';
  * expect(eventProcessor(SOME_EXCEPTION_EVENT)).toBe(null);
  * ```
  *
- * @param options options passed into the InboundFilters integration
+ * @param options options passed into the EventFilters integration
  * @param clientOptions options passed into the mock Sentry client
  */
 function createEventFiltersEventProcessor(
@@ -409,11 +409,8 @@ function createUndefinedIsNotAnObjectEvent(evaluatingStr: string): Event {
   };
 }
 
-describe.each([
-  // eslint-disable-next-line typescript/no-deprecated
-  ['InboundFilters', inboundFiltersIntegration],
-  ['EventFilters', eventFiltersIntegration],
-])('%s', (_, integrationFn) => {
+describe('EventFilters', () => {
+  const integrationFn = eventFiltersIntegration;
   describe('ignoreErrors', () => {
     it('string filter with partial match', () => {
       const eventProcessor = createEventFiltersEventProcessor(integrationFn, {

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -324,7 +324,7 @@ describe('captureSpan', () => {
         release: '1.0.0',
         environment: 'staging',
         integrations: [
-          { name: 'InboundFilters', setupOnce: () => {} },
+          { name: 'EventFilters', setupOnce: () => {} },
           { name: 'BrowserTracing', setupOnce: () => {} },
         ],
         _metadata: {
@@ -369,7 +369,7 @@ describe('captureSpan', () => {
         [SENTRY_SDK_VERSION]: { value: '9.0.0', type: 'string' },
         [SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS]: {
           type: 'array',
-          value: ['InboundFilters', 'BrowserTracing'],
+          value: ['EventFilters', 'BrowserTracing'],
         },
       },
       _segmentSpan: span,
@@ -381,7 +381,7 @@ describe('captureSpan', () => {
       getDefaultTestClientOptions({
         dsn: 'https://dsn@ingest.f00.f00/1',
         tracesSampleRate: 1,
-        integrations: [{ name: 'InboundFilters', setupOnce: () => {} }],
+        integrations: [{ name: 'EventFilters', setupOnce: () => {} }],
       }),
     );
     client.init();

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -69,8 +69,6 @@ export {
   startNewTrace,
   bindScopeToEmitter,
   suppressTracing,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   functionToStringIntegration,

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -2,9 +2,9 @@ import type { Client, Integration, Options, ServerRuntimeClientOptions, StackPar
 import {
   createStackParser,
   dedupeIntegration,
+  eventFiltersIntegration,
   functionToStringIntegration,
   getIntegrationsToSetup,
-  inboundFiltersIntegration,
   initAndBind,
   linkedErrorsIntegration,
   nodeStackLineParser,
@@ -54,9 +54,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
   // We return a copy of the defaultIntegrations here to avoid mutating this
   return [
     // Common
-    // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line typescript/no-deprecated
-    inboundFiltersIntegration(),
+    eventFiltersIntegration(),
     requestDataIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),

--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -47,7 +47,7 @@ snapshot[`captureMessage 1`] = `
   platform: "javascript",
   sdk: {
     integrations: [
-      "InboundFilters",
+      "EventFilters",
       "RequestData",
       "FunctionToString",
       "LinkedErrors",
@@ -152,7 +152,7 @@ snapshot[`captureMessage twice 1`] = `
   platform: "javascript",
   sdk: {
     integrations: [
-      "InboundFilters",
+      "EventFilters",
       "RequestData",
       "FunctionToString",
       "LinkedErrors",
@@ -264,7 +264,7 @@ snapshot[`captureMessage twice 2`] = `
   platform: "javascript",
   sdk: {
     integrations: [
-      "InboundFilters",
+      "EventFilters",
       "RequestData",
       "FunctionToString",
       "LinkedErrors",

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -70,8 +70,6 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   setMeasurement,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -71,8 +71,6 @@ export {
   requestDataIntegration,
   fsIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   setMeasurement,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -81,8 +81,6 @@ export {
   withMonitor,
   requestDataIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   addEventProcessor,

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -5,11 +5,11 @@ import {
   conversationIdIntegration,
   debug,
   envToBool,
+  eventFiltersIntegration,
   functionToStringIntegration,
   getCurrentScope,
   getIntegrationsToSetup,
   hasSpansEnabled,
-  inboundFiltersIntegration,
   linkedErrorsIntegration,
   propagationContextFromHeaders,
   requestDataIntegration,
@@ -48,9 +48,7 @@ import { initOpenTelemetry } from './initOtel';
 function getBaseDefaultIntegrations(): Integration[] {
   return [
     // Common
-    // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line typescript/no-deprecated
-    inboundFiltersIntegration(),
+    eventFiltersIntegration(),
     functionToStringIntegration(),
     linkedErrorsIntegration(),
     requestDataIntegration(),

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -96,8 +96,6 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,
   extraErrorDataIntegration,

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -52,8 +52,6 @@ export {
   httpIntegration,
   httpServerIntegration,
   httpServerSpansIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -55,8 +55,6 @@ export {
   httpIntegration,
   httpServerIntegration,
   httpServerSpansIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -52,8 +52,6 @@ export {
   getTraceMetaTags,
   graphqlIntegration,
   hapiIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   initOpenTelemetry,
   isInitialized,

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -43,8 +43,6 @@ export {
   getSpanStatusFromHttpCode,
   getTraceData,
   getTraceMetaTags,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   isInitialized,
   isEnabled,
   lastEventId,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -71,8 +71,6 @@ export {
   getSpanDescendants,
   continueTrace,
   functionToStringIntegration,
-  // eslint-disable-next-line typescript/no-deprecated
-  inboundFiltersIntegration,
   eventFiltersIntegration,
   linkedErrorsIntegration,
   requestDataIntegration,

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -6,11 +6,11 @@ import {
   createStackParser,
   debug,
   dedupeIntegration,
+  eventFiltersIntegration,
   functionToStringIntegration,
   getCurrentScope,
   getIntegrationsToSetup,
   GLOBAL_OBJ,
-  inboundFiltersIntegration,
   linkedErrorsIntegration,
   nodeStackLineParser,
   requestDataIntegration,
@@ -38,9 +38,7 @@ const nodeStackParser = createStackParser(nodeStackLineParser());
 export function getDefaultIntegrations(): Integration[] {
   return [
     dedupeIntegration(),
-    // TODO(v11): Replace with `eventFiltersIntegration` once we remove the deprecated `inboundFiltersIntegration`
-    // eslint-disable-next-line typescript/no-deprecated
-    inboundFiltersIntegration(),
+    eventFiltersIntegration(),
     functionToStringIntegration(),
     conversationIdIntegration(),
     linkedErrorsIntegration(),


### PR DESCRIPTION
closes getsentry/sentry-javascript#15431  <br>closes getsentry/sentry-javascript#15431

The alias was a thin wrapper around `eventFiltersIntegration` (only the integration name differed) and has been deprecated since v10. All SDKs now set up `eventFiltersIntegration` as the default, which renames the integration in the `sdk.integrations` payload from `InboundFilters` to `EventFilters`.