### PR TITLE
chore(bugbot): Add rule to flag `getClient` usage when avoidable

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -49,6 +49,9 @@ Unless explicitly noted (e.g. in the `Testing Conventions` section), only flag t
 - Flag direct `console.log` / `console.warn` / `console.error` / `console.info` / `console.debug` calls in SDK source. The accepted patterns are:
   - The SDK's `debug` logger (gated with `DEBUG_BUILD && debug.*`) for SDK-internal diagnostics.
   - `consoleSandbox(() => { console.warn(...) })` for intentional user-facing warnings (e.g. init-time misconfiguration messages). The `consoleSandbox` wrapper prevents the SDK's own console instrumentation from intercepting the call. Bare `console.*` calls outside very early init paths (e.g. before the logger is available) should be flagged.
+- Flag usage of the following APIs: `getCurrentScope()`, `getIsolationScope()`, `getClient()` if they are avoidable. Flag it with severity Low and acknowledge from the start that this is more a "is this necessary" check, rather than a rule violation.
+  - Reason for flagging: Usage of these APIs is problematic for multi-client setups where either there is no "current" client/scope, or the wrong client might be used. Calling these APIs would create a current scope, thereby misleading any future calls to these APIs.
+  - What to do instead: Use an existing reference to the scope or client. For example, this is possible in most `Integration` hooks.
 
 ### Code quality
 


### PR DESCRIPTION
We should use this API sparingly. Usage is not the end of the world and multi-client usage is already kinda broken but let's try to avoid making it worse. 