### PR TITLE
fix(cloudflare): Try/catch on non-configurable prototypes

### DIFF
--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -327,7 +327,11 @@ function instrumentPrototypeRpcMethods(obj: object, excludedMethods?: ReadonlySe
       }
 
       const wrapped = createRpcPrototypeWrapper(methodName, descriptor.value as UncheckedMethod);
-      Object.defineProperty(prototype, methodName, { ...descriptor, value: wrapped });
+
+      try {
+        Object.defineProperty(prototype, methodName, { ...descriptor, value: wrapped });
+      } catch {}
+
       // Only the wrapper is marked, not the original method: `wrapMethodWithSentry` resolves
       // through the same global map and must not resolve the original to this wrapper,
       // which would recurse.

--- a/packages/cloudflare/test/durableobject.test.ts
+++ b/packages/cloudflare/test/durableobject.test.ts
@@ -348,6 +348,43 @@ describe('instrumentDurableObjectWithSentry', () => {
     expect(obj.rpcMethod()).toBe('result');
   });
 
+  it('skips non-configurable prototype methods instead of failing construction', () => {
+    const testClass = class {
+      sealedMethod() {
+        return 'sealed-result';
+      }
+
+      rpcMethod() {
+        return 'rpc-result';
+      }
+    };
+    Object.defineProperty(testClass.prototype, 'sealedMethod', {
+      value: testClass.prototype.sealedMethod,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+    const originalSealedMethod = testClass.prototype.sealedMethod;
+
+    const instrumented = instrumentDurableObjectWithSentry(
+      vi.fn().mockReturnValue({ enableRpcTracePropagation: true }),
+      testClass as any,
+    );
+
+    let obj: any;
+    expect(() => {
+      obj = Reflect.construct(instrumented, []);
+    }).not.toThrow();
+
+    // The non-configurable method keeps its original (unwrapped) implementation
+    expect(testClass.prototype.sealedMethod).toBe(originalSealedMethod);
+    expect(obj.sealedMethod()).toBe('sealed-result');
+
+    // Other methods on the same prototype are still wrapped
+    expect(getInstrumented(obj.rpcMethod)).toBeTruthy();
+    expect(obj.rpcMethod()).toBe('rpc-result');
+  });
+
   it('does not wrap Object.prototype methods as RPC methods', () => {
     const testClass = class {
       rpcMethod() {


### PR DESCRIPTION
Missed a comment here: https://github.com/getsentry/sentry-javascript/pull/23057#discussion_r3729812899