### PR TITLE
feat(aws-serverless): Remove deprecated `disableAwsContextPropagation` option

### DIFF
--- a/packages/aws-serverless/src/integration/awslambda.ts
+++ b/packages/aws-serverless/src/integration/awslambda.ts
@@ -4,15 +4,6 @@ import { createRequire } from 'node:module';
 import { DEBUG_BUILD } from '../debug-build';
 import { parseHandlerString, resolveHandlerFile } from '../handlerResolution';
 
-interface AwsLambdaOptions {
-  // TODO(v11): Remove this option since it's no longer used.
-  /**
-   * @deprecated This option no longer does anything and will be removed in a future major version.
-   * Sentry trace propagation always takes precedence.
-   */
-  disableAwsContextPropagation?: boolean;
-}
-
 const SHIM_MODULE_ID = '@sentry/aws-serverless/run-lambda-handler';
 
 function resolveShimFile(): string | undefined {
@@ -101,7 +92,7 @@ const AWS_LAMBDA_CONTEXT_FIELDS = [
 
 const AWS_CLOUDWATCH_CONTEXT_FIELDS = ['log_group', 'log_stream', 'url'] as const;
 
-const _awsLambdaIntegration = ((_options: AwsLambdaOptions = {}) => {
+const _awsLambdaIntegration = (() => {
   return {
     name: 'AwsLambda' as const,
     setupOnce() {


### PR DESCRIPTION
Removes the deprecated, no-op `disableAwsContextPropagation` option (and its now-empty `AwsLambdaOptions` interface) from the AWS Lambda integration for the v11 major.

Fixes getsentry/sentry-javascript#21830