### PR TITLE
ref(node): Stop inferring url-attributes for spans

### DIFF
--- a/packages/opentelemetry/src/applyOtelSpanData.ts
+++ b/packages/opentelemetry/src/applyOtelSpanData.ts
@@ -47,14 +47,6 @@ export function applyOtelSpanData(span: Span, options: { finalizeStatus?: boolea
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, inferred.op);
   }
 
-  if (inferred.data) {
-    Object.entries(inferred.data).forEach(([key, value]) => {
-      if (value !== undefined && attributes[key] === undefined) {
-        span.setAttribute(key, value);
-      }
-    });
-  }
-
   if (options.finalizeStatus) {
     applyOtelCompatibilityAttributes(span, attributes);
     const client = getClient();

--- a/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
+++ b/packages/opentelemetry/src/utils/backfillStreamedSpanData.ts
@@ -1,7 +1,6 @@
 import type { SpanAttributes, StreamedSpanJSON } from '@sentry/core';
 import { safeSetSpanJSONAttributes, SEMANTIC_ATTRIBUTE_SENTRY_OP } from '@sentry/core';
 import { inferSpanData } from './parseSpanDescription';
-import { SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 
 /**
  * Backfill op, source, name and data on a streamed span JSON from OTel semantic conventions.
@@ -17,15 +16,9 @@ import { SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 export function backfillStreamedSpanDataFromOtel(spanJSON: StreamedSpanJSON): void {
   const attributes = spanJSON.attributes ?? {};
 
-  const { op, data } = inferSpanData(attributes as unknown as SpanAttributes);
+  const { op } = inferSpanData(attributes as unknown as SpanAttributes);
 
   safeSetSpanJSONAttributes(spanJSON, {
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
-    // If nothing in the chain previously set an origin, we now default it to 'manual'
-    // For transactions, this is done in the SpanExporter.
-    // TODO (v11): Remove this again once we fully moved away from OTel's TracerProvider.
-    // at this point, we use `SentrySpan` everywhere, which defaults its origin to 'manual'.
-    [SENTRY_ORIGIN]: 'manual',
-    ...data,
   });
 }

--- a/packages/opentelemetry/src/utils/parseSpanDescription.ts
+++ b/packages/opentelemetry/src/utils/parseSpanDescription.ts
@@ -11,9 +11,7 @@ import {
   MESSAGING_SYSTEM,
   RPC_SERVICE,
   SENTRY_KIND,
-  URL_FRAGMENT,
   URL_FULL,
-  URL_QUERY,
 } from '@sentry/conventions/attributes';
 import {
   GENERAL_FUNCTION_SPAN_OP,
@@ -28,21 +26,16 @@ import {
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   getSanitizedUrlString,
-  getUrlFragment,
-  getUrlQuery,
   parseUrl,
   SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   spanToJSON,
   stripUrlQueryAndFragment,
-  filterCollectedUrl,
-  filterCollectedUrlQuery,
 } from '@sentry/core';
 
 interface SpanDescription {
   op: string | undefined;
-  data?: Record<string, string | undefined>;
 }
 
 /**
@@ -176,29 +169,8 @@ export function descriptionForHttpMethod(attributes: Attributes): SpanDescriptio
         ? WEB_SERVER_HTTP_SERVER_SPAN_OP
         : WEB_SERVER_HTTP_SPAN_OP;
 
-  const { urlPath, url, query, fragment } = getSanitizedUrl(attributes);
-
-  if (!urlPath) {
-    return { op };
-  }
-
-  const data: Record<string, string> = {};
-
-  if (url) {
-    data[URL_FULL] = filterCollectedUrl(url);
-  }
-  const urlQuery = filterCollectedUrlQuery(getUrlQuery(query));
-  if (urlQuery) {
-    data[URL_QUERY] = urlQuery;
-  }
-  const urlFragment = getUrlFragment(fragment);
-  if (urlFragment) {
-    data[URL_FRAGMENT] = urlFragment;
-  }
-
   return {
     op,
-    data,
   };
 }
 

--- a/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
+++ b/packages/opentelemetry/test/utils/parseSpanDescription.test.ts
@@ -312,9 +312,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.client',
-        data: {
-          'url.full': 'https://www.example.com/my-path',
-        },
       },
     ],
     [
@@ -328,9 +325,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.client',
-        data: {
-          'url.full': 'https://www.example.com/my-path',
-        },
       },
     ],
     [
@@ -343,9 +337,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.server',
-        data: {
-          'url.full': 'https://www.example.com/my-path',
-        },
       },
     ],
     [
@@ -359,9 +350,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.client',
-        data: {
-          'url.full': 'https://www.example.com/my-path/123',
-        },
       },
     ],
     [
@@ -373,9 +361,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http',
-        data: {
-          'url.full': 'https://www.example.com/my-path',
-        },
       },
     ],
     [
@@ -390,9 +375,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.client',
-        data: {
-          'url.full': 'https://www.example.com/my-path/123',
-        },
       },
     ],
     [
@@ -408,9 +390,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.client',
-        data: {
-          'url.full': 'https://www.example.com/my-path/123',
-        },
       },
     ],
     [
@@ -426,9 +405,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.client',
-        data: {
-          'url.full': 'https://www.example.com/my-path/123',
-        },
       },
     ],
     [
@@ -441,11 +417,6 @@ describe('descriptionForHttpMethod', () => {
       },
       {
         op: 'http.client',
-        data: {
-          'url.full': 'https://www.example.com/my-path',
-          'url.query': 'id=1',
-          'url.fragment': 'section',
-        },
       },
     ],
   ])('%s', (_, attributes, expected) => {


### PR DESCRIPTION
This is the only thing that we still used data-inferral for in spans, and we should already have replaced this usage in previous PRs here I believe.

Also removing the origin=manual fallback which should also no longer be needed I believe.