### PR TITLE
docs(migration): Fix `httpHeaders` shape in `dataCollection` baseline

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -226,7 +226,10 @@ Sentry.init({
   dataCollection: {
     userInfo: false,
     cookies: false,
-    httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+    httpHeaders: {
+      request: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      response: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+    },
     httpBodies: [],
     urlQueryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
     genAI: { inputs: false, outputs: false },

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -233,7 +233,10 @@ Sentry.init({
   dataCollection: {
     userInfo: false,
     cookies: false,
-    httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+    httpHeaders: {
+      request: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+      response: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+    },
     httpBodies: [],
     urlQueryParams: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
     genAI: { inputs: false, outputs: false },


### PR DESCRIPTION
## What

Fix the `httpHeaders` entry in the "keep the v10 default behavior" example, in both `MIGRATION.md` and `docs/migration/v11-end-state.md`.

```diff
- httpHeaders: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+ httpHeaders: {
+   request: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+   response: { deny: ['forwarded', '-ip', 'remote-', 'via', '-user'] },
+ },
```

Closes: getsentry/sentry-javascript#23168

## Why

`httpHeaders` takes `{ request, response }`, not a bare `CollectBehavior`. A top-level `deny` matches neither key, so `resolveDataCollectionOptions` fell back to the `true` default for both and collected every header, the opposite of what the example promises. TypeScript users hit a compile error, but JavaScript configs failed silently while appearing to opt out.