### PR TITLE
feat!: Replace `skipOpenTelemetrySetup` with `enableOpenTelemetrySetup`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -84,7 +84,7 @@ If you only use the Sentry SDK, day-to-day tracing remains **unchanged**.
 
 #### Choosing an OpenTelemetry setup
 
-There are three ways to run the Sentry and OpenTelemetry SDKs together, and which one you want depends on who should own spans. This is controlled by the existing `skipOpenTelemetrySetup` option, whose default was flipped in v11: it is now `true` for most server SDKs (including `@sentry/node`, `@sentry/bun`, the serverless SDKs and `@sentry/cloudflare`) and `false` for `@sentry/nextjs` and `@sentry/sveltekit`.
+There are three ways to run the Sentry and OpenTelemetry SDKs together, and which one you want depends on who should own spans. This is controlled by the new `enableOpenTelemetrySetup` option, which replaces v10's `skipOpenTelemetrySetup` with inverted meaning (`skipOpenTelemetrySetup: true` becomes `enableOpenTelemetrySetup: false`). It defaults to `false` for most server SDKs (including `@sentry/node`, `@sentry/bun`, the serverless SDKs and `@sentry/cloudflare`) and `true` for `@sentry/nextjs` and `@sentry/sveltekit`.
 
 ##### 1. Sentry only
 
@@ -101,13 +101,13 @@ If a library you depend on emits its own OpenTelemetry spans and you want those 
 
 ##### 2. OpenTelemetry-compatible mode, everything goes to Sentry
 
-Set `skipOpenTelemetrySetup: false`:
+Set `enableOpenTelemetrySetup: true`:
 
 ```js
 Sentry.init({
   dsn: '__DSN__',
   tracesSampleRate: 1.0,
-  skipOpenTelemetrySetup: false,
+  enableOpenTelemetrySetup: true,
 });
 ```
 
@@ -117,7 +117,7 @@ Spans go to Sentry. This is not a general OpenTelemetry pipeline: there is no ex
 
 ##### 3. Your own OpenTelemetry, Sentry linked to it
 
-Leave `skipOpenTelemetrySetup` unset or set it to `true`, turn Sentry tracing off, use your own OpenTelemetry setup, and add the Sentry `otlpIntegration()`:
+Leave `enableOpenTelemetrySetup` unset or set it to `false`, turn Sentry tracing off, use your own OpenTelemetry setup, and add the Sentry `otlpIntegration()`:
 
 ```js
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -138,7 +138,7 @@ Sentry.init({
 });
 ```
 
-`skipOpenTelemetrySetup` already defaults to `true` on most server SDKs, so there is nothing to set. On `@sentry/nextjs` and `@sentry/sveltekit` it defaults to `false`, so you have to set it explicitly. Otherwise Sentry registers its own tracer provider and you end up in setup 2 rather than this one.
+`enableOpenTelemetrySetup` already defaults to `false` on most server SDKs, so there is nothing to set. On `@sentry/nextjs` and `@sentry/sveltekit` it defaults to `true`, so you have to set it to `false` explicitly. Otherwise Sentry registers its own tracer provider and you end up in setup 2 rather than this one.
 
 OpenTelemetry owns spans end to end. Sentry captures errors and logs, and the Sentry `otlpIntegration()` attaches them to the active OpenTelemetry span so all your telemetry is connected in one trace. `getOtlpTracesEndpoint()` turns your DSN into the URL and auth headers for Sentry's OTLP endpoint, so you can point your own exporter at Sentry, at your own collector, or at both.
 
@@ -148,7 +148,7 @@ Sentry does not touch your pipeline: no exporter, no span processor, no tracer p
 
 Sentry instruments many of the same libraries OpenTelemetry does (Express, Postgres, Redis, Prisma, Kafka and so on), so enabling Sentry tracing on top of your own instrumentation gives you two spans for every operation. Leave `tracesSampleRate` in your `Sentry.init` unset to avoid duplicate spans. With tracing off, Sentry's instrumentation stays installed and keeps isolating requests, but emits no spans.
 
