### PR TITLE
feat(v10/core): Deprecate `scope.clear()` method

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -549,6 +549,9 @@ export class Scope {
   /**
    * Clears the current scope and resets its properties.
    * Note: The client will not be cleared.
+   *
+   * @deprecated This method will be removed in v11. To reset scope state, re-initialize the SDK or run
+   * your code in a fresh scope via `withScope` instead.
    */
   public clear(): this {
     // client is not cleared here on purpose!


### PR DESCRIPTION
Marks `Scope.clear()` as `@deprecated` ahead of its removal in v11, giving consumers an IDE deprecation warning and a migration path on v10.

`clear()` mutates a scope's fields in place but intentionally leaves the client attached, which makes it an awkward reset primitive. The recommended replacements are re-initializing the SDK or running code in a fresh scope via `withScope`/`withIsolationScope`.

This is a JSDoc-only change — no runtime behavior changes on v10. The removal itself lands on `develop` for v11. https://github.com/getsentry/sentry-javascript/pull/23230

🤖 Generated with [Claude Code](https://claude.com/claude-code)