### PR TITLE
test(v10/e2e): Fix failing `sveltekit-3` test

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./.svelte-kit/tsconfig.json",
+  "extends": "$app/tsconfig",
   "compilerOptions": {
     "allowJs": true,
     "esModuleInterop": true,


### PR DESCRIPTION
https://github.com/sveltejs/kit/pull/16458 was a breaking change that requires tsconfigs to point to another location for extension. This PR adjusts our test app's tsconfig so that the app gets built correctly again.