### PR TITLE
feat(aws-serverless)!: Remove unused `startTrace` option and `tryPatchHandler`

### DIFF
--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -176,5 +176,5 @@ export { awsLambdaIntegration } from './integration/awslambda';
 
 export { getDefaultIntegrations, init } from './init';
 // eslint-disable-next-line typescript/no-deprecated
-export { tryPatchHandler, wrapHandler } from './sdk';
+export { wrapHandler } from './sdk';
 export type { WrapperOptions } from './sdk';

--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -1,5 +1,5 @@
 import type { Scope } from '@sentry/core';
-import { consoleSandbox, debug } from '@sentry/core';
+import { debug } from '@sentry/core';
 import { captureException, captureMessage, flush, getCurrentScope, withScope } from '@sentry/node';
 import type { Context, Handler, StreamifyHandler } from 'aws-lambda';
 import { performance } from 'perf_hooks';
@@ -32,12 +32,6 @@ export interface WrapperOptions {
    * @default false
    */
   captureAllSettledReasons: boolean;
-  // TODO(v11): Remove this option since its no longer used.
-  /**
-   * @deprecated This option has no effect and will be removed in a future major version.
-   * If you want to disable tracing, set `SENTRY_TRACES_SAMPLE_RATE` to `0.0`, otherwise OpenTelemetry will automatically trace the handler.
-   */
-  startTrace: boolean;
 }
 
 /** */
@@ -59,17 +53,6 @@ function getRejectedReasons<T>(results: PromiseSettledResult<T>[]): T[] {
     if (result.status === 'rejected' && result.reason) rejected.push(result.reason);
     return rejected;
   }, []);
-}
-
-/**
- * TODO(v11): Remove this function
- * @deprecated This function is no longer used and will be removed in a future major version.
- */
-export function tryPatchHandler(_taskRoot: string, _handlerPath: string): void {
-  consoleSandbox(() => {
-    // eslint-disable-next-line no-console
-    console.warn('The `tryPatchHandler` function is deprecated and will be removed in a future major version.');
-  });
 }
 
 /**
@@ -168,24 +151,12 @@ export function wrapHandler<TEvent, TResult>(
 ): Handler<TEvent, TResult> | StreamifyHandler<TEvent, TResult> {
   const START_TIME = performance.now();
 
-  // eslint-disable-next-line typescript/no-deprecated
-  if (typeof wrapOptions.startTrace !== 'undefined') {
-    consoleSandbox(() => {
-      // eslint-disable-next-line no-console
-      console.warn(
-        'The `startTrace` option is deprecated and will be removed in a future major version. If you want to disable tracing, set `SENTRY_TRACES_SAMPLE_RATE` to `0.0`.',
-      );
-    });
-  }
-
   const options: WrapperOptions = {
     flushTimeout: 2000,
     callbackWaitsForEmptyEventLoop: false,
     captureTimeoutWarning: true,
     timeoutWarningLimit: 500,
     captureAllSettledReasons: false,
-    // oxlint-disable-next-line typescript/no-deprecated -- set only to satisfy the type; see the TODO below
-    startTrace: true, // TODO(v11): Remove this option. Set to true here to satisfy the type, but has no effect.
     ...wrapOptions,
   };
 


### PR DESCRIPTION
Removes two deprecated, unused parts of the `@sentry/aws-serverless` public API:

* The `startTrace` option on `wrapHandler` — it had no effect (to disable tracing, set `tracesSampleRate` to `0`).
* The `tryPatchHandler` function.

Both are already documented in `docs/migration/v11-end-state.md`.

Fixes getsentry/sentry-javascript#22252