### PR TITLE
ref(node): Stop tracing `messages.countTokens` in Anthropic AI

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
@@ -6,12 +6,6 @@ function startMockAnthropicServer() {
   const app = express();
   app.use(express.json());
 
-  app.post('/anthropic/v1/messages/count_tokens', (req, res) => {
-    res.send({
-      input_tokens: 15,
-    });
-  });
-
   app.get('/anthropic/v1/models/:model', (req, res) => {
     res.send({
       id: req.params.model,
@@ -133,16 +127,10 @@ async function run() {
       // Error is expected and handled
     }
 
-    // Third test: count tokens with cached tokens
-    await client.messages.countTokens({
-      model: 'claude-3-haiku-20240307',
-      messages: [{ role: 'user', content: 'What is the capital of France?' }],
-    });
-
-    // Fourth test: models.retrieve
+    // Third test: models.retrieve
     await client.models.retrieve('claude-3-haiku-20240307');
 
-    // Fifth test: streaming via messages.create
+    // Fourth test: streaming via messages.create
     const stream = await client.messages.create({
       model: 'claude-3-haiku-20240307',
       messages: [{ role: 'user', content: 'What is the capital of France?' }],
@@ -153,7 +141,7 @@ async function run() {
       void _;
     }
 
-    // Sixth test: streaming via messages.stream
+    // Fifth test: streaming via messages.stream
     await client.messages
       .stream({
         model: 'claude-3-haiku-20240307',

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
@@ -104,7 +104,7 @@ describe('Anthropic integration', () => {
         .expect({ transaction: expectModelsSpanOnTransaction })
         .expect({
           span: container => {
-            expect(container.items).toHaveLength(4);
+            expect(container.items).toHaveLength(3);
             const completionSpan = container.items.find(
               span => span.attributes[GEN_AI_RESPONSE_ID]?.value === 'msg_mock123',
             );
@@ -115,15 +115,6 @@ describe('Anthropic integration', () => {
             const errorSpan = container.items.find(span => span.name === 'chat error-model');
             expect(errorSpan).toBeDefined();
             expect(errorSpan!.status).toBe('error');
-
-            const tokenCountingSpan = container.items.find(
-              span =>
-                span.name === 'chat claude-3-haiku-20240307' &&
-                span.status === 'ok' &&
-                span.attributes[GEN_AI_RESPONSE_ID] === undefined,
-            );
-            expect(tokenCountingSpan).toBeDefined();
-            expect(tokenCountingSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
 
             const streamingSpan = container.items.find(
               span => span.attributes[GEN_AI_RESPONSE_ID]?.value === 'msg_stream123',
@@ -154,7 +145,7 @@ describe('Anthropic integration', () => {
         .expect({ transaction: expectModelsSpanOnTransaction })
         .expect({
           span: container => {
-            expect(container.items).toHaveLength(4);
+            expect(container.items).toHaveLength(3);
             const completionSpan = container.items.find(
               span => span.attributes[GEN_AI_RESPONSE_ID]?.value === 'msg_mock123',
             );
@@ -185,14 +176,6 @@ describe('Anthropic integration', () => {
             expect(errorSpan!.name).toBe('chat error-model');
             expect(errorSpan!.status).toBe('error');
             expect(errorSpan!.attributes[GEN_AI_REQUEST_MODEL].value).toBe('error-model');
-
-            const tokenCountingSpan = container.items.find(
-              span => span.attributes[GEN_AI_RESPONSE_TEXT]?.value === '15',
-            );
-            expect(tokenCountingSpan).toBeDefined();
-            expect(tokenCountingSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(tokenCountingSpan!.status).toBe('ok');
-            expect(tokenCountingSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
 
             // TODO: messages.stream() should produce its own distinct gen_ai span, but it
             // currently does not (pre-existing bug). Once fixed, add an additional indexed span assertion.
@@ -245,7 +228,7 @@ describe('Anthropic integration', () => {
         })
         .expect({
           span: container => {
-            expect(container.items).toHaveLength(4);
+            expect(container.items).toHaveLength(3);
             const completionSpan = container.items.find(
               span => span.attributes[GEN_AI_RESPONSE_ID]?.value === 'msg_mock123',
             );
@@ -260,15 +243,6 @@ describe('Anthropic integration', () => {
             expect(errorSpan).toBeDefined();
             expect(errorSpan!.status).toBe('error');
             expect(errorSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-
-            const tokenCountingSpan = container.items.find(
-              span => span.attributes[GEN_AI_RESPONSE_TEXT]?.value === '15',
-            );
-            expect(tokenCountingSpan).toBeDefined();
-            expect(tokenCountingSpan!.name).toBe('chat claude-3-haiku-20240307');
-            expect(tokenCountingSpan!.status).toBe('ok');
-            expect(tokenCountingSpan!.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(tokenCountingSpan!.attributes[GEN_AI_OPERATION_NAME].value).toBe('chat');
 
             const streamingSpan = container.items.find(
               span => span.attributes[GEN_AI_RESPONSE_ID]?.value === 'msg_stream123',

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -612,7 +612,7 @@ Affected SDKs: All server-side SDKs.
 
 AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as:
 
-- Anthropic `messages.countTokens` (pre-flight token counting).
+- Anthropic `messages.countTokens` (token counting).
 - LangGraph `gen_ai.create_agent` on graph compilation (`gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected).
 
 If you reference these spans in dashboards or alerts, update them accordingly.

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -612,6 +612,12 @@ Affected SDKs: All server-side SDKs.
 
 The LangGraph instrumentation no longer emits `gen_ai.create_agent` spans when a graph is compiled. `gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected. If you reference `create_agent` spans in dashboards or alerts, update them accordingly.
 
+### AI integrations no longer trace non-inference operations
+
+Affected SDKs: All server-side SDKs.
+
+AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as pre-flight token counting. The Anthropic integration no longer emits a span for `messages.countTokens`. If you reference these spans in dashboards or alerts, update them accordingly.
+
 ### `thirdPartyErrorFilterIntegration` filters internal frames by default
 
 Affected SDKs: All SDKs.

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -610,10 +610,10 @@ These changes are not caught by TypeScript. If you filter, group, or alert on sp
 
 Affected SDKs: All server-side SDKs.
 
-AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as pre-flight token counting or graph compilation:
+AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as:
 
-- The Anthropic integration no longer emits a span for `messages.countTokens`.
-- The LangGraph integration no longer emits `gen_ai.create_agent` spans when a graph is compiled (`gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected).
+- Anthropic `messages.countTokens` (pre-flight token counting).
+- LangGraph `gen_ai.create_agent` on graph compilation (`gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected).
 
 If you reference these spans in dashboards or alerts, update them accordingly.
 

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -612,7 +612,7 @@ Affected SDKs: All server-side SDKs.
 
 AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as:
 
-- Anthropic `messages.countTokens` (token counting).
+- Anthropic `messages.countTokens`.
 - LangGraph `gen_ai.create_agent` on graph compilation (`gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected).
 
 If you reference these spans in dashboards or alerts, update them accordingly.

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -606,17 +606,16 @@ These changes are not caught by TypeScript. If you filter, group, or alert on sp
 | `browser.TLS/SSL`               | `browser.tls_ssl`                  |
 | `browser.DNS`                   | `browser.dns`                      |
 
-### LangGraph no longer emits `create_agent` spans
-
-Affected SDKs: All server-side SDKs.
-
-The LangGraph instrumentation no longer emits `gen_ai.create_agent` spans when a graph is compiled. `gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected. If you reference `create_agent` spans in dashboards or alerts, update them accordingly.
-
 ### AI integrations no longer trace non-inference operations
 
 Affected SDKs: All server-side SDKs.
 
-AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as pre-flight token counting. The Anthropic integration no longer emits a span for `messages.countTokens`. If you reference these spans in dashboards or alerts, update them accordingly.
+AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as pre-flight token counting or graph compilation:
+
+- The Anthropic integration no longer emits a span for `messages.countTokens`.
+- The LangGraph integration no longer emits `gen_ai.create_agent` spans when a graph is compiled (`gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected).
+
+If you reference these spans in dashboards or alerts, update them accordingly.
 
 ### `thirdPartyErrorFilterIntegration` filters internal frames by default
 

--- a/packages/server-utils/src/ai/anthropic-ai/constants.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/constants.ts
@@ -7,7 +7,6 @@ export const ANTHROPIC_AI_INTEGRATION_NAME = 'Anthropic_AI' as const;
 export const ANTHROPIC_METHOD_REGISTRY = {
   'messages.create': { operation: 'chat' },
   'messages.stream': { operation: 'chat', streaming: true },
-  'messages.countTokens': { operation: 'chat' },
   'models.get': { operation: 'models' },
   'completions.create': { operation: 'chat' },
   'models.retrieve': { operation: 'models' },

--- a/packages/server-utils/src/ai/anthropic-ai/index.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/index.ts
@@ -125,10 +125,6 @@ function addContentAttributes(span: Span, response: AnthropicAiResponse): void {
   if ('completion' in response) {
     span.setAttributes({ [GEN_AI_RESPONSE_TEXT]: response.completion });
   }
-  // Models.countTokens
-  if ('input_tokens' in response) {
-    span.setAttributes({ [GEN_AI_RESPONSE_TEXT]: JSON.stringify(response.input_tokens) });
-  }
 }
 
 /**

--- a/packages/server-utils/src/ai/anthropic-ai/types.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/types.ts
@@ -46,7 +46,6 @@ type SuccessfulResponse = {
   messages?: Array<Message>;
   content?: string | Array<ContentBlock>; // Available for Messages.create
   completion?: string; // Available for Completions.create
-  input_tokens?: number; // Available for Models.countTokens
   usage?: {
     input_tokens: number;
     output_tokens: number;
@@ -65,7 +64,6 @@ export type AnthropicAiResponse = SuccessfulResponse | MessageError;
 export interface AnthropicAiClient {
   messages?: {
     create: (...args: unknown[]) => Promise<AnthropicAiResponse>;
-    countTokens: (...args: unknown[]) => Promise<AnthropicAiResponse>;
   };
   models?: {
     list: (...args: unknown[]) => Promise<AnthropicAiResponse>;

--- a/packages/server-utils/src/orchestrion/config/anthropic-ai.ts
+++ b/packages/server-utils/src/orchestrion/config/anthropic-ai.ts
@@ -3,13 +3,11 @@ import { getModuleNames } from './module-names';
 
 export const anthropicAiConfig = [
   // One entry each for CJS/ESM
-  ...['resources/messages/messages.js', 'resources/messages/messages.mjs'].flatMap(filePath =>
-    (['create', 'countTokens'] as const).map(methodName => ({
-      channelName: 'chat',
-      module: { name: '@anthropic-ai/sdk', versionRange: '>=0.19.2 <1', filePath },
-      functionQuery: { className: 'Messages', methodName, kind: 'Auto' as const },
-    })),
-  ),
+  ...['resources/messages/messages.js', 'resources/messages/messages.mjs'].map(filePath => ({
+    channelName: 'chat',
+    module: { name: '@anthropic-ai/sdk', versionRange: '>=0.19.2 <1', filePath },
+    functionQuery: { className: 'Messages', methodName: 'create', kind: 'Auto' as const },
+  })),
   ...['resources/completions.js', 'resources/completions.mjs'].map(filePath => ({
     channelName: 'chat',
     module: { name: '@anthropic-ai/sdk', versionRange: '>=0.19.2 <1', filePath },


### PR DESCRIPTION
`messages.countTokens` only counts tokens and runs no model inference, so the Anthropic integration no longer emits a span for it.

Fixes getsentry/sentry-javascript#23148