### PR TITLE
ref(core)!: Remove deprecated `addAutoIpAddressToUser` export

### DIFF
--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -98,8 +98,6 @@ export { parameterize, fmt } from './utils/parameterize';
 export type { HandleTunnelRequestOptions } from './utils/tunnel';
 export { handleTunnelRequest } from './utils/tunnel';
 export { addAutoIpAddressToSession } from './utils/ipAddress';
-// eslint-disable-next-line typescript/no-deprecated
-export { addAutoIpAddressToUser } from './utils/ipAddress';
 export {
   convertSpanLinksForEnvelope,
   spanToTraceHeader,

--- a/packages/core/src/utils/ipAddress.ts
+++ b/packages/core/src/utils/ipAddress.ts
@@ -1,22 +1,8 @@
 import type { Session, SessionAggregates } from '../types/session';
-import type { User } from '../types/user';
 
 // By default, we want to infer the IP address, unless this is explicitly set to `null`
 // We do this after all other processing is done
 // If `ip_address` is explicitly set to `null` or a value, we leave it as is
-
-/**
- * @internal
- * @deprecated -- set ip inferral via via SDK metadata options on client instead.
- */
-export function addAutoIpAddressToUser(objWithMaybeUser: { user?: User | null }): void {
-  if (objWithMaybeUser.user?.ip_address === undefined) {
-    objWithMaybeUser.user = {
-      ...objWithMaybeUser.user,
-      ip_address: '{{auto}}',
-    };
-  }
-}
 
 /**
  * @internal


### PR DESCRIPTION
Removes the internal, deprecated `addAutoIpAddressToUser` export from `@sentry/core`, which was dead code with no remaining call sites — IP inferral is now controlled via SDK metadata options on the client. This is already documented in the v11 migration guide.

Fixes getsentry/sentry-javascript#17363