### PR TITLE
ref(core)!: Remove deprecated positional `spanOrigin` argument from `instrumentFetchRequest`

### DIFF
--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -657,6 +657,7 @@ Affected SDKs: `@sentry/cloudflare`.
 ### `@sentry/core` / All SDKs
 
 - The internal, deprecated `addAutoIpAddressToUser` export was removed.
+- The deprecated positional `spanOrigin` argument of `instrumentFetchRequest` was removed. Pass an options object (e.g. `{ spanOrigin }`) as the last argument instead.
 - The `createSpanEnvelope` function and the `SpanEnvelope` / `SpanItem` types were removed. They existed only to send standalone (v1) spans as their own segment envelope, which the SDK no longer does. Standalone spans are gone; spans are sent either on their transaction or, with span streaming, as streamed spans (`StreamedSpanEnvelope`).
 - The `disableInstrumentationWarnings` option and the `MissingInstrumentationContext` type were removed. Now that instrumentation is channel-based, the SDK can no longer detect the "you imported a framework before `Sentry.init()`" case, so the warning it gated and the context it attached no longer exist.
 - The deprecated `sendDefaultPii` option was removed. Use [`dataCollection`](#senddefaultpii-is-replaced-by-datacollection) instead.

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -44,8 +44,6 @@ interface InstrumentFetchRequestOptions {
 /**
  * Create and track fetch request spans for usage in combination with `addFetchInstrumentationHandler`.
  *
- * @deprecated pass an options object instead of the spanOrigin parameter
- *
  * @returns Span if a span was created, otherwise void.
  */
 export function instrumentFetchRequest(
@@ -53,33 +51,7 @@ export function instrumentFetchRequest(
   shouldCreateSpan: (url: string) => boolean,
   shouldAttachHeaders: (url: string) => boolean,
   spans: Record<string, Span>,
-  spanOrigin: SpanOrigin,
-): Span | undefined;
-/**
- * Create and track fetch request spans for usage in combination with `addFetchInstrumentationHandler`.
- *
- * @returns Span if a span was created, otherwise void.
- */
-export function instrumentFetchRequest(
-  handlerData: HandlerDataFetch,
-  shouldCreateSpan: (url: string) => boolean,
-  shouldAttachHeaders: (url: string) => boolean,
-  spans: Record<string, Span>,
-  // eslint-disable-next-line @typescript-eslint/unified-signatures -- needed because the other overload is deprecated
-  instrumentFetchRequestOptions: InstrumentFetchRequestOptions,
-): Span | undefined;
-
-/**
- * Create and track fetch request spans for usage in combination with `addFetchInstrumentationHandler`.
- *
- * @returns Span if a span was created, otherwise void.
- */
-export function instrumentFetchRequest(
-  handlerData: HandlerDataFetch,
-  shouldCreateSpan: (url: string) => boolean,
-  shouldAttachHeaders: (url: string) => boolean,
-  spans: Record<string, Span>,
-  spanOriginOrOptions?: SpanOrigin | InstrumentFetchRequestOptions,
+  instrumentFetchRequestOptions?: InstrumentFetchRequestOptions,
 ): Span | undefined {
   if (!handlerData.fetchData) {
     return undefined;
@@ -99,7 +71,7 @@ export function instrumentFetchRequest(
       // Only end the span and call hooks if we're actually recording
       if (shouldCreateSpanResult) {
         endSpan(span, handlerData);
-        _callOnRequestSpanEnd(span, handlerData, spanOriginOrOptions);
+        _callOnRequestSpanEnd(span, handlerData, instrumentFetchRequestOptions);
       }
 
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
@@ -109,11 +81,7 @@ export function instrumentFetchRequest(
     return undefined;
   }
 
-  // Backwards-compatible with the old signature. Needed to introduce the combined optional parameter
-  // to avoid API breakage for anyone calling this function with the optional spanOrigin parameter
-  // TODO (v11): remove this backwards-compatible code and only accept the options parameter
-  const { spanOrigin = 'auto.http.browser', propagateTraceparent = false } =
-    typeof spanOriginOrOptions === 'object' ? spanOriginOrOptions : { spanOrigin: spanOriginOrOptions };
+  const { spanOrigin = 'auto.http.browser', propagateTraceparent = false } = instrumentFetchRequestOptions ?? {};
 
   const client = getClient();
   const hasParent = !!getActiveSpan();
@@ -176,14 +144,9 @@ export function instrumentFetchRequest(
 export function _callOnRequestSpanEnd(
   span: Span,
   handlerData: HandlerDataFetch,
-  spanOriginOrOptions?: SpanOrigin | InstrumentFetchRequestOptions,
+  instrumentFetchRequestOptions?: InstrumentFetchRequestOptions,
 ): void {
-  const onRequestSpanEnd =
-    typeof spanOriginOrOptions === 'object' && spanOriginOrOptions !== null
-      ? spanOriginOrOptions.onRequestSpanEnd
-      : undefined;
-
-  onRequestSpanEnd?.(span, {
+  instrumentFetchRequestOptions?.onRequestSpanEnd?.(span, {
     headers: handlerData.response?.headers,
     error: handlerData.error,
   });


### PR DESCRIPTION
Removes the deprecated positional `spanOrigin` argument from `instrumentFetchRequest` in favour of the options object; already documented in the v11 migration guide.

Fixes getsentry/sentry-javascript#22256