### PR TITLE
feat(angular,ember,sveltekit)!: Use `router` span op for frontend routers

### DIFF
--- a/dev-packages/e2e-tests/test-applications/angular-17/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-17/tests/performance.test.ts
@@ -159,7 +159,7 @@ test('groups redirects within one navigation root span', async ({ page }) => {
     },
   });
 
-  const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+  const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
   expect(routingSpan).toBeDefined();
   expect(routingSpan?.description).toBe('/redirect1');
@@ -196,7 +196,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe('/cancel');
@@ -234,7 +234,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe(nonExistentRoute);

--- a/dev-packages/e2e-tests/test-applications/angular-18/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-18/tests/performance.test.ts
@@ -159,7 +159,7 @@ test('groups redirects within one navigation root span', async ({ page }) => {
     },
   });
 
-  const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+  const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
   expect(routingSpan).toBeDefined();
   expect(routingSpan?.description).toBe('/redirect1');
@@ -196,7 +196,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe('/cancel');
@@ -234,7 +234,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe(nonExistentRoute);

--- a/dev-packages/e2e-tests/test-applications/angular-19/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-19/tests/performance.test.ts
@@ -159,7 +159,7 @@ test('groups redirects within one navigation root span', async ({ page }) => {
     },
   });
 
-  const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+  const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
   expect(routingSpan).toBeDefined();
   expect(routingSpan?.description).toBe('/redirect1');
@@ -196,7 +196,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe('/cancel');
@@ -234,7 +234,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe(nonExistentRoute);

--- a/dev-packages/e2e-tests/test-applications/angular-20/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-20/tests/performance.test.ts
@@ -159,7 +159,7 @@ test('groups redirects within one navigation root span', async ({ page }) => {
     },
   });
 
-  const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+  const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
   expect(routingSpan).toBeDefined();
   expect(routingSpan?.description).toBe('/redirect1');
@@ -196,7 +196,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe('/cancel');
@@ -234,7 +234,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe(nonExistentRoute);

--- a/dev-packages/e2e-tests/test-applications/angular-21/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-21/tests/performance.test.ts
@@ -159,7 +159,7 @@ test('groups redirects within one navigation root span', async ({ page }) => {
     },
   });
 
-  const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+  const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
   expect(routingSpan).toBeDefined();
   expect(routingSpan?.description).toBe('/redirect1');
@@ -196,7 +196,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe('/cancel');
@@ -234,7 +234,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe(nonExistentRoute);

--- a/dev-packages/e2e-tests/test-applications/angular-22/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/angular-22/tests/performance.test.ts
@@ -159,7 +159,7 @@ test('groups redirects within one navigation root span', async ({ page }) => {
     },
   });
 
-  const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+  const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
   expect(routingSpan).toBeDefined();
   expect(routingSpan?.description).toBe('/redirect1');
@@ -196,7 +196,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe('/cancel');
@@ -234,7 +234,7 @@ test.describe('finish routing span', () => {
       },
     });
 
-    const routingSpan = navigationTxn.spans?.find(span => span.op === 'ui.angular.routing');
+    const routingSpan = navigationTxn.spans?.find(span => span.op === 'router');
 
     expect(routingSpan).toBeDefined();
     expect(routingSpan?.description).toBe(nonExistentRoute);

--- a/dev-packages/e2e-tests/test-applications/ember-classic/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/tests/performance.test.ts
@@ -167,7 +167,7 @@ test('captures correct spans for navigation', async ({ page }) => {
     },
   });
 
-  const transitionSpans = spans.filter(span => span.op === 'ui.ember.transition');
+  const transitionSpans = spans.filter(span => span.op === 'router');
   const beforeModelSpans = spans.filter(
     span => span.op === 'function' && span.data?.['code.function.name'] === 'beforeModel',
   );
