### PR TITLE
feat(core): Add `refs` field to `Scope` for non-serialized references

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -18,11 +18,12 @@ import type { PropagationContext } from './types/tracing';
 import type { User } from './types/user';
 import { debug } from './utils/debug-logger';
 import { isPlainObject } from './utils/is';
+import { addNonEnumerableProperty } from './utils/object';
 import { merge } from './utils/merge';
 import { uuid4 } from './utils/misc';
 import { generateTraceId } from './utils/propagationContext';
 import { safeMathRandom } from './utils/randomSafeContext';
-import { _getSpanForScope, _setSpanForScope } from './utils/spanOnScope';
+import { _getSpanForScope } from './utils/spanOnScope';
 import { truncate } from './utils/string';
 import { dateTimestampInSeconds } from './utils/time';
 
@@ -156,6 +157,15 @@ export class Scope {
   /** Conversation ID */
   protected _conversationId?: string;
 
+  /**
+   * A place to stash references to objects that are associated with this scope but should not be serialized,
+   * such as the currently active span (core) or the OpenTelemetry context (opentelemetry).
+   * These are cloned as-is (shallow) when the scope is cloned, so they survive `clone()`.
+   *
+   * This is non-enumerable so it does not leak into `toJSON`, `Object.keys` or structural comparisons.
+   */
+  public refs!: Record<string, unknown>;
+
   // NOTE: Any field which gets added here should get added not only to the constructor but also to the `clone` method.
 
   public constructor() {
@@ -170,6 +180,7 @@ export class Scope {
     this._extra = {};
     this._contexts = {};
     this._sdkProcessingMetadata = {};
+    addNonEnumerableProperty(this, 'refs', {});
     this._propagationContext = {
       traceId: generateTraceId(),
       sampleRand: safeMathRandom(),
@@ -206,8 +217,7 @@ export class Scope {
     newScope._client = this._client;
     newScope._lastEventId = this._lastEventId;
     newScope._conversationId = this._conversationId;
-
-    _setSpanForScope(newScope, _getSpanForScope(this));
+    newScope.refs = { ...this.refs };
 
     return newScope;
   }

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -23,7 +23,6 @@ import { merge } from './utils/merge';
 import { uuid4 } from './utils/misc';
 import { generateTraceId } from './utils/propagationContext';
 import { safeMathRandom } from './utils/randomSafeContext';
-import { _getSpanForScope } from './utils/spanOnScope';
 import { truncate } from './utils/string';
 import { dateTimestampInSeconds } from './utils/time';
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -164,7 +164,7 @@ export class Scope {
    *
    * This is non-enumerable so it does not leak into `toJSON`, `Object.keys` or structural comparisons.
    */
-  public refs!: Record<string, unknown>;
+  public declare refs: Record<string, unknown>;
 
   // NOTE: Any field which gets added here should get added not only to the constructor but also to the `clone` method.
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -164,7 +164,7 @@ export class Scope {
    *
    * This is non-enumerable so it does not leak into `toJSON`, `Object.keys` or structural comparisons.
    */
-  public declare refs: Record<string, unknown>;
+  declare public refs: Record<string, unknown>;
 
   // NOTE: Any field which gets added here should get added not only to the constructor but also to the `clone` method.
 

--- a/packages/core/src/utils/spanOnScope.ts
+++ b/packages/core/src/utils/spanOnScope.ts
@@ -1,13 +1,8 @@
 import type { Scope } from '../scope';
 import type { Span } from '../types/span';
-import { addNonEnumerableProperty } from '../utils/object';
 import { derefWeakRef, makeWeakRef, type MaybeWeakRef } from './weakRef';
 
-const SCOPE_SPAN_FIELD = '_sentrySpan';
-
-type ScopeWithMaybeSpan = Scope & {
-  [SCOPE_SPAN_FIELD]?: MaybeWeakRef<Span>;
-};
+const SCOPE_SPAN_FIELD = 'span';
 
 /**
  * Set the active span for a given scope.
@@ -16,10 +11,10 @@ type ScopeWithMaybeSpan = Scope & {
 export function _setSpanForScope(scope: Scope, span: Span | undefined): void {
   if (span) {
     // Use WeakRef to avoid circular reference with span holding scope
-    addNonEnumerableProperty(scope, SCOPE_SPAN_FIELD, makeWeakRef(span));
+    scope.refs[SCOPE_SPAN_FIELD] = makeWeakRef(span);
   } else {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    delete (scope as ScopeWithMaybeSpan)[SCOPE_SPAN_FIELD];
+    delete scope.refs[SCOPE_SPAN_FIELD];
   }
 }
 
@@ -27,6 +22,6 @@ export function _setSpanForScope(scope: Scope, span: Span | undefined): void {
  * Get the active span for a given scope.
  * NOTE: This should NOT be used directly, but is only used internally by the trace methods.
  */
-export function _getSpanForScope(scope: ScopeWithMaybeSpan): Span | undefined {
-  return derefWeakRef(scope[SCOPE_SPAN_FIELD]);
+export function _getSpanForScope(scope: Scope): Span | undefined {
+  return derefWeakRef(scope.refs[SCOPE_SPAN_FIELD] as MaybeWeakRef<Span> | undefined);
 }

--- a/packages/opentelemetry/src/utils/contextData.ts
+++ b/packages/opentelemetry/src/utils/contextData.ts
@@ -1,14 +1,10 @@
 import type { Context } from '@opentelemetry/api';
 import type { Scope } from '@sentry/core';
-import { addNonEnumerableProperty, derefWeakRef, makeWeakRef, type MaybeWeakRef } from '@sentry/core';
+import { derefWeakRef, makeWeakRef, type MaybeWeakRef } from '@sentry/core';
 import { SENTRY_SCOPES_CONTEXT_KEY } from '../constants';
 import type { CurrentScopes } from '../types';
 
-const SCOPE_CONTEXT_FIELD = '_scopeContext';
-
-type ScopeWithContext = Scope & {
-  [SCOPE_CONTEXT_FIELD]?: MaybeWeakRef<Context>;
-};
+const SCOPE_CONTEXT_FIELD = 'context';
 
 /**
  * Try to get the current scopes from the given OTEL context.
@@ -37,7 +33,7 @@ export function setScopesOnContext(context: Context, scopes: CurrentScopes): Con
  * request completes but pooled connections retain patched callbacks).
  */
 export function setContextOnScope(scope: Scope, context: Context): void {
-  addNonEnumerableProperty(scope, SCOPE_CONTEXT_FIELD, makeWeakRef(context));
+  scope.refs[SCOPE_CONTEXT_FIELD] = makeWeakRef(context);
 }
 
 /**
@@ -45,5 +41,5 @@ export function setContextOnScope(scope: Scope, context: Context): void {
  * Returns undefined if the context has been garbage collected (when WeakRef is used).
  */
 export function getContextFromScope(scope: Scope): Context | undefined {
-  return derefWeakRef((scope as ScopeWithContext)[SCOPE_CONTEXT_FIELD]);
+  return derefWeakRef(scope.refs[SCOPE_CONTEXT_FIELD] as MaybeWeakRef<Context> | undefined);
 }

--- a/packages/opentelemetry/test/utils/contextData.test.ts
+++ b/packages/opentelemetry/test/utils/contextData.test.ts
@@ -72,17 +72,23 @@ describe('contextData', () => {
       expect(getContextFromScope(scope)).toBe(context);
     });
 
-    it('stores context as non-enumerable property', () => {
+    it('stores context on the scope refs', () => {
       const scope = new Scope();
       const context = ROOT_CONTEXT;
 
       setContextOnScope(scope, context);
 
-      // The _scopeContext property should not appear in Object.keys
-      expect(Object.keys(scope)).not.toContain('_scopeContext');
-
-      // But the context should still be retrievable
       expect(getContextFromScope(scope)).toBe(context);
+    });
+
+    it('is preserved when the scope is cloned', () => {
+      const scope = new Scope();
+      const context = ROOT_CONTEXT;
+
+      setContextOnScope(scope, context);
+
+      const clonedScope = scope.clone();
+      expect(getContextFromScope(clonedScope)).toBe(context);
     });
 
     it('allows overwriting context on scope', () => {
@@ -105,9 +111,8 @@ describe('contextData', () => {
 
         setContextOnScope(scope, context);
 
-        // Access the internal property to verify WeakRef is used
-        const scopeWithContext = scope as unknown as { _scopeContext?: unknown };
-        const storedRef = scopeWithContext._scopeContext;
+        // Access the internal ref to verify WeakRef is used
+        const storedRef = scope.refs.context;
 
         // If WeakRef is available, the stored value should have a deref method
         if (typeof WeakRef !== 'undefined') {
@@ -123,7 +128,7 @@ describe('contextData', () => {
         const mockWeakRef = {
           deref: () => undefined,
         };
-        (scope as unknown as { _scopeContext: unknown })._scopeContext = mockWeakRef;
+        scope.refs.context = mockWeakRef;
 
         expect(getContextFromScope(scope)).toBeUndefined();
       });
@@ -137,7 +142,7 @@ describe('contextData', () => {
             throw new Error('deref failed');
           },
         };
-        (scope as unknown as { _scopeContext: unknown })._scopeContext = mockWeakRef;
+        scope.refs.context = mockWeakRef;
 
         expect(getContextFromScope(scope)).toBeUndefined();
       });
@@ -147,7 +152,7 @@ describe('contextData', () => {
         const context = ROOT_CONTEXT;
 
         // Simulate environment without WeakRef by directly setting a non-WeakRef value
-        (scope as unknown as { _scopeContext: unknown })._scopeContext = context;
+        scope.refs.context = context;
 
         expect(getContextFromScope(scope)).toBe(context);
       });


### PR DESCRIPTION
Adds a `refs` field to `Scope` — a shared bag for object references that are associated with a scope but must not be serialized (the active span in core, the OpenTelemetry `Context` in the opentelemetry package). `refs` is cloned as-is (shallow) in `Scope.clone()`.

_Root cause_

The active span and the OTel context were stored in two separate, ad-hoc non-enumerable fields (`_sentrySpan` and `_scopeContext`). `Scope.clone()` only knew about the core span field and explicitly re-set it on the clone; it had no knowledge of the opentelemetry-owned `_scopeContext`. As a result, cloning a scope under OTel dropped the context reference, so `getActiveSpan(clonedScope)` — which reads the span out of the context attached to the scope — resolved to `undefined`. The two implementations disagreed on whether a clone preserved the active span.

Consolidating both references into a single `refs` object that `clone()` copies wholesale removes that asymmetry: a cloned scope now retains its span (core) and its context (OTel) uniformly.

This also allows us to remove some span/scope specifics from the scope class to keep this more generic. the scope class will simply clone/reset refs, whatever they may be.

Notable decisions:

- `refs` is stored as a **non-enumerable** property (via `addNonEnumerableProperty`), matching the previous behavior of `_sentrySpan`/`_scopeContext`. This keeps it out of `toEqual`, `Object.keys`, `toJSON`, and event serialization — an enumerable field would otherwise leak the active span into structural comparisons and serialized payloads.
- `clone()` does a shallow spread (`{ ...this.refs }`), consistent with how the other reference-holding scope fields are copied.
- `clear()` resets `refs` to `{}`, replacing the previous per-field span reset.

The existing `MaybeWeakRef` wrapping is preserved for both the span and the context, so the GC/circular-reference protections are unchanged.