### PR TITLE
ref(opentelemetry): Vendor OTel context suppress helpers

### DIFF
--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -1,6 +1,6 @@
 import type { Context, Span, SpanContext, SpanOptions, TimeInput, Tracer } from '@opentelemetry/api';
 import { context, SpanStatusCode, trace, TraceFlags } from '@opentelemetry/api';
-import { isTracingSuppressed, suppressTracing } from '@opentelemetry/core';
+import { isTracingSuppressed, suppressTracing } from './utils/suppressTracing';
 import type { Client, Scope, Span as SentrySpan } from '@sentry/core';
 import {
   getClient,

--- a/packages/opentelemetry/src/tracer.ts
+++ b/packages/opentelemetry/src/tracer.ts
@@ -1,6 +1,6 @@
 import type { Context, Span as OpenTelemetrySpan, SpanOptions, Tracer } from '@opentelemetry/api';
 import { context, isSpanContextValid, trace } from '@opentelemetry/api';
-import { isTracingSuppressed } from '@opentelemetry/core';
+import { isTracingSuppressed } from './utils/suppressTracing';
 import {
   _INTERNAL_safeMathRandom,
   _INTERNAL_setSpanForScope,

--- a/packages/opentelemetry/src/utils/suppressTracing.ts
+++ b/packages/opentelemetry/src/utils/suppressTracing.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * NOTICE from the Sentry authors:
+ * - Minimal vendored implementation of the tracing-suppression helpers from
+ *   `@opentelemetry/core` to avoid pulling in that dependency.
+ * - The context key string must stay byte-identical to OTel's, since other
+ *   OpenTelemetry instrumentation (e.g. `@opentelemetry/instrumentation-http`)
+ *   writes to the same key and our tracer reads it back to suppress spans.
+ * - `unsuppressTracing` is dropped, as the SDK never removes the flag.
+ */
+import type { Context } from '@opentelemetry/api';
+import { createContextKey } from '@opentelemetry/api';
+
+const SUPPRESS_TRACING_KEY = createContextKey('OpenTelemetry SDK Context Key SUPPRESS_TRACING');
+
+/** Returns a new context with tracing suppressed, so no spans are created within it. */
+export function suppressTracing(context: Context): Context {
+  return context.setValue(SUPPRESS_TRACING_KEY, true);
+}
+
+/** Whether tracing is suppressed in the given context. */
+export function isTracingSuppressed(context: Context): boolean {
+  return context.getValue(SUPPRESS_TRACING_KEY) === true;
+}

--- a/packages/opentelemetry/test/tracerProvider.test.ts
+++ b/packages/opentelemetry/test/tracerProvider.test.ts
@@ -1,5 +1,5 @@
 import { context, SpanKind, trace, TraceFlags } from '@opentelemetry/api';
-import { suppressTracing } from '@opentelemetry/core';
+import { suppressTracing } from '../src/utils/suppressTracing';
 import {
   getActiveSpan,
   getCapturedScopesOnSpan,


### PR DESCRIPTION
Vendors the OTel-context-based `suppressTracing`/`isTracingSuppressed` helpers from `@opentelemetry/core` into a local module, in preparation for dropping that dependency. The vendored copy reuses OTel's exact context key string, since third-party instrumentation like `@opentelemetry/instrumentation-http` writes suppression to the same key and `SentryTracer` reads it back to produce non-recording spans.

Fixes getsentry/sentry-javascript#22282