@@ -189,11 +189,11 @@ test('captures correct spans for navigation', async ({ page }) => {
 
   expect(transitionSpans[0]).toEqual({
     data: {
-      'sentry.op': 'ui.ember.transition',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.ember',
     },
     description: 'route:tracing -> route:slow-loading-route.index',
-    op: 'ui.ember.transition',
+    op: 'router',
     origin: 'auto.ui.ember',
     status: 'ok',
     parent_span_id: spanId,

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/tests/performance.test.ts
@@ -167,7 +167,7 @@ test('captures correct spans for navigation', async ({ page }) => {
     },
   });
 
-  const transitionSpans = spans.filter(span => span.op === 'ui.ember.transition');
+  const transitionSpans = spans.filter(span => span.op === 'router');
   const beforeModelSpans = spans.filter(
     span => span.op === 'function' && span.data?.['code.function.name'] === 'beforeModel',
   );
@@ -189,11 +189,11 @@ test('captures correct spans for navigation', async ({ page }) => {
 
   expect(transitionSpans[0]).toEqual({
     data: {
-      'sentry.op': 'ui.ember.transition',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.ember',
     },
     description: 'route:tracing -> route:slow-loading-route.index',
-    op: 'ui.ember.transition',
+    op: 'router',
     origin: 'auto.ui.ember',
     status: 'ok',
     parent_span_id: spanId,

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/tests/tracing.test.ts
@@ -256,15 +256,15 @@ test('captures a navigation transaction directly after pageload', async ({ page 
     },
   });
 
-  const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'router');
   expect(routingSpans).toHaveLength(1);
 
   const routingSpan = routingSpans && routingSpans[0];
   expect(routingSpan).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/users/[id]',
@@ -321,15 +321,15 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
     },
   });
 
-  const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'router');
   expect(redirect1Spans).toHaveLength(1);
 
   const redirect1Span = redirect1Spans && redirect1Spans[0];
   expect(redirect1Span).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/redirect1',
@@ -361,15 +361,15 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
     },
   });
 
-  const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'router');
   expect(redirect2Spans).toHaveLength(1);
 
   const redirect2Span = redirect2Spans && redirect2Spans[0];
   expect(redirect2Span).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/redirect2',
@@ -401,15 +401,15 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
     },
   });
 
-  const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'router');
   expect(redirect3Spans).toHaveLength(1);
 
   const redirect3Span = redirect3Spans && redirect3Spans[0];
   expect(redirect3Span).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/users/[id]',

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/tests/performance.test.ts
@@ -249,15 +249,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'router');
     expect(routingSpans).toHaveLength(1);
 
     const routingSpan = routingSpans && routingSpans[0];
     expect(routingSpan).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/users/[id]',
@@ -314,15 +314,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'router');
     expect(redirect1Spans).toHaveLength(1);
 
     const redirect1Span = redirect1Spans && redirect1Spans[0];
     expect(redirect1Span).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/redirect1',
@@ -354,15 +354,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'router');
     expect(redirect2Spans).toHaveLength(1);
 
     const redirect2Span = redirect2Spans && redirect2Spans[0];
     expect(redirect2Span).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/redirect2',
@@ -394,15 +394,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'router');
     expect(redirect3Spans).toHaveLength(1);
 
     const redirect3Span = redirect3Spans && redirect3Spans[0];
     expect(redirect3Span).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/users/[id]',

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/tests/performance.test.ts
@@ -249,15 +249,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'router');
     expect(routingSpans).toHaveLength(1);
 
     const routingSpan = routingSpans && routingSpans[0];
     expect(routingSpan).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/users/[id]',
@@ -314,15 +314,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'router');
     expect(redirect1Spans).toHaveLength(1);
 
     const redirect1Span = redirect1Spans && redirect1Spans[0];
     expect(redirect1Span).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/redirect1',
@@ -354,15 +354,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'router');
     expect(redirect2Spans).toHaveLength(1);
 
     const redirect2Span = redirect2Spans && redirect2Spans[0];
     expect(redirect2Span).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/redirect2',
@@ -394,15 +394,15 @@ test.describe('performance events', () => {
       },
     });
 
-    const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+    const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'router');
     expect(redirect3Spans).toHaveLength(1);
 
     const redirect3Span = redirect3Spans && redirect3Spans[0];
     expect(redirect3Span).toMatchObject({
-      op: 'ui.sveltekit.routing',
+      op: 'router',
       description: 'SvelteKit Route Change',
       data: {
-        'sentry.op': 'ui.sveltekit.routing',
+        'sentry.op': 'router',
         'sentry.origin': 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/',
         'sentry.sveltekit.navigation.to': '/users/[id]',

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/tests/tracing.test.ts
@@ -233,15 +233,15 @@ test('captures a navigation transaction directly after pageload', async ({ page 
     },
   });
 
-  const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const routingSpans = navigationTxnEvent.spans?.filter(s => s.op === 'router');
   expect(routingSpans).toHaveLength(1);
 
   const routingSpan = routingSpans && routingSpans[0];
   expect(routingSpan).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/users/[id]',
@@ -295,15 +295,15 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
     },
   });
 
