### PR TITLE
fix(v10/core,browser): Handle errors from other realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by @Jxxunnn and @kamilogorek. Thank you for your contributions!
+Work in this release was contributed by @davidmurdoch, @Jxxunnn, and @kamilogorek. Thank you for your contributions!
 
 ## 10.69.0
 

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/cross-realm-error-cause/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/cross-realm-error-cause/subject.js
@@ -1,0 +1,15 @@
+const iframe = document.createElement('iframe');
+
+iframe.srcdoc = `
+  <script>
+    try {
+      throw new Error('iframe root error', {
+        cause: new Error('iframe cause error'),
+      });
+    } catch (error) {
+      parent.Sentry.captureException(error);
+    }
+  <\/script>
+`;
+
+document.body.appendChild(iframe);

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/cross-realm-error-cause/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/cross-realm-error-cause/test.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../utils/fixtures';
+import { envelopeRequestParser, waitForErrorRequestOnUrl } from '../../../../utils/helpers';
+
+sentryTest('captures causes from errors thrown in an iframe @firefox', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+  const req = await waitForErrorRequestOnUrl(page, url);
+  const eventData = envelopeRequestParser(req);
+
+  expect(eventData.exception?.values).toHaveLength(2);
+  expect(eventData.exception?.values).toEqual([
+    expect.objectContaining({
+      type: 'Error',
+      value: 'iframe cause error',
+      mechanism: {
+        exception_id: 1,
+        handled: true,
+        parent_id: 0,
+        source: 'cause',
+        type: 'chained',
+      },
+    }),
+    expect.objectContaining({
+      type: 'Error',
+      value: 'iframe root error',
+      mechanism: {
+        exception_id: 0,
+        handled: true,
+        type: 'generic',
+      },
+    }),
+  ]);
+});

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -410,5 +410,5 @@ function getObjectClassName(obj: unknown): string | undefined | void {
 
 /** If a plain object has a property that is an `Error`, return this error. */
 function getErrorPropertyFromObject(obj: Record<string, unknown>): Error | undefined {
-  return Object.values(obj).find((v): v is Error => v instanceof Error);
+  return Object.values(obj).find(isError);
 }

--- a/packages/browser/test/eventbuilder.test.ts
+++ b/packages/browser/test/eventbuilder.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 
+import { runInNewContext } from 'node:vm';
 import { addNonEnumerableProperty } from '@sentry/core/browser';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { defaultStackParser } from '../src';
@@ -138,6 +139,22 @@ describe('eventFromUnknownInput', () => {
         },
       },
     });
