### PR TITLE
fix(cloudflare): Use correct types for Vite plugin

### DIFF
--- a/dev-packages/cloudflare-integration-tests/tsconfig.json
+++ b/dev-packages/cloudflare-integration-tests/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
 
-  "include": ["suites/**/*.ts", "*.ts"],
+  "include": ["suites/**/*.ts", "*.ts", "suites/**/*.mts"],
 
   // `suites/prisma` imports a Prisma-generated client (`./generated`) that only exists after codegen,
   // so it can't be type-checked as part of the static suite check.

--- a/packages/cloudflare/src/vite/index.ts
+++ b/packages/cloudflare/src/vite/index.ts
@@ -77,7 +77,9 @@ export interface SentryCloudflareVitePluginOptions {
  * });
  * ```
  */
-export function sentryCloudflareVitePlugin(options: SentryCloudflareVitePluginOptions = {}) {
+export function sentryCloudflareVitePlugin(
+  options: SentryCloudflareVitePluginOptions = {},
+): Array<{ name: string }> {
   return [
     sentryOrchestrionPlugin({
       injectChannelSubscribers: true,

--- a/packages/cloudflare/src/vite/index.ts
+++ b/packages/cloudflare/src/vite/index.ts
@@ -77,9 +77,7 @@ export interface SentryCloudflareVitePluginOptions {
  * });
  * ```
  */
-export function sentryCloudflareVitePlugin(
-  options: SentryCloudflareVitePluginOptions = {},
-): Array<{ name: string }> {
+export function sentryCloudflareVitePlugin(options: SentryCloudflareVitePluginOptions = {}): Array<{ name: string }> {
   return [
     sentryOrchestrionPlugin({
       injectChannelSubscribers: true,


### PR DESCRIPTION
This uses 1. the correct types for our Cloudflare Vite plugin and 2. runs the types against our `.mts` files as well, as we have `vitest.config.mts` files in there.