### PR TITLE
ref(browser): Remove deprecated `trackFetchStreamPerformance` flag

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/src/index.tsx
@@ -26,7 +26,6 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
     }),
     replay,
   ],

--- a/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/src/index.tsx
@@ -28,8 +28,8 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
     }),
+    Sentry.fetchStreamPerformanceIntegration(),
     replay,
   ],
   // We recommend adjusting this value in production, or using tracesSampler

--- a/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/src/index.tsx
@@ -28,7 +28,6 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
     }),
     replay,
   ],

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/src/index.tsx
@@ -88,7 +88,6 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
       enableAsyncRouteHandlers: true,
       lazyRouteTimeout: runtimeConfig.lazyRouteTimeout,
       idleTimeout: runtimeConfig.idleTimeout,

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa-streaming/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa-streaming/src/main.tsx
@@ -26,7 +26,6 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
     }),
     Sentry.spanStreamingIntegration(),
     replay,

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/src/main.tsx
@@ -28,7 +28,6 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
     }),
     replay,
   ],

--- a/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/src/index.tsx
@@ -28,7 +28,6 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
     }),
     replay,
   ],

--- a/dev-packages/e2e-tests/test-applications/react-router-8-spa/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-spa/src/main.tsx
@@ -28,7 +28,6 @@ Sentry.init({
       useNavigationType,
       createRoutesFromChildren,
       matchRoutes,
-      trackFetchStreamPerformance: true,
     }),
     replay,
   ],

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -47,7 +47,6 @@ import {
 import { DEBUG_BUILD } from '../debug-build';
 import { filterCollectedUrl } from '@sentry/core';
 import { getHttpRequestData, WINDOW } from '../helpers';
-import { fetchStreamPerformanceIntegration } from '../integrations/fetchStreamPerformance';
 import { WEB_VITALS_INTEGRATION_NAME, webVitalsIntegration } from '../integrations/webVitals';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
@@ -166,17 +165,6 @@ export interface BrowserTracingOptions {
    * Default: true
    */
   traceXHR: boolean;
-
-  /**
-   * Flag to disable tracking of long-lived streams, like server-sent events (SSE) via fetch.
-   * Do not enable this in case you have live streams or very long running streams.
-   *
-   * Default: false
-   *
-   * @deprecated Use `fetchStreamPerformanceIntegration()` instead. Add it to your `integrations` array
-   * to track the duration of streamed fetch response bodies.
-   */
-  trackFetchStreamPerformance: boolean;
 
   /**
    * If true, Sentry will capture http timings and add them to the corresponding http spans.
@@ -354,8 +342,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
     markBackgroundSpan,
     traceFetch,
     traceXHR,
-    // eslint-disable-next-line typescript/no-deprecated
-    trackFetchStreamPerformance,
     shouldCreateSpanForRequest,
     enableHTTPTimings,
     ignoreResourceSpans,
@@ -712,10 +698,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         onRequestSpanStart,
         onRequestSpanEnd,
       });
-
-      if (trackFetchStreamPerformance) {
-        client.addIntegration(fetchStreamPerformanceIntegration());
-      }
     },
   };
 }) satisfies IntegrationFn;

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -91,20 +91,6 @@ export interface RequestInstrumentationOptions {
   traceXHR: boolean;
 
   /**
-   * Flag to disable tracking of long-lived streams, like server-sent events (SSE) via fetch.
-   * Do not enable this in case you have live streams or very long running streams.
-   *
-   * Disabled by default since it can lead to issues with streams using the `cancel()` api
-   * (https://github.com/getsentry/sentry-javascript/issues/13950)
-   *
-   * Default: false
-   *
-   * @deprecated Use `fetchStreamPerformanceIntegration()` instead. Add it to your `integrations` array
-   * to track the duration of streamed fetch response bodies.
-   */
-  trackFetchStreamPerformance: boolean;
-
-  /**
    * If true, Sentry will capture http timings and add them to the corresponding http spans.
    *
    * Default: true
@@ -134,8 +120,6 @@ export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions
   traceFetch: true,
   traceXHR: true,
   enableHTTPTimings: true,
-  // oxlint-disable-next-line typescript/no-deprecated -- default for the deprecated option, kept until it is removed
-  trackFetchStreamPerformance: false,
 };
 
 /** Registers span creators for xhr and fetch requests  */


### PR DESCRIPTION
Removes the deprecated `trackFetchStreamPerformance` option from `browserTracingIntegration`; streamed fetch tracking is now opt-in via the `fetchStreamPerformanceIntegration()` added to the `integrations` array. Migration is already documented in the final v11 guide.

Fixes getsentry/sentry-javascript#21189