### PR TITLE
feat(solid,solidstart): Support `@solidjs/router` v1

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -59,7 +59,7 @@
     "@sentry/conventions": "^0.16.0"
   },
   "peerDependencies": {
-    "@solidjs/router": "^0.13.4 || ^0.14.0 || ^0.15.0",
+    "@solidjs/router": ">=0.13.4 <2.0.0-0",
     "@tanstack/solid-router": "^1.132.27",
     "solid-js": "^1.8.4"
   },
@@ -72,7 +72,7 @@
     }
   },
   "devDependencies": {
-    "@solidjs/router": "^0.15.0",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/testing-library": "0.8.5",
     "@tanstack/solid-router": "^1.169.2",
     "@testing-library/dom": "^7.21.4",

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -71,7 +71,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@solidjs/router": "^0.13.4 || ^0.14.0 || ^0.15.0 || ^1.0.0",
+    "@solidjs/router": ">=0.13.4 <2.0.0-0",
     "@solidjs/start": "^1.0.0 || ^2.0.0"
   },
   "peerDependenciesMeta": {
@@ -89,7 +89,7 @@
     "@sentry/conventions": "0.16.0"
   },
   "devDependencies": {
-    "@solidjs/router": "^0.15.0",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "^1.2.1",
     "@solidjs/testing-library": "0.8.5",
     "@testing-library/jest-dom": "^6.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8191,10 +8191,10 @@
   resolved "https://registry.yarnpkg.com/@solidjs/meta/-/meta-0.29.4.tgz#28a444db5200d1c9e4e62d8762ea808d3e8beffd"
   integrity sha512-zdIWBGpR9zGx1p1bzIPqF5Gs+Ks/BH8R6fWhmUa/dcK1L2rUC8BAcZJzNRYBQv74kScf1TSOs0EY//Vd/I0V8g==
 
-"@solidjs/router@^0.15.0":
-  version "0.15.4"
-  resolved "https://registry.yarnpkg.com/@solidjs/router/-/router-0.15.4.tgz#e2b2d797541dcbdc36641e5f610f93ab4fa11c8a"
-  integrity sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ==
+"@solidjs/router@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@solidjs/router/-/router-1.0.0.tgz#9e4e5d6dbdeb725e8e4a9b5a3c7158c39fff096f"
+  integrity sha512-cCSk1hvgCowiMa9bzzYWHiLu1U4E22+DfJe6/rOwAyECKrxc3jrd5QnoW3sDDJtW+e077cz/M67bPl3DqOBw1Q==
 
 "@solidjs/start@^1.2.1":
   version "1.2.1"


### PR DESCRIPTION
## What

Widen the `@solidjs/router` peer dependency range in `@sentry/solid` and `@sentry/solidstart` to `>=0.13.4 <2.0.0-0`.

* Adds support for `@solidjs/router` v0.16 and v1.0.
* Excludes the in-progress Solid 2 router (`2.0.0-next.*`) via the `-0` upper bound.
* Bumps the dev dependency to v1 in both packages so unit tests run against it.

Closes: getsentry/sentry-javascript#23160

## Why

`@sentry/solid` capped at v0.15, so it conflicted with `@sentry/solidstart` on SolidStart 2, which requires router `>=0.16.0 <2.0.0-0`. Router v1.0 is a version realignment with no code changes from the 0.16 line, and none of the APIs the SDK uses changed.