### PR TITLE
chore(deps): Bump `@sentry/conventions` to 0.19.0

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -63,7 +63,7 @@
     "@sentry/browser": "10.67.0",
     "@sentry/replay": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",
-    "@sentry/conventions": "0.16.0",
+    "@sentry/conventions": "0.19.0",
     "@supabase/supabase-js": "2.49.3",
     "axios": "1.18.0",
     "babel-loader": "^10.1.1",

--- a/dev-packages/cloudflare-integration-tests/package.json
+++ b/dev-packages/cloudflare-integration-tests/package.json
@@ -33,7 +33,7 @@
     "@cloudflare/workers-types": "^4.20260426.0",
     "@cloudflare/workers-types-v5": "npm:@cloudflare/workers-types@5.20260710.1",
     "@sentry-internal/test-utils": "10.67.0",
-    "@sentry/conventions": "0.16.0",
+    "@sentry/conventions": "0.19.0",
     "eslint-plugin-regexp": "^3.1.0",
     "prisma": "6.15.0",
     "vite": "7.3.5",

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@opentelemetry/instrumentation-http": "0.220.0",
-    "@sentry/conventions": "0.16.0",
+    "@sentry/conventions": "0.19.0",
     "@sentry-internal/test-utils": "10.67.0",
     "@types/amqplib": "^0.10.5",
     "@types/node-cron": "^3.0.11",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0"

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0",

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "web-vitals": "^6.0.1"
   },
   "scripts": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@sentry/browser-utils": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/feedback": "10.67.0",
     "@sentry/replay": "10.67.0",
     "@sentry/replay-canvas": "10.67.0",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.4",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"
   },

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "magic-string": "~0.30.21"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,6 +93,6 @@
     "zod": "^3.24.1"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.16.0"
+    "@sentry/conventions": "^0.19.0"
   }
 }

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@sentry/bun": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0"
+    "@sentry/conventions": "^0.19.0"
   },
   "peerDependencies": {
     "elysia": "^1.4.0"

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -34,7 +34,7 @@
     "@embroider/macros": "^1.16.0",
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "ember-auto-import": "^2.7.2",
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.1.1",

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0"
+    "@sentry/conventions": "^0.19.0"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.x",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -68,7 +68,7 @@
     "@rollup/plugin-commonjs": "28.0.1",
     "@sentry/browser-utils": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@sentry/bundler-plugins": "^10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",
     "@sentry/server-utils": "10.67.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -56,7 +56,7 @@
     "@nuxt/kit": "^3.13.2",
     "@sentry/browser": "10.67.0",
     "@sentry/cloudflare": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0"
   },
   "peerDependencies": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -48,7 +48,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser": "10.67.0",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0"
