### PR TITLE
ref(core)!: Remove deprecated `patchExpressModule(options)` signature

### DIFF
--- a/packages/core/src/integrations/express/index.ts
+++ b/packages/core/src/integrations/express/index.ts
@@ -56,24 +56,6 @@ import { patchLayer } from './patch-layer';
 import { setSDKProcessingMetadata } from './set-sdk-processing-metadata';
 import { getDefaultExport } from '../../utils/get-default-export';
 
-function isLegacyOptions(
-  options: ExpressModuleExport | (ExpressIntegrationOptions & { express: ExpressModuleExport }),
-): options is ExpressIntegrationOptions & { express: ExpressModuleExport } {
-  return !!(options as { express: ExpressModuleExport }).express;
-}
-
-// TODO: remove this deprecation handling in v11
-let didLegacyDeprecationWarning = false;
-function deprecationWarning() {
-  if (!didLegacyDeprecationWarning) {
-    didLegacyDeprecationWarning = true;
-    DEBUG_BUILD &&
-      debug.warn(
-        '[Express] `patchExpressModule(options)` is deprecated. Use `patchExpressModule(moduleExports, getOptions)` instead.',
-      );
-  }
-}
-
 /**
  * This is a portable instrumentatiton function that works in any environment
  * where Express can be loaded, without depending on OpenTelemetry.
@@ -89,30 +71,9 @@ function deprecationWarning() {
 export function patchExpressModule(
   moduleExports: ExpressModuleExport,
   getOptions: () => ExpressIntegrationOptions,
-): ExpressModuleExport;
-/**
- * @deprecated Pass the Express module export as the first argument and options getter as the second argument.
- */
-export function patchExpressModule(
-  options: ExpressIntegrationOptions & { express: ExpressModuleExport },
-): ExpressModuleExport;
-export function patchExpressModule(
-  optionsOrExports: ExpressModuleExport | (ExpressIntegrationOptions & { express: ExpressModuleExport }),
-  maybeGetOptions?: () => ExpressIntegrationOptions,
 ): ExpressModuleExport {
-  let getOptions: () => ExpressIntegrationOptions;
-  let moduleExports: ExpressModuleExport;
-  if (!maybeGetOptions && isLegacyOptions(optionsOrExports)) {
-    // eslint-disable-next-line typescript/no-deprecated
-    const { express, ...options } = optionsOrExports;
-    moduleExports = express;
-    getOptions = () => options;
-    deprecationWarning();
-  } else if (typeof maybeGetOptions !== 'function') {
+  if (typeof getOptions !== 'function') {
     throw new TypeError('`patchExpressModule(moduleExports, getOptions)` requires a `getOptions` callback');
-  } else {
-    getOptions = maybeGetOptions;
-    moduleExports = optionsOrExports as ExpressModuleExport;
   }
 
   // pass in the require() or import() result of express

--- a/packages/core/src/integrations/express/types.ts
+++ b/packages/core/src/integrations/express/types.ts
@@ -136,12 +136,6 @@ export type ExpressRouter = {
 export type IgnoreMatcher = string | RegExp | ((name: string) => boolean);
 
 export type ExpressIntegrationOptions = {
-  /**
-   * @deprecated Pass the express module as the first argument, and an
-   * options getter as the second argument to patchExpressModule.
-   */
-  express?: ExpressModuleExport;
-
   /** Ignore specific based on their name */
   ignoreLayers?: IgnoreMatcher[];
   /** Ignore specific layers based on their type */

--- a/packages/core/test/lib/integrations/express/index.test.ts
+++ b/packages/core/test/lib/integrations/express/index.test.ts
@@ -52,10 +52,9 @@ vi.mock('../../../../src/debug-build', () => ({
   DEBUG_BUILD: true,
 }));
 const debugErrors: [string, Error][] = [];
-const debugWarnings: string[] = [];
 vi.mock('../../../../src/utils/debug-logger', () => ({
   debug: {
-    warn: (msg: string) => debugWarnings.push(msg),
+    warn: () => {},
     error: (msg: string, er: Error) => {
       debugErrors.push([msg, er]);
     },
@@ -155,10 +154,7 @@ describe('patchExpressModule', () => {
       expect((r.route as WrappedFunction).__sentry_original__).toBe(undefined);
       expect((a.use as WrappedFunction).__sentry_original__).toBe(undefined);
 
-      patchExpressModule({ express: moduleExports });
-      expect(debugWarnings).toStrictEqual([
-        '[Express] `patchExpressModule(options)` is deprecated. Use `patchExpressModule(moduleExports, getOptions)` instead.',
-      ]);
+      patchExpressModule(moduleExports, () => ({}));
 
       expect(typeof (r.use as WrappedFunction).__sentry_original__).toBe('function');
       expect(typeof (r.route as WrappedFunction).__sentry_original__).toBe('function');
@@ -176,13 +172,7 @@ describe('patchExpressModule', () => {
       expect((r.prototype.route as WrappedFunction).__sentry_original__).toBe(undefined);
       expect((a.use as WrappedFunction).__sentry_original__).toBe(undefined);
 
-      // verify that the debug warning doesn't fire a second time
-      // vitest doesn't guarantee test ordering, so just verify
-      // in both places that there's only one warning.
-      patchExpressModule({ express: moduleExports });
-      expect(debugWarnings).toStrictEqual([
-        '[Express] `patchExpressModule(options)` is deprecated. Use `patchExpressModule(moduleExports, getOptions)` instead.',
-      ]);
+      patchExpressModule(moduleExports, () => ({}));
 
       expect(typeof (r.prototype.use as WrappedFunction).__sentry_original__).toBe('function');
       expect(typeof (r.prototype.route as WrappedFunction).__sentry_original__).toBe('function');


### PR DESCRIPTION
Removes the deprecated single-argument `patchExpressModule(options)` signature in favour of `patchExpressModule(moduleExports, getOptions)`. Already documented in the v11 migration guide.

Fixes getsentry/sentry-javascript#22361