### PR TITLE
ref(cloudflare)!: Remove deprecated `instrumentD1WithSentry` export

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/index.ts
@@ -28,17 +28,6 @@ export default Sentry.withSentry(
         return new Response('ok');
       }
 
-      if (url.pathname === '/double-instrument') {
-        const prepareBeforeManual = env.DB.prepare;
-        const db = Sentry.instrumentD1WithSentry(env.DB);
-        const prepareAfterManual = db.prepare;
-
-        await db.prepare('SELECT * FROM users WHERE id = ?').bind(1).all();
-
-        const isSameRef = prepareBeforeManual === prepareAfterManual ? 'true' : 'false';
-        return new Response(isSameRef);
-      }
-
       if (url.pathname === '/error') {
         await env.DB.prepare('SELECT * FROM non_existent_table').all();
         return new Response('ok');

--- a/dev-packages/cloudflare-integration-tests/suites/d1/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/d1/test.ts
@@ -133,25 +133,6 @@ it('instruments D1 exec() automatically via env', async ({ signal }) => {
   await runner.completed();
 });
 
-it('does not double-instrument when instrumentD1WithSentry is used on top of env instrumentation', async ({
-  signal,
-}) => {
-  const runner = createRunner(__dirname)
-    .ignore('event')
-    .expect((envelope: Envelope) => {
-      expect(envelopeItemType(envelope)).toBe('transaction');
-      const d1Spans = findD1Spans(envelope);
-
-      const querySpans = d1Spans.filter(s => s.description === 'SELECT * FROM users WHERE id = ?');
-      expect(querySpans).toHaveLength(1);
-    })
-    .start(signal);
-
-  const response = await runner.makeRequest('get', '/double-instrument');
-  expect(response).toBe('true');
-  await runner.completed();
-});
-
 it('instruments D1 withSession().batch() identically to db.batch()', async ({ signal }) => {
   let directBatchSpan: Record<string, unknown> | undefined;
   let sessionBatchSpan: Record<string, unknown> | undefined;

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/d1/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/d1/index.ts
@@ -14,7 +14,7 @@ export default Sentry.withSentry(
   {
     async fetch(request, env, _ctx) {
       const url = new URL(request.url);
-      const db = Sentry.instrumentD1WithSentry(env.DB);
+      const db = env.DB;
 
       if (url.pathname === '/init') {
         await db.exec('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)');

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -167,16 +167,12 @@ Sentry.captureEvent({
 
 ## Cloudflare D1 Instrumentation
 
-You can use the `instrumentD1WithSentry` method to instrument [Cloudflare D1](https://developers.cloudflare.com/d1/),
-Cloudflare's serverless SQL database with Sentry.
+`withSentry()` automatically instruments all [Cloudflare D1](https://developers.cloudflare.com/d1/) bindings on `env`,
+Cloudflare's serverless SQL database. Just use the binding as usual:
 
 ```javascript
-import * as Sentry from '@sentry/cloudflare';
-
 // env.DB is the D1 DB binding configured in your `wrangler.toml`
-const db = Sentry.instrumentD1WithSentry(env.DB);
-// Now you can use the database as usual
-await db.prepare('SELECT * FROM table WHERE id = ?').bind(1).run();
+await env.DB.prepare('SELECT * FROM table WHERE id = ?').bind(1).run();
 ```
 
 ## Cron Monitoring (Cloudflare Workers)

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -133,9 +133,6 @@ export {
   instrumentCreateReactAgent,
 } from '@sentry/server-utils';
 
-// eslint-disable-next-line typescript/no-deprecated
-export { instrumentD1WithSentry } from './instrumentations/worker/instrumentD1';
-
 export { instrumentWorkflowWithSentry } from './workflows';
 
 export { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';

--- a/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
@@ -214,23 +214,3 @@ function _instrumentD1(db: D1Database): D1Database {
 export function instrumentD1(db: D1Database): D1Database {
   return ensureInstrumented(db, _instrumentD1);
 }
-
-// todo(v11): Remove this export
-/**
- * Instruments Cloudflare D1 bindings with Sentry.
- *
- * @deprecated `withSentry()` automatically instruments all D1 bindings via `env`
- * so this function is not needed anymore. It will be removed in the next major version of the SDK.
- *
- * @example
- *
- * ```js
- * // env.DB is the D1 DB binding configured in your `wrangler.toml`
- * const db = instrumentD1WithSentry(env.DB);
- * // Now you can use the database as usual
- * await db.prepare('SELECT * FROM table WHERE id = ?').bind(1).run();
- * ```
- */
-export function instrumentD1WithSentry(db: D1Database): D1Database {
-  return instrumentD1(db);
-}

--- a/packages/cloudflare/test/instrumentations/worker/instrumentD1.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentD1.test.ts
@@ -1,7 +1,7 @@
 import type { D1Database, D1DatabaseSession, D1PreparedStatement } from '@cloudflare/workers-types';
 import * as SentryCore from '@sentry/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { instrumentD1, instrumentD1WithSentry } from '../../../src/instrumentations/worker/instrumentD1';
+import { instrumentD1 } from '../../../src/instrumentations/worker/instrumentD1';
 
 const MOCK_FIRST_RETURN_VALUE = { id: 1, name: 'Foo' };
 
@@ -51,20 +51,6 @@ function createMockD1Session(): D1DatabaseSession {
     getBookmark: vi.fn().mockReturnValue(null),
   } as unknown as D1DatabaseSession;
 }
-
-describe('instrumentD1WithSentry (deprecated)', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  test('still instruments the database', async () => {
-    const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
-    const instrumentedDb = instrumentD1WithSentry(createMockD1Database());
-    await instrumentedDb.prepare('SELECT 1').first();
-
-    expect(startSpanSpy).toHaveBeenCalledTimes(1);
-  });
-});
 
 describe('instrumentD1', () => {
   beforeEach(() => {
@@ -475,19 +461,6 @@ describe('instrumentD1', () => {
 
       expect(first).toBe(second);
       expect(second.prepare).toBe(prepareAfterFirst);
-    });
-
-    test('does not double-instrument when instrumentD1WithSentry is also used', async () => {
-      vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-      const db = createMockD1Database();
-      const fromEnv = instrumentD1(db);
-      const prepareAfterFirst = fromEnv.prepare;
-
-      const fromManual = instrumentD1WithSentry(db);
-
-      expect(fromEnv).toBe(fromManual);
-      expect(fromManual.prepare).toBe(prepareAfterFirst);
     });
   });
 });


### PR DESCRIPTION
closes getsentry/sentry-javascript#22362

Just removes the export `instrumentD1WithSentry`