### PR TITLE
fix(v10/sveltekit): Export `metrics` from worker entry point

### DIFF
--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.server.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import { E2E_TEST_DSN } from '$env/static/private';
-import { handleErrorWithSentry, initCloudflareSentryHandle, sentryHandle } from '@sentry/sveltekit';
+import { handleErrorWithSentry, initCloudflareSentryHandle, sentryHandle, metrics } from '@sentry/sveltekit';
 import { sequence } from '@sveltejs/kit/hooks';
 
 export const handleError = handleErrorWithSentry();
@@ -10,4 +10,8 @@ export const handle = sequence(
     tracesSampleRate: 1.0,
   }),
   sentryHandle(),
+  ({ event, resolve }) => {
+    metrics.count('requests');
+    return resolve(event);
+  },
 );

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -50,6 +50,7 @@ export {
   lastEventId,
   linkedErrorsIntegration,
   logger,
+  metrics,
   requestDataIntegration,
   rewriteFramesIntegration,
   Scope,


### PR DESCRIPTION
backport of https://github.com/getsentry/sentry-javascript/pull/23026