### PR TITLE
feat(browser)!: Do not include metrics in base CDN bundle

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/metrics/metricsShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/metrics/metricsShim/init.js
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  traceLifecycle: 'static',
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});
+
+// These should not actually work, but still not error out
+Sentry.metrics.count('test.counter', 1);
+Sentry.metrics.gauge('test.gauge', 42);
+Sentry.metrics.distribution('test.distribution', 200);

--- a/dev-packages/browser-integration-tests/suites/public-api/metrics/metricsShim/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/metrics/metricsShim/test.ts
@@ -1,0 +1,36 @@
+import { expect } from '@playwright/test';
+import { sentryTest } from '../../../../utils/fixtures';
+
+sentryTest('exports a shim metrics namespace for non-metrics bundles', async ({ getLocalTestUrl, page }) => {
+  const bundle = process.env.PW_BUNDLE;
+
+  // Only run this for CDN bundles that do NOT include metrics
+  // Skip minified bundles because DEBUG_BUILD is false and warnings won't appear
+  if (!bundle?.startsWith('bundle') || bundle.includes('metrics') || bundle.includes('min')) {
+    sentryTest.skip();
+  }
+
+  const consoleMessages: string[] = [];
+  page.on('console', msg => consoleMessages.push(msg.text()));
+
+  let requestCount = 0;
+  await page.route(/^https:\/\/dsn\.ingest\.sentry\.io\//, route => {
+    requestCount++;
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname, skipDsnRouteHandler: true });
+
+  await page.goto(url);
+
+  // Wait a bit to ensure no requests are made
+  await page.waitForTimeout(500);
+
+  expect(requestCount).toBe(0);
+
+  expect(consoleMessages).toContain('You are using Sentry.metrics.* even though this bundle does not include metrics.');
+});

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -976,7 +976,7 @@ The utility `@sentry/tanstackstart` package was removed. Use the `@sentry/tansta
 
 Affected SDKs: `@sentry/browser` (CDN bundles).
 
-Metrics are no longer included in the base CDN bundle. Metrics are now shipped only in the dedicated `*.metrics` CDN bundles. If you use metrics via the CDN, switch to a `*.metrics` bundle.
+Metrics are no longer included in the base CDN bundle. Metrics are now shipped only in the dedicated `*.logs.metrics` CDN bundles. If you use metrics via the CDN, switch to a `*.logs.metrics` bundle. On the other bundles, `Sentry.metrics.*` is a no-op shim that warns in debug builds.
 
 ## 5. Renames
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -73,7 +73,6 @@ export {
   withStaticSpan,
   // oxlint-disable-next-line typescript/no-deprecated
   withStreamedSpan,
-  metrics,
 } from '@sentry/core/browser';
 
 export {

--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   elementTimingIntegrationShim,
   loggerShim,
+  metricsShim,
   replayIntegrationShim,
   spanStreamingIntegrationShim,
   fetchStreamPerformanceIntegrationShim,
@@ -11,8 +12,7 @@ import { feedbackAsyncIntegration } from './feedbackAsync';
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metricsShim here once we remove metrics from the base bundle.
-export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger };
+export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger, metricsShim as metrics };
 
 export { getFeedback, sendFeedback } from '@sentry/feedback';
 

--- a/packages/browser/src/index.bundle.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.logs.metrics.ts
@@ -8,8 +8,7 @@ import {
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metrics here once we remove it from the base bundle.
-export { logger, consoleLoggingIntegration } from '@sentry/core/browser';
+export { logger, consoleLoggingIntegration, metrics } from '@sentry/core/browser';
 
 export { elementTimingIntegration } from '@sentry/browser-utils';
 

--- a/packages/browser/src/index.bundle.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.replay.feedback.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   elementTimingIntegrationShim,
   loggerShim,
+  metricsShim,
   spanStreamingIntegrationShim,
   fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
@@ -10,8 +11,7 @@ import { feedbackAsyncIntegration } from './feedbackAsync';
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metricsShim here once we remove metrics from the base bundle.
-export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger };
+export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger, metricsShim as metrics };
 
 export { getFeedback, sendFeedback } from '@sentry/feedback';
 

--- a/packages/browser/src/index.bundle.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.replay.logs.metrics.ts
@@ -7,8 +7,7 @@ import {
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metrics here once we remove it from the base bundle.
-export { logger, consoleLoggingIntegration } from '@sentry/core/browser';
+export { logger, consoleLoggingIntegration, metrics } from '@sentry/core/browser';
 
 export { replayIntegration, getReplay } from '@sentry/replay';
 

--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -4,14 +4,14 @@ import {
   elementTimingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  metricsShim,
   spanStreamingIntegrationShim,
   fetchStreamPerformanceIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metricsShim here once we remove metrics from the base bundle.
-export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger };
+export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger, metricsShim as metrics };
 
 export { replayIntegration, getReplay } from '@sentry/replay';
 

--- a/packages/browser/src/index.bundle.tracing.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.logs.metrics.ts
@@ -5,8 +5,7 @@ registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metrics here once we remove it from the base bundle.
-export { logger, consoleLoggingIntegration } from '@sentry/core/browser';
+export { logger, consoleLoggingIntegration, metrics } from '@sentry/core/browser';
 
 export {
   getActiveSpan,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
@@ -5,7 +5,6 @@ registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metrics here once we remove it from the base bundle.
 export {
   getActiveSpan,
   getRootSpan,
@@ -18,6 +17,7 @@ export {
   withActiveSpan,
   logger,
   consoleLoggingIntegration,
+  metrics,
 } from '@sentry/core/browser';
 
 export {

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   elementTimingIntegrationShim,
   loggerShim,
+  metricsShim,
 } from '@sentry-internal/integration-shims';
 import { feedbackAsyncIntegration } from './feedbackAsync';
 
@@ -10,8 +11,7 @@ registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metricsShim here once we remove metrics from the base bundle.
-export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger };
+export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger, metricsShim as metrics };
 
 export {
   getActiveSpan,

--- a/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
@@ -5,8 +5,7 @@ registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metrics here once we remove it from the base bundle.
-export { logger, consoleLoggingIntegration } from '@sentry/core/browser';
+export { logger, consoleLoggingIntegration, metrics } from '@sentry/core/browser';
 
 export {
   getActiveSpan,

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -4,14 +4,14 @@ import {
   elementTimingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  metricsShim,
 } from '@sentry-internal/integration-shims';
 
 registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metricsShim here once we remove metrics from the base bundle.
-export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger };
+export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger, metricsShim as metrics };
 
 export {
   getActiveSpan,

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -4,6 +4,7 @@ import {
   elementTimingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  metricsShim,
   replayIntegrationShim,
 } from '@sentry-internal/integration-shims';
 
@@ -11,8 +12,7 @@ registerSpanErrorInstrumentation();
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metricsShim here once we remove metrics from the base bundle.
-export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger };
+export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger, metricsShim as metrics };
 
 export {
   getActiveSpan,

--- a/packages/browser/src/index.bundle.ts
+++ b/packages/browser/src/index.bundle.ts
@@ -4,6 +4,7 @@ import {
   elementTimingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  metricsShim,
   replayIntegrationShim,
   spanStreamingIntegrationShim,
   fetchStreamPerformanceIntegrationShim,
@@ -11,8 +12,7 @@ import {
 
 export * from './index.bundle.base';
 
-// TODO(v11): Export metricsShim here once we remove metrics from the base bundle.
-export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger };
+export { consoleLoggingIntegrationShim as consoleLoggingIntegration, loggerShim as logger, metricsShim as metrics };
 
 export {
   browserTracingIntegrationShim as browserTracingIntegration,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -9,14 +9,6 @@ export { contextLinesIntegration } from './integrations/contextlines';
 export { graphqlClientIntegration } from './integrations/graphqlClient';
 export { viewHierarchyIntegration } from './integrations/view-hierarchy';
 
-export {
-  captureConsoleIntegration,
-  extraErrorDataIntegration,
-  rewriteFramesIntegration,
-  consoleLoggingIntegration,
-  createConsolaReporter,
-} from '@sentry/core/browser';
-
 export { replayIntegration, getReplay } from '@sentry/replay';
 export type {
   ReplayEventType,
@@ -52,6 +44,11 @@ export { userTimingIntegration } from './integrations/usertiming';
 
 export type { RequestInstrumentationOptions } from './tracing/request';
 export {
+  captureConsoleIntegration,
+  extraErrorDataIntegration,
+  rewriteFramesIntegration,
+  consoleLoggingIntegration,
+  createConsolaReporter,
   registerSpanErrorInstrumentation,
   getActiveSpan,
   getRootSpan,
@@ -74,6 +71,7 @@ export {
   thirdPartyErrorFilterIntegration,
   featureFlagsIntegration,
   logger,
+  metrics,
 } from '@sentry/core/browser';
 export type { Span, FeatureFlagsIntegration } from '@sentry/core/browser';
 export { makeBrowserOfflineTransport } from './transports/offline';

--- a/packages/browser/test/index.bundle.feedback.test.ts
+++ b/packages/browser/test/index.bundle.feedback.test.ts
@@ -2,6 +2,7 @@ import {
   browserTracingIntegrationShim,
   consoleLoggingIntegrationShim,
   loggerShim,
+  metricsShim,
   replayIntegrationShim,
   spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
@@ -19,5 +20,6 @@ describe('index.bundle.feedback', () => {
 
     expect(FeedbackBundle.logger).toBe(loggerShim);
     expect(FeedbackBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);
+    expect(FeedbackBundle.metrics).toBe(metricsShim);
   });
 });

--- a/packages/browser/test/index.bundle.replay.feedback.test.ts
+++ b/packages/browser/test/index.bundle.replay.feedback.test.ts
@@ -2,6 +2,7 @@ import {
   browserTracingIntegrationShim,
   consoleLoggingIntegrationShim,
   loggerShim,
+  metricsShim,
   spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
@@ -18,5 +19,6 @@ describe('index.bundle.replay.feedback', () => {
 
     expect(ReplayFeedbackBundle.logger).toBe(loggerShim);
     expect(ReplayFeedbackBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);
+    expect(ReplayFeedbackBundle.metrics).toBe(metricsShim);
   });
 });

--- a/packages/browser/test/index.bundle.replay.test.ts
+++ b/packages/browser/test/index.bundle.replay.test.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  metricsShim,
   spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
@@ -19,5 +20,6 @@ describe('index.bundle.replay', () => {
 
     expect(ReplayBundle.logger).toBe(loggerShim);
     expect(ReplayBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);
+    expect(ReplayBundle.metrics).toBe(metricsShim);
   });
 });

--- a/packages/browser/test/index.bundle.test.ts
+++ b/packages/browser/test/index.bundle.test.ts
@@ -3,6 +3,7 @@ import {
   consoleLoggingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  metricsShim,
   replayIntegrationShim,
   spanStreamingIntegrationShim,
 } from '@sentry-internal/integration-shims';
@@ -19,5 +20,6 @@ describe('index.bundle', () => {
 
     expect(Bundle.logger).toBe(loggerShim);
     expect(Bundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);
+    expect(Bundle.metrics).toBe(metricsShim);
   });
 });

--- a/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.feedback.test.ts
@@ -1,4 +1,4 @@
-import { consoleLoggingIntegrationShim, loggerShim } from '@sentry-internal/integration-shims';
+import { consoleLoggingIntegrationShim, loggerShim, metricsShim } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import {
   browserTracingIntegration,
@@ -20,5 +20,6 @@ describe('index.bundle.tracing.replay.feedback', () => {
 
     expect(TracingReplayFeedbackBundle.logger).toBe(loggerShim);
     expect(TracingReplayFeedbackBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);
+    expect(TracingReplayFeedbackBundle.metrics).toBe(metricsShim);
   });
 });

--- a/packages/browser/test/index.bundle.tracing.replay.test.ts
+++ b/packages/browser/test/index.bundle.tracing.replay.test.ts
@@ -1,4 +1,9 @@
-import { consoleLoggingIntegrationShim, feedbackIntegrationShim, loggerShim } from '@sentry-internal/integration-shims';
+import {
+  consoleLoggingIntegrationShim,
+  feedbackIntegrationShim,
+  loggerShim,
+  metricsShim,
+} from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
 import { browserTracingIntegration, replayIntegration, spanStreamingIntegration, webVitalsIntegration } from '../src';
 import * as TracingReplayBundle from '../src/index.bundle.tracing.replay';
@@ -14,5 +19,6 @@ describe('index.bundle.tracing.replay', () => {
 
     expect(TracingReplayBundle.logger).toBe(loggerShim);
     expect(TracingReplayBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);
+    expect(TracingReplayBundle.metrics).toBe(metricsShim);
   });
 });

--- a/packages/browser/test/index.bundle.tracing.test.ts
+++ b/packages/browser/test/index.bundle.tracing.test.ts
@@ -2,6 +2,7 @@ import {
   consoleLoggingIntegrationShim,
   feedbackIntegrationShim,
   loggerShim,
+  metricsShim,
   replayIntegrationShim,
 } from '@sentry-internal/integration-shims';
 import { describe, expect, it } from 'vitest';
@@ -19,5 +20,6 @@ describe('index.bundle.tracing', () => {
 
     expect(TracingBundle.logger).toBe(loggerShim);
     expect(TracingBundle.consoleLoggingIntegration).toBe(consoleLoggingIntegrationShim);
+    expect(TracingBundle.metrics).toBe(metricsShim);
   });
 });


### PR DESCRIPTION
`metrics` was exported from `exports.ts`, which every CDN bundle star-exports, so it shipped in all 12 bundles. It now ships only in the 5 `*.logs.metrics` bundles; the other 7 export `metricsShim`. The npm entry is unchanged.

Removing the public API lets `_INTERNAL_captureMetric` tree-shake out — the base bundle drops 723 bytes gzipped (-2.2%). The flush path stays in every bundle, since `Client` imports it unconditionally.

Also unifies the two `@sentry/core/browser` re-export blocks in `index.ts` into one.

closes getsentry/sentry-javascript#18583

Note to reviewers: ~~the size report here is misleading, I verified this locally with actual builds~~ seems to be ok now