### PR TITLE
fix(bundler-plugin-tests): Normalize prerelease versions in telemetry snapshots

### DIFF
--- a/dev-packages/bundler-plugin-integration-tests/fixtures/utils.ts
+++ b/dev-packages/bundler-plugin-integration-tests/fixtures/utils.ts
@@ -81,10 +81,10 @@ export function readAllFiles(
             .replace(/"duration":[\d.]+/g, '"duration":DURATION')
             .replace(/"start_timestamp":[\d.]+/g, '"start_timestamp":START_TIMESTAMP')
             .replace(/"timestamp":[\d.]+/g, '"timestamp":TIMESTAMP')
-            .replace(/"release":"[\d.]+"/g, '"release":"PLUGIN_VERSION"')
+            .replace(/"release":"[\d.]+(?:-[\w.]+)?"/g, '"release":"PLUGIN_VERSION"')
             // Normalize the Sentry SDK version (from the bundled-out, now-external `@sentry/core`).
             // It tracks the live monorepo version and would otherwise rot this snapshot on every release.
-            .replace(/"version":"[\d.]+"/g, '"version":"SDK_VERSION"')
+            .replace(/"version":"[\d.]+(?:-[\w.]+)?"/g, '"version":"SDK_VERSION"')
             .replace(/"sample_rand":"\d.?\d*"/g, '"sample_rand":"SAMPLE_RAND"');
         } else {
           // Normalize Windows line endings for cross-platform snapshots


### PR DESCRIPTION
The 8 `telemetry.test.ts` bundler fixtures failed on the `release/11.0.0-alpha.0` branch because the version normalizer in `fixtures/utils.ts` only matched plain `X.Y.Z` semver.

The `release` and `version` normalization regexes used the character class `[\d.]+`, which stops at the first non-digit/non-dot character. On a prerelease version like `11.0.0-alpha.0`, the `-alpha.0` suffix is left unmatched, so the literal version leaked into the telemetry payload instead of being replaced with the `PLUGIN_VERSION` / `SDK_VERSION` placeholders the inline snapshots expect — mismatching all 8 fixtures.

This never surfaced on regular PRs because `develop` always carries a plain semver; it only triggers on a release branch, and would break the check on every alpha/beta/rc.

Both regexes now accept an optional prerelease suffix (`(?:-[\w.]+)?`). The committed inline snapshots already contain the placeholders, so no snapshots need regenerating.

_Root cause_: version normalization regex did not account for prerelease identifiers.