### PR TITLE
ref(core): Remove experimental flag from `ignoreSentryInternalFrames`

### DIFF
--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -612,12 +612,6 @@ Affected SDKs: All server-side SDKs.
 
 The LangGraph instrumentation no longer emits `gen_ai.create_agent` spans when a graph is compiled. `gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected. If you reference `create_agent` spans in dashboards or alerts, update them accordingly.
 
-### `thirdPartyErrorFilterIntegration` filters internal frames by default
-
-Affected SDKs: All SDKs.
-
-`ignoreSentryInternalFrames` is now the default behaviour for `thirdPartyErrorFilterIntegration`.
-
 ### Console breadcrumbs handled by `consoleIntegration`
 
 Affected SDKs: `@sentry/browser` and `@sentry/deno` (and their dependents).

--- a/packages/core/src/integrations/third-party-errors-filter.ts
+++ b/packages/core/src/integrations/third-party-errors-filter.ts
@@ -36,9 +36,12 @@ interface Options {
     | 'apply-tag-if-exclusively-contains-third-party-frames';
 
   /**
-   * @experimental
-   * If set to true, the integration will ignore frames that are internal to the Sentry SDK from the third-party frame detection.
-   * Note that enabling this option might lead to errors being misclassified as third-party errors.
+   * Whether frames that are internal to the Sentry SDK are excluded from the third-party frame detection.
+   *
+   * In minified bundles the SDK wrapper frame is detected heuristically, so an application frame can be
+   * mistaken for an SDK frame — with a `drop-*` behaviour, that error is dropped.
+   *
+   * @default false
    */
   ignoreSentryInternalFrames?: boolean;
 }
@@ -47,6 +50,8 @@ interface Options {
  * This integration allows you to filter out, or tag error events that do not come from user code marked with a bundle key via the Sentry bundler plugins.
  */
 export const thirdPartyErrorFilterIntegration = defineIntegration((options: Options) => {
+  const ignoreSentryInternalFrames = options.ignoreSentryInternalFrames ?? false;
+
   return {
     name: 'ThirdPartyErrorsFilter' as const,
     setup(client) {
@@ -79,7 +84,7 @@ export const thirdPartyErrorFilterIntegration = defineIntegration((options: Opti
       // Snapshot the depth counter onto the event before any event processors run.
       // This is necessary because async event processors could cause the finally block
       // in sentryWrapped to decrement the counter before processEvent reads it.
-      if (options.ignoreSentryInternalFrames && (GLOBAL_OBJ._sentryWrappedDepth ?? 0) > 0) {
+      if (ignoreSentryInternalFrames && (GLOBAL_OBJ._sentryWrappedDepth ?? 0) > 0) {
         event.sdkProcessingMetadata = {
           ...event.sdkProcessingMetadata,
           insideSentryWrapped: true,
@@ -88,14 +93,10 @@ export const thirdPartyErrorFilterIntegration = defineIntegration((options: Opti
     },
 
     processEvent(event) {
-      const insideSentryWrapped = options.ignoreSentryInternalFrames
+      const insideSentryWrapped = ignoreSentryInternalFrames
         ? event.sdkProcessingMetadata?.insideSentryWrapped === true && event.exception?.values?.length === 1
         : false;
-      const frameKeys = getBundleKeysForAllFramesWithFilenames(
-        event,
-        options.ignoreSentryInternalFrames,
-        insideSentryWrapped,
-      );
+      const frameKeys = getBundleKeysForAllFramesWithFilenames(event, ignoreSentryInternalFrames, insideSentryWrapped);
 
       if (frameKeys) {
         const arrayMethod =

--- a/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
+++ b/packages/core/test/lib/integrations/third-party-errors-filter.test.ts
@@ -362,7 +362,7 @@ describe('ThirdPartyErrorFilter', () => {
     });
   });
 
-  describe('experimentalExcludeSentryInternalFrames', () => {
+  describe('ignoreSentryInternalFrames', () => {
     describe('drop-error-if-exclusively-contains-third-party-frames', () => {
       it('drops event with only third-party + Sentry internal frames when option is enabled', async () => {
         const integration = thirdPartyErrorFilterIntegration({
@@ -404,12 +404,10 @@ describe('ThirdPartyErrorFilter', () => {
         const integration = thirdPartyErrorFilterIntegration({
           behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
           filterKeys: ['some-key'],
-          // experimentalExcludeSentryInternalFrames not set, should default to false
         });
 
         const event = clone(eventWithThirdPartyAndSentryInternalFrames);
         const result = await integration.processEvent?.(event, {}, MOCK_CLIENT);
-        // Should not drop because option defaults to false
         expect(result).toBeDefined();
       });
     });


### PR DESCRIPTION
Marks the `ignoreSentryInternalFrames` option of `thirdPartyErrorFilterIntegration` as stable and documents its default. No behaviour change.

We're keeping it opt-in for now until we get further signal on how it performs in the wild. Detecting the SDK wrapper frame in minified bundles is heuristic, so defaulting it on risks dropping first-party errors under a `drop-*` behaviour before we know how often that misfires.

closes getsentry/sentry-javascript#18634