### PR TITLE
feat(browser): Add shim for metrics

### DIFF
--- a/packages/integration-shims/src/index.ts
+++ b/packages/integration-shims/src/index.ts
@@ -4,5 +4,6 @@ export { browserTracingIntegrationShim } from './BrowserTracing';
 export { launchDarklyIntegrationShim, buildLaunchDarklyFlagUsedHandlerShim } from './launchDarkly';
 export { elementTimingIntegrationShim } from './ElementTiming';
 export { loggerShim, consoleLoggingIntegrationShim } from './logs';
+export { metricsShim } from './metrics';
 export { spanStreamingIntegrationShim } from './SpanStreaming';
 export { fetchStreamPerformanceIntegrationShim } from './FetchStreamPerformance';

--- a/packages/integration-shims/src/metrics.ts
+++ b/packages/integration-shims/src/metrics.ts
@@ -1,0 +1,21 @@
+import { consoleSandbox } from '@sentry/core/browser';
+import { DEBUG_BUILD } from './debug-build';
+
+/**
+ * This is a shim for the metrics namespace.
+ * It is needed in order for the CDN bundles to continue working when users add/remove metrics
+ * from it, without changing their config. This is necessary for the loader mechanism.
+ */
+function metricShim(_name: unknown, _value?: unknown, _options?: unknown): void {
+  DEBUG_BUILD &&
+    consoleSandbox(() => {
+      // eslint-disable-next-line no-console
+      console.warn('You are using Sentry.metrics.* even though this bundle does not include metrics.');
+    });
+}
+
+export const metricsShim = {
+  count: metricShim,
+  gauge: metricShim,
+  distribution: metricShim,
+};

--- a/packages/integration-shims/test/metrics.test.ts
+++ b/packages/integration-shims/test/metrics.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mockDebugBuild = true;
+
+vi.mock('../src/debug-build', () => ({
+  get DEBUG_BUILD() {
+    return mockDebugBuild;
+  },
+}));
+
+// Must import after mocking
+const { metricsShim } = await import('../src/metrics');
+
+describe('metrics shims', () => {
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleWarnSpy.mockClear();
+  });
+
+  afterEach(() => {
+    mockDebugBuild = true;
+  });
+
+  describe('when DEBUG_BUILD is true', () => {
+    beforeEach(() => {
+      mockDebugBuild = true;
+    });
+
+    it.each(['count', 'gauge', 'distribution'] as const)('metricsShim.%s should warn', method => {
+      metricsShim[method]('test', 1);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'You are using Sentry.metrics.* even though this bundle does not include metrics.',
+      );
+    });
+  });
+
+  describe('when DEBUG_BUILD is false', () => {
+    beforeEach(() => {
+      mockDebugBuild = false;
+    });
+
+    it('metricsShim methods should NOT warn', () => {
+      metricsShim.count('test', 1);
+      metricsShim.gauge('test', 1);
+      metricsShim.distribution('test', 1);
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Adds a `metricsShim` to `@sentry-internal/integration-shims`, mirroring the existing logs shim.

It will be exported as `metrics` from the CDN bundles that don't ship metrics, so the loader can swap bundles without `Sentry.metrics.*` calls throwing. Not wired into any bundle yet — no behavior change in this PR.

Ref #18583