-  const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const redirect1Spans = redirect1TxnEvent.spans?.filter(s => s.op === 'router');
   expect(redirect1Spans).toHaveLength(1);
 
   const redirect1Span = redirect1Spans && redirect1Spans[0];
   expect(redirect1Span).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/redirect1',
@@ -332,15 +332,15 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
     },
   });
 
-  const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const redirect2Spans = redirect2TxnEvent.spans?.filter(s => s.op === 'router');
   expect(redirect2Spans).toHaveLength(1);
 
   const redirect2Span = redirect2Spans && redirect2Spans[0];
   expect(redirect2Span).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/redirect2',
@@ -369,15 +369,15 @@ test('captures one navigation transaction per redirect', async ({ page }) => {
     },
   });
 
-  const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'ui.sveltekit.routing');
+  const redirect3Spans = redirect3TxnEvent.spans?.filter(s => s.op === 'router');
   expect(redirect3Spans).toHaveLength(1);
 
   const redirect3Span = redirect3Spans && redirect3Spans[0];
   expect(redirect3Span).toMatchObject({
-    op: 'ui.sveltekit.routing',
+    op: 'router',
     description: 'SvelteKit Route Change',
     data: {
-      'sentry.op': 'ui.sveltekit.routing',
+      'sentry.op': 'router',
       'sentry.origin': 'auto.ui.sveltekit',
       'sentry.sveltekit.navigation.from': '/',
       'sentry.sveltekit.navigation.to': '/users/[id]',

--- a/packages/angular/src/constants.ts
+++ b/packages/angular/src/constants.ts
@@ -1,4 +1,2 @@
-export const ANGULAR_ROUTING_OP = 'ui.angular.routing';
-
 // TODO(v11): Replace with the `ui.mount` constant from `@sentry/conventions/op` once it is registered there.
 export const ANGULAR_INIT_OP = 'ui.mount';

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -28,7 +28,7 @@ import { debug, parseStringToURLObject, stripUrlQueryAndFragment, timestampInSec
 import type { Observable } from 'rxjs';
 import { Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
-import { ANGULAR_INIT_OP, ANGULAR_ROUTING_OP } from './constants';
+import { ANGULAR_INIT_OP } from './constants';
 import { IS_DEBUG_BUILD } from './flags';
 import { runOutsideAngular } from './zone';
 
@@ -131,8 +131,9 @@ export class TraceService implements OnDestroy {
           runOutsideAngular(() =>
             startInactiveSpan({
               name: `${navigationEvent.url}`,
-              op: ANGULAR_ROUTING_OP,
               attributes: {
+                // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
+                [SENTRY_OP]: 'router',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular',
                 [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
                 [URL_FULL]: strippedUrl,

--- a/packages/ember/addon/utils/instrumentEmberAppInstanceForPerformance.ts
+++ b/packages/ember/addon/utils/instrumentEmberAppInstanceForPerformance.ts
@@ -14,7 +14,7 @@ import {
 import type { Client, Span } from '@sentry/core';
 import type { EmberRouterMain } from '../types';
 import { getBackburner } from './performance';
-import { URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 type TransitionWithIntent = Transition & { intent?: { url?: string } };
 
@@ -200,9 +200,10 @@ function _instrumentEmberRouter(
 
     transitionSpan = startInactiveSpan({
       attributes: {
+        // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
+        [SENTRY_OP]: 'router',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.ember',
       },
-      op: 'ui.ember.transition',
       name: `route:${fromRoute} -> route:${toRoute}`,
       onlyIfParent: true,
     });

--- a/packages/ember/tests/acceptance/sentry-performance-test.ts
+++ b/packages/ember/tests/acceptance/sentry-performance-test.ts
@@ -15,7 +15,7 @@ module('Acceptance | Sentry Performance', function (hooks) {
 
     assertSentryTransactionCount(assert, 1);
     assertSentryTransactions(assert, 0, {
-      spans: ['ui.ember.transition | route:undefined -> route:tracing', 'ui.render | component:test-section'],
+      spans: ['router | route:undefined -> route:tracing', 'ui.render | component:test-section'],
       transaction: 'route:tracing',
       attributes: {
         fromRoute: undefined,
@@ -32,7 +32,7 @@ module('Acceptance | Sentry Performance', function (hooks) {
     assertSentryTransactionCount(assert, 2);
     assertSentryTransactions(assert, 1, {
       spans: [
-        'ui.ember.transition | route:tracing -> route:slow-loading-route.index',
+        'router | route:tracing -> route:slow-loading-route.index',
         'function:beforeModel | slow-loading-route',
         'function:model | slow-loading-route',
         'function:afterModel | slow-loading-route',
@@ -59,7 +59,7 @@ module('Acceptance | Sentry Performance', function (hooks) {
     assertSentryTransactionCount(assert, 1);
     assertSentryTransactions(assert, 0, {
       spans: [
-        'ui.ember.transition | route:undefined -> route:with-loading.index',
+        'router | route:undefined -> route:with-loading.index',
         'function:beforeModel | with-loading.index',
         'function:model | with-loading.index',
         'function:afterModel | with-loading.index',
@@ -82,7 +82,7 @@ module('Acceptance | Sentry Performance', function (hooks) {
     assertSentryTransactionCount(assert, 1);
     assertSentryTransactions(assert, 0, {
       spans: [
-        'ui.ember.transition | route:undefined -> route:with-error.index',
+        'router | route:undefined -> route:with-error.index',
         'function:beforeModel | with-error.index',
         'function:model | with-error.index',
       ],

--- a/packages/sveltekit/src/client/svelte4BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte4BrowserTracing.ts
@@ -7,7 +7,7 @@ import {
   startInactiveSpan,
   WINDOW,
 } from '@sentry/svelte';
-import { URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
 import type { Navigation, Page } from '@sveltejs/kit';
 // eslint-disable-next-line typescript/no-deprecated
 import { navigating, page } from '$app/stores';
@@ -125,9 +125,10 @@ function _instrumentNavigations(client: Client, navigatingStore: Readable<Naviga
     );
 
     routingSpan = startInactiveSpan({
-      op: 'ui.sveltekit.routing',
       name: 'SvelteKit Route Change',
       attributes: {
+        // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
+        [SENTRY_OP]: 'router',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
         ...navigationInfo,
       },

--- a/packages/sveltekit/src/client/svelte5BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte5BrowserTracing.ts
@@ -7,7 +7,7 @@ import {
   startInactiveSpan,
   WINDOW,
 } from '@sentry/svelte';
-import { URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
 import type { Navigation } from '@sveltejs/kit';
 import { getCurrentNavigation, onNavigationChange, onPageRouteChange } from './navigationState.svelte';
 
@@ -105,9 +105,10 @@ function _instrumentNavigations(client: Client): void {
     );
 
     routingSpan = startInactiveSpan({
-      op: 'ui.sveltekit.routing',
       name: 'SvelteKit Route Change',
       attributes: {
+        // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
+        [SENTRY_OP]: 'router',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
         ...navigationInfo,
       },

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -10,7 +10,7 @@ import { writable } from 'svelte/store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { navigating, page } from '$app/stores';
 import { browserTracingIntegration } from '../../src/client';
-import { URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 // we have to overwrite the global mock from `vitest.setup.ts` here to reset the
 // `navigating` store for each test.
@@ -231,9 +231,9 @@ describe('browserTracingIntegration', () => {
     );
 
     expect(startInactiveSpanSpy).toHaveBeenCalledWith({
-      op: 'ui.sveltekit.routing',
       name: 'SvelteKit Route Change',
       attributes: {
+        [SENTRY_OP]: 'router',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
         'sentry.sveltekit.navigation.from': '/users',
         'sentry.sveltekit.navigation.to': '/users/[id]',
@@ -309,9 +309,9 @@ describe('browserTracingIntegration', () => {
       );
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
-        op: 'ui.sveltekit.routing',
         name: 'SvelteKit Route Change',
         attributes: {
+          [SENTRY_OP]: 'router',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
           'sentry.sveltekit.navigation.from': '/users/[id]',
           'sentry.sveltekit.navigation.to': '/users/[id]',


### PR DESCRIPTION
Collapse the framework-specific `ui.angular.routing`, `ui.sveltekit.routing` and `ui.ember.transition` span ops into the framework-neutral `router` op.

part of getsentry/sentry-javascript#22446