### PR TITLE
chore(e2e): Bump `@solidjs/router` to v1 in solidstart test apps

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
@@ -18,7 +18,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.15.0",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "^1.0.2",
     "@solidjs/testing-library": "^0.8.7",
     "@testing-library/jest-dom": "^6.4.2",

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
@@ -18,7 +18,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.15.0",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "^1.0.2",
     "@solidjs/testing-library": "^0.8.7",
     "@testing-library/jest-dom": "^6.4.2",

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
@@ -18,7 +18,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.15.0",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "^1.0.2",
     "@solidjs/testing-library": "^0.8.7",
     "@testing-library/jest-dom": "^6.4.2",

--- a/dev-packages/e2e-tests/test-applications/solidstart/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart/package.json
@@ -20,7 +20,7 @@
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
-    "@solidjs/router": "^0.15.0",
+    "@solidjs/router": "^1.0.0",
     "@solidjs/start": "^1.0.2",
     "@solidjs/testing-library": "^0.8.7",
     "@testing-library/jest-dom": "^6.4.2",


### PR DESCRIPTION
## What

Bump `@solidjs/router` from `^0.15.0` to `^1.0.0` in the SolidStart 1 e2e test apps.

- `solidstart`, `solidstart-spa`, `solidstart-top-level-import`, `solidstart-dynamic-import`

## Why

#23162 widened the `@solidjs/router` peer range to `>=0.13.4 <2.0.0-0`, but only the `solidstart-2` app ran against v1, so the SolidStart 1 + router v1 combination the range now advertises had no coverage. The equivalent bump on v10 (#23163) passes all four suites locally.
