### PR TITLE
feat(effect): Derive span ops for Effect tracer spans

### DIFF
--- a/dev-packages/e2e-tests/test-applications/effect-3-node/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-3-node/tests/transactions.test.ts
@@ -53,16 +53,19 @@ test('Sends Effect spans with correct parent-child structure', async ({ baseURL 
     expect.objectContaining({
       contexts: expect.objectContaining({
         trace: expect.objectContaining({
+          op: 'http.server',
           origin: 'auto.http.effect',
         }),
       }),
       spans: [
         expect.objectContaining({
           description: 'custom-effect-span',
+          op: 'function',
           origin: 'auto.function.effect',
         }),
         expect.objectContaining({
           description: 'nested-span',
+          op: 'function',
           origin: 'auto.function.effect',
         }),
       ],

--- a/dev-packages/e2e-tests/test-applications/effect-4-node/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-4-node/tests/transactions.test.ts
@@ -53,16 +53,19 @@ test('Sends Effect spans with correct parent-child structure', async ({ baseURL 
     expect.objectContaining({
       contexts: expect.objectContaining({
         trace: expect.objectContaining({
+          op: 'http.server',
           origin: 'auto.http.effect',
         }),
       }),
       spans: [
         expect.objectContaining({
           description: 'custom-effect-span',
+          op: 'function',
           origin: 'auto.function.effect',
         }),
         expect.objectContaining({
           description: 'nested-span',
+          op: 'function',
           origin: 'auto.function.effect',
         }),
       ],

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@sentry/browser": "10.67.0",
+    "@sentry/conventions": "^0.16.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0"
   },

--- a/packages/effect/src/tracer.ts
+++ b/packages/effect/src/tracer.ts
@@ -1,3 +1,9 @@
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import {
+  GENERAL_FUNCTION_SPAN_OP,
+  WEB_SERVER_HTTP_CLIENT_SPAN_OP,
+  WEB_SERVER_HTTP_SERVER_SPAN_OP,
+} from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   isObjectLike,
@@ -17,6 +23,23 @@ function deriveOrigin(name: string): string {
   }
 
   return 'auto.function.effect';
+}
+
+/**
+ * Effect span names are chosen by user code, so the name is the only signal available. `@effect/platform`
+ * names its HTTP spans `http.server`/`http.client`, which map onto the matching Sentry ops; everything
+ * else is arbitrary user work and falls back to `function`.
+ */
+function deriveOp(name: string): string {
+  if (name.startsWith('http.server')) {
+    return WEB_SERVER_HTTP_SERVER_SPAN_OP;
+  }
+
+  if (name.startsWith('http.client')) {
+    return WEB_SERVER_HTTP_CLIENT_SPAN_OP;
+  }
+
+  return GENERAL_FUNCTION_SPAN_OP;
 }
 
 type HrTime = [number, number];
@@ -172,6 +195,7 @@ function createSentrySpan(
     name,
     startTime: nanosToHrTime(startTime),
     attributes: {
+      [SENTRY_OP]: deriveOp(name),
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: deriveOrigin(name),
     },
     ...(parentSentrySpan ? { parentSpan: parentSentrySpan } : {}),

--- a/packages/effect/test/tracer.test.ts
+++ b/packages/effect/test/tracer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as sentryCore from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { Effect } from 'effect';
 import { afterEach, vi } from 'vitest';
 import { SentryEffectTracer } from '../src/tracer';
@@ -203,7 +203,7 @@ describe('SentryEffectTracer', () => {
     }).pipe(withSentryTracer),
   );
 
-  it.effect('sets origin to auto.function.effect for regular spans', () =>
+  it.effect('sets origin and op for regular spans', () =>
     Effect.gen(function* () {
       let capturedAttributes: Record<string, unknown> | undefined;
 
@@ -223,12 +223,13 @@ describe('SentryEffectTracer', () => {
 
       expect(capturedAttributes).toBeDefined();
       expect(capturedAttributes?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toBe('auto.function.effect');
+      expect(capturedAttributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toBe('function');
 
       mockStartInactiveSpan.mockRestore();
     }).pipe(withSentryTracer),
   );
 
-  it.effect('sets origin to auto.http.effect for http.server spans', () =>
+  it.effect('sets origin and op for http.server spans', () =>
     Effect.gen(function* () {
       let capturedAttributes: Record<string, unknown> | undefined;
 
@@ -248,12 +249,13 @@ describe('SentryEffectTracer', () => {
 
       expect(capturedAttributes).toBeDefined();
       expect(capturedAttributes?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toBe('auto.http.effect');
+      expect(capturedAttributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toBe('http.server');
 
       mockStartInactiveSpan.mockRestore();
     }).pipe(withSentryTracer),
   );
 
-  it.effect('sets origin to auto.http.effect for http.client spans', () =>
+  it.effect('sets origin and op for http.client spans', () =>
     Effect.gen(function* () {
       let capturedAttributes: Record<string, unknown> | undefined;
 
@@ -273,6 +275,7 @@ describe('SentryEffectTracer', () => {
 
       expect(capturedAttributes).toBeDefined();
       expect(capturedAttributes?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]).toBe('auto.http.effect');
+      expect(capturedAttributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toBe('http.client');
 
       mockStartInactiveSpan.mockRestore();
     }).pipe(withSentryTracer),


### PR DESCRIPTION
Effect spans are named by user code, the tracer already derives the origin from the span name. The op now follows the same signal: `@effect/platform` names its HTTP spans `http.server`/`http.client`, which map onto the matching ops, and everything else is arbitrary user work that falls back to `function`.

part of getsentry/sentry-javascript#23138