### PR TITLE
feat(google-cloud-serverless)!: Use `function.gcp` op for GCP functions

### DIFF
--- a/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
@@ -1,3 +1,5 @@
+import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import {
   debug,
   handleCallbackErrors,
@@ -37,8 +39,9 @@ function _wrapCloudEventFunction(
     return startSpanManual(
       {
         name: context.type || '<unknown>',
-        op: 'function.gcp.cloud_event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
         },

--- a/packages/google-cloud-serverless/src/gcpfunction/events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/events.ts
@@ -1,3 +1,5 @@
+import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import {
   debug,
   handleCallbackErrors,
@@ -40,8 +42,9 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
     return startSpanManual(
       {
         name: context.eventType,
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },

--- a/packages/google-cloud-serverless/src/gcpfunction/http.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/http.ts
@@ -1,3 +1,5 @@
+import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import {
   debug,
   handleCallbackErrors,
@@ -51,8 +53,9 @@ function _wrapHttpFunction(fn: HttpFunction, options: Partial<WrapperOptions>): 
       return startSpanManual(
         {
           name: `${reqMethod} ${reqUrl}`,
-          op: 'function.gcp.http',
           attributes: {
+            [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+            [FAAS_TRIGGER]: 'http',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_http',
           },

--- a/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
@@ -1,3 +1,5 @@
+import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { wrapCloudEventFunction } from '../../src/gcpfunction/cloud_events';
@@ -73,8 +75,9 @@ describe('wrapCloudEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.cloud_event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
         },
@@ -98,8 +101,9 @@ describe('wrapCloudEventFunction', () => {
 
         const fakeTransactionContext = {
           name: 'event.type',
-          op: 'function.gcp.cloud_event',
           attributes: {
+            [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+            [FAAS_TRIGGER]: 'cloud_event',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
           },
@@ -124,8 +128,9 @@ describe('wrapCloudEventFunction', () => {
 
         const fakeTransactionContext = {
           name: 'event.type',
-          op: 'function.gcp.cloud_event',
           attributes: {
+            [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+            [FAAS_TRIGGER]: 'cloud_event',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
           },
@@ -161,8 +166,9 @@ describe('wrapCloudEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.cloud_event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
         },
@@ -198,8 +204,9 @@ describe('wrapCloudEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.cloud_event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
         },
@@ -220,8 +227,9 @@ describe('wrapCloudEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.cloud_event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
         },
@@ -256,8 +264,9 @@ describe('wrapCloudEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.cloud_event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
         },

--- a/packages/google-cloud-serverless/test/gcpfunction/events.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/events.test.ts
@@ -1,3 +1,5 @@
+import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import type { Event } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -69,8 +71,9 @@ describe('wrapEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },
@@ -91,8 +94,9 @@ describe('wrapEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },
@@ -118,8 +122,9 @@ describe('wrapEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },
@@ -144,8 +149,9 @@ describe('wrapEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },
@@ -168,8 +174,9 @@ describe('wrapEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },
@@ -190,8 +197,9 @@ describe('wrapEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },
@@ -213,8 +221,9 @@ describe('wrapEventFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'function.gcp.event',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
         },

--- a/packages/google-cloud-serverless/test/gcpfunction/http.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/http.test.ts
@@ -1,3 +1,5 @@
+import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
+import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
 import type { Integration } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { beforeEach, describe, expect, type MockInstance, test, vi } from 'vitest';
@@ -92,8 +94,9 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'POST /path',
-        op: 'function.gcp.http',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'http',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_http',
         },
@@ -115,8 +118,9 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'POST /path',
-        op: 'function.gcp.http',
         attributes: {
+          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [FAAS_TRIGGER]: 'http',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_http',
         },


### PR DESCRIPTION
Rename the span op for HTTP, event, and cloud event GCP function wrappers to `function.gcp` from conventions. 
The trigger type (`http`, `event`, `cloud_event`) now lives in the `faas.trigger` attribute.

part of #22446 