+    "@sentry/conventions": "^0.19.0"
   },
   "peerDependencies": {
     "react": "17.x || 18.x || 19.x"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@remix-run/router": "^1.23.3",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -103,7 +103,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0"
   },
   "devDependencies": {

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -20,7 +20,6 @@ import {
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
-import { GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP, GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_skipAiProviderWrapping,
@@ -56,6 +55,8 @@ const GEN_AI_TOOL_CALL_ID_ATTRIBUTE = 'gen_ai.tool.call.id';
 const GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE = 'gen_ai.tool.description';
 const GEN_AI_EMBEDDINGS_OPERATION = 'embeddings';
 const GEN_AI_RERANK_OPERATION = 'rerank';
+const GEN_AI_INVOKE_AGENT_OPERATION = 'invoke_agent';
+const GEN_AI_EXECUTE_TOOL_OPERATION = 'execute_tool';
 // The model-call op matches the Vercel AI OTel integration (`gen_ai.generate_content`) rather than
 // the generic `gen_ai.chat`, so v6 (OTel) and v7 (channel) produce the same spans.
 const GEN_AI_GENERATE_CONTENT_OPERATION = 'generate_content';
@@ -430,7 +431,7 @@ function buildInvokeAgentSpan(
   if (callId) {
     operationIdByCallId.set(callId, { operationId, isStream });
   }
-  const span = startGenAiSpan(GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP, functionId, {
+  const span = startGenAiSpan(GEN_AI_INVOKE_AGENT_OPERATION, functionId, {
     ...baseAttributes,
     [VERCEL_AI_OPERATION_ID_ATTRIBUTE]: operationId,
     [GEN_AI_RESPONSE_STREAMING]: isStream,
@@ -472,7 +473,7 @@ function buildToolSpan(event: Record<string, unknown>, recordInputs: boolean): S
   // Gated on `recordInputs` to match the OTel path (descriptions come from the recorded tools list).
   const description =
     recordInputs && toolName ? resolveToolDescription(asString(event.callId), toolName, event.tools) : undefined;
-  return startGenAiSpan(GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP, toolName, {
+  return startGenAiSpan(GEN_AI_EXECUTE_TOOL_OPERATION, toolName, {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
     ...(toolName ? { [GEN_AI_TOOL_NAME]: toolName } : {}),
     ...(toolCallId ? { [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: toolCallId } : {}),

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -20,7 +20,7 @@ import {
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
-import { GEN_AI_EXECUTE_TOOL_SPAN_OP, GEN_AI_INVOKE_AGENT_SPAN_OP } from '@sentry/conventions/op';
+import { GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP, GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_skipAiProviderWrapping,
@@ -430,7 +430,7 @@ function buildInvokeAgentSpan(
   if (callId) {
     operationIdByCallId.set(callId, { operationId, isStream });
   }
-  const span = startGenAiSpan(GEN_AI_INVOKE_AGENT_SPAN_OP, functionId, {
+  const span = startGenAiSpan(GEN_AI_GEN_AI_INVOKE_AGENT_SPAN_OP, functionId, {
     ...baseAttributes,
     [VERCEL_AI_OPERATION_ID_ATTRIBUTE]: operationId,
     [GEN_AI_RESPONSE_STREAMING]: isStream,
@@ -472,7 +472,7 @@ function buildToolSpan(event: Record<string, unknown>, recordInputs: boolean): S
   // Gated on `recordInputs` to match the OTel path (descriptions come from the recorded tools list).
   const description =
     recordInputs && toolName ? resolveToolDescription(asString(event.callId), toolName, event.tools) : undefined;
-  return startGenAiSpan(GEN_AI_EXECUTE_TOOL_SPAN_OP, toolName, {
+  return startGenAiSpan(GEN_AI_GEN_AI_EXECUTE_TOOL_SPAN_OP, toolName, {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
     ...(toolName ? { [GEN_AI_TOOL_NAME]: toolName } : {}),
     ...(toolCallId ? { [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: toolCallId } : {}),

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0"
+    "@sentry/conventions": "^0.19.0"
   },
   "peerDependencies": {
     "@solidjs/router": "^0.13.4 || ^0.14.0 || ^0.15.0",

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -86,7 +86,7 @@
     "@sentry/server-utils": "10.67.0",
     "@sentry/solid": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",
-    "@sentry/conventions": "0.16.0"
+    "@sentry/conventions": "0.19.0"
   },
   "devDependencies": {
     "@solidjs/router": "^0.15.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "magic-string": "~0.30.0"
   },

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@sentry/cloudflare": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "@sentry/svelte": "10.67.0",

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser-utils": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.16.0"
+    "@sentry/conventions": "^0.19.0"
   },
   "peerDependencies": {
     "@tanstack/vue-router": "^1.64.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7499,10 +7499,10 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
-"@sentry/conventions@0.16.0", "@sentry/conventions@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
-  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
+"@sentry/conventions@0.19.0", "@sentry/conventions@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.19.0.tgz#da81dd1b8c4f2f42aca2d74251a07ff9f8718e42"
+  integrity sha512-nYciB7Pt/Ujf6pJSt1FnHeJBp908P5Ibod4FMlTzASJcqU1RvixI5EFzkbe8gvUxP3XAMoWDgeWeG8agCjKYVA==
 
 "@sentry/node-cpu-profiler@^2.4.3":
   version "2.4.3"


### PR DESCRIPTION
Bumps `@sentry/conventions` from 0.16.0 to 0.19.0 across every workspace.

The bump renamed two op constants (breaking change, so those had to be renamed), might be a bug that I'm checking separately.