### PR TITLE
feat(opentelemetry)!: Infer op from `faas.trigger`

### DIFF
--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -16,10 +16,12 @@ import {
   URL_QUERY,
 } from '@sentry/conventions/attributes';
 import {
+  GENERAL_FUNCTION_SPAN_OP,
   MESSAGING_QUEUE_PROCESS_SPAN_OP,
   MESSAGING_QUEUE_PUBLISH_SPAN_OP,
   MESSAGING_QUEUE_RECEIVE_SPAN_OP,
   MESSAGING_QUEUE_SPAN_OP,
+  WEB_SERVER_HTTP_SERVER_SPAN_OP,
 } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
@@ -81,15 +83,30 @@ export function inferSpanData(attributes: SpanAttributes): SpanDescription {
   }
 
   // If faas.trigger exists then this is a function as a service span.
-  // eslint-disable-next-line typescript/no-deprecated
   const faasTrigger = attributes[FAAS_TRIGGER];
   if (faasTrigger) {
     return {
-      op: faasTrigger.toString(),
+      op: getFaasOp(faasTrigger),
     };
   }
 
   return { op: undefined };
+}
+
+/**
+ * Maps an OTel `faas.trigger` to a registered span op. `http` triggers are inbound HTTP requests and
+ * `pubsub` triggers process queued messages; everything else (`timer`, `datasource`, `other`, or any
+ * non-conformant value) is a plain function invocation.
+ */
+function getFaasOp(trigger: unknown): string {
+  switch (trigger) {
+    case 'http':
+      return WEB_SERVER_HTTP_SERVER_SPAN_OP;
+    case 'pubsub':
+      return MESSAGING_QUEUE_PROCESS_SPAN_OP;
+    default:
+      return GENERAL_FUNCTION_SPAN_OP;
+  }
 }
 
 /**

--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -229,12 +229,30 @@ describe('inferSpanData', () => {
       },
     ],
     [
-      'works with faas trigger',
+      'works with http faas trigger',
+      {
+        [FAAS_TRIGGER]: 'http',
+      },
+      {
+        op: 'http.server',
+      },
+    ],
+    [
+      'works with pubsub faas trigger',
+      {
+        [FAAS_TRIGGER]: 'pubsub',
+      },
+      {
+        op: 'queue.process',
+      },
+    ],
+    [
+      'falls back to function op for unknown faas trigger',
       {
         [FAAS_TRIGGER]: 'test-faas-trigger',
       },
       {
-        op: 'test-faas-trigger',
+        op: 'function',
       },
     ],
     [
@@ -244,7 +262,7 @@ describe('inferSpanData', () => {
         [FAAS_TRIGGER]: 'test-faas-trigger',
       },
       {
-        op: 'test-faas-trigger',
+        op: 'function',
       },
     ],
     [
@@ -255,7 +273,7 @@ describe('inferSpanData', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       {
-        op: 'test-faas-trigger',
+        op: 'function',
       },
     ],
     [
@@ -266,7 +284,7 @@ describe('inferSpanData', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME]: 'custom name',
       },
       {
-        op: 'test-faas-trigger',
+        op: 'function',
       },
     ],
   ] as const)('%s', (_, attributes, expected) => {


### PR DESCRIPTION
Map `faas.trigger` to ops for otel-inferred faas spans.

- `faas.trigger = 'http'` => `http.server`
- `faas.trigger = 'pubsub'` => `queue.process`
- else => `function`

part of #22446 
