### PR TITLE
ref(server-utils)!: Use `function.gcp` op for firebase function spans

### DIFF
--- a/packages/server-utils/src/integrations/tracing-channel/firebase/functions.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/firebase/functions.ts
@@ -1,4 +1,5 @@
-import { FAAS_NAME, FAAS_TRIGGER, SENTRY_KIND } from '@sentry/conventions/attributes';
+import { FAAS_NAME, FAAS_TRIGGER, SENTRY_KIND, SENTRY_OP } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import type { SpanAttributes } from '@sentry/core';
 import {
   captureException,
@@ -58,6 +59,8 @@ function wrapHandler(handler: Handler, triggerType: string): Handler {
       [FAAS_TRIGGER]: triggerType,
       'faas.provider': 'firebase',
       [SENTRY_KIND]: 'server',
+      [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+      [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
     };
 
     if (process.env.GCLOUD_PROJECT) {
@@ -72,11 +75,7 @@ function wrapHandler(handler: Handler, triggerType: string): Handler {
     return startSpanManual(
       {
         name: `firebase.function.${triggerType}`,
-        op: 'function.firebase',
-        attributes: {
-          ...attributes,
-          [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
-        },
+        attributes,
       },
       async span => {
         try {

--- a/packages/server-utils/test/orchestrion/firebase.test.ts
+++ b/packages/server-utils/test/orchestrion/firebase.test.ts
@@ -107,9 +107,9 @@ describe('wrapFunctionsRegistration', () => {
     expect(startSpanManualSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'firebase.function.http.request',
-        op: 'function.firebase',
         attributes: expect.objectContaining({
           'sentry.origin': 'auto.firebase.functions',
+          'sentry.op': 'function.gcp',
           'faas.trigger': 'http.request',
           'faas.provider': 'firebase',
         }),


### PR DESCRIPTION
Firebase functions run on GCP, use `function.gcp` here so that we don't have too many different ops

part of getsentry/sentry-javascript#22446