### PR TITLE
ref(react-router)!: Remove deprecated Vite build options and back-compat shims

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -854,41 +854,6 @@ export default defineConfig({
 });
 ```
 
-### `@sentry/react-router`
-
-The deprecated `sourceMapsUploadOptions` option was removed from `sentryReactRouter()`. Move its fields to the root level of the `sentryConfig` passed to `sentryReactRouter()`. Note that `enabled` was replaced by `sourcemaps.disable` (inverted: `enabled: false` becomes `sourcemaps: { disable: true }`).
-
-```ts
-// vite.config.ts
-import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
-import { defineConfig } from 'vite';
-
-export const sentryConfig: SentryReactRouterBuildOptions = {
-  // before
-  sourceMapsUploadOptions: {
-    enabled: false,
-    filesToDeleteAfterUpload: ['./build/**/*.map'],
-    release: { name: 'my-release' },
-  },
-
-  // after
-  org: 'my-org',
-  project: 'my-project',
-  authToken: process.env.SENTRY_AUTH_TOKEN,
-  sourcemaps: {
-    disable: true,
-    filesToDeleteAfterUpload: ['./build/**/*.map'],
-  },
-  release: { name: 'my-release' },
-};
-
-export default defineConfig(config => ({
-  plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
-  sentryConfig,
-}));
-```
-
 ## 4. Package Removals
 
 ### `@sentry/types` is no longer published

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -778,6 +778,7 @@ Sentry.init({
   actions are instrumented automatically via the instrumentation API - export
   `instrumentations = [Sentry.createSentryServerInstrumentation()]` from your `entry.server.tsx`
   instead of wrapping them individually.
+- The deprecated `sentryHandleRequest` export was removed. Use `wrapSentryHandleRequest` instead.
 
 ### `@sentry/profiling-node`
 
@@ -785,7 +786,7 @@ Sentry.init({
 
 ### Meta-framework build options
 
-The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin options were removed from `@sentry/nuxt` and `@sentry/sveltekit`. Use the top-level equivalents (e.g. `sourcemaps`, `release`, `authToken`, `org`, `project`, `telemetry`) instead.
+The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin options were removed from `@sentry/nuxt`, `@sentry/sveltekit`, and `@sentry/react-router`. Use the top-level equivalents (e.g. `sourcemaps`, `release`, `authToken`, `org`, `project`, `telemetry`) instead.
 
 ### `@sentry/nuxt`
 
@@ -851,6 +852,41 @@ export default defineConfig({
     sveltekit(),
   ],
 });
+```
+
+### `@sentry/react-router`
+
+The deprecated `sourceMapsUploadOptions` option was removed from `sentryReactRouter()`. Move its fields to the root level of the `sentryConfig` passed to `sentryReactRouter()`. Note that `enabled` was replaced by `sourcemaps.disable` (inverted: `enabled: false` becomes `sourcemaps: { disable: true }`).
+
+```ts
+// vite.config.ts
+import { reactRouter } from '@react-router/dev/vite';
+import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
+import { defineConfig } from 'vite';
+
+export const sentryConfig: SentryReactRouterBuildOptions = {
+  // before
+  sourceMapsUploadOptions: {
+    enabled: false,
+    filesToDeleteAfterUpload: ['./build/**/*.map'],
+    release: { name: 'my-release' },
+  },
+
+  // after
+  org: 'my-org',
+  project: 'my-project',
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  sourcemaps: {
+    disable: true,
+    filesToDeleteAfterUpload: ['./build/**/*.map'],
+  },
+  release: { name: 'my-release' },
+};
+
+export default defineConfig(config => ({
+  plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
+  sentryConfig,
+}));
 ```
 
 ## 4. Package Removals

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -778,7 +778,6 @@ Sentry.init({
   actions are instrumented automatically via the instrumentation API - export
   `instrumentations = [Sentry.createSentryServerInstrumentation()]` from your `entry.server.tsx`
   instead of wrapping them individually.
-- The deprecated `sentryHandleRequest` export was removed. Use `wrapSentryHandleRequest` instead.
 
 ### `@sentry/profiling-node`
 
@@ -786,7 +785,7 @@ Sentry.init({
 
 ### Meta-framework build options
 
-The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin options were removed from `@sentry/nuxt`, `@sentry/sveltekit`, and `@sentry/react-router`. Use the top-level equivalents (e.g. `sourcemaps`, `release`, `authToken`, `org`, `project`, `telemetry`) instead.
+The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin options were removed from `@sentry/nuxt` and `@sentry/sveltekit`. Use the top-level equivalents (e.g. `sourcemaps`, `release`, `authToken`, `org`, `project`, `telemetry`) instead.
 
 ### `@sentry/nuxt`
 

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -944,6 +944,10 @@ export default defineConfig({
 });
 ```
 
+### `@sentry/react-router`
+
+The deprecated `sourceMapsUploadOptions` option was removed from `sentryReactRouter()`. Move its fields to the root level of the `sentryConfig` passed to `sentryReactRouter()`. Note that `enabled` was replaced by `sourcemaps.disable` (inverted: `enabled: false` becomes `sourcemaps: { disable: true }`).
+
 ## 4. Package Removals
 
 ### `@sentry/types` is no longer published

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -853,6 +853,7 @@ Sentry.init({
   actions are instrumented automatically via the instrumentation API - export
   `instrumentations = [Sentry.createSentryServerInstrumentation()]` from your `entry.server.tsx`
   instead of wrapping them individually.
+- The deprecated `sentryHandleRequest` export was removed. Use `wrapSentryHandleRequest` instead.
 
 ### `@sentry/profiling-node`
 

--- a/packages/react-router/src/server/index.ts
+++ b/packages/react-router/src/server/index.ts
@@ -4,8 +4,7 @@
 export * from '@sentry/node';
 
 export { init } from './sdk';
-// eslint-disable-next-line typescript/no-deprecated
-export { wrapSentryHandleRequest, sentryHandleRequest } from './wrapSentryHandleRequest';
+export { wrapSentryHandleRequest } from './wrapSentryHandleRequest';
 export { createSentryHandleRequest, type SentryHandleRequestOptions } from './createSentryHandleRequest';
 export { createSentryHandleError, type SentryHandleErrorOptions } from './createSentryHandleError';
 export { getMetaTagTransformer } from './getMetaTagTransformer';

--- a/packages/react-router/src/server/integration/lowQualityTransactionsFilterIntegration.ts
+++ b/packages/react-router/src/server/integration/lowQualityTransactionsFilterIntegration.ts
@@ -1,6 +1,5 @@
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration } from '@sentry/core';
-import type { NodeOptions } from '@sentry/node';
 
 const LOW_QUALITY_TRANSACTIONS_FILTERS = [
   /GET \/node_modules\//,
@@ -11,8 +10,7 @@ const LOW_QUALITY_TRANSACTIONS_FILTERS = [
   { attributes: { 'http.target': /\/__manifest/ } },
 ];
 
-// TODO(v11): Remove the `_options` parameter (unused and only kept for back-compat with the previous signature)
-const _lowQualityTransactionsFilterIntegration = ((_options?: NodeOptions) => ({
+const _lowQualityTransactionsFilterIntegration = (() => ({
   name: 'LowQualityTransactionsFilter' as const,
   beforeSetup(client) {
     const opts = client.getOptions();

--- a/packages/react-router/src/server/sdk.ts
+++ b/packages/react-router/src/server/sdk.ts
@@ -13,7 +13,7 @@ import { reactRouterServerIntegration } from './integration/reactRouterServer';
 export function getDefaultReactRouterServerIntegrations(options: NodeOptions): Integration[] {
   return [
     ...getNodeDefaultIntegrations(options),
-    lowQualityTransactionsFilterIntegration(options),
+    lowQualityTransactionsFilterIntegration(),
     reactRouterServerIntegration(),
   ];
 }

--- a/packages/react-router/src/server/wrapSentryHandleRequest.ts
+++ b/packages/react-router/src/server/wrapSentryHandleRequest.ts
@@ -128,7 +128,3 @@ export function wrapSentryHandleRequest(
     }
   };
 }
-
-// todo(v11): remove this
-/** @deprecated Use `wrapSentryHandleRequest` instead. */
-export const sentryHandleRequest = wrapSentryHandleRequest;

--- a/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
+++ b/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
@@ -22,11 +22,6 @@ function getSentryConfig(viteConfig: unknown): SentryReactRouterBuildOptions {
  * top-level config only would silently ignore `unstable_sentryVitePluginOptions`.
  */
 function resolveSourceMapsDisable(sentryConfig: SentryReactRouterBuildOptions): boolean | 'disable-upload' | undefined {
-  // eslint-disable-next-line typescript/no-deprecated
-  if (sentryConfig.sourceMapsUploadOptions?.enabled === false) {
-    return true;
-  }
-
   return sentryConfig.sourcemaps?.disable ?? sentryConfig.unstable_sentryVitePluginOptions?.sourcemaps?.disable;
 }
 
@@ -38,12 +33,6 @@ function resolveSourceMapsDisable(sentryConfig: SentryReactRouterBuildOptions): 
 export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteConfig }) => {
   const sentryConfig = getSentryConfig(viteConfig);
 
-  // todo(v11): Remove deprecated sourceMapsUploadOptions support (no need for spread/pick anymore)
-  const {
-    sourceMapsUploadOptions, // extract to exclude from rest config
-    ...sentryConfigWithoutDeprecatedSourceMapOption
-  } = sentryConfig;
-
   const unstableSentryVitePluginOptions = sentryConfig.unstable_sentryVitePluginOptions;
 
   const {
@@ -53,15 +42,14 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
     release,
     sourcemaps = { disable: false },
     debug = false,
-  }: Omit<SentryReactRouterBuildOptions, 'sourcemaps' | 'sourceMapsUploadOptions'> &
+  }: Omit<SentryReactRouterBuildOptions, 'sourcemaps'> &
     // Pick 'sourcemaps' from Vite plugin options as the types allow more (e.g. Promise values for `deleteFilesAfterUpload`)
     Pick<SentryVitePluginOptions, 'sourcemaps'> = {
     ...unstableSentryVitePluginOptions,
-    ...sentryConfigWithoutDeprecatedSourceMapOption, // spread in the config without the deprecated sourceMapsUploadOptions
+    ...sentryConfig,
     sourcemaps: {
       ...unstableSentryVitePluginOptions?.sourcemaps,
       ...sentryConfig.sourcemaps,
-      ...sourceMapsUploadOptions,
       disable: resolveSourceMapsDisable(sentryConfig),
     },
     release: {
@@ -72,7 +60,7 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
       ? Array.isArray(unstableSentryVitePluginOptions?.project)
         ? unstableSentryVitePluginOptions?.project[0]
         : unstableSentryVitePluginOptions?.project
-      : sentryConfigWithoutDeprecatedSourceMapOption.project,
+      : sentryConfig.project,
   };
 
   const cliInstance = new SentryCli(null, {
@@ -143,7 +131,7 @@ export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteCo
     debug &&
       // eslint-disable-next-line no-console
       console.info(
-        `[Sentry] Automatically setting \`sourceMapsUploadOptions.filesToDeleteAfterUpload: ${JSON.stringify(
+        `[Sentry] Automatically setting \`sourcemaps.filesToDeleteAfterUpload: ${JSON.stringify(
           updatedFilesToDeleteAfterUpload,
         )}\` to delete generated source maps after they were uploaded to Sentry.`,
       );

--- a/packages/react-router/src/vite/types.ts
+++ b/packages/react-router/src/vite/types.ts
@@ -1,52 +1,6 @@
 import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
 import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
 
-type SourceMapsOptions = {
-  /**
-   * If this flag is `true`, and an auth token is detected, the Sentry SDK will
-   * automatically generate and upload source maps to Sentry during a production build.
-   *
-   * @default true
-   * @deprecated Use `sourcemaps.disable` option instead of `sourceMapsUploadOptions.enabled`.
-   */
-  enabled?: boolean;
-
-  /**
-   * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact
-   * upload to Sentry has been completed.
-   *
-   * @default [] - By default no files are deleted.
-   *
-   * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
-   *
-   * @deprecated Use `sourcemaps.filesToDeleteAfterUpload` option instead of `sourceMapsUploadOptions.filesToDeleteAfterUpload`.
-   */
-  filesToDeleteAfterUpload?: string | Array<string>;
-
-  /**
-   * Options related to managing the Sentry releases for a build.
-   *
-   * More info: https://docs.sentry.io/product/releases/
-   *
-   * @deprecated Use the `release` option at the root of `SentryVitePluginOptions` instead.
-   */
-  // todo(v11): Remove this option (currently it's not in use either, but it's kept to not cause a breaking change)
-  release?: {
-    /**
-     * Unique identifier for the release you want to create.
-     *
-     * This value can also be specified via the `SENTRY_RELEASE` environment variable.
-     *
-     * Defaults to automatically detecting a value for your environment.
-     * This includes values for Cordova, Heroku, AWS CodeBuild, CircleCI, Xcode, and Gradle, and otherwise uses the git `HEAD`'s commit SHA.
-     * (the latter requires access to git CLI and for the root directory to be a valid repository)
-     *
-     * If you didn't provide a value and the plugin can't automatically detect one, no release will be created.
-     */
-    name?: string;
-  };
-};
-
 export type SentryReactRouterBuildOptions = BuildTimeOptionsBase &
   UnstableVitePluginOptions<Partial<SentryVitePluginOptions>> & {
     /**
@@ -67,11 +21,4 @@ export type SentryReactRouterBuildOptions = BuildTimeOptionsBase &
        */
       ignoredComponents?: string[];
     };
-
-    /**
-     * Options for the Sentry Vite plugin to customize the source maps upload process.
-     *
-     */
-    sourceMapsUploadOptions?: SourceMapsOptions;
-    // todo(v11): Remove this option (all options already exist in BuildTimeOptionsBase)
   };

--- a/packages/react-router/test/server/lowQualityTransactionsFilterIntegration.test.ts
+++ b/packages/react-router/test/server/lowQualityTransactionsFilterIntegration.test.ts
@@ -9,7 +9,7 @@ function makeMockClient(initial: Partial<ClientOptions> = {}): Client {
 }
 
 function setupIntegrationAndGetIgnoreSpans(initial: Partial<ClientOptions> = {}) {
-  const integration = lowQualityTransactionsFilterIntegration({});
+  const integration = lowQualityTransactionsFilterIntegration();
   const client = makeMockClient(initial);
   integration.beforeSetup!(client);
   return client.getOptions().ignoreSpans!;

--- a/packages/react-router/test/vite/buildEnd/handleOnBuildEnd.test.ts
+++ b/packages/react-router/test/vite/buildEnd/handleOnBuildEnd.test.ts
@@ -134,15 +134,18 @@ describe('sentryOnBuildEnd', () => {
     expect(mockSentryCliInstance.releases.new).toHaveBeenCalledWith('v1.0.0');
   });
 
-  it('should upload source maps when enabled', async () => {
+  it('resolves root-level BuildTimeOptionsBase options for release creation and source map upload', async () => {
     const config = {
       ...defaultConfig,
       viteConfig: {
         ...defaultConfig.viteConfig,
         sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          sourceMapsUploadOptions: {
-            enabled: true,
+          org: 'my-org',
+          project: 'my-project',
+          authToken: 'my-token',
+          release: { name: '1.2.3' },
+          sourcemaps: {
+            filesToDeleteAfterUpload: ['./build/custom/**/*.map'],
           },
         },
       } as unknown as TestConfig,
@@ -150,6 +153,26 @@ describe('sentryOnBuildEnd', () => {
 
     // @ts-expect-error - mocking the React config
     await sentryOnBuildEnd(config);
+
+    expect(SentryCli).toHaveBeenCalledWith(null, {
+      authToken: 'my-token',
+      org: 'my-org',
+      project: 'my-project',
+    });
+    expect(mockSentryCliInstance.releases.new).toHaveBeenCalledWith('1.2.3');
+    expect(mockSentryCliInstance.releases.uploadSourceMaps).toHaveBeenCalledWith('1.2.3', {
+      include: [{ paths: ['/build'] }],
+      live: 'rejectOnError',
+    });
+    expect(glob).toHaveBeenCalledWith(['./build/custom/**/*.map'], {
+      absolute: true,
+      nodir: true,
+    });
+  });
+
+  it('should upload source maps when enabled', async () => {
+    // @ts-expect-error - mocking the React config
+    await sentryOnBuildEnd(defaultConfig);
 
     expect(mockSentryCliInstance.releases.uploadSourceMaps).toHaveBeenCalledTimes(1);
     expect(mockSentryCliInstance.releases.uploadSourceMaps).toHaveBeenCalledWith('undefined', {
@@ -158,27 +181,7 @@ describe('sentryOnBuildEnd', () => {
     });
   });
 
-  it('should not upload source maps when explicitly disabled', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          sourceMapsUploadOptions: {
-            enabled: false,
-          },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(mockSentryCliInstance.releases.uploadSourceMaps).not.toHaveBeenCalled();
-  });
-
-  it('should not upload source maps when disabled via top-level sourcemaps.disable', async () => {
+  it('should not upload or inject source maps when disabled via top-level sourcemaps.disable', async () => {
     const config = {
       ...defaultConfig,
       viteConfig: {
@@ -330,24 +333,6 @@ describe('sentryOnBuildEnd', () => {
     expect(fs.promises.rm).not.toHaveBeenCalled();
   });
 
-  it('should not delete source maps when disabled via the deprecated sourceMapsUploadOptions', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          sourceMapsUploadOptions: { enabled: false },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(glob).not.toHaveBeenCalled();
-  });
-
   it('should delete source maps after upload with default pattern', async () => {
     // @ts-expect-error - mocking the React config
     await sentryOnBuildEnd(defaultConfig);
@@ -365,7 +350,7 @@ describe('sentryOnBuildEnd', () => {
         ...defaultConfig.viteConfig,
         sentryConfig: {
           ...defaultConfig.viteConfig.sentryConfig,
-          sourceMapsUploadOptions: {
+          sourcemaps: {
             filesToDeleteAfterUpload: '/custom/**/*.map',
           },
         },
@@ -406,21 +391,8 @@ describe('sentryOnBuildEnd', () => {
   });
 
   it('should inject debug IDs before uploading source maps', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          sourceMapsUploadOptions: {
-            enabled: true,
-          },
-        },
-      } as unknown as TestConfig,
-    };
-
     // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
+    await sentryOnBuildEnd(defaultConfig);
 
     expect(mockSentryCliInstance.execute).toHaveBeenCalledWith(['sourcemaps', 'inject', '/build'], false);
   });

--- a/packages/react-router/test/vite/types.test-d.ts
+++ b/packages/react-router/test/vite/types.test-d.ts
@@ -70,35 +70,6 @@ describe('Sentry React-Router build-time options type', () => {
     expectTypeOf(completeOptions).toEqualTypeOf<SentryReactRouterBuildOptions>();
   });
 
-  it('includes all deprecated options', () => {
-    const completeOptions: SentryReactRouterBuildOptions = {
-      // SentryNuxtModuleOptions specific options
-      reactComponentAnnotation: { enabled: true, ignoredComponents: ['IgnoredComponent1', 'IgnoredComponent2'] },
-
-      unstable_sentryVitePluginOptions: {
-        // Rollup plugin options
-        bundleSizeOptimizations: {
-          excludeDebugStatements: true,
-        },
-        // Vite plugin options
-        sourcemaps: {
-          assets: './dist/**/*',
-        },
-      },
-
-      // Deprecated sourceMapsUploadOptions
-      sourceMapsUploadOptions: {
-        release: {
-          name: 'deprecated-release',
-        },
-        enabled: true,
-        filesToDeleteAfterUpload: ['./build/*.map'],
-      },
-    };
-
-    expectTypeOf(completeOptions).toEqualTypeOf<SentryReactRouterBuildOptions>();
-  });
-
   it('allows partial configuration', () => {
     const minimalOptions: SentryReactRouterBuildOptions = { reactComponentAnnotation: { enabled: true } };
 


### PR DESCRIPTION
Removes the deprecated Vite build options and back-compat shims in `@sentry/react-router` that were kept to avoid breaking changes.

Closes #https://github.com/getsentry/sentry-javascript/issues/22251
