### PR TITLE
feat(v10/server-utils): Add `GenAiOptions` and deprecate `VercelAiOptions`

### DIFF
--- a/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
+++ b/packages/cloudflare/src/nodejs_compat/integrations/tracing/vercelai.ts
@@ -10,6 +10,7 @@ import { defineIntegration } from '@sentry/core';
 import { vercelAiIntegration as serverUtilsVercelAiIntegration, type VercelAiOptions } from '@sentry/server-utils';
 import { vercelAIIntegration as cloudflareVercelAIIntegration } from '../../../integrations/tracing/vercelai';
 
+// oxlint-disable-next-line typescript/no-deprecated
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   const inner = serverUtilsVercelAiIntegration(options);
   const instrumentation = cloudflareVercelAIIntegration(options);

--- a/packages/deno/src/integrations/tracing/vercelai.ts
+++ b/packages/deno/src/integrations/tracing/vercelai.ts
@@ -6,6 +6,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { addVercelAiProcessors, defineIntegration, extendIntegration } from '@sentry/core';
 import { vercelAiIntegration as serverUtilsVercelAiIntegration, type VercelAiOptions } from '@sentry/server-utils';
 
+// oxlint-disable-next-line typescript/no-deprecated
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   const inner = serverUtilsVercelAiIntegration(options);
 

--- a/packages/node/src/integrations/tracing/vercelai/types.ts
+++ b/packages/node/src/integrations/tracing/vercelai/types.ts
@@ -46,6 +46,7 @@ export declare type AttributeValue =
   | Array<null | undefined | number>
   | Array<null | undefined | boolean>;
 
+// oxlint-disable-next-line typescript/no-deprecated
 export interface VercelAiOptions extends VercelAiBaseOptions {
   /**
    * By default, the instrumentation will register span processors only when the ai package is used.

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -28,7 +28,12 @@ export type {
   TracingChannelPayloadWithSpan,
 } from './tracing-channel';
 export type { InstrumentationConfig } from './orchestrion';
-export { vercelAiIntegration, type VercelAiOptions } from './vercel-ai';
+export {
+  vercelAiIntegration,
+  type GenAiOptions,
+  // oxlint-disable-next-line typescript/no-deprecated
+  type VercelAiOptions,
+} from './vercel-ai';
 export {
   fastifyIntegration,
   // oxlint-disable-next-line typescript/no-deprecated

--- a/packages/server-utils/src/vercel-ai/index.ts
+++ b/packages/server-utils/src/vercel-ai/index.ts
@@ -2,7 +2,13 @@ import { defineIntegration, waitForTracingChannelBinding, type IntegrationFn } f
 import { subscribeVercelAiTracingChannel } from './vercel-ai-dc-subscriber';
 import * as dc from 'node:diagnostics_channel';
 
-export interface VercelAiOptions {
+/**
+ * Recording options shared by all AI integrations.
+ *
+ * In v11 every AI integration accepts this single type; prefer it over the
+ * per-integration option types.
+ */
+export interface GenAiOptions {
   /**
    * Enable or disable input recording. Enabled if `dataCollection.genAI.inputs` (or the deprecated `sendDefaultPii` option) is `true`
    * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
@@ -16,14 +22,23 @@ export interface VercelAiOptions {
    * Integration-level options take precedence over global `dataCollection` config.
    */
   recordOutputs?: boolean;
+}
 
+/**
+ * @deprecated Use {@link GenAiOptions} instead. This type will be removed in v11.
+ * Note that `enableTruncation` is also removed in v11 (gen_ai input truncation no longer exists).
+ */
+export interface VercelAiOptions extends GenAiOptions {
   /**
    * Enable or disable truncation of recorded input messages.
    * Defaults to `true`.
+   *
+   * @deprecated gen_ai input truncation is removed in v11; this option no longer has an effect there.
    */
   enableTruncation?: boolean;
 }
 
+// oxlint-disable-next-line typescript/no-deprecated
 const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {
   return {
     name: 'VercelAI' as const,


### PR DESCRIPTION
Forward-compat for the v11 change that consolidates all AI integration option types into a single shared `GenAiOptions` (see #23103).

`VercelAiOptions` has been a public export of `@sentry/server-utils` since v10.68. v11 removes it in favour of `GenAiOptions`. To give v10 users a warning and a migration path ahead of that:

- Adds `GenAiOptions` (`{ recordInputs?, recordOutputs? }`) to `@sentry/server-utils`.
- Marks `VercelAiOptions` `@deprecated`, pointing to `GenAiOptions`. It still `extends GenAiOptions` and keeps `enableTruncation` (which still works on v10), so this is fully backward compatible — no runtime or type-shape change, just a deprecation notice.

```js
// v10 (still works, now deprecated)
import type { VercelAiOptions } from "@sentry/server-utils";
// preferred going into v11
import type { GenAiOptions } from "@sentry/server-utils";
```

Draft to let CI confirm.