### PR TITLE
chore(aws-serverless)!: Drop `nodejs18.x` from the Lambda layer runtimes

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -159,7 +159,6 @@ targets:
     compatibleRuntimes:
       - name: node
         versions:
-          - nodejs18.x
           - nodejs20.x
           - nodejs22.x
           - nodejs24.x

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -66,6 +66,8 @@ The SDK and bundler plugins now use Sentry CLI v3. This is an internal change fo
 A new AWS Lambda Layer for version 11 will be published as `SentryNodeServerlessSDKv11`.
 The ARN will be published in the [Sentry docs](https://docs.sentry.io/platforms/javascript/guides/aws-lambda/install/cjs-layer/) once available.
 
+The layer is compatible with the `nodejs20.x`, `nodejs22.x` and `nodejs24.x` runtimes. Functions still on `nodejs18.x` need to move to a newer runtime before upgrading.
+
 Updates and fixes for version 10 will be published as `SentryNodeServerlessSDKv10`.
 
 ## 2. Behaviour Changes

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-layer/src/stack.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-layer/src/stack.ts
@@ -39,7 +39,7 @@ export class LocalLambdaStack extends Stack {
       type: 'AWS::Serverless::LayerVersion',
       properties: {
         ContentUri: path.join(LAYER_DIR, layerZipFile),
-        CompatibleRuntimes: ['nodejs20.x', 'nodejs22.x'],
+        CompatibleRuntimes: ['nodejs20.x', 'nodejs22.x', 'nodejs24.x'],
         CompatibleArchitectures: [samLambdaArchitecture()],
       },
     });

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-layer/src/stack.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-layer/src/stack.ts
@@ -39,7 +39,7 @@ export class LocalLambdaStack extends Stack {
       type: 'AWS::Serverless::LayerVersion',
       properties: {
         ContentUri: path.join(LAYER_DIR, layerZipFile),
-        CompatibleRuntimes: ['nodejs18.x', 'nodejs20.x', 'nodejs22.x'],
+        CompatibleRuntimes: ['nodejs20.x', 'nodejs22.x'],
         CompatibleArchitectures: [samLambdaArchitecture()],
       },
     });

--- a/scripts/aws-deploy-local-layer.sh
+++ b/scripts/aws-deploy-local-layer.sh
@@ -32,7 +32,7 @@ aws lambda publish-layer-version \
   --region "eu-central-1" \
   --zip-file "fileb://build/aws/dist-serverless/$ZIP" \
   --description "Local test build of SentryNodeServerlessSDK (can be deleted)" \
-  --compatible-runtimes nodejs10.x nodejs12.x nodejs14.x nodejs16.x nodejs18.x
+  --compatible-runtimes nodejs20.x nodejs22.x nodejs24.x
 
 echo "Done deploying zipped Lambda layer to AWS as 'SentryNodeServerlessSDK-local-dev'."
 


### PR DESCRIPTION
## What

The AWS Lambda layer no longer advertises `nodejs18.x` as a compatible runtime.

- Removed `nodejs18.x` from the `aws-lambda-layer` target in `.craft.yml`
- Removed it from the layer built by the `aws-serverless-layer` E2E app
- Refreshed the runtime list in the local layer deploy script, which still listed `nodejs10.x` through `nodejs18.x`

## Why

v11 requires Node 20.19.0 or higher, so a layer claiming Node 18 compatibility would hand users an SDK that cannot run.