### PR TITLE
chore(e2e): Link `@sentry/bundler-plugins` into the aws-serverless lambda test app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/aws-serverless/src/stack.ts
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless/src/stack.ts
@@ -63,6 +63,7 @@ export class LocalLambdaStack extends Stack {
         { dir: 'core', name: '@sentry/core' },
         { dir: 'opentelemetry', name: '@sentry/opentelemetry' },
         { dir: 'server-utils', name: '@sentry/server-utils' },
+        { dir: 'bundler-plugins', name: '@sentry/bundler-plugins' },
       ];
       const dependencies: Record<string, string> = {};
 


### PR DESCRIPTION
## What

The aws-serverless lambda test app now installs `@sentry/bundler-plugins` from the workspace instead of npm.

- Adds `bundler-plugins` to the list of packages the lambda functions link via `file:`.

## Why

`@sentry/node` depends on `@sentry/bundler-plugins`, which the test app was resolving from the registry. On release branches that version isn't published yet, so the install failed with `ETARGET` and the whole aws-serverless E2E job went down. This showed up on `release/11.0.0-alpha.0`.
