### PR TITLE
ref: Drop the `@opentelemetry/core` dependency

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -94,7 +94,6 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/core": "^2.9.0",
     "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -27,8 +27,6 @@ yarn add @sentry/opentelemetry
 Note that `@sentry/opentelemetry` depends on the following peer dependencies:
 
 - `@opentelemetry/api` version `1.0.0` or greater
-- `@opentelemetry/core` version `1.0.0` or greater
-  `@opentelemetry/sdk-node`.
 
 ## Usage
 

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -31,12 +31,10 @@
     "@sentry/core": "10.67.0"
   },
   "peerDependencies": {
-    "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/core": "^1.30.1 || ^2.1.0"
+    "@opentelemetry/api": "^1.9.0"
   },
   "devDependencies": {
-    "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/core": "^2.9.0"
+    "@opentelemetry/api": "^1.9.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6160,7 +6160,7 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.9.1.tgz#c1b0346de336ba55af2d5a7970882037baedec05"
   integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
 
-"@opentelemetry/core@2.9.0", "@opentelemetry/core@^2.9.0":
+"@opentelemetry/core@2.9.0":
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/core/-/core-2.9.0.tgz#49de86106f86255b471b2ff035ef1003a851b252"
   integrity sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==


### PR DESCRIPTION
All direct usage of `@opentelemetry/core` was removed across previous PRs (resource/`SDK_INFO`, RPC metadata, and the suppress helpers), so it is no longer imported anywhere in `src`. This drops the direct declaration from `@sentry/node` and `@sentry/opentelemetry`, leaving `@opentelemetry/api` as the only OpenTelemetry package the SDK depends on.

Note: The entry still remains in the lock file, because we have a node-integration test that depends on `@opentelemetry/instrumentation-http` which depends on`@opentelemetry/core`.

Fixes getsentry/sentry-javascript#21674  <br>Fixes [https://github.com/getsentry/sentry-javascript/issues/21972](<https://github.com/getsentry/sentry-javascript/issues/21972>)