### PR TITLE
fix(browser)!: Use snake_case consistently for ops

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -123,7 +123,7 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
     trace_id: pageloadSpan.trace_id, // same trace id as pageload
   });
 
-  const loAFSpans = interactionSpanTree.filter(span => getSpanOp(span)?.startsWith('ui.long-animation-frame'));
+  const loAFSpans = interactionSpanTree.filter(span => getSpanOp(span)?.startsWith('ui.long_animation_frame'));
   expect(loAFSpans).toHaveLength(browserName === 'chromium' ? 1 : 0);
 
   const interactionSpan = interactionSpanTree.find(span => getSpanOp(span) === 'ui.interaction.click');

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions/test.ts
@@ -33,7 +33,7 @@ sentryTest('should capture interaction transaction. @firefox', async ({ browserN
   expect(eventData.platform).toBe('javascript');
   expect(eventData.type).toBe('transaction');
 
-  const spans = eventData.spans?.filter(span => !span.op?.startsWith('ui.long-animation-frame'));
+  const spans = eventData.spans?.filter(span => !span.op?.startsWith('ui.long_animation_frame'));
   expect(spans).toHaveLength(1);
 
   const interactionSpan = spans![0];
@@ -64,7 +64,7 @@ sentryTest(
       await page.waitForTimeout(1000);
       await page.locator('[data-test-id=interaction-button]').click();
       const envelope = await envelopePromise;
-      const spans = envelope[0].spans?.filter(span => !span.op?.startsWith('ui.long-animation-frame'));
+      const spans = envelope[0].spans?.filter(span => !span.op?.startsWith('ui.long_animation_frame'));
       expect(spans).toHaveLength(1);
     }
   },
@@ -91,7 +91,7 @@ sentryTest(
     const envelopes = await envelopePromise;
     expect(envelopes).toHaveLength(1);
     const eventData = envelopes[0];
-    const spans = eventData.spans?.filter(span => !span.op?.startsWith('ui.long-animation-frame'));
+    const spans = eventData.spans?.filter(span => !span.op?.startsWith('ui.long_animation_frame'));
     expect(spans).toHaveLength(1);
 
     const interactionSpan = spans![0];
@@ -122,7 +122,7 @@ sentryTest(
     expect(envelopes).toHaveLength(1);
 
     const eventData = envelopes[0];
-    const spans = eventData.spans?.filter(span => !span.op?.startsWith('ui.long-animation-frame'));
+    const spans = eventData.spans?.filter(span => !span.op?.startsWith('ui.long_animation_frame'));
     expect(spans).toHaveLength(1);
 
     const interactionSpan = spans![0];

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/test.ts
@@ -19,7 +19,7 @@ sentryTest(
 
     const spans = await navigationSpansPromise;
 
-    const loafSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long-animation-frame'));
+    const loafSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long_animation_frame'));
     expect(loafSpans).toHaveLength(0);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation/test.ts
@@ -23,7 +23,7 @@ sentryTest(
 
     expect(navigationTransactionEvent.contexts?.trace?.op).toBe('navigation');
 
-    const loafSpans = navigationTransactionEvent.spans?.filter(s => s.op?.startsWith('ui.long-animation-frame'));
+    const loafSpans = navigationTransactionEvent.spans?.filter(s => s.op?.startsWith('ui.long_animation_frame'));
 
     expect(loafSpans?.length).toEqual(0);
   },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled-streamed/test.ts
@@ -25,7 +25,7 @@ sentryTest(
     const spans = await spansPromise;
     const pageloadSpan = spans.find(s => getSpanOp(s) === 'pageload')!;
 
-    const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long-animation-frame'));
+    const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long_animation_frame'));
 
     expect(uiSpans.length).toBeGreaterThanOrEqual(1);
 
@@ -45,7 +45,7 @@ sentryTest(
             value: 'https://sentry-test-site.example/path/to/script.js',
           },
           'browser.script.invoker_type': { type: 'string', value: 'classic-script' },
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long-animation-frame' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long_animation_frame' },
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'auto.ui.browser.metrics' },
         }),
       }),
