### PR TITLE
feat(server-utils): Add cache span ops for DataLoader `prime`, `clear` and `clearAll`

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/dataloader/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/dataloader/test.ts
@@ -7,6 +7,7 @@ import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runn
 // diagnostics-channel one, which stamps a different origin.
 const ORIGIN = isOrchestrionEnabled() ? 'auto.db.dataloader' : 'auto.db.otel.dataloader';
 const CACHE_GET_OP = 'cache.get';
+const CACHE_MUTATION_OPS = { prime: 'cache.put', clear: 'cache.remove', clearAll: 'cache.remove' } as const;
 
 describe('dataloader auto-instrumentation', () => {
   afterAll(() => {
@@ -30,6 +31,7 @@ describe('dataloader auto-instrumentation', () => {
             expect(loadSpan?.data?.['sentry.origin']).toBe(ORIGIN);
             expect(loadSpan?.data?.['sentry.op']).toBe(CACHE_GET_OP);
             expect(loadSpan?.data?.['cache.key']).toEqual(['user-1']);
+            expect(loadSpan?.data?.['db.operation.name']).toBe('load');
             // A direct operation is a client call; the deferred `batch` below gets no kind
             expect(loadSpan?.data?.['sentry.kind']).toBe('client');
 
@@ -75,16 +77,21 @@ describe('dataloader auto-instrumentation', () => {
 
             const spans = event.spans || [];
 
-            // prime/clear/clearAll are not cache reads, so they get an origin but no `op`
-            for (const operation of ['prime', 'clear', 'clearAll']) {
+            // prime writes to the cache, clear/clearAll remove from it
+            for (const [operation, op] of Object.entries(CACHE_MUTATION_OPS)) {
               const span = spans.find(s => s.description === `dataloader.${operation}`);
               expect(span, `expected a dataloader.${operation} span`).toBeDefined();
               expect(span?.origin).toBe(ORIGIN);
               expect(span?.status).toBe('ok');
-              expect(span?.op).toBeUndefined();
+              expect(span?.op).toBe(op);
               expect(span?.data?.['sentry.origin']).toBe(ORIGIN);
-              expect(span?.data?.['sentry.op']).toBeUndefined();
+              expect(span?.data?.['db.operation.name']).toBe(operation);
             }
+
+            // `clearAll` takes no key, the other two act on a single key
+            expect(spans.find(s => s.description === 'dataloader.prime')?.data?.['cache.key']).toEqual(['user-1']);
+            expect(spans.find(s => s.description === 'dataloader.clear')?.data?.['cache.key']).toEqual(['user-1']);
+            expect(spans.find(s => s.description === 'dataloader.clearAll')?.data?.['cache.key']).toBeUndefined();
           },
         })
         .expect({

--- a/packages/server-utils/src/integrations/tracing-channel/dataloader.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/dataloader.ts
@@ -1,5 +1,10 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
-import { CACHE_KEY, SENTRY_KIND } from '@sentry/conventions/attributes';
+import { CACHE_KEY, DB_OPERATION_NAME, SENTRY_KIND, SENTRY_OP } from '@sentry/conventions/attributes';
+import {
+  DATABASE_CACHE_GET_SPAN_OP,
+  DATABASE_CACHE_PUT_SPAN_OP,
+  DATABASE_CACHE_REMOVE_SPAN_OP,
+} from '@sentry/conventions/op';
 import type { IntegrationFn, Span, StartSpanOptions } from '@sentry/core';
 import {
   debug,
@@ -22,10 +27,21 @@ const INTEGRATION_NAME = 'Dataloader' as const;
 const MODULE_NAME = 'dataloader';
 const ORIGIN = 'auto.db.dataloader';
 
-// `load`, `loadMany` and `batch` are cache reads; the rest are cache mutations that get no `op`.
-const CACHE_GET_OP = 'cache.get';
-
 type Operation = 'load' | 'loadMany' | 'batch' | 'prime' | 'clear' | 'clearAll';
+
+/**
+ * Maps each operation to a convention cache op. `load`, `loadMany` and `batch` are cache reads,
+ * `prime` writes an entry, and `clear`/`clearAll` remove entries. The precise operation stays
+ * available on `db.operation.name`.
+ */
+const OPERATION_SPAN_OPS = {
+  load: DATABASE_CACHE_GET_SPAN_OP,
+  loadMany: DATABASE_CACHE_GET_SPAN_OP,
+  batch: DATABASE_CACHE_GET_SPAN_OP,
+  prime: DATABASE_CACHE_PUT_SPAN_OP,
+  clear: DATABASE_CACHE_REMOVE_SPAN_OP,
+  clearAll: DATABASE_CACHE_REMOVE_SPAN_OP,
+} as const satisfies Record<Operation, string>;
 
 // The link shape shared between a `load` span and the `batch` span it triggers.
 type DataLoaderSpanLink = { context: ReturnType<Span['spanContext']> };
@@ -61,8 +77,8 @@ function getSpanName(loader: DataLoaderInstance | undefined, operation: Operatio
   return name ? `${MODULE_NAME}.${operation} ${name}` : `${MODULE_NAME}.${operation}`;
 }
 
-// `load` receives a single key, `loadMany`/`batch` receive a key array. Normalize both to the
-// `string[]` shape `cache.key` expects.
+// `load`/`prime`/`clear` receive a single key, `loadMany`/`batch` receive a key array. Normalize
+// both to the `string[]` shape `cache.key` expects. `clearAll` takes no key and yields `undefined`.
 function getCacheKey(keyArg: unknown): string[] | undefined {
   if (Array.isArray(keyArg)) {
     return keyArg.map(key => String(key));
@@ -76,19 +92,18 @@ function makeSpanOptions(
   operation: Operation,
   keyArg?: unknown,
 ): StartSpanOptions {
-  const isCacheGet = operation === 'load' || operation === 'loadMany' || operation === 'batch';
-
   return {
     name: getSpanName(loader, operation),
-    op: isCacheGet ? CACHE_GET_OP : undefined,
     onlyIfParent: true,
     attributes: {
+      [SENTRY_OP]: OPERATION_SPAN_OPS[operation],
       // Every direct operation (`load`/`loadMany`/`prime`/`clear`/`clearAll`) is a client call, matching
       // the vendored OTel instrumentation. The `batch` runs off a deferred tick with no obvious network
       // peer, so it gets no kind.
       [SENTRY_KIND]: operation === 'batch' ? undefined : 'client',
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-      [CACHE_KEY]: isCacheGet ? getCacheKey(keyArg) : undefined,
+      [DB_OPERATION_NAME]: operation,
+      [CACHE_KEY]: getCacheKey(keyArg),
     },
   };
 }


### PR DESCRIPTION
The DataLoader cache mutations created spans without an op, only the read path (`cache.get`) was classified. `prime` now emits `cache.put` and `clear`/`clearAll` emit `cache.remove`. The specific operation stays queryable via `db.operation.name`, and `cache.key` is now recorded for the keyed mutations too.

part of #23138 