+  });
+
+  it('handles object with error prop created in another realm', () => {
+    const error = runInNewContext(`new Error('Some error')`) as Error;
+    expect(error).not.toBeInstanceOf(Error);
+
+    const event = eventFromUnknownInput(defaultStackParser, {
+      err: error,
+    });
+
+    expect(event.exception?.values?.[0]).toEqual(
+      expect.objectContaining({
+        type: 'Error',
+        value: 'Some error',
+      }),
+    );
   });
 
   it('handles class with error prop', () => {

--- a/packages/core/src/instrument/fetch.ts
+++ b/packages/core/src/instrument/fetch.ts
@@ -124,7 +124,8 @@ function instrumentFetch(onFetchResolved?: (response: Response) => void, skipNat
 
           if (
             shouldEnhance &&
-            error instanceof TypeError &&
+            isError(error) &&
+            error.name === 'TypeError' &&
             (error.message === 'Failed to fetch' ||
               error.message === 'Load failed' ||
               error.message === 'NetworkError when attempting to fetch resource.')

--- a/packages/core/src/utils/aggregate-errors.ts
+++ b/packages/core/src/utils/aggregate-errors.ts
@@ -2,7 +2,7 @@ import type { ExtendedError } from '../types/error';
 import type { Event, EventHint } from '../types/event';
 import type { Exception } from '../types/exception';
 import type { StackParser } from '../types/stacktrace';
-import { isInstanceOf } from './is';
+import { isError } from './is';
 
 /**
  * Creates exceptions inside `event.exception.values` for errors that are nested on properties based on the `key` parameter.
@@ -15,7 +15,7 @@ export function applyAggregateErrorsToEvent(
   event: Event,
   hint?: EventHint,
 ): void {
-  if (!event.exception?.values || !hint || !isInstanceOf(hint.originalException, Error)) {
+  if (!event.exception?.values || !hint || !isError(hint.originalException)) {
     return;
   }
 
@@ -55,7 +55,7 @@ function aggregateExceptionsFromError(
   let newExceptions = [...prevExceptions];
 
   // Recursively call this function in order to walk down a chain of errors
-  if (isInstanceOf(error[key], Error)) {
+  if (isError(error[key])) {
     applyExceptionGroupFieldsForParentException(exception, exceptionId, error);
     const newException = exceptionFromErrorImplementation(parser, error[key] as Error);
     const newExceptionId = newExceptions.length;
@@ -76,7 +76,7 @@ function aggregateExceptionsFromError(
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
   if (isExceptionGroup(error)) {
     error.errors.forEach((childError, i) => {
-      if (isInstanceOf(childError, Error)) {
+      if (isError(childError)) {
         applyExceptionGroupFieldsForParentException(exception, exceptionId, error);
         const newException = exceptionFromErrorImplementation(parser, childError as Error);
         const newExceptionId = newExceptions.length;

--- a/packages/core/src/utils/aggregate-errors.ts
+++ b/packages/core/src/utils/aggregate-errors.ts
@@ -57,7 +57,7 @@ function aggregateExceptionsFromError(
   // Recursively call this function in order to walk down a chain of errors
   if (isError(error[key])) {
     applyExceptionGroupFieldsForParentException(exception, exceptionId, error);
-    const newException = exceptionFromErrorImplementation(parser, error[key] as Error);
+    const newException = exceptionFromErrorImplementation(parser, error[key]);
     const newExceptionId = newExceptions.length;
     applyExceptionGroupFieldsForChildException(newException, key, newExceptionId, exceptionId);
     newExceptions = aggregateExceptionsFromError(
@@ -78,7 +78,7 @@ function aggregateExceptionsFromError(
     error.errors.forEach((childError, i) => {
       if (isError(childError)) {
         applyExceptionGroupFieldsForParentException(exception, exceptionId, error);
-        const newException = exceptionFromErrorImplementation(parser, childError as Error);
+        const newException = exceptionFromErrorImplementation(parser, childError);
         const newExceptionId = newExceptions.length;
         applyExceptionGroupFieldsForChildException(newException, `errors[${i}]`, newExceptionId, exceptionId);
         newExceptions = aggregateExceptionsFromError(

--- a/packages/core/src/utils/eventbuilder.ts
+++ b/packages/core/src/utils/eventbuilder.ts
@@ -63,7 +63,7 @@ function getErrorPropertyFromObject(obj: Record<string, unknown>): Error | undef
   for (const prop in obj) {
     if (Object.prototype.hasOwnProperty.call(obj, prop)) {
       const value = obj[prop];
-      if (value instanceof Error) {
+      if (isError(value)) {
         return value;
       }
     }

--- a/packages/core/test/lib/instrument/fetch.test.ts
+++ b/packages/core/test/lib/instrument/fetch.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { runInNewContext } from 'node:vm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { parseFetchArgs } from '../../../src/instrument/fetch';
+import { GLOBAL_OBJ } from '../../../src/utils/worldwide';
 
 describe('instrument > parseFetchArgs', () => {
   it.each([
@@ -51,5 +53,45 @@ describe('instrument > parseFetchArgs', () => {
 
       expect(actual).toEqual(expected);
     });
+  });
+});
+
+describe('instrument > addFetchInstrumentationHandler', () => {
+  const globalWithFetch = GLOBAL_OBJ as typeof GLOBAL_OBJ & { fetch?: (...args: unknown[]) => unknown };
+  const originalFetchDescriptor = Object.getOwnPropertyDescriptor(globalWithFetch, 'fetch');
+
+  // `maybeInstrument` patches the global `fetch` only once per module instance, so each test needs a
+  // fresh copy of the instrumentation modules - otherwise only the first one actually wraps `fetch`.
+  async function loadFetchModule() {
+    vi.resetModules();
+    return import('../../../src/instrument/fetch');
+  }
+
+  let addFetchInstrumentationHandler: Awaited<ReturnType<typeof loadFetchModule>>['addFetchInstrumentationHandler'];
+
+  beforeEach(async () => {
+    ({ addFetchInstrumentationHandler } = await loadFetchModule());
+  });
+
+  afterEach(() => {
+    if (originalFetchDescriptor) {
+      Object.defineProperty(globalWithFetch, 'fetch', originalFetchDescriptor);
+    } else {
+      Reflect.deleteProperty(globalWithFetch, 'fetch');
+    }
+
+    vi.restoreAllMocks();
+  });
+
+  it('enhances a fetch TypeError created in another realm', async () => {
+    const error = runInNewContext(`new TypeError('Failed to fetch')`) as TypeError;
+    expect(error).not.toBeInstanceOf(TypeError);
+
+    globalThis.fetch = vi.fn<typeof fetch>().mockRejectedValue(error);
+    addFetchInstrumentationHandler(() => undefined);
+
+    await expect(globalThis.fetch('https://example.com/path')).rejects.toBe(error);
+
+    expect(error.message).toBe('Failed to fetch (example.com)');
   });
 });

--- a/packages/core/test/lib/utils/aggregate-errors.test.ts
+++ b/packages/core/test/lib/utils/aggregate-errors.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'node:vm';
 import { describe, expect, test } from 'vitest';
 import type { ExtendedError } from '../../../src/types/error';
 import type { Event, EventHint } from '../../../src/types/event';
@@ -113,6 +114,24 @@ describe('applyAggregateErrorsToEvent()', () => {
         ],
       },
     });
+  });
+
+  test('recursively walks errors created in another realm', () => {
+    const originalException = runInNewContext(
+      `new AggregateError([new Error('Aggregate child')], 'Root Error', { cause: new Error('Cause') })`,
+    ) as ExtendedError;
+    expect(originalException).not.toBeInstanceOf(Error);
+
+    const event: Event = { exception: { values: [exceptionFromError(stackParser, originalException)] } };
+    const eventHint: EventHint = { originalException };
+
+    applyAggregateErrorsToEvent(exceptionFromError, stackParser, 'cause', 100, event, eventHint);
+
+    expect(event.exception?.values?.map(exception => exception.value)).toStrictEqual([
+      'Aggregate child',
+      'Cause',
+      'Root Error',
+    ]);
   });
 
   test('should not modify event if there are no attached errors', () => {

--- a/packages/core/test/lib/utils/eventbuilder.test.ts
+++ b/packages/core/test/lib/utils/eventbuilder.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from 'node:vm';
 import { describe, expect, it, test } from 'vitest';
 import type { Client } from '../../../src/client';
 import { eventFromMessage, eventFromUnknownInput, exceptionFromError } from '../../../src/utils/eventbuilder';
@@ -104,6 +105,22 @@ describe('eventFromUnknownInput', () => {
         },
       },
     });
+  });
+
+  test('object with error prop created in another realm', () => {
+    const error = runInNewContext(`new Error('Some error')`) as Error;
+    expect(error).not.toBeInstanceOf(Error);
+
+    const event = eventFromUnknownInput(fakeClient, stackParser, {
+      err: error,
+    });
+
+    expect(event.exception?.values?.[0]).toEqual(
+      expect.objectContaining({
+        type: 'Error',
+        value: 'Some error',
+      }),
+    );
   });
 
   it('handles class with error prop', () => {


### PR DESCRIPTION
Backport of: #22926

the code paths changed a bit from `develop` but the change (replacing an `instanceof` with the more lenient `isError` checks) is the same.