### PR TITLE
test(v10/e2e): Add missing `@sentry/core` dep to nextjs-16-userfeedback

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/package.json
@@ -11,6 +11,7 @@
     "test:assert": "pnpm test:prod"
   },
   "dependencies": {
+    "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@sentry/nextjs": "file:../../packed/sentry-nextjs-packed.tgz",
     "@types/node": "^20",
     "@types/react": "^19",


### PR DESCRIPTION
Backport of: #22988