### PR TITLE
feat(server-utils): Add `db` span op for generic-pool acquire spans

### DIFF
--- a/dev-packages/deno-integration-tests/suites/orchestrion-generic-pool/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-generic-pool/test.ts
@@ -45,11 +45,11 @@ Deno.test('generic-pool instrumentation: orchestrion:generic-pool:acquire channe
     "'parent' transaction",
   );
 
-  // generic-pool sets a name + origin but no `op`, so match on description.
   const poolSpan = parent.spans?.find(s => s.description === 'generic-pool.acquire');
   assertExists(
     poolSpan,
     `expected a generic-pool.acquire span, got descriptions: ${parent.spans?.map(s => s.description).join(', ')}`,
   );
   assertEquals(poolSpan!.data?.['sentry.origin'], 'auto.db.generic_pool');
+  assertEquals(poolSpan!.op, 'db');
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/tests/generic-pool.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-orchestrion/tests/generic-pool.test.ts
@@ -17,6 +17,7 @@ test('Instruments generic-pool automatically via orchestrion', async ({ baseURL 
   expect(spans).toContainEqual(
     expect.objectContaining({
       description: 'generic-pool.acquire',
+      op: 'db',
       origin: 'auto.db.generic_pool',
       status: 'ok',
       data: expect.objectContaining({

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool-v2/test.ts
@@ -1,14 +1,10 @@
 import { afterAll, describe, expect } from 'vitest';
-import { isOrchestrionEnabled } from '../../../utils';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
 describe('genericPool v2 auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
-
-  // The orchestrion channel integration replaces the OTel one 1:1 but tags spans with its own origin.
-  const ORIGIN = isOrchestrionEnabled() ? 'auto.db.generic_pool' : 'auto.db.otel.generic_pool';
 
   createEsmAndCjsTests(
     __dirname,
@@ -21,19 +17,21 @@ describe('genericPool v2 auto instrumentation', () => {
           spans: expect.arrayContaining([
             expect.objectContaining({
               description: 'generic-pool.acquire',
-              origin: ORIGIN,
-              data: {
-                'sentry.origin': ORIGIN,
-              },
+              op: 'db',
+              origin: 'auto.db.generic_pool',
+              data: expect.objectContaining({
+                'sentry.origin': 'auto.db.generic_pool',
+              }),
               status: 'ok',
             }),
 
             expect.objectContaining({
               description: 'generic-pool.acquire',
-              origin: ORIGIN,
-              data: {
-                'sentry.origin': ORIGIN,
-              },
+              op: 'db',
+              origin: 'auto.db.generic_pool',
+              data: expect.objectContaining({
+                'sentry.origin': 'auto.db.generic_pool',
+              }),
               status: 'ok',
             }),
           ]),
@@ -51,18 +49,14 @@ describe('genericPool v2 auto instrumentation', () => {
     'instrument.mjs',
     (createRunner, test) => {
       test('marks the `generic-pool.acquire` span as errored when acquiring fails', async () => {
-        // The orchestrion path also records the rejection's `error.type` on the span.
-        const errorData = isOrchestrionEnabled()
-          ? { 'sentry.origin': ORIGIN, 'error.type': 'Error' }
-          : { 'sentry.origin': ORIGIN };
-
         const EXPECTED_TRANSACTION = {
           transaction: 'Test Transaction',
           spans: expect.arrayContaining([
             expect.objectContaining({
               description: 'generic-pool.acquire',
-              origin: ORIGIN,
-              data: errorData,
+              op: 'db',
+              origin: 'auto.db.generic_pool',
+              data: expect.objectContaining({ 'sentry.origin': 'auto.db.generic_pool', 'error.type': 'Error' }),
               status: 'internal_error',
             }),
           ]),

--- a/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/genericPool/test.ts
@@ -1,14 +1,10 @@
 import { afterAll, describe, expect } from 'vitest';
-import { isOrchestrionEnabled } from '../../../utils';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
 describe('genericPool auto instrumentation', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
-
-  // The orchestrion channel integration replaces the OTel one 1:1 but tags spans with its own origin.
-  const ORIGIN = isOrchestrionEnabled() ? 'auto.db.generic_pool' : 'auto.db.otel.generic_pool';
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('should auto-instrument `genericPool` package when calling pool.require()', async () => {
@@ -17,19 +13,21 @@ describe('genericPool auto instrumentation', () => {
         spans: expect.arrayContaining([
           expect.objectContaining({
             description: 'generic-pool.acquire',
-            origin: ORIGIN,
-            data: {
-              'sentry.origin': ORIGIN,
-            },
+            op: 'db',
+            origin: 'auto.db.generic_pool',
+            data: expect.objectContaining({
+              'sentry.origin': 'auto.db.generic_pool',
+            }),
             status: 'ok',
           }),
 
           expect.objectContaining({
             description: 'generic-pool.acquire',
-            origin: ORIGIN,
-            data: {
-              'sentry.origin': ORIGIN,
-            },
+            op: 'db',
+            origin: 'auto.db.generic_pool',
+            data: expect.objectContaining({
+              'sentry.origin': 'auto.db.generic_pool',
+            }),
             status: 'ok',
           }),
         ]),
@@ -41,18 +39,17 @@ describe('genericPool auto instrumentation', () => {
 
   createEsmAndCjsTests(__dirname, 'scenario-error.mjs', 'instrument.mjs', (createRunner, test) => {
     test('marks the `generic-pool.acquire` span as errored when acquiring fails', async () => {
-      // The orchestrion path also records the rejection's `error.type` on the span.
-      const errorData = isOrchestrionEnabled()
-        ? { 'sentry.origin': ORIGIN, 'error.type': 'TimeoutError' }
-        : { 'sentry.origin': ORIGIN };
-
       const EXPECTED_TRANSACTION = {
         transaction: 'Test Transaction',
         spans: expect.arrayContaining([
           expect.objectContaining({
             description: 'generic-pool.acquire',
-            origin: ORIGIN,
-            data: errorData,
+            op: 'db',
+            origin: 'auto.db.generic_pool',
+            data: expect.objectContaining({
+              'sentry.origin': 'auto.db.generic_pool',
+              'error.type': 'TimeoutError',
+            }),
             status: 'internal_error',
           }),
         ]),

--- a/packages/server-utils/src/integrations/tracing-channel/generic-pool.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/generic-pool.ts
@@ -1,4 +1,6 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { DATABASE_DB_SPAN_OP } from '@sentry/conventions/op';
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 import { CHANNELS } from '../../orchestrion/channels';
@@ -38,6 +40,7 @@ function instrumentGenericPool(): void {
       startInactiveSpan({
         name: 'generic-pool.acquire',
         attributes: {
+          [SENTRY_OP]: DATABASE_DB_SPAN_OP,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.generic_pool',
         },
       }),


### PR DESCRIPTION
`generic-pool.acquire` spans carried an `auto.db.generic_pool` origin but no op. They now have the generic `db` op (rather than `db.query`, since pool acquisition is no query) 

part of #23138

