### PR TITLE
feat(cloudflare): Add span ops for rate limit and Durable Object WebSocket spans

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/ratelimit/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/ratelimit/test.ts
@@ -27,10 +27,12 @@ it('instruments an allowed rate limiter call automatically via env', async ({ si
 
       expect(event.spans).toEqual([
         {
-          data: {
+          data: expect.objectContaining({
             'sentry.origin': 'auto.faas.cloudflare.rate_limit',
-          },
+            'rpc.service': 'cloudflare.rate_limit',
+          }),
           description: 'rate_limit MY_RATE_LIMITER',
+          op: 'rpc',
           origin: 'auto.faas.cloudflare.rate_limit',
           status: 'ok',
           parent_span_id: expect.any(String),

--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import { WEB_SERVER_WEBSOCKET_SPAN_OP } from '@sentry/conventions/op';
 import { captureException, isObjectLike } from '@sentry/core';
 import type { DurableObject } from 'cloudflare:workers';
 import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';
@@ -195,21 +196,39 @@ function instrumentDurableObjectHandlers<E, T extends DurableObject<E>>(
 
   if (obj.webSocketMessage && typeof obj.webSocketMessage === 'function') {
     obj.webSocketMessage = wrapMethodWithSentry(
-      { options, context, spanName: 'webSocketMessage', origin: 'auto.faas.cloudflare.durable_object' },
+      {
+        options,
+        context,
+        spanName: 'webSocketMessage',
+        spanOp: WEB_SERVER_WEBSOCKET_SPAN_OP,
+        origin: 'auto.faas.cloudflare.durable_object',
+      },
       obj.webSocketMessage.bind(obj),
     );
   }
 
   if (obj.webSocketClose && typeof obj.webSocketClose === 'function') {
     obj.webSocketClose = wrapMethodWithSentry(
-      { options, context, spanName: 'webSocketClose', origin: 'auto.faas.cloudflare.durable_object' },
+      {
+        options,
+        context,
+        spanName: 'webSocketClose',
+        spanOp: WEB_SERVER_WEBSOCKET_SPAN_OP,
+        origin: 'auto.faas.cloudflare.durable_object',
+      },
       obj.webSocketClose.bind(obj),
     );
   }
 
   if (obj.webSocketError && typeof obj.webSocketError === 'function') {
     obj.webSocketError = wrapMethodWithSentry(
-      { options, context, spanName: 'webSocketError', origin: 'auto.faas.cloudflare.durable_object' },
+      {
+        options,
+        context,
+        spanName: 'webSocketError',
+        spanOp: WEB_SERVER_WEBSOCKET_SPAN_OP,
+        origin: 'auto.faas.cloudflare.durable_object',
+      },
       obj.webSocketError.bind(obj),
       (_, error) =>
         captureException(error, {

--- a/packages/cloudflare/src/instrumentations/worker/instrumentRateLimit.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentRateLimit.ts
@@ -1,7 +1,10 @@
 import type { RateLimit, RateLimitOptions, RateLimitOutcome } from '@cloudflare/workers-types';
+import { RPC_SERVICE, SENTRY_OP } from '@sentry/conventions/attributes';
+import { WEB_SERVER_RPC_SPAN_OP } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 
 const ORIGIN = 'auto.faas.cloudflare.rate_limit';
+const RATE_LIMIT_SERVICE = 'cloudflare.rate_limit';
 
 /**
  * Wraps a Cloudflare rate limiter binding to create a span on each `limit()` call.
@@ -20,7 +23,9 @@ export function instrumentRateLimit<T extends RateLimit>(rateLimit: T, bindingNa
           {
             name: `rate_limit ${bindingName}`,
             attributes: {
+              [SENTRY_OP]: WEB_SERVER_RPC_SPAN_OP,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
+              [RPC_SERVICE]: RATE_LIMIT_SERVICE,
             },
           },
           () => Reflect.apply(original, target, [options]),

--- a/packages/cloudflare/test/durableobject.test.ts
+++ b/packages/cloudflare/test/durableobject.test.ts
@@ -242,6 +242,32 @@ describe('instrumentDurableObjectWithSentry', () => {
     }
   });
 
+  it.each(['webSocketMessage', 'webSocketClose', 'webSocketError'])('%s creates a websocket span', async methodName => {
+    const startSpanSpy = vi.spyOn(SentryCore, 'startSpan');
+    const testClass = class {
+      webSocketMessage() {}
+
+      webSocketClose() {}
+
+      webSocketError() {}
+    };
+    const instrumented = instrumentDurableObjectWithSentry(vi.fn().mockReturnValue({}), testClass as any);
+    const obj = Reflect.construct(instrumented, [{ waitUntil: vi.fn() }, {}]);
+
+    await (obj as any)[methodName]();
+
+    expect(startSpanSpy).toHaveBeenCalledWith(
+      {
+        name: methodName,
+        attributes: {
+          'sentry.op': 'websocket',
+          'sentry.origin': 'auto.faas.cloudflare.durable_object',
+        },
+      },
+      expect.any(Function),
+    );
+  });
+
   it('Built-in durable object methods are own properties and not wrapped as RPC', () => {
     const testClass = class {
       fetch() {

--- a/packages/cloudflare/test/instrumentations/worker/instrumentRateLimit.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentRateLimit.test.ts
@@ -41,7 +41,7 @@ describe('instrumentRateLimit', () => {
       expect(outcome).toEqual({ success: false });
     });
 
-    test('starts a span with the binding name and origin', async () => {
+    test('starts a span with the binding name, op and origin', async () => {
       const wrapped = instrumentRateLimit(createMockRateLimit(true), 'MY_RATE_LIMITER');
       await wrapped.limit({ key: 'user-123' });
 
@@ -50,7 +50,9 @@ describe('instrumentRateLimit', () => {
         {
           name: 'rate_limit MY_RATE_LIMITER',
           attributes: {
+            'sentry.op': 'rpc',
             'sentry.origin': 'auto.faas.cloudflare.rate_limit',
+            'rpc.service': 'cloudflare.rate_limit',
           },
         },
         expect.any(Function),


### PR DESCRIPTION
Rate limit binding calls now emit the `rpc` op with `rpc.service`, and the Durable Object `webSocketMessage`/`webSocketClose`/`webSocketError` handlers emit the `websocket` op. Both sets of spans previously had no op at all.

closes #23138 