-Note that this changed since v10, where setting `skipOpenTelemetrySetup: true` also turned Sentry's HTTP and fetch spans off by default. Sentry now emits those whenever tracing is enabled, regardless of `skipOpenTelemetrySetup`.
+Note that this changed since v10, where setting `skipOpenTelemetrySetup: true` also turned Sentry's HTTP and fetch spans off by default. Sentry now emits those whenever tracing is enabled, regardless of `enableOpenTelemetrySetup`.
 
 If you do want Sentry spans alongside your own, keep `tracesSampleRate` set and drop the integrations that overlap. HTTP and fetch are the exception: turn off only their spans, because `httpIntegration` also provides request isolation, request data and session tracking:
 

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/v6/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/vercelai/v6/index.ts
@@ -13,7 +13,7 @@ export default Sentry.withSentry(
     tracesSampleRate: 1,
     // The Vercel AI SDK emits its spans through `@opentelemetry/api`, so they are only picked up when
     // the Cloudflare OpenTelemetry tracer provider is set up.
-    skipOpenTelemetrySetup: false,
+    enableOpenTelemetrySetup: true,
   }),
   {
     async fetch(_request, _env, _ctx) {

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/src/instrument.ts
@@ -12,5 +12,5 @@ Sentry.init({
   },
   // Opt into the Sentry OpenTelemetry tracer provider in the "(tracer provider)" e2e variant.
   // Leaving it `undefined` otherwise keeps the SDK's default (no provider).
-  skipOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? false : undefined,
+  enableOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? true : undefined,
 });

--- a/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/src/app.ts
@@ -16,7 +16,7 @@ Sentry.init({
   tracesSampleRate: 1,
   // Opt into the Sentry OpenTelemetry tracer provider in the "(tracer provider)" e2e variant.
   // Leaving it `undefined` otherwise keeps the SDK's default (no provider).
-  skipOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? false : undefined,
+  enableOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? true : undefined,
   integrations: [
     Sentry.nativeNodeFetchIntegration({
       headersToSpanAttributes: {

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/src/app.ts
@@ -40,7 +40,7 @@ Sentry.init({
   tracePropagationTargets: ['http://localhost:3030', '/external-allowed'],
   // Opt into the Sentry OpenTelemetry tracer provider in the "(tracer provider)" e2e variant.
   // Leaving it `undefined` otherwise keeps the SDK's default (no provider).
-  skipOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? false : undefined,
+  enableOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? true : undefined,
 });
 
 import type * as H from 'http';

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/sentry.server.config.ts
@@ -7,5 +7,5 @@ Sentry.init({
   tunnel: 'http://localhost:3031/', // proxy server
   // Opt into the Sentry OpenTelemetry tracer provider in the "(tracer provider)" e2e variant.
   // Leaving it `undefined` otherwise keeps the SDK's default (no provider).
-  skipOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? false : undefined,
+  enableOpenTelemetrySetup: process.env.E2E_TEST_OTEL_SETUP === 'true' ? true : undefined,
 });

--- a/dev-packages/node-integration-tests/suites/tracing/tracer-start-active-span-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tracer-start-active-span-error/instrument.mjs
@@ -8,5 +8,5 @@ Sentry.init({
   transport: loggingTransport,
   // This suite drives the raw OpenTelemetry tracer (`client.tracer.startActiveSpan`), which only
   // produces spans when Sentry owns the tracer provider.
-  skipOpenTelemetrySetup: false,
+  enableOpenTelemetrySetup: true,
 });

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -88,7 +88,7 @@ If you only use the Sentry SDK, day-to-day tracing remains **unchanged**.
 
 #### Choosing an OpenTelemetry setup
 
-There are three ways to run the Sentry and OpenTelemetry SDKs together, and which one you want depends on who should own spans. This is controlled by the existing `skipOpenTelemetrySetup` option, whose default was flipped in v11: it is now `true` for most server SDKs (including `@sentry/node`, `@sentry/bun`, the serverless SDKs and `@sentry/cloudflare`) and `false` for `@sentry/nextjs` and `@sentry/sveltekit`.
+There are three ways to run the Sentry and OpenTelemetry SDKs together, and which one you want depends on who should own spans. This is controlled by the new `enableOpenTelemetrySetup` option, which replaces v10's `skipOpenTelemetrySetup` with inverted meaning (`skipOpenTelemetrySetup: true` becomes `enableOpenTelemetrySetup: false`). It defaults to `false` for most server SDKs (including `@sentry/node`, `@sentry/bun`, the serverless SDKs and `@sentry/cloudflare`) and `true` for `@sentry/nextjs` and `@sentry/sveltekit`.
 
 ##### 1. Sentry only
 
@@ -105,13 +105,13 @@ If a library you depend on emits its own OpenTelemetry spans and you want those 
 
 ##### 2. OpenTelemetry-compatible mode, everything goes to Sentry
 
-Set `skipOpenTelemetrySetup: false`:
+Set `enableOpenTelemetrySetup: true`:
 
 ```js
 Sentry.init({
   dsn: '__DSN__',
   tracesSampleRate: 1.0,
-  skipOpenTelemetrySetup: false,
+  enableOpenTelemetrySetup: true,
 });
 ```
 
@@ -121,7 +121,7 @@ Spans go to Sentry. This is not a general OpenTelemetry pipeline: there is no ex
 
 ##### 3. Your own OpenTelemetry, Sentry linked to it
 
-Leave `skipOpenTelemetrySetup` unset or set it to `true`, turn Sentry tracing off, use your own OpenTelemetry setup, and add the Sentry `otlpIntegration()`:
+Leave `enableOpenTelemetrySetup` unset or set it to `false`, turn Sentry tracing off, use your own OpenTelemetry setup, and add the Sentry `otlpIntegration()`:
 
 ```js
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -142,7 +142,7 @@ Sentry.init({
 });
 ```
 
-`skipOpenTelemetrySetup` already defaults to `true` on most server SDKs, so there is nothing to set. On `@sentry/nextjs` and `@sentry/sveltekit` it defaults to `false`, so you have to set it explicitly. Otherwise Sentry registers its own tracer provider and you end up in setup 2 rather than this one.
+`enableOpenTelemetrySetup` already defaults to `false` on most server SDKs, so there is nothing to set. On `@sentry/nextjs` and `@sentry/sveltekit` it defaults to `true`, so you have to set it to `false` explicitly. Otherwise Sentry registers its own tracer provider and you end up in setup 2 rather than this one.
 
 OpenTelemetry owns spans end to end. Sentry captures errors and logs, and the Sentry `otlpIntegration()` attaches them to the active OpenTelemetry span so all your telemetry is connected in one trace. `getOtlpTracesEndpoint()` turns your DSN into the URL and auth headers for Sentry's OTLP endpoint, so you can point your own exporter at Sentry, at your own collector, or at both.
 
@@ -152,7 +152,7 @@ Sentry does not touch your pipeline: no exporter, no span processor, no tracer p
 
 Sentry instruments many of the same libraries OpenTelemetry does (Express, Postgres, Redis, Prisma, Kafka and so on), so enabling Sentry tracing on top of your own instrumentation gives you two spans for every operation. Leave `tracesSampleRate` in your `Sentry.init` unset to avoid duplicate spans. With tracing off, Sentry's instrumentation stays installed and keeps isolating requests, but emits no spans.
 
-Note that this changed since v10, where setting `skipOpenTelemetrySetup: true` also turned Sentry's HTTP and fetch spans off by default. Sentry now emits those whenever tracing is enabled, regardless of `skipOpenTelemetrySetup`.
+Note that this changed since v10, where setting `skipOpenTelemetrySetup: true` also turned Sentry's HTTP and fetch spans off by default. Sentry now emits those whenever tracing is enabled, regardless of `enableOpenTelemetrySetup`.
 
 If you do want Sentry spans alongside your own, keep `tracesSampleRate` set and drop the integrations that overlap. HTTP and fetch are the exception: turn off only their spans, because `httpIntegration` also provides request isolation, request data and session tracking:
 

--- a/packages/cloudflare/src/baseSdk.ts
+++ b/packages/cloudflare/src/baseSdk.ts
@@ -96,7 +96,7 @@ export function initWithDefaultIntegrations(
     transport: options.transport || makeCloudflareTransport,
     // Like most Node-based SDKs, Cloudflare defaults to running without a Sentry OpenTelemetry tracer
     // provider. Scope isolation is handled by the entrypoint wrappers' AsyncLocalStorage strategy.
-    skipOpenTelemetrySetup: options.skipOpenTelemetrySetup ?? true,
+    enableOpenTelemetrySetup: options.enableOpenTelemetrySetup ?? false,
     flushLock,
   };
 
@@ -110,9 +110,9 @@ export function initWithDefaultIntegrations(
   }
   /*! rollup-include-development-only-end */
 
-  // Opt-in only: when `skipOpenTelemetrySetup` is `false`, set up a custom trace provider so spans
+  // Opt-in only: when `enableOpenTelemetrySetup` is `true`, set up a custom trace provider so spans
   // emitted via `@opentelemetry/api` are captured by Sentry. See the option's docs for the caveats.
-  if (!clientOptions.skipOpenTelemetrySetup) {
+  if (clientOptions.enableOpenTelemetrySetup) {
     setupOpenTelemetryTracer();
   }
 

--- a/packages/cloudflare/src/client.ts
+++ b/packages/cloudflare/src/client.ts
@@ -175,17 +175,17 @@ interface BaseCloudflareOptions {
   enableDedupe?: boolean;
 
   /**
-   * The Cloudflare SDK is not OpenTelemetry native. By default (`true`) it does not set up a tracer
+   * The Cloudflare SDK is not OpenTelemetry native. By default (`false`) it does not set up a tracer
    * provider; spans are emitted via the SDK's own instrumentation and scopes are isolated with
    * AsyncLocalStorage.
    *
-   * Set this to `false` to opt into the OpenTelemetry compatibility tracer, which captures spans
+   * Set this to `true` to opt into the OpenTelemetry compatibility tracer, which captures spans
    * emitted via `@opentelemetry/api`. Big caveat: it does not handle custom context, always working
    * off the current scope. This is good enough for many, but not all, integrations.
    *
-   * @default true
+   * @default false
    */
-  skipOpenTelemetrySetup?: boolean;
+  enableOpenTelemetrySetup?: boolean;
 
   /**
    * Enable trace propagation for RPC calls between Workers, Durable Objects, and Service Bindings.

--- a/packages/cloudflare/test/opentelemetry.test.ts
+++ b/packages/cloudflare/test/opentelemetry.test.ts
@@ -10,14 +10,14 @@ describe('opentelemetry compatibility', () => {
     resetSdk();
   });
 
-  test('should not capture spans emitted via @opentelemetry/api when skipOpenTelemetrySetup is true', async () => {
+  test('should not capture spans emitted via @opentelemetry/api when enableOpenTelemetrySetup is false', async () => {
     const transactionEvents: TransactionEvent[] = [];
 
     const client = init({
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
       traceLifecycle: 'static',
-      skipOpenTelemetrySetup: true,
+      enableOpenTelemetrySetup: false,
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;
@@ -48,7 +48,7 @@ describe('opentelemetry compatibility', () => {
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
       traceLifecycle: 'static',
-      skipOpenTelemetrySetup: false,
+      enableOpenTelemetrySetup: true,
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;
@@ -110,7 +110,7 @@ describe('opentelemetry compatibility', () => {
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
       traceLifecycle: 'static',
-      skipOpenTelemetrySetup: false,
+      enableOpenTelemetrySetup: true,
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;
@@ -155,7 +155,7 @@ describe('opentelemetry compatibility', () => {
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
       traceLifecycle: 'static',
-      skipOpenTelemetrySetup: false,
+      enableOpenTelemetrySetup: true,
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;
@@ -184,7 +184,7 @@ describe('opentelemetry compatibility', () => {
       dsn: 'https://username@domain/123',
       tracesSampleRate: 1,
       traceLifecycle: 'static',
-      skipOpenTelemetrySetup: false,
+      enableOpenTelemetrySetup: true,
       beforeSendTransaction: event => {
         transactionEvents.push(event);
         return null;

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -162,7 +162,7 @@ export function init(options: DenoOptions = {}): Client {
 
   // Set up OpenTelemetry compatibility to capture spans from libraries using @opentelemetry/api
   // Note: This is separate from Deno's native OTEL support and doesn't capture auto-instrumented spans
-  if (!options.skipOpenTelemetrySetup) {
+  if (options.enableOpenTelemetrySetup ?? true) {
     setupOpenTelemetryTracer();
   }
 

--- a/packages/deno/src/types.ts
+++ b/packages/deno/src/types.ts
@@ -29,11 +29,11 @@ export interface BaseDenoOptions {
    * HOWEVER, big caveat: This does not handle custom context handling, it will always work off the current scope.
    * This should be good enough for many, but not all integrations.
    *
-   * If you want to opt-out of setting up the OpenTelemetry compatibility tracer, set this to `true`.
+   * If you want to opt-out of setting up the OpenTelemetry compatibility tracer, set this to `false`.
    *
-   * @default false
+   * @default true
    */
-  skipOpenTelemetrySetup?: boolean;
+  enableOpenTelemetrySetup?: boolean;
 
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(this: void, error: Error): void;

--- a/packages/deno/test/opentelemetry.test.ts
+++ b/packages/deno/test/opentelemetry.test.ts
@@ -22,7 +22,7 @@ function resetSdk(): void {
   cleanupOtel();
 }
 
-Deno.test('should not capture spans emitted via @opentelemetry/api when skipOpenTelemetrySetup is true', async () => {
+Deno.test('should not capture spans emitted via @opentelemetry/api when enableOpenTelemetrySetup is false', async () => {
   resetSdk();
   const transactionEvents: any[] = [];
 
@@ -30,7 +30,7 @@ Deno.test('should not capture spans emitted via @opentelemetry/api when skipOpen
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     traceLifecycle: 'static',
-    skipOpenTelemetrySetup: true,
+    enableOpenTelemetrySetup: false,
     beforeSendTransaction: event => {
       transactionEvents.push(event);
       return null;

--- a/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
+++ b/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
@@ -22,9 +22,12 @@ const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
  * 2. Requests to Sentry ingest (after rewrite) via fetch spans
  */
 export function dropMiddlewareTunnelRequests(span: Span, attrs: SpanAttributes | undefined): void {
-  // When the user brings their own OTel setup (skipOpenTelemetrySetup: true), we should not
+  // When the user brings their own OTel setup (enableOpenTelemetrySetup: false), we should not
   // mutate their spans with Sentry-internal attributes as it pollutes their tracing backends.
-  if ((getClient()?.getOptions() as { skipOpenTelemetrySetup?: boolean } | undefined)?.skipOpenTelemetrySetup) {
+  if (
+    (getClient()?.getOptions() as { enableOpenTelemetrySetup?: boolean } | undefined)?.enableOpenTelemetrySetup ===
+    false
+  ) {
     return;
   }
 

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -128,7 +128,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
   // Turn off Next.js' own fetch instrumentation (only when we manage OTEL)
   // https://github.com/lforst/nextjs-fork/blob/1994fd186defda77ad971c36dc3163db263c993f/packages/next/src/server/lib/patch-fetch.ts#L245
   // Enable with custom OTel setup: https://github.com/getsentry/sentry-javascript/issues/17581
-  if (!options.skipOpenTelemetrySetup) {
+  if (options.enableOpenTelemetrySetup ?? true) {
     process.env.NEXT_OTEL_FETCH_DISABLED = '1';
   }
 
@@ -148,7 +148,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
     defaultIntegrations: customDefaultIntegrations,
     // Next.js emits its own OpenTelemetry spans, so it defaults to registering the Sentry tracer
     // provider (unlike most Node-based SDKs). A user-provided value still overrides this via `...options`.
-    skipOpenTelemetrySetup: false,
+    enableOpenTelemetrySetup: true,
     ...options,
     // Override runtime to 'cloudflare' when running on OpenNext/Cloudflare
     ...cloudflareConfig,

--- a/packages/nextjs/test/utils/dropMiddlewareTunnelRequests.test.ts
+++ b/packages/nextjs/test/utils/dropMiddlewareTunnelRequests.test.ts
@@ -131,11 +131,11 @@ describe('dropMiddlewareTunnelRequests', () => {
     });
   });
 
-  describe('skipOpenTelemetrySetup', () => {
-    it('does not process spans when skipOpenTelemetrySetup is true', async () => {
+  describe('enableOpenTelemetrySetup', () => {
+    it('does not process spans when enableOpenTelemetrySetup is false', async () => {
       const core = await import('@sentry/core');
       vi.spyOn(core, 'getClient').mockReturnValueOnce({
-        getOptions: () => ({ skipOpenTelemetrySetup: true }),
+        getOptions: () => ({ enableOpenTelemetrySetup: false }),
       } as any);
 
       globalWithInjectedValues._sentryRewritesTunnelPath = '/monitoring';

--- a/packages/node/src/sdk/index.ts
+++ b/packages/node/src/sdk/index.ts
@@ -174,7 +174,7 @@ function _init(
   // AsyncLocalStorage strategy instead of the OpenTelemetry context strategy. Instrumentation still
   // emits spans via core `startSpan`; there is just no OTel provider or propagator behind them.
   let asyncLocalStorageLookup: ReturnType<typeof setOpenTelemetryContextAsyncContextStrategy> | undefined;
-  if (clientOptions.skipOpenTelemetrySetup) {
+  if (!clientOptions.enableOpenTelemetrySetup) {
     // The ALS store already is the `{ scope, isolationScope }` object, so no `contextSymbol` is needed
     // to reach it (unlike the OTel context strategy, where it is nested under the OTel context).
     const asyncLocalStorage = setAsyncLocalStorageAsyncContextStrategy();
@@ -229,7 +229,7 @@ function _init(
   // Add Node SDK specific OpenTelemetry setup. `setupEventContextTrace` reads the active span from the
   // OpenTelemetry context, so it only belongs here: without a Sentry tracer provider a foreign OTel
   // span could otherwise override the Sentry trace on error events.
-  if (!clientOptions.skipOpenTelemetrySetup) {
+  if (clientOptions.enableOpenTelemetrySetup) {
     setupEventContextTrace(client);
     initOpenTelemetry(client);
   }
@@ -266,8 +266,8 @@ function getClientOptions(
     spotlight,
     traceLifecycle,
     // Most Node-based SDKs default to running without a Sentry OpenTelemetry tracer provider. SDKs
-    // that need OTel spans surfaced in Sentry (nextjs, sveltekit) opt back in by passing `false`.
-    skipOpenTelemetrySetup: options.skipOpenTelemetrySetup ?? true,
+    // that need OTel spans surfaced in Sentry (nextjs, sveltekit) opt back in by passing `true`.
+    enableOpenTelemetrySetup: options.enableOpenTelemetrySetup ?? false,
     debug: envToBool(options.debug ?? process.env.SENTRY_DEBUG),
   };
 

--- a/packages/node/src/sdk/initOtel.ts
+++ b/packages/node/src/sdk/initOtel.ts
@@ -39,7 +39,7 @@ function registerGlobalTracerProvider(provider: TracerProvider): boolean {
   if (registry && !registry.trace) {
     DEBUG_BUILD &&
       coreDebug.warn(
-        'Replaced a pre-existing OpenTelemetry API registry that was created by a different @opentelemetry/api version and would have blocked tracing. If you want to manage OpenTelemetry yourself, set `skipOpenTelemetrySetup: true` in `Sentry.init()`.',
+        'Replaced a pre-existing OpenTelemetry API registry that was created by a different @opentelemetry/api version and would have blocked tracing. If you want to manage OpenTelemetry yourself, set `enableOpenTelemetrySetup: false` in `Sentry.init()`.',
       );
     otelGlobal[OTEL_API_GLOBAL_KEY] = undefined;
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -10,19 +10,19 @@ export interface OpenTelemetryServerRuntimeOptions extends ServerRuntimeOptions 
   /**
    * Controls whether the SDK registers its own Sentry OpenTelemetry tracer provider.
    *
-   * When `true` (the default for most SDKs), no tracer provider is set up. The SDK isolates scopes
+   * When `false` (the default for most SDKs), no tracer provider is set up. The SDK isolates scopes
    * with a native AsyncLocalStorage context strategy and still emits spans via its own
    * instrumentation, but spans created through `@opentelemetry/api` are not captured.
    *
-   * When `false`, the SDK registers its own `SentryTracerProvider` (and `SentryPropagator`) as the
+   * When `true`, the SDK registers its own `SentryTracerProvider` (and `SentryPropagator`) as the
    * global OpenTelemetry tracer provider, so spans created through `@opentelemetry/api` become Sentry
    * spans. This is the default for the Next.js and SvelteKit SDKs. If you run your own tracer provider,
-   * keep this `true` so the SDK does not register a competing provider; note the SDK no longer feeds
+   * keep this `false` so the SDK does not register a competing provider; note the SDK no longer feeds
    * spans into a user-owned provider, so those spans stay in your OpenTelemetry pipeline.
    *
-   * @default true
+   * @default false
    */
-  skipOpenTelemetrySetup?: boolean;
+  enableOpenTelemetrySetup?: boolean;
 }
 
 /**

--- a/packages/node/test/integration/eventContextTrace.test.ts
+++ b/packages/node/test/integration/eventContextTrace.test.ts
@@ -51,7 +51,7 @@ describe('setupEventContextTrace gating', () => {
     vi.spyOn(trace, 'getActiveSpan').mockReturnValue(foreignOtelSpan);
 
     const beforeSend = vi.fn(() => null);
-    mockSdkInit({ beforeSend, skipOpenTelemetrySetup: false });
+    mockSdkInit({ beforeSend, enableOpenTelemetrySetup: true });
     const client = Sentry.getClient() as NodeClient;
 
     const error = new Error('boom');

--- a/packages/node/test/integration/transactions.test.ts
+++ b/packages/node/test/integration/transactions.test.ts
@@ -23,7 +23,7 @@ describe('Integration | Transactions', () => {
       tracesSampleRate: 1,
       beforeSendTransaction,
       release: '8.0.0',
-      skipOpenTelemetrySetup: false,
+      enableOpenTelemetrySetup: true,
     });
 
     const client = Sentry.getClient()!;
@@ -299,7 +299,7 @@ describe('Integration | Transactions', () => {
   it('correctly creates concurrent transaction & spans when using native OTEL tracer', async () => {
     const beforeSendTransaction = vi.fn(() => null);
 
-    mockSdkInit({ tracesSampleRate: 1, beforeSendTransaction, skipOpenTelemetrySetup: false });
+    mockSdkInit({ tracesSampleRate: 1, beforeSendTransaction, enableOpenTelemetrySetup: true });
 
     const client = Sentry.getClient<Sentry.NodeClient>();
 
@@ -447,7 +447,7 @@ describe('Integration | Transactions', () => {
       traceFlags: TraceFlags.SAMPLED,
     };
 
-    mockSdkInit({ tracesSampleRate: 1, beforeSendTransaction, skipOpenTelemetrySetup: false });
+    mockSdkInit({ tracesSampleRate: 1, beforeSendTransaction, enableOpenTelemetrySetup: true });
 
     const client = Sentry.getClient()!;
 

--- a/packages/node/test/sdk/diagnosticsChannelInjection.test.ts
+++ b/packages/node/test/sdk/diagnosticsChannelInjection.test.ts
@@ -38,14 +38,14 @@ describe('diagnostics-channel injection default', () => {
   });
 
   it('registers the injection hooks and runs detection when span recording is enabled', () => {
-    init({ dsn: PUBLIC_DSN, tracesSampleRate: 1, skipOpenTelemetrySetup: true });
+    init({ dsn: PUBLIC_DSN, tracesSampleRate: 1, enableOpenTelemetrySetup: false });
 
     expect(registerDiagnosticsChannelInjection).toHaveBeenCalledTimes(1);
     expect(detectOrchestrionSetup).toHaveBeenCalledTimes(1);
   });
 
   it('does not register the injection hooks when tracing is disabled', () => {
-    init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
+    init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: false });
 
     expect(registerDiagnosticsChannelInjection).not.toHaveBeenCalled();
     expect(detectOrchestrionSetup).not.toHaveBeenCalled();

--- a/packages/node/test/sdk/init.test.ts
+++ b/packages/node/test/sdk/init.test.ts
@@ -220,7 +220,7 @@ describe('init()', () => {
     });
 
     it('allows to opt-in to OpenTelemetry setup', () => {
-      init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: false });
+      init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: true });
 
       const client = getClient<NodeClient>();
 
@@ -231,7 +231,7 @@ describe('init()', () => {
       const alsStrategySpy = vi.spyOn(SentryServerUtils, 'setAsyncLocalStorageAsyncContextStrategy');
       const otelStrategySpy = vi.spyOn(SentryOpentelemetry, 'setOpenTelemetryContextAsyncContextStrategy');
 
-      init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: false });
+      init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: true });
 
       expect(otelStrategySpy).toHaveBeenCalledTimes(1);
       expect(alsStrategySpy).not.toHaveBeenCalled();
@@ -250,7 +250,7 @@ describe('init()', () => {
         propagation: propagator,
       };
 
-      init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: false });
+      init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: true });
 
       const registry = global[OTEL_API_GLOBAL_KEY];
 
@@ -266,7 +266,7 @@ describe('init()', () => {
       const existingRegistry = { version: '0.0.1', trace: existingProvider };
       global[OTEL_API_GLOBAL_KEY] = existingRegistry;
 
-      init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: false });
+      init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: true });
 
       const client = getClient<NodeClient>();
 
@@ -279,7 +279,7 @@ describe('init()', () => {
   });
 
   it('returns initialized client', () => {
-    const client = init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
+    const client = init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: false });
 
     expect(client).toBeInstanceOf(NodeClient);
   });
@@ -290,7 +290,7 @@ describe('init()', () => {
 
     const baselineListeners = process.listeners('SIGTERM');
 
-    init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
+    init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: false });
 
     const postInitListeners = process.listeners('SIGTERM');
     const addedListeners = postInitListeners.filter(l => !baselineListeners.includes(l));
@@ -308,7 +308,7 @@ describe('init()', () => {
 
     const baselineListeners = process.listeners('SIGTERM');
 
-    const client = init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
+    const client = init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: false });
     expect(client).toBeInstanceOf(NodeClient);
 
     const flushSpy = vi.spyOn(client as NodeClient, 'flush').mockResolvedValue(true);
@@ -332,7 +332,7 @@ describe('init()', () => {
 
     const baselineListeners = process.listeners('SIGTERM');
 
-    init({ dsn: PUBLIC_DSN, skipOpenTelemetrySetup: true });
+    init({ dsn: PUBLIC_DSN, enableOpenTelemetrySetup: false });
 
     const postInitListeners = process.listeners('SIGTERM');
     const addedListeners = postInitListeners.filter(l => !baselineListeners.includes(l));

--- a/packages/sveltekit/src/server/sdk.ts
+++ b/packages/sveltekit/src/server/sdk.ts
@@ -21,7 +21,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
     defaultIntegrations,
     // SvelteKit emits its own OpenTelemetry spans, so it defaults to registering the Sentry tracer
     // provider (unlike most Node-based SDKs). A user-provided value still overrides this via `...options`.
-    skipOpenTelemetrySetup: false,
+    enableOpenTelemetrySetup: true,
     ...options,
   };
 

--- a/packages/sveltekit/src/worker/cloudflare.ts
+++ b/packages/sveltekit/src/worker/cloudflare.ts
@@ -25,7 +25,7 @@ export function initCloudflareSentryHandle(options: CloudflareOptions): Handle {
     // SvelteKit emits its own OpenTelemetry spans (Kit tracing), so — like the Node SvelteKit SDK — it
     // defaults to registering the tracer provider instead of inheriting Cloudflare's no-provider default.
     // A user-provided value still overrides this via `...options`.
-    skipOpenTelemetrySetup: false,
+    enableOpenTelemetrySetup: true,
     ...options,
   };
 

--- a/packages/sveltekit/test/worker/cloudflare.test.ts
+++ b/packages/sveltekit/test/worker/cloudflare.test.ts
@@ -55,7 +55,7 @@ describe('initCloudflareSentryHandle', () => {
       {
         // SvelteKit emits its own OpenTelemetry spans, so it opts into the tracer provider rather than
         // inheriting Cloudflare's no-provider default.
-        options: expect.objectContaining({ dsn: options.dsn, skipOpenTelemetrySetup: false }),
+        options: expect.objectContaining({ dsn: options.dsn, enableOpenTelemetrySetup: true }),
         request,
         context,
         captureErrors: false,

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -95,7 +95,7 @@ export function init(options: VercelEdgeOptions = {}): Client {
 
   // If users opt-out of this, they _have_ to set up OpenTelemetry themselves
   // There is no way to use this SDK without OpenTelemetry!
-  if (!options.skipOpenTelemetrySetup) {
+  if (options.enableOpenTelemetrySetup ?? true) {
     setupOtel(client);
   }
 

--- a/packages/vercel-edge/src/types.ts
+++ b/packages/vercel-edge/src/types.ts
@@ -41,12 +41,14 @@ export interface BaseVercelEdgeOptions {
   clientClass?: typeof VercelEdgeClient;
 
   /**
-   * If this is set to true, the SDK will not set up OpenTelemetry automatically.
+   * If this is set to false, the SDK will not set up OpenTelemetry automatically.
    * In this case, you _have_ to ensure to set it up correctly yourself, including:
    * * The `SentryTracerProvider`
    * * The `SentryPropagator`
+   *
+   * @default true
    */
-  skipOpenTelemetrySetup?: boolean;
+  enableOpenTelemetrySetup?: boolean;
 
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(this: void, error: Error): void;

--- a/packages/vercel-edge/test/sdk.test.ts
+++ b/packages/vercel-edge/test/sdk.test.ts
@@ -8,7 +8,7 @@ describe('getDefaultIntegrations', () => {
   });
 
   it('collects and filters request cookies by default', () => {
-    const client = init({ skipOpenTelemetrySetup: true });
+    const client = init({ enableOpenTelemetrySetup: false });
     const requestDataIntegration = getDefaultIntegrations().find(integration => integration.name === 'RequestData');
     const event: Event = {
       sdkProcessingMetadata: {
@@ -24,7 +24,7 @@ describe('getDefaultIntegrations', () => {
   });
 
   it('does not collect request cookies when dataCollection.cookies is disabled', () => {
-    const client = init({ dataCollection: { cookies: false }, skipOpenTelemetrySetup: true });
+    const client = init({ dataCollection: { cookies: false }, enableOpenTelemetrySetup: false });
     const requestDataIntegration = getDefaultIntegrations().find(integration => integration.name === 'RequestData');
     const event: Event = {
       sdkProcessingMetadata: {


### PR DESCRIPTION
## What

Replace the `skipOpenTelemetrySetup` option with `enableOpenTelemetrySetup: boolean` (inverted meaning, per-package behavior unchanged).

* `@sentry/node`, `@sentry/cloudflare`: defaults to `false` (no Sentry tracer provider)exit
* `@sentry/nextjs`, `@sentry/sveltekit`: pass `true` since they own OTel spans by default
* `@sentry/deno`, `@sentry/vercel-edge`: keep OTel setup on by default, so the flag defaults to `true` there
* Migration docs updated to document the rename; historical v8/v9 docs and changelog left untouched

## Why

Since v11 most server SDKs no longer set up OpenTelemetry by default, so the option is now an opt-in and a positive `enable` flag reads clearer than the double negative `skip: false`. The nextjs tunnel-drop check only bails on an explicit `false` so edge clients without the merged node default keep processing spans as before.