### PR TITLE
ref(node): Remove `OpenTelemetryServerRuntimeOptions` type

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -683,7 +683,6 @@ Sentry.init({
 ### `@sentry/node` / Server-side SDKs
 
 - `SentryContextManager` is no longer exported. It is no longer needed now that Sentry does not set up OpenTelemetry by default.
-- The `OpenTelemetryServerRuntimeOptions` type was removed. Its only remaining option, `enableOpenTelemetrySetup`, is part of the SDK-specific options types (e.g. `NodeOptions`).
 - The deprecated `honoIntegration` was removed. Use the [`@sentry/hono`](https://www.npmjs.com/package/@sentry/hono) SDK to instrument Hono.
 - The `connect` instrumentation was removed.
 - The deprecated `prismaInstrumentation` option was removed. It was no longer used, as Prisma works out of the box.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -683,6 +683,7 @@ Sentry.init({
 ### `@sentry/node` / Server-side SDKs
 
 - `SentryContextManager` is no longer exported. It is no longer needed now that Sentry does not set up OpenTelemetry by default.
+- The `OpenTelemetryServerRuntimeOptions` type was removed. Its only remaining option, `enableOpenTelemetrySetup`, is part of the SDK-specific options types (e.g. `NodeOptions`).
 - The deprecated `honoIntegration` was removed. Use the [`@sentry/hono`](https://www.npmjs.com/package/@sentry/hono) SDK to instrument Hono.
 - The `connect` instrumentation was removed.
 - The deprecated `prismaInstrumentation` option was removed. It was no longer used, as Prisma works out of the box.

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -749,6 +749,7 @@ Sentry.init({
 ### `@sentry/node` / Server-side SDKs
 
 - `SentryContextManager` is no longer exported. It is no longer needed now that Sentry does not set up OpenTelemetry by default.
+- The `OpenTelemetryServerRuntimeOptions` type was removed. Its only remaining option, `enableOpenTelemetrySetup`, is part of the SDK-specific options types (e.g. `NodeOptions`).
 - The deprecated `honoIntegration` was removed. Use the [`@sentry/hono`](https://www.npmjs.com/package/@sentry/hono) SDK to instrument Hono.
 - The `connect` instrumentation was removed.
 - The deprecated `prismaInstrumentation` option was removed. It was no longer used, as Prisma works out of the box.
@@ -826,7 +827,6 @@ Sentry.init({
 ### `@sentry/opentelemetry`
 
 - `getTraceContextForScope` was removed. Scope-to-trace-context resolution now goes through the shared core implementation.
-- `OpenTelemetryServerRuntimeOptions` was removed.
 - The `@opentelemetry/core` peer dependency was removed; its APIs are now vendored internally.
 - `getSentryResource` was removed.
 - OpenTelemetry resources are no longer collected, and `contexts.otel.resource` was dropped from events. As a result, the `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` environment variables are no longer read by the SDK.

--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -1,12 +1,26 @@
-import type { BaseTransportOptions, ClientOptions, Options } from '@sentry/core';
-import type { OpenTelemetryServerRuntimeOptions } from '@sentry/node';
+import type { BaseTransportOptions, ClientOptions, Options, ServerRuntimeOptions } from '@sentry/core';
 
 /**
  * Base options for the Sentry Bun SDK.
- * Extends the common WinterTC options with OpenTelemetry support shared with Node.js and other server-side SDKs.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface BaseBunOptions extends OpenTelemetryServerRuntimeOptions {}
+export interface BaseBunOptions extends ServerRuntimeOptions {
+  /**
+   * Controls whether the SDK registers its own Sentry OpenTelemetry tracer provider.
+   *
+   * When `false` (the default), no tracer provider is set up. The SDK isolates scopes with a native
+   * AsyncLocalStorage context strategy and still emits spans via its own instrumentation, but spans
+   * created through `@opentelemetry/api` are not captured.
+   *
+   * When `true`, the SDK registers its own `SentryTracerProvider` (and `SentryPropagator`) as the
+   * global OpenTelemetry tracer provider, so spans created through `@opentelemetry/api` become Sentry
+   * spans. If you run your own tracer provider, keep this `false` so the SDK does not register a
+   * competing provider; note the SDK no longer feeds spans into a user-owned provider, so those spans
+   * stay in your OpenTelemetry pipeline.
+   *
+   * @default false
+   */
+  enableOpenTelemetrySetup?: boolean;
+}
 
 /**
  * Configuration options for the Sentry Bun SDK

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -63,7 +63,7 @@ export {
 export { initOpenTelemetry } from './sdk/initOtel';
 export { getAutoPerformanceIntegrations } from './integrations/tracing';
 
-export type { NodeOptions, OpenTelemetryServerRuntimeOptions } from './types';
+export type { NodeOptions } from './types';
 
 export { setOpenTelemetryContextAsyncContextStrategy } from '@sentry/opentelemetry';
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -2,11 +2,9 @@ import type { ClientOptions, Options, SamplingContext, Scope, ServerRuntimeOptio
 import type { NodeTransportOptions } from './transports';
 
 /**
- * Base options for WinterTC-compatible server-side JavaScript runtimes with OpenTelemetry support.
- * This interface extends the base ServerRuntimeOptions from @sentry/core with OpenTelemetry-specific configuration options.
- * Used by Node.js, Bun, and other WinterTC-compliant runtime SDKs that support OpenTelemetry instrumentation.
+ * Base options for the Sentry Node SDK.
  */
-export interface OpenTelemetryServerRuntimeOptions extends ServerRuntimeOptions {
+export interface BaseNodeOptions extends ServerRuntimeOptions {
   /**
    * Controls whether the SDK registers its own Sentry OpenTelemetry tracer provider.
    *
@@ -23,13 +21,7 @@ export interface OpenTelemetryServerRuntimeOptions extends ServerRuntimeOptions 
    * @default false
    */
   enableOpenTelemetrySetup?: boolean;
-}
 
-/**
- * Base options for the Sentry Node SDK.
- * Extends the common WinterTC options with OpenTelemetry support shared with Bun and other server-side SDKs.
- */
-export interface BaseNodeOptions extends OpenTelemetryServerRuntimeOptions {
   /**
    * Override the runtime name reported in events.
    * Defaults to 'node' with the current process version if not specified.


### PR DESCRIPTION
## What

Removes the `OpenTelemetryServerRuntimeOptions` type. Its only remaining option, `enableOpenTelemetrySetup`, now lives directly on the SDK-specific option types.

* `BaseNodeOptions` declares `enableOpenTelemetrySetup` and extends `ServerRuntimeOptions` directly.
* `BaseBunOptions` declares its own `enableOpenTelemetrySetup`, matching how the Deno, Cloudflare and Vercel Edge SDKs already declare it.
* `@sentry/node` no longer exports the type.
* Migration docs updated.

## Why

The type existed to share OpenTelemetry options across server runtimes, but the rest of those options (`skipOpenTelemetrySetup`, `openTelemetryInstrumentations`, `openTelemetrySpanProcessors`, `validateOpenTelemetrySetup`) are already gone. With a single option left, the shared base only added indirection.

Closes: getsentry/sentry-javascript#21118