### PR TITLE
feat(core): Use `getActiveSpan` instead of  `_getSpanFromScope` for logs & metrics

### DIFF
--- a/packages/core/src/logs/internal.ts
+++ b/packages/core/src/logs/internal.ts
@@ -9,7 +9,7 @@ import type { Log, SerializedLog } from '../types/log';
 import { consoleSandbox, debug } from '../utils/debug-logger';
 import { isParameterizedString } from '../utils/is';
 import { getCombinedScopeData } from '../utils/scopeData';
-import { _getSpanForScope } from '../utils/spanOnScope';
+import { getActiveSpan } from '../utils/spanUtils';
 import { timestampInSeconds } from '../utils/time';
 import { getSequenceAttribute } from '../utils/timestampSequence';
 import { _getTraceInfoFromScope } from '../utils/trace-info';
@@ -138,7 +138,7 @@ export function _INTERNAL_captureLog(
     });
   }
 
-  const span = _getSpanForScope(currentScope);
+  const span = getActiveSpan(currentScope);
   // Add the parent span ID to the log attributes for trace context
   setLogAttribute(processedLogAttributes, 'sentry.trace.parent_span_id', span?.spanContext().spanId);
 

--- a/packages/core/src/metrics/internal.ts
+++ b/packages/core/src/metrics/internal.ts
@@ -9,7 +9,7 @@ import type { Metric, SerializedMetric } from '../types/metric';
 import type { User } from '../types/user';
 import { debug } from '../utils/debug-logger';
 import { getCombinedScopeData } from '../utils/scopeData';
-import { _getSpanForScope } from '../utils/spanOnScope';
+import { getActiveSpan } from '../utils/spanUtils';
 import { timestampInSeconds } from '../utils/time';
 import { getSequenceAttribute } from '../utils/timestampSequence';
 import { _getTraceInfoFromScope } from '../utils/trace-info';
@@ -132,7 +132,7 @@ function _buildSerializedMetric(
 ): SerializedMetric {
   // Get trace context
   const [, traceContext] = _getTraceInfoFromScope(client, currentScope);
-  const span = _getSpanForScope(currentScope);
+  const span = getActiveSpan(currentScope);
   const traceId = span ? span.spanContext().traceId : traceContext?.trace_id;
   const spanId = span ? span.spanContext().spanId : undefined;
 


### PR DESCRIPTION
Use this API instead of a stack-specific one.