@@ -78,7 +78,7 @@ sentryTest('captures long animation frame span for event listener.', async ({ br
   const spans = await spansPromise;
   const pageloadSpan = spans.find(s => getSpanOp(s) === 'pageload')!;
 
-  const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long-animation-frame'));
+  const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long_animation_frame'));
 
   expect(uiSpans.length).toBeGreaterThanOrEqual(2);
 
@@ -94,7 +94,7 @@ sentryTest('captures long animation frame span for event listener.', async ({ br
         'browser.script.invoker': { type: 'string', value: 'BUTTON#clickme.onclick' },
         'browser.script.invoker_type': { type: 'string', value: 'event-listener' },
         'code.filepath': { type: 'string', value: 'https://sentry-test-site.example/path/to/script.js' },
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long-animation-frame' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long_animation_frame' },
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'auto.ui.browser.metrics' },
       }),
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-enabled/test.ts
@@ -27,7 +27,7 @@ sentryTest(
 
     const eventData = await promise;
 
-    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long-animation-frame'));
+    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long_animation_frame'));
 
     expect(uiSpans?.length).toBeGreaterThanOrEqual(1);
 
@@ -36,7 +36,7 @@ sentryTest(
     )!;
     expect(topLevelUISpan).toEqual(
       expect.objectContaining({
-        op: 'ui.long-animation-frame',
+        op: 'ui.long_animation_frame',
         description: 'Main UI thread blocked',
         parent_span_id: eventData.contexts?.trace?.span_id,
         data: {
@@ -44,7 +44,7 @@ sentryTest(
           'browser.script.source_char_position': 0,
           'browser.script.invoker': 'https://sentry-test-site.example/path/to/script.js',
           'browser.script.invoker_type': 'classic-script',
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long_animation_frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
         },
       }),
@@ -83,7 +83,7 @@ sentryTest(
 
     const eventData = await promise;
 
-    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long-animation-frame')) || [];
+    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long_animation_frame')) || [];
 
     expect(uiSpans.length).toBeGreaterThanOrEqual(2);
 
@@ -91,14 +91,14 @@ sentryTest(
 
     expect(eventListenerUISpan).toEqual(
       expect.objectContaining({
-        op: 'ui.long-animation-frame',
+        op: 'ui.long_animation_frame',
         description: 'Main UI thread blocked',
         parent_span_id: eventData.contexts?.trace?.span_id,
         data: {
           'browser.script.invoker': 'BUTTON#clickme.onclick',
           'browser.script.invoker_type': 'event-listener',
           'code.filepath': 'https://sentry-test-site.example/path/to/script.js',
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long_animation_frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
         },
       }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled-streamed/test.ts
@@ -27,7 +27,7 @@ sentryTest(
     const spans = await spansPromise;
     const pageloadSpan = spans.find(s => getSpanOp(s) === 'pageload')!;
 
-    const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long-animation-frame'));
+    const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long_animation_frame'));
 
     expect(uiSpans.length).toBeGreaterThanOrEqual(1);
 
@@ -47,7 +47,7 @@ sentryTest(
             value: 'https://sentry-test-site.example/path/to/script.js',
           },
           'browser.script.invoker_type': { type: 'string', value: 'classic-script' },
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long-animation-frame' },
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long_animation_frame' },
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'auto.ui.browser.metrics' },
         }),
       }),
@@ -80,7 +80,7 @@ sentryTest('captures long animation frame span for event listener.', async ({ br
   const spans = await spansPromise;
   const pageloadSpan = spans.find(s => getSpanOp(s) === 'pageload')!;
 
-  const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long-animation-frame'));
+  const uiSpans = spans.filter(s => getSpanOp(s)?.startsWith('ui.long_animation_frame'));
 
   expect(uiSpans.length).toBeGreaterThanOrEqual(2);
 
@@ -96,7 +96,7 @@ sentryTest('captures long animation frame span for event listener.', async ({ br
         'browser.script.invoker': { type: 'string', value: 'BUTTON#clickme.onclick' },
         'browser.script.invoker_type': { type: 'string', value: 'event-listener' },
         'code.filepath': { type: 'string', value: 'https://sentry-test-site.example/path/to/script.js' },
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long-animation-frame' },
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: { type: 'string', value: 'ui.long_animation_frame' },
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: { type: 'string', value: 'auto.ui.browser.metrics' },
       }),
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-and-animation-frame-enabled/test.ts
@@ -29,7 +29,7 @@ sentryTest(
 
     const eventData = await promise;
 
-    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long-animation-frame'));
+    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long_animation_frame'));
 
     expect(uiSpans?.length).toBeGreaterThanOrEqual(1);
 
@@ -38,7 +38,7 @@ sentryTest(
     )!;
     expect(topLevelUISpan).toEqual(
       expect.objectContaining({
-        op: 'ui.long-animation-frame',
+        op: 'ui.long_animation_frame',
         description: 'Main UI thread blocked',
         parent_span_id: eventData.contexts?.trace?.span_id,
         data: {
@@ -46,7 +46,7 @@ sentryTest(
           'browser.script.source_char_position': 0,
           'browser.script.invoker': 'https://sentry-test-site.example/path/to/script.js',
           'browser.script.invoker_type': 'classic-script',
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long_animation_frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
         },
       }),
@@ -85,7 +85,7 @@ sentryTest(
 
     const eventData = await promise;
 
-    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long-animation-frame')) || [];
+    const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui.long_animation_frame')) || [];
 
     expect(uiSpans.length).toBeGreaterThanOrEqual(2);
 
@@ -93,14 +93,14 @@ sentryTest(
 
     expect(eventListenerUISpan).toEqual(
       expect.objectContaining({
-        op: 'ui.long-animation-frame',
+        op: 'ui.long_animation_frame',
         description: 'Main UI thread blocked',
         parent_span_id: eventData.contexts?.trace?.span_id,
         data: {
           'browser.script.invoker': 'BUTTON#clickme.onclick',
           'browser.script.invoker_type': 'event-listener',
           'code.filepath': 'https://sentry-test-site.example/path/to/script.js',
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long-animation-frame',
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.long_animation_frame',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
         },
       }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/test.ts
@@ -23,7 +23,7 @@ sentryTest(
     const navigationSpan = spans.find(s => getSpanOp(s) === 'navigation');
     expect(navigationSpan).toBeDefined();
 
-    const longTaskSpans = spans.filter(s => getSpanOp(s) === 'ui.long-task');
+    const longTaskSpans = spans.filter(s => getSpanOp(s) === 'ui.long_task');
     expect(longTaskSpans).toHaveLength(0);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/test.ts
@@ -24,7 +24,7 @@ sentryTest(
 
     expect(navigationTransactionEvent.contexts?.trace?.op).toBe('navigation');
 
-    const longTaskSpans = navigationTransactionEvent?.spans?.filter(span => span.op === 'ui.long-task');
+    const longTaskSpans = navigationTransactionEvent?.spans?.filter(span => span.op === 'ui.long_task');
     expect(longTaskSpans).toHaveLength(0);
   },
 );

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled-streamed/test.ts
@@ -28,7 +28,7 @@ sentryTest('captures long task.', async ({ browserName, getLocalTestUrl, page })
       name: 'Main UI thread blocked',
       parent_span_id: pageloadSpan.span_id,
       attributes: expect.objectContaining({
-        'sentry.op': { type: 'string', value: 'ui.long-task' },
+        'sentry.op': { type: 'string', value: 'ui.long_task' },
       }),
     }),
   );

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-enabled/test.ts
@@ -22,7 +22,7 @@ sentryTest('should capture long task.', async ({ browserName, getLocalTestUrl, p
   const [firstUISpan] = uiSpans || [];
   expect(firstUISpan).toEqual(
     expect.objectContaining({
-      op: 'ui.long-task',
+      op: 'ui.long_task',
       description: 'Main UI thread blocked',
       parent_span_id: eventData.contexts?.trace?.span_id,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-no-animation-frame/test.ts
@@ -22,7 +22,7 @@ sentryTest('should capture long task.', async ({ browserName, getLocalTestUrl, p
   const [firstUISpan] = uiSpans || [];
   expect(firstUISpan).toEqual(
     expect.objectContaining({
-      op: 'ui.long-task',
+      op: 'ui.long_task',
       description: 'Main UI thread blocked',
       parent_span_id: eventData.contexts?.trace?.span_id,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
@@ -13,11 +13,11 @@ sentryTest('should add browser-related spans to pageload transaction', async ({ 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const browserSpans = eventData.spans?.filter(({ op }) => op?.startsWith('browser'));
 
-  // Spans `domContentLoadedEvent`, `connect`, `cache` and `DNS` are not
+  // Spans `dom_content_loaded_event`, `connect`, `cache` and `dns` are not
   // always inside `pageload` transaction.
   expect(browserSpans?.length).toBeGreaterThanOrEqual(4);
 
-  ['loadEvent', 'request', 'response'].forEach(eventDesc =>
+  ['load_event', 'request', 'response'].forEach(eventDesc =>
     expect(browserSpans).toContainEqual(
       expect.objectContaining({
         op: `browser.${eventDesc}`,

--- a/dev-packages/browser-integration-tests/suites/tracing/user-timing/pageload-measure-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/user-timing/pageload-measure-spans/test.ts
@@ -14,7 +14,7 @@ sentryTest('should add browser-related spans to pageload transaction', async ({ 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const browserSpans = eventData.spans?.filter(({ op }) => op?.startsWith('browser'));
 
-  // Spans `domContentLoadedEvent`, `connect`, `cache` and `DNS` are not
+  // Spans `dom_content_loaded_event`, `connect`, `cache` and `dns` are not
   // always inside `pageload` transaction.
   expect(browserSpans?.length).toBeGreaterThanOrEqual(4);
 

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/tests/transactions.test.ts
@@ -50,10 +50,10 @@ test('Captures a pageload transaction', async ({ page }) => {
   expect(transactionEvent.spans).toContainEqual({
     data: {
       'sentry.origin': 'auto.ui.browser.metrics',
-      'sentry.op': 'browser.domContentLoadedEvent',
+      'sentry.op': 'browser.dom_content_loaded_event',
     },
     description: page.url(),
-    op: 'browser.domContentLoadedEvent',
+    op: 'browser.dom_content_loaded_event',
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
     span_id: expect.stringMatching(/[a-f0-9]{16}/),
     start_timestamp: expect.any(Number),

--- a/packages/browser-utils/src/metrics/browserMetrics.ts
+++ b/packages/browser-utils/src/metrics/browserMetrics.ts
@@ -131,7 +131,7 @@ export function startTrackingLongTasks(): void {
 
       startAndEndSpan(parent, startTime, startTime + duration, {
         name: 'Main UI thread blocked',
-        op: 'ui.long-task',
+        op: 'ui.long_task',
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
         },
@@ -190,7 +190,7 @@ export function startTrackingLongAnimationFrames(): void {
 
       startAndEndSpan(parent, startTime, startTime + duration, {
         name: 'Main UI thread blocked',
-        op: 'ui.long-animation-frame',
+        op: 'ui.long_animation_frame',
         attributes,
       });
     }
@@ -297,7 +297,7 @@ interface AddPerformanceEntriesOptions {
    *
    * Default: []
    */
-  ignoreResourceSpans: Array<'resouce.script' | 'resource.css' | 'resource.img' | 'resource.other' | string>;
+  ignoreResourceSpans: Array<'resource.script' | 'resource.css' | 'resource.img' | 'resource.other' | string>;
 
   /**
    * Whether span streaming is enabled.
@@ -496,12 +496,14 @@ function _addPaintSpan(
  * exported only for tests
  */
 export function _addNavigationSpans(span: Span, entry: PerformanceNavigationTiming, timeOrigin: number): void {
-  (['unloadEvent', 'redirect', 'domContentLoadedEvent', 'loadEvent', 'connect'] as const).forEach(event => {
-    _addPerformanceNavigationTiming(span, entry, event, timeOrigin);
-  });
-  _addPerformanceNavigationTiming(span, entry, 'secureConnection', timeOrigin, 'TLS/SSL');
+  _addPerformanceNavigationTiming(span, entry, 'unloadEvent', timeOrigin, 'unload_event');
+  _addPerformanceNavigationTiming(span, entry, 'redirect', timeOrigin, 'redirect');
+  _addPerformanceNavigationTiming(span, entry, 'domContentLoadedEvent', timeOrigin, 'dom_content_loaded_event');
+  _addPerformanceNavigationTiming(span, entry, 'loadEvent', timeOrigin, 'load_event');
+  _addPerformanceNavigationTiming(span, entry, 'connect', timeOrigin, 'connect');
+  _addPerformanceNavigationTiming(span, entry, 'secureConnection', timeOrigin, 'tls_ssl');
   _addPerformanceNavigationTiming(span, entry, 'fetch', timeOrigin, 'cache');
-  _addPerformanceNavigationTiming(span, entry, 'domainLookup', timeOrigin, 'DNS');
+  _addPerformanceNavigationTiming(span, entry, 'domainLookup', timeOrigin, 'dns');
 
   _addRequest(span, entry, timeOrigin);
 }

--- a/packages/browser-utils/test/browser/browserMetrics.test.ts
+++ b/packages/browser-utils/test/browser/browserMetrics.test.ts
@@ -662,22 +662,22 @@ describe('_addNavigationSpans', () => {
       expect.arrayContaining([
         expect.objectContaining({
           data: {
-            'sentry.op': 'browser.domContentLoadedEvent',
+            'sentry.op': 'browser.dom_content_loaded_event',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
           description: 'https://santry.com/test',
-          op: 'browser.domContentLoadedEvent',
+          op: 'browser.dom_content_loaded_event',
           origin: 'auto.ui.browser.metrics',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
           data: {
-            'sentry.op': 'browser.loadEvent',
+            'sentry.op': 'browser.load_event',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
           description: 'https://santry.com/test',
-          op: 'browser.loadEvent',
+          op: 'browser.load_event',
           origin: 'auto.ui.browser.metrics',
           parent_span_id,
           trace_id,
@@ -695,11 +695,11 @@ describe('_addNavigationSpans', () => {
         }),
         expect.objectContaining({
           data: {
-            'sentry.op': 'browser.TLS/SSL',
+            'sentry.op': 'browser.tls_ssl',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
           description: 'https://santry.com/test',
-          op: 'browser.TLS/SSL',
+          op: 'browser.tls_ssl',
           origin: 'auto.ui.browser.metrics',
           parent_span_id,
           trace_id,
@@ -717,11 +717,11 @@ describe('_addNavigationSpans', () => {
         }),
         expect.objectContaining({
           data: {
-            'sentry.op': 'browser.DNS',
+            'sentry.op': 'browser.dns',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
           description: 'https://santry.com/test',
-          op: 'browser.DNS',
+          op: 'browser.dns',
           origin: 'auto.ui.browser.metrics',
           parent_span_id,
           trace_id,

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -189,7 +189,7 @@ export interface BrowserTracingOptions {
    *
    * Default: []
    */
-  ignoreResourceSpans: Array<'resouce.script' | 'resource.css' | 'resource.img' | 'resource.other' | string>;
+  ignoreResourceSpans: Array<'resource.script' | 'resource.css' | 'resource.img' | 'resource.other' | string>;
 
   /**
    * By default, the SDK will try to detect redirects and avoid creating separate spans for them.

--- a/packages/ember/tests/helpers/utils.ts
+++ b/packages/ember/tests/helpers/utils.ts
@@ -69,11 +69,11 @@ export function assertSentryTransactions(
 
   // instead of checking the specific order of runloop spans (which is brittle),
   // we check (below) that _any_ runloop spans are added
-  // Also we ignore ui.long-task spans and ui.long-animation-frame, as they are brittle and may or may not appear
+  // Also we ignore ui.long_task spans and ui.long_animation_frame, as they are brittle and may or may not appear
   const filteredSpans = spans
     .filter(span => {
       const op = span.op;
-      return !isRunloopSpan(span) && !op?.startsWith('ui.long-task') && !op?.startsWith('ui.long-animation-frame');
+      return !isRunloopSpan(span) && !op?.startsWith('ui.long_task') && !op?.startsWith('ui.long_animation_frame');
     })
     .map(spanJson => {
       // Route hooks all share the `function` op, so the hook name is what distinguishes them

--- a/packages/replay-internal/test/fixtures/transaction.ts
+++ b/packages/replay-internal/test/fixtures/transaction.ts
@@ -46,7 +46,7 @@ export function Transaction(traceId?: string, obj?: Partial<Event>): any {
       },
       {
         description: 'Main UI thread blocked',
-        op: 'ui.long-task',
+        op: 'ui.long_task',
         parent_span_id: 'b44b173b1c74a782',
         span_id: '808967f15cae9251',
         start_timestamp: 1668184224.4343,


### PR DESCRIPTION
Some `browser.*` and `ui.*` ops used inconsistent casing, this aligns them to snake_case as set by conventions.

| Before | Now |
| --- | --- |
| `ui.long-task` | `ui.long_task` |
| `ui.long-animation-frame` | `ui.long_animation_frame` |
| `browser.unloadEvent` | `browser.unload_event` |
| `browser.domContentLoadedEvent` | `browser.dom_content_loaded_event` |
| `browser.loadEvent` | `browser.load_event` |
| `browser.TLS/SSL` | `browser.tls_ssl` |
| `browser.DNS` | `browser.dns` |
| `resouce.script` (typo) | `resource.script` |
