### PR TITLE
feat(core): Allow to pass scope to `getActiveSpan`

### DIFF
--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -23,8 +23,15 @@ import { hasSpanStreamingEnabled } from './spans/hasSpanStreamingEnabled';
 import { parseSampleRate } from '../utils/parseSampleRate';
 import { generateTraceId } from '../utils/propagationContext';
 import { safeMathRandom } from '../utils/randomSafeContext';
-import { _getSpanForScope, _setSpanForScope } from '../utils/spanOnScope';
-import { addChildSpanToSpan, getRootSpan, spanIsSampled, spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';
+import { _setSpanForScope } from '../utils/spanOnScope';
+import {
+  addChildSpanToSpan,
+  getActiveSpan,
+  getRootSpan,
+  spanIsSampled,
+  spanTimeInputToSeconds,
+  spanToJSON,
+} from '../utils/spanUtils';
 import { propagationContextFromHeaders, shouldContinueTrace } from '../utils/tracing';
 import { freezeDscOnSpan, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { logSpanStart } from './logSpans';
@@ -360,7 +367,7 @@ function createChildOrRootSpan({
   forceTransaction,
   scope,
 }: {
-  parentSpan: SentrySpan | undefined;
+  parentSpan: Span | undefined;
   spanArguments: SentrySpanArguments;
   forceTransaction?: boolean;
   scope: Scope;
@@ -610,10 +617,10 @@ function _startChildSpan(
   return childSpan;
 }
 
-function getParentSpan(scope: Scope, customParentSpan: Span | null | undefined): SentrySpan | undefined {
+function getParentSpan(scope: Scope, customParentSpan: Span | null | undefined): Span | undefined {
   // always use the passed in span directly
   if (customParentSpan) {
-    return customParentSpan as SentrySpan;
+    return customParentSpan;
   }
 
   // This is different from `undefined` as it means the user explicitly wants no parent span
@@ -621,7 +628,7 @@ function getParentSpan(scope: Scope, customParentSpan: Span | null | undefined):
     return undefined;
   }
 
-  const span = _getSpanForScope(scope) as SentrySpan | undefined;
+  const span = getActiveSpan(scope);
 
   if (!span) {
     return undefined;
@@ -630,7 +637,7 @@ function getParentSpan(scope: Scope, customParentSpan: Span | null | undefined):
   const client = getClient();
   const options: Partial<ClientOptions> = client ? client.getOptions() : {};
   if (options.parentSpanIsAlwaysRootSpan) {
-    return getRootSpan(span) as SentrySpan;
+    return getRootSpan(span);
   }
 
   return span;

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -4,6 +4,7 @@ import type { RawAttributes } from '../attributes';
 import { serializeAttributes } from '../attributes';
 import { getMainCarrier } from '../carrier';
 import { getCurrentScope } from '../currentScopes';
+import type { Scope } from '../scope';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -429,14 +430,14 @@ export function INTERNAL_getSegmentSpan(span: SpanWithPotentialChildren): Span {
 /**
  * Returns the currently active span.
  */
-export function getActiveSpan(): Span | undefined {
+export function getActiveSpan(scope?: Scope): Span | undefined {
   const carrier = getMainCarrier();
   const acs = getAsyncContextStrategy(carrier);
   if (acs.getActiveSpan) {
-    return acs.getActiveSpan();
+    return acs.getActiveSpan(scope);
   }
 
-  return _getSpanForScope(getCurrentScope());
+  return _getSpanForScope(scope || getCurrentScope());
 }
 
 /**

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, test } from 'vitest';
 import {
   convertSpanLinksForEnvelope,
+  getCurrentScope,
+  Scope,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -16,12 +18,15 @@ import {
   startSpan,
   timestampInSeconds,
   TRACEPARENT_REGEXP,
+  withScope,
 } from '../../../src';
 import type { SpanLink } from '../../../src/types/link';
 import type { Span, SpanAttributes, SpanTimeInput, StreamedSpanJSON } from '../../../src/types/span';
 import type { SpanStatus } from '../../../src/types/spanStatus';
+import { _setSpanForScope } from '../../../src/utils/spanOnScope';
 import type { OpenTelemetrySdkTraceBaseSpan } from '../../../src/utils/spanUtils';
 import {
+  getActiveSpan,
   getRootSpan,
   spanIsSampled,
   spanTimeInputToSeconds,
@@ -776,6 +781,60 @@ describe('getRootSpan', () => {
           expect(getRootSpan(inactiveSpan)).toBe(root);
         });
       });
+    });
+  });
+});
+
+describe('getActiveSpan', () => {
+  beforeEach(() => {
+    const client = new TestClient(getDefaultTestClientOptions({ tracesSampleRate: 1 }));
+    setCurrentClient(client);
+  });
+
+  it('returns undefined if no span is active on the current scope', () => {
+    expect(getActiveSpan()).toBeUndefined();
+  });
+
+  it('returns the span active on the current scope', () => {
+    startSpan({ name: 'test' }, span => {
+      expect(getActiveSpan()).toBe(span);
+    });
+  });
+
+  it('returns the span for the passed-in scope instead of the current scope', () => {
+    const span = new SentrySpan({ name: 'test' });
+    const scope = new Scope();
+    _setSpanForScope(scope, span);
+
+    expect(getActiveSpan(scope)).toBe(span);
+  });
+
+  it('returns the span of the passed-in scope even when a different span is active on the current scope', () => {
+    const scopeSpan = new SentrySpan({ name: 'scope-span' });
+    const scope = new Scope();
+    _setSpanForScope(scope, scopeSpan);
+
+    startSpan({ name: 'active-span' }, activeSpan => {
+      expect(getActiveSpan()).toBe(activeSpan);
+      expect(getActiveSpan(scope)).toBe(scopeSpan);
+    });
+  });
+
+  it('returns undefined if the passed-in scope has no span', () => {
+    const scope = new Scope();
+
+    startSpan({ name: 'active-span' }, () => {
+      expect(getActiveSpan(scope)).toBeUndefined();
+    });
+  });
+
+  it('reads the span from the current scope when no scope is passed in', () => {
+    const span = new SentrySpan({ name: 'test' });
+
+    withScope(scope => {
+      _setSpanForScope(scope, span);
+      expect(scope).toBe(getCurrentScope());
+      expect(getActiveSpan()).toBe(span);
     });
   });
 });

--- a/packages/opentelemetry/src/utils/getActiveSpan.ts
+++ b/packages/opentelemetry/src/utils/getActiveSpan.ts
@@ -1,9 +1,21 @@
 import type { Span } from '@opentelemetry/api';
 import { trace } from '@opentelemetry/api';
+import type { Scope } from '@sentry/core';
+import { getContextFromScope } from './contextData';
 
 /**
  * Returns the currently active span.
  */
-export function getActiveSpan(): Span | undefined {
-  return trace.getActiveSpan();
+export function getActiveSpan(scope?: Scope): Span | undefined {
+  if (!scope) {
+    return trace.getActiveSpan();
+  }
+
+  const ctx = getContextFromScope(scope);
+  if (ctx) {
+    return trace.getSpan(ctx);
+  }
+
+  // If ctx cannot be picked from scope, return undefined
+  return undefined;
 }

--- a/packages/opentelemetry/test/utils/getActiveSpan.test.ts
+++ b/packages/opentelemetry/test/utils/getActiveSpan.test.ts
@@ -1,6 +1,7 @@
-import { trace } from '@opentelemetry/api';
-import { getRootSpan } from '@sentry/core';
+import { context, trace } from '@opentelemetry/api';
+import { getRootSpan, Scope } from '@sentry/core';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { setContextOnScope } from '../../src/utils/contextData';
 import { getActiveSpan } from '../../src/utils/getActiveSpan';
 import { mockSdkInit } from '../helpers/mockSdkInit';
 
@@ -70,6 +71,61 @@ describe('getActiveSpan', () => {
     });
 
     expect(getActiveSpan()).toBeUndefined();
+  });
+
+  describe('with a scope argument', () => {
+    it('returns the span of the context bound to the passed-in scope', () => {
+      const tracer = trace.getTracer('test');
+
+      tracer.startActiveSpan('scope-span', span => {
+        const ctx = trace.setSpan(context.active(), span);
+        const scope = new Scope();
+        setContextOnScope(scope, ctx);
+
+        expect(getActiveSpan(scope)).toBe(span);
+
+        span.end();
+      });
+    });
+
+    it('reads the span from the passed-in scope instead of the currently active context', () => {
+      const tracer = trace.getTracer('test');
+
+      tracer.startActiveSpan('scope-span', scopeSpan => {
+        const scopedCtx = trace.setSpan(context.active(), scopeSpan);
+        const scope = new Scope();
+        setContextOnScope(scope, scopedCtx);
+
+        scopeSpan.end();
+
+        tracer.startActiveSpan('active-span', activeSpan => {
+          // The active context has `activeSpan`, but the passed-in scope points at `scopeSpan`
+          expect(getActiveSpan()).toBe(activeSpan);
+          expect(getActiveSpan(scope)).toBe(scopeSpan);
+
+          activeSpan.end();
+        });
+      });
+    });
+
+    it('returns undefined if the passed-in scope has no context bound to it', () => {
+      const scope = new Scope();
+
+      const tracer = trace.getTracer('test');
+      tracer.startActiveSpan('active-span', span => {
+        // A scope without a bound context must not fall back to the active context
+        expect(getActiveSpan(scope)).toBeUndefined();
+
+        span.end();
+      });
+    });
+
+    it('returns undefined if the context bound to the passed-in scope has no span', () => {
+      const scope = new Scope();
+      setContextOnScope(scope, context.active());
+
+      expect(getActiveSpan(scope)).toBeUndefined();
+    });
   });
 });
 


### PR DESCRIPTION
This is a primitive we can use to refactor some otel-specific things away.