### PR TITLE
test(e2e): Raise TanStack version floor in tanstackstart-react-cloudflare

### DIFF
--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
@@ -16,8 +16,8 @@
     "@sentry/browser": "file:../../packed/sentry-browser-packed.tgz",
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",
     "@sentry/tanstackstart-react": "file:../../packed/sentry-tanstackstart-react-packed.tgz",
-    "@tanstack/react-start": "^1.136.0",
-    "@tanstack/react-router": "^1.136.0",
+    "@tanstack/react-start": "^1.168.35",
+    "@tanstack/react-router": "^1.170.18",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },


### PR DESCRIPTION
Raises the `@tanstack/react-start` / `@tanstack/react-router` floor in the `tanstackstart-react-cloudflare` e2e app from `^1.136.0` to `^1.168.35` / `^1.170.18` — the versions the sibling `tanstackstart-react` app was set to in #23046.

_Root cause_

The job did not fail on an assertion — the app never built. A broken upstream publish made `pnpm install` fail outright:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @tanstack/router-generator@1.167.25
This error happened while installing the dependencies of @tanstack/react-start@1.168.39
 at @tanstack/start-plugin-core@1.171.30
The latest release of @tanstack/router-generator is "1.167.24".
```

TanStack published `start-plugin-core@1.171.30` with an exact dependency on `router-generator@1.167.25` before that version was on npm. On `develop` the job passed at 09:54 UTC and failed at 11:20 with no SDK change in between.

Only this app was affected because it still carried floating `^1.136.0` ranges, so a fresh install picked up whatever TanStack had published minutes earlier. `tanstackstart-react` was unaffected — #23046 pinned it two days ago, and since TanStack pins its own internal deps exactly, that froze its whole transitive tree.

_Scope of this change — worth a look before merging_

This raises the floor but keeps caret ranges, so it does **not** freeze the tree. `^1.136.0` and `^1.168.35` both resolve to `@tanstack/react-start@1.168.39` today, so resolution is unchanged from what CI already attempted. The job is green again because upstream backfilled the missing `router-generator@1.167.25`, not because of this change — the next bad publish will break it the same way.

Exact pins (`1.168.35` / `1.170.18`, matching #23046) would actually prevent recurrence, at the cost of not exercising newer TanStack releases here. That tradeoff is already covered elsewhere: the canary workflow runs `tanstackstart-react` with `test:build-latest`. Happy to switch to exact pins if reviewers prefer.

Verified locally: install, build, and all 11 tests pass against the currently-resolving tree (`react-start@1.168.39`, `react-router@1.170.22`).