### PR TITLE
test(cloudflare): Cover `enableDedupe` option

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/index.ts
@@ -32,9 +32,8 @@ class StepContextTestWorkflowBase extends WorkflowEntrypoint<Env, WorkflowParams
         // Both errors originate from the same line so they share a stack trace, which is what the
         // Dedupe integration keys on
         if (event.payload.captureManualTwice) {
-          for (let i = 0; i < 2; i++) {
-            Sentry.captureException(new Error('Manual capture'));
-          }
+          Sentry.captureException(new Error('Manual capture'));
+          Sentry.captureException(new Error('Manual capture'));
         }
 
         if (remainingFailures > 0) {

--- a/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/index.ts
@@ -10,6 +10,7 @@ interface Env {
 interface WorkflowParams {
   failCount: number;
   captureManual?: boolean;
+  captureManualTwice?: boolean;
 }
 class StepContextTestWorkflowBase extends WorkflowEntrypoint<Env, WorkflowParams> {
   async run(event: WorkflowEvent<WorkflowParams>, step: WorkflowStep): Promise<void> {
@@ -26,6 +27,14 @@ class StepContextTestWorkflowBase extends WorkflowEntrypoint<Env, WorkflowParams
       async ctx => {
         if (event.payload.captureManual) {
           Sentry.captureException(new Error(`Manual capture on attempt ${ctx.attempt}`));
+        }
+
+        // Both errors originate from the same line so they share a stack trace, which is what the
+        // Dedupe integration keys on
+        if (event.payload.captureManualTwice) {
+          for (let i = 0; i < 2; i++) {
+            Sentry.captureException(new Error('Manual capture'));
+          }
         }
 
         if (remainingFailures > 0) {
@@ -59,10 +68,11 @@ export default Sentry.withSentry(
       if (url.pathname === '/trigger-workflow') {
         const failCount = parseInt(url.searchParams.get('failCount') || '0', 10);
         const captureManual = url.searchParams.get('captureManual') === 'true';
+        const captureManualTwice = url.searchParams.get('captureManualTwice') === 'true';
 
         try {
           const instance = await env.STEP_CONTEXT_WORKFLOW.create({
-            params: { failCount, captureManual },
+            params: { failCount, captureManual, captureManualTwice },
           });
 
           return new Response(JSON.stringify({ id: instance.id }), { headers: { 'Content-Type': 'application/json' } });

--- a/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/workflows/step-context/test.ts
@@ -72,6 +72,36 @@ it('No error event when step eventually succeeds within retry limit', async ({ s
   await runner.completed();
 });
 
+// Workflows opt out of the Dedupe integration via `enableDedupe: false`, so identical errors
+// captured within one run are all delivered instead of being collapsed into a single event.
+it('Identical exceptions captured within one run are all sent (Dedupe is disabled)', async ({ signal }) => {
+  const runner = createRunner(__dirname)
+    .expectN(2, (envelope: Envelope): void => {
+      const [, items] = envelope;
+      const [itemHeader, itemBody] = items[0] as [{ type: string }, Record<string, unknown>];
+
+      expect(itemHeader.type).toBe('event');
+
+      const exception = itemBody.exception as { values?: Array<{ value?: string }> };
+      expect(exception?.values?.[0]?.value).toBe('Manual capture');
+    })
+    .expect(flushMarkerMatcher)
+    .unordered()
+    .start(signal);
+
+  const trigger = await runner.makeRequest<TriggerResponse>(
+    'get',
+    '/trigger-workflow?failCount=0&captureManualTwice=true',
+  );
+  expect(trigger?.id).toBeDefined();
+
+  const status = await waitForWorkflowStatus(runner.makeRequest.bind(runner), trigger!.id);
+  expect(status?.status?.status).toBe('complete');
+
+  await runner.makeRequest('get', '/flush-marker');
+  await runner.completed();
+});
+
 it('Manually captured exceptions are always sent on every attempt', async ({ signal }) => {
   const runner = createRunner(__dirname)
     .expectN(3, (envelope: Envelope): void => {

--- a/packages/cloudflare/test/sdk.test.ts
+++ b/packages/cloudflare/test/sdk.test.ts
@@ -46,6 +46,28 @@ describe('init', () => {
     );
   });
 
+  test('installs Dedupe integration by default', () => {
+    init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
+    const client = getClient();
+
+    expect(client?.getOptions()).toEqual(
+      expect.objectContaining({
+        integrations: expect.arrayContaining([expect.objectContaining({ name: 'Dedupe' })]),
+      }),
+    );
+  });
+
+  test('does not install Dedupe integration when enableDedupe is false', () => {
+    init({ dsn: 'https://public@dsn.ingest.sentry.io/1337', enableDedupe: false });
+    const client = getClient();
+
+    expect(client?.getOptions()).toEqual(
+      expect.objectContaining({
+        integrations: expect.not.arrayContaining([expect.objectContaining({ name: 'Dedupe' })]),
+      }),
+    );
+  });
+
   type MarkedIntegration = Integration & { _custom?: boolean };
 
   test("doesn't add spanStreamingIntegration if user added it manually", () => {


### PR DESCRIPTION
Adds tests to check if `enableDedupes` is really disabled for workflows

original trigger: https://github.com/getsentry/sentry-javascript/pull/23151#discussion_r3736191649