### PR TITLE
ref(node): Stop tracing `models.retrieve` / `models.get` in Anthropic AI

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-errors.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-errors.mjs
@@ -27,17 +27,6 @@ function startMockAnthropicServer() {
     });
   });
 
-  app.get('/anthropic/v1/models/:model', (req, res) => {
-    if (req.params.model === 'nonexistent-model') {
-      res
-        .status(404)
-        .set('x-request-id', 'mock-model-retrieval-error')
-        .send({ type: 'error', error: { type: 'not_found_error', message: 'Model not found' } });
-      return;
-    }
-    res.send({ id: req.params.model, name: req.params.model, created_at: 1715145600, model: req.params.model });
-  });
-
   return new Promise(resolve => {
     const server = app.listen(0, () => {
       resolve(server);
@@ -72,14 +61,7 @@ async function run() {
       // Error expected
     }
 
-    // 2. Model retrieval error
-    try {
-      await client.models.retrieve('nonexistent-model');
-    } catch {
-      // Error expected
-    }
-
-    // 3. Successful tool usage for comparison
+    // 2. Successful tool usage for comparison
     await client.messages.create({
       model: 'claude-3-haiku-20240307',
       messages: [{ role: 'user', content: 'Calculate 2+2' }],

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario.mjs
@@ -6,15 +6,6 @@ function startMockAnthropicServer() {
   const app = express();
   app.use(express.json());
 
-  app.get('/anthropic/v1/models/:model', (req, res) => {
-    res.send({
-      id: req.params.model,
-      name: req.params.model,
-      created_at: 1715145600,
-      model: req.params.model,
-    });
-  });
-
   app.post('/anthropic/v1/messages', (req, res) => {
     const model = req.body.model;
 
@@ -127,10 +118,7 @@ async function run() {
       // Error is expected and handled
     }
 
-    // Third test: models.retrieve
-    await client.models.retrieve('claude-3-haiku-20240307');
-
-    // Fourth test: streaming via messages.create
+    // Third test: streaming via messages.create
     const stream = await client.messages.create({
       model: 'claude-3-haiku-20240307',
       messages: [{ role: 'user', content: 'What is the capital of France?' }],
@@ -141,7 +129,7 @@ async function run() {
       void _;
     }
 
-    // Fifth test: streaming via messages.stream
+    // Fourth test: streaming via messages.stream
     await client.messages
       .stream({
         model: 'claude-3-haiku-20240307',

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
@@ -1,5 +1,4 @@
 import { afterAll, describe, expect } from 'vitest';
-import type { TransactionEvent } from '@sentry/core';
 import {
   GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
@@ -27,16 +26,6 @@ describe('Anthropic integration', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
-
-  // `models.retrieve` reports a generic `function` op (model retrieval is not an inference call), so it is
-  // delivered as a plain transaction span rather than extracted into the gen_ai span container.
-  const expectModelsSpanOnTransaction = (event: TransactionEvent): void => {
-    expect(event.transaction).toBe('main');
-    const modelsSpan = (event.spans ?? []).find(span => span.description === 'models claude-3-haiku-20240307');
-    expect(modelsSpan).toBeDefined();
-    expect(modelsSpan!.op).toBe('function');
-    expect(modelsSpan!.status).toBe('ok');
-  };
 
   const EXPECTED_MODEL_ERROR = {
     exception: {
@@ -101,7 +90,7 @@ describe('Anthropic integration', () => {
       }
 
       await runner
-        .expect({ transaction: expectModelsSpanOnTransaction })
+        .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
@@ -142,7 +131,7 @@ describe('Anthropic integration', () => {
       }
 
       await runner
-        .expect({ transaction: expectModelsSpanOnTransaction })
+        .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
@@ -212,20 +201,7 @@ describe('Anthropic integration', () => {
       }
 
       await runner
-        .expect({
-          transaction: event => {
-            expect(event.transaction).toBe('main');
-            const modelsSpan = (event.spans ?? []).find(span => span.description === 'models claude-3-haiku-20240307');
-            expect(modelsSpan).toBeDefined();
-            expect(modelsSpan!.op).toBe('function');
-            expect(modelsSpan!.status).toBe('ok');
-            expect(modelsSpan!.data[GEN_AI_OPERATION_NAME]).toBe('models');
-            expect(modelsSpan!.data[GEN_AI_PROVIDER_NAME]).toBe('anthropic');
-            expect(modelsSpan!.data[GEN_AI_REQUEST_MODEL]).toBe('claude-3-haiku-20240307');
-            expect(modelsSpan!.data[GEN_AI_RESPONSE_ID]).toBe('claude-3-haiku-20240307');
-            expect(modelsSpan!.data[GEN_AI_RESPONSE_MODEL]).toBe('claude-3-haiku-20240307');
-          },
-        })
+        .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
             expect(container.items).toHaveLength(3);
@@ -523,19 +499,10 @@ describe('Anthropic integration', () => {
   });
 
   createEsmAndCjsTests(__dirname, 'scenario-errors.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
-    test('handles tool errors and model retrieval errors correctly', async () => {
+    test('handles tool errors correctly', async () => {
       await createRunner()
         .ignore('event')
-        .expect({
-          transaction: event => {
-            expect(event.transaction).toBe('main');
-            const modelErrorSpan = (event.spans ?? []).find(span => span.description === 'models nonexistent-model');
-            expect(modelErrorSpan).toBeDefined();
-            expect(modelErrorSpan!.op).toBe('function');
-            expect(modelErrorSpan!.status).toBe('internal_error');
-            expect(modelErrorSpan!.data[GEN_AI_REQUEST_MODEL]).toBe('nonexistent-model');
-          },
-        })
+        .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
             expect(container.items).toHaveLength(2);

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -612,7 +612,7 @@ Affected SDKs: All server-side SDKs.
 
 AI integrations now only trace model invocations, tool calls, and agent invocations. Spans are no longer emitted for operations that don't run model inference, such as:
 
-- Anthropic `messages.countTokens`.
+- Anthropic `messages.countTokens`, `models.retrieve`, and `models.get`.
 - LangGraph `gen_ai.create_agent` on graph compilation (`gen_ai.invoke_agent` and `gen_ai.execute_tool` spans are unaffected).
 
 If you reference these spans in dashboards or alerts, update them accordingly.

--- a/packages/server-utils/src/ai/anthropic-ai/constants.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/constants.ts
@@ -3,12 +3,9 @@ import type { InstrumentedMethodRegistry } from '../core/utils';
 export const ANTHROPIC_AI_INTEGRATION_NAME = 'Anthropic_AI' as const;
 
 // https://docs.anthropic.com/en/api/messages
-// https://docs.anthropic.com/en/api/models-list
 export const ANTHROPIC_METHOD_REGISTRY = {
   'messages.create': { operation: 'chat' },
   'messages.stream': { operation: 'chat', streaming: true },
-  'models.get': { operation: 'models' },
   'completions.create': { operation: 'chat' },
-  'models.retrieve': { operation: 'models' },
   'beta.messages.create': { operation: 'chat' },
 } as const satisfies InstrumentedMethodRegistry;

--- a/packages/server-utils/src/ai/anthropic-ai/index.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/index.ts
@@ -48,11 +48,7 @@ const INSTRUMENTED_METHODS = new WeakSet<object>();
 /**
  * Extract request attributes from method arguments
  */
-export function extractRequestAttributes(
-  args: unknown[],
-  methodPath: string,
-  operationName: string,
-): Record<string, unknown> {
+export function extractRequestAttributes(args: unknown[], operationName: string): Record<string, unknown> {
   const attributes: Record<string, unknown> = {
     [GEN_AI_PROVIDER_NAME]: 'anthropic',
     [GEN_AI_OPERATION_NAME]: operationName,
@@ -72,9 +68,6 @@ export function extractRequestAttributes(
     if ('top_k' in params) attributes[GEN_AI_REQUEST_TOP_K] = params.top_k;
     if ('frequency_penalty' in params) attributes[GEN_AI_REQUEST_FREQUENCY_PENALTY] = params.frequency_penalty;
     if ('max_tokens' in params) attributes[GEN_AI_REQUEST_MAX_TOKENS] = params.max_tokens;
-  } else if (methodPath === 'models.retrieve' || methodPath === 'models.get') {
-    // `models.retrieve(model-id)` / `models.get(model-id)` pass the model id as a positional arg
-    attributes[GEN_AI_REQUEST_MODEL] = args[0];
   } else {
     attributes[GEN_AI_REQUEST_MODEL] = 'unknown';
   }
@@ -283,7 +276,7 @@ function instrumentMethod<T extends unknown[], R>(
       }
 
       const operationName = instrumentedMethod.operation || 'unknown';
-      const requestAttributes = extractRequestAttributes(args, methodPath, operationName);
+      const requestAttributes = extractRequestAttributes(args, operationName);
       const model = requestAttributes[GEN_AI_REQUEST_MODEL] ?? 'unknown';
 
       const params = typeof args[0] === 'object' ? (args[0] as Record<string, unknown>) : undefined;

--- a/packages/server-utils/src/ai/anthropic-ai/types.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/types.ts
@@ -42,7 +42,6 @@ type SuccessfulResponse = {
   id: string;
   model: string;
   created?: number;
-  created_at?: number; // Available for Models.retrieve
   messages?: Array<Message>;
   content?: string | Array<ContentBlock>; // Available for Messages.create
   completion?: string; // Available for Completions.create
@@ -64,10 +63,6 @@ export type AnthropicAiResponse = SuccessfulResponse | MessageError;
 export interface AnthropicAiClient {
   messages?: {
     create: (...args: unknown[]) => Promise<AnthropicAiResponse>;
-  };
-  models?: {
-    list: (...args: unknown[]) => Promise<AnthropicAiResponse>;
-    get: (...args: unknown[]) => Promise<AnthropicAiResponse>;
   };
   completions?: {
     create: (...args: unknown[]) => Promise<AnthropicAiResponse>;

--- a/packages/server-utils/src/ai/core/utils.ts
+++ b/packages/server-utils/src/ai/core/utils.ts
@@ -42,15 +42,15 @@ export interface InstrumentedMethodEntry {
  */
 export type InstrumentedMethodRegistry = Record<string, InstrumentedMethodEntry>;
 
-// Operation names that are not inference calls: `models` retrieves model metadata and `unknown` is
-// the fallback for methods with no registered operation. Neither should surface as a `gen_ai.*` op
-// (an unknown string must not masquerade as a convention), so they map to the generic `function` op.
-// The operation name itself is preserved on `gen_ai.operation.name`.
-const NON_INFERENCE_OPERATIONS = new Set(['models', 'unknown']);
+// Operation names that are not inference calls: `unknown` is the fallback for methods with no
+// registered operation. It should not surface as a `gen_ai.*` op (an unknown string must not
+// masquerade as a convention), so it maps to the generic `function` op. The operation name itself
+// is preserved on `gen_ai.operation.name`.
+const NON_INFERENCE_OPERATIONS = new Set(['unknown']);
 
 /**
  * Derive the span op from a gen_ai operation name. Inference operations become `gen_ai.<operation>`;
- * non-inference operations (`models`, `unknown`) become the generic `function` op.
+ * non-inference operations (`unknown`) become the generic `function` op.
  */
 export function getGenAiSpanOp(operationName: string): string {
   return NON_INFERENCE_OPERATIONS.has(operationName) ? GENERAL_FUNCTION_SPAN_OP : `gen_ai.${operationName}`;

--- a/packages/server-utils/src/integrations/tracing-channel/anthropic.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/anthropic.ts
@@ -24,12 +24,10 @@ const ORIGIN = 'auto.ai.anthropic';
 
 // `stream` determines how the span is ended
 const INSTRUMENTED_CHANNELS = [
-  { channel: CHANNELS.ANTHROPIC_CHAT, operation: 'chat', methodPath: 'messages.create', stream: 'async-iterable' },
-  { channel: CHANNELS.ANTHROPIC_MODELS, operation: 'models', methodPath: 'models.retrieve', stream: 'none' },
+  { channel: CHANNELS.ANTHROPIC_CHAT, operation: 'chat', stream: 'async-iterable' },
   {
     channel: CHANNELS.ANTHROPIC_MESSAGES_STREAM,
     operation: 'chat',
-    methodPath: 'messages.stream',
     stream: 'message-stream',
   },
 ] as const;
@@ -51,10 +49,10 @@ const _anthropicIntegration = ((options: AnthropicAiOptions = {}) => {
 }) satisfies IntegrationFn;
 
 function instrumentAnthropic(options: AnthropicAiOptions): void {
-  for (const { channel, operation, methodPath, stream } of INSTRUMENTED_CHANNELS) {
+  for (const { channel, operation, stream } of INSTRUMENTED_CHANNELS) {
     bindTracingChannelToSpan(
       diagnosticsChannel.tracingChannel<AnthropicChannelContext>(channel),
-      data => createGenAiSpan(data, operation, methodPath, options),
+      data => createGenAiSpan(data, operation, options),
       {
         beforeSpanEnd: (span, data) => {
           addResponseAttributes(
@@ -76,7 +74,6 @@ function instrumentAnthropic(options: AnthropicAiOptions): void {
 function createGenAiSpan(
   data: AnthropicChannelContext,
   operation: string,
-  methodPath: string,
   options: AnthropicAiOptions,
 ): Span | undefined {
   const args = data.arguments ?? [];
@@ -99,7 +96,7 @@ function createGenAiSpan(
 
   const { recordInputs } = resolveAIRecordingOptions(options);
 
-  const attributes = extractRequestAttributes(args, methodPath, operation);
+  const attributes = extractRequestAttributes(args, operation);
   const model = (attributes[GEN_AI_REQUEST_MODEL] as string) || 'unknown';
   attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] = ORIGIN;
 
@@ -161,7 +158,7 @@ function wrapStreamResult(
 
 /**
  * Orchestrion-driven Anthropic integration. Subscribes to the `orchestrion:@anthropic-ai/sdk:*`
- * diagnostics_channels injected into the SDK's chat (`messages`/`completions`/beta `messages`), `models`, and
+ * diagnostics_channels injected into the SDK's chat (`messages`/`completions`/beta `messages`) and
  * `messages.stream()` methods, so it requires the orchestrion runtime hook or bundler plugin.
  */
 export const anthropicIntegration = defineIntegration(_anthropicIntegration);

--- a/packages/server-utils/src/orchestrion/config/anthropic-ai.ts
+++ b/packages/server-utils/src/orchestrion/config/anthropic-ai.ts
@@ -18,11 +18,6 @@ export const anthropicAiConfig = [
     module: { name: '@anthropic-ai/sdk', versionRange: '>=0.19.2 <1', filePath },
     functionQuery: { className: 'Messages', methodName: 'create', kind: 'Auto' as const },
   })),
-  ...['resources/models.js', 'resources/models.mjs'].map(filePath => ({
-    channelName: 'models',
-    module: { name: '@anthropic-ai/sdk', versionRange: '>=0.19.2 <1', filePath },
-    functionQuery: { className: 'Models', methodName: 'retrieve', kind: 'Auto' as const },
-  })),
   // `messages.stream()` returns a synchronous emitter, not a promise, so `kind: 'Sync'` is required:
   // `Auto`'s promise wrapper never publishes `end` for a non-thenable return, so the span would never end.
   ...['resources/messages/messages.js', 'resources/messages/messages.mjs'].map(filePath => ({
@@ -36,6 +31,5 @@ export const anthropicAiModuleNames = getModuleNames(anthropicAiConfig);
 
 export const anthropicAiChannels = {
   ANTHROPIC_CHAT: 'orchestrion:@anthropic-ai/sdk:chat',
-  ANTHROPIC_MODELS: 'orchestrion:@anthropic-ai/sdk:models',
   ANTHROPIC_MESSAGES_STREAM: 'orchestrion:@anthropic-ai/sdk:messages-stream',
 } as const;


### PR DESCRIPTION
`models.retrieve` and `models.get` (the same underlying call) only read model metadata and run no inference, so the Anthropic integration no longer emits spans for them.

Fixes getsentry/sentry-javascript#23147<br>Fixes getsentry/sentry-javascript#23146