### PR TITLE
test(effect): Re-enable effect server transaction e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/effect-3-node/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-3-node/tests/transactions.test.ts
@@ -1,14 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 
-// TODO(v11): `@sentry/effect` server used to run on `@sentry/node-core/light`, which set an
-// AsyncLocalStorage-based async context strategy that matched Effect's fiber model, so the Effect
-// tracer's spans became the `http.server GET` transaction. On full `@sentry/node` the SDK installs
-// the OpenTelemetry context strategy instead, and the Effect tracer's span context no longer
-// propagates as expected, so no transaction is emitted. Marked fixme until the Effect SDK's server
-// tracing is adapted to the full-node async context model.
-
-test.fixme('Sends an HTTP transaction', async ({ baseURL }) => {
+test('Sends an HTTP transaction', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-3-node', transactionEvent => {
     return transactionEvent?.transaction === 'http.server GET';
   });
@@ -20,7 +13,7 @@ test.fixme('Sends an HTTP transaction', async ({ baseURL }) => {
   expect(transactionEvent.transaction).toBe('http.server GET');
 });
 
-test.fixme('Sends transaction with manual Effect span', async ({ baseURL }) => {
+test('Sends transaction with manual Effect span', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-3-node', transactionEvent => {
     return (
       transactionEvent?.transaction === 'http.server GET' &&
@@ -42,7 +35,7 @@ test.fixme('Sends transaction with manual Effect span', async ({ baseURL }) => {
   ]);
 });
 
-test.fixme('Sends Effect spans with correct parent-child structure', async ({ baseURL }) => {
+test('Sends Effect spans with correct parent-child structure', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-3-node', transactionEvent => {
     return (
       transactionEvent?.transaction === 'http.server GET' &&
@@ -93,7 +86,7 @@ test.fixme('Sends Effect spans with correct parent-child structure', async ({ ba
   expect(nestedSpan).toBe(parentSpan);
 });
 
-test.fixme('Sends transaction for error route', async ({ baseURL }) => {
+test('Sends transaction for error route', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-3-node', transactionEvent => {
     return transactionEvent?.transaction === 'http.server GET';
   });

--- a/dev-packages/e2e-tests/test-applications/effect-4-node/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-4-node/tests/transactions.test.ts
@@ -1,14 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 
-// TODO(v11): `@sentry/effect` server used to run on `@sentry/node-core/light`, which set an
-// AsyncLocalStorage-based async context strategy that matched Effect's fiber model, so the Effect
-// tracer's spans became the `http.server GET` transaction. On full `@sentry/node` the SDK installs
-// the OpenTelemetry context strategy instead, and the Effect tracer's span context no longer
-// propagates as expected, so no transaction is emitted. Marked fixme until the Effect SDK's server
-// tracing is adapted to the full-node async context model.
-
-test.fixme('Sends an HTTP transaction', async ({ baseURL }) => {
+test('Sends an HTTP transaction', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-4-node', transactionEvent => {
     return transactionEvent?.transaction === 'http.server GET';
   });
@@ -20,7 +13,7 @@ test.fixme('Sends an HTTP transaction', async ({ baseURL }) => {
   expect(transactionEvent.transaction).toBe('http.server GET');
 });
 
-test.fixme('Sends transaction with manual Effect span', async ({ baseURL }) => {
+test('Sends transaction with manual Effect span', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-4-node', transactionEvent => {
     return (
       transactionEvent?.transaction === 'http.server GET' &&
@@ -42,7 +35,7 @@ test.fixme('Sends transaction with manual Effect span', async ({ baseURL }) => {
   ]);
 });
 
-test.fixme('Sends Effect spans with correct parent-child structure', async ({ baseURL }) => {
+test('Sends Effect spans with correct parent-child structure', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-4-node', transactionEvent => {
     return (
       transactionEvent?.transaction === 'http.server GET' &&
@@ -93,7 +86,7 @@ test.fixme('Sends Effect spans with correct parent-child structure', async ({ ba
   expect(nestedSpan).toBe(parentSpan);
 });
 
-test.fixme('Sends transaction for error route', async ({ baseURL }) => {
+test('Sends transaction for error route', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('effect-4-node', transactionEvent => {
     return transactionEvent?.transaction === 'http.server GET';
   });


### PR DESCRIPTION
## What

Un-`fixme` the transaction e2e tests in `effect-3-node` and `effect-4-node`. No SDK code change is needed.

## Why

The no-tracer-provider default landed for `@sentry/node` (`skipOpenTelemetrySetup` defaults to `true`), which installs the AsyncLocalStorage async-context strategy instead of the OpenTelemetry one. That strategy matches Effect's fiber model, so the `SentryEffectTracer` span propagates across the HTTP request boundary and becomes the `http.server` transaction again, exactly as it did under the old `@sentry/node-core/light` setup. The tests were fixme'd during the node-core merge; the dependency work has since unblocked them.

Closes: getsentry/sentry-javascript#22487