### PR TITLE
ref: Migrate internal `spanToJSON` callers to `spanToStreamedSpanJSON`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -346,7 +346,7 @@ Sentry.init({
 // After
 Sentry.init({
   beforeSendSpan: span => {
-    if (span.attributes?.['sentry.op'] === 'db.query') {
+    if (span.attributes['sentry.op'] === 'db.query') {
       span.name = scrub(span.name);
       span.attributes['db.statement'] = scrub(span.attributes['db.statement']);
     }

--- a/dev-packages/deno-integration-tests/suites/orchestrion-aws/test.ts
+++ b/dev-packages/deno-integration-tests/suites/orchestrion-aws/test.ts
@@ -3,11 +3,12 @@
 import { tracingChannel } from 'node:diagnostics_channel';
 import type { Span } from '@sentry/core';
 import type { DenoClient } from '@sentry/deno';
-import { init, spanToJSON, startSpan } from '@sentry/deno';
+import { init, spanToStreamedSpanJSON, startSpan } from '@sentry/deno';
 import { assert } from 'https://deno.land/std@0.212.0/assert/assert.ts';
 import { assertExists } from 'https://deno.land/std@0.212.0/assert/assert_exists.ts';
 import { assertEquals } from 'https://deno.land/std@0.212.0/assert/assert_equals.ts';
 import { resetGlobals, transactionSink, withTimeout } from '../../src/index.ts';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 Deno.test('aws-sdk instrumentation: included in default integrations (Deno 2.8.0+)', () => {
   resetGlobals();
@@ -37,7 +38,7 @@ Deno.test('aws-sdk instrumentation: orchestrion @smithy/smithy-client:send chann
   // child has actually ended and can be captured on the transaction.
   const rpcSpanEnded = new Promise<void>(resolve => {
     client.on('spanEnd', (span: Span) => {
-      if (spanToJSON(span).op === 'rpc') {
+      if (spanToStreamedSpanJSON(span).attributes[SENTRY_OP] === 'rpc') {
         resolve();
       }
     });

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -16,7 +16,7 @@ import {
   getRootSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startBrowserTracingNavigationSpan,
   startInactiveSpan,
   getAbsoluteUrl,
@@ -68,7 +68,7 @@ export function _updateSpanAttributesForParametrizedUrl(route: string, url: stri
     return;
   }
 
-  const { data: attributes, op } = spanToJSON(span);
+  const attributes = spanToStreamedSpanJSON(span).attributes;
 
   if (!attributes || attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'url') {
     span.updateName(route);
@@ -76,7 +76,7 @@ export function _updateSpanAttributesForParametrizedUrl(route: string, url: stri
     const absoluteUrl = getAbsoluteUrl(url);
 
     span.setAttributes({
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.${op}.angular`,
+      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.${attributes[SENTRY_OP]}.angular`,
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
       [URL_FULL]: filterCollectedUrl(absoluteUrl),
       [URL_PATH]: parseStringToURLObject(absoluteUrl)?.pathname,
@@ -259,7 +259,7 @@ export class TraceService implements OnDestroy {
 
     const rootSpan = getRootSpan(activeSpan);
 
-    this._pageloadOngoing = spanToJSON(rootSpan).op === 'pageload';
+    this._pageloadOngoing = spanToStreamedSpanJSON(rootSpan).attributes[SENTRY_OP] === 'pageload';
     return this._pageloadOngoing;
   }
 }

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -3,7 +3,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SentrySpan,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import { describe, it } from 'vitest';
 import { browserTracingIntegration, init, TraceDirective } from '../src/index';
@@ -82,9 +82,9 @@ describe('Angular Tracing', () => {
 
       _updateSpanAttributesForParametrizedUrl(route, url, span);
 
-      expect(spanToJSON(span)).toEqual(
+      expect(spanToStreamedSpanJSON(span)).toEqual(
         expect.objectContaining({
-          data: expect.objectContaining({
+          attributes: expect.objectContaining({
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.undefined.angular',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
             [URL_TEMPLATE]: route,
@@ -92,7 +92,7 @@ describe('Angular Tracing', () => {
             [URL_FULL]: expect.stringContaining('/users/123/'),
             [URL_PATH]: '/users/123/',
           }),
-          description: route,
+          name: route,
         }),
       );
     });
@@ -107,13 +107,13 @@ describe('Angular Tracing', () => {
 
       _updateSpanAttributesForParametrizedUrl(route, url, span);
 
-      expect(spanToJSON(span)).toEqual(
+      expect(spanToStreamedSpanJSON(span)).toEqual(
         expect.objectContaining({
-          data: {
+          attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'sample-source',
           },
-          description: 'initial-span-name',
+          name: 'initial-span-name',
         }),
       );
     });

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -129,6 +129,7 @@ export {
   setUser,
   spanToBaggageHeader,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spotlightIntegration,
   startInactiveSpan,

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { HTTP_ROUTE, URL_FRAGMENT, URL_FULL, URL_PATH, URL_QUERY } from '@sentry/conventions/attributes';
+import { HTTP_ROUTE, SENTRY_OP, URL_FRAGMENT, URL_FULL, URL_PATH, URL_QUERY } from '@sentry/conventions/attributes';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   addNonEnumerableProperty,
@@ -10,7 +10,7 @@ import {
   getUrlQuery,
   objectify,
   SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   winterCGRequestToRequestData,
   filterCollectedUrl,
   filterCollectedUrlQuery,
@@ -98,7 +98,7 @@ export const handleRequest: (options?: MiddlewareOptions) => MiddlewareHandler =
     const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 
     // if there is an active span, we just want to enhance it with routing data etc.
-    if (rootSpan && spanToJSON(rootSpan).op === 'http.server') {
+    if (rootSpan && spanToStreamedSpanJSON(rootSpan).attributes[SENTRY_OP] === 'http.server') {
       return enhanceHttpServerSpan(ctx, next, rootSpan);
     }
 

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -125,6 +125,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   systemErrorIntegration,

--- a/packages/browser-utils/src/performance/entries.ts
+++ b/packages/browser-utils/src/performance/entries.ts
@@ -7,7 +7,7 @@ import {
   parseUrl,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   setMeasurement,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   filterCollectedUrl,
 } from '@sentry/core';
 import { SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
@@ -73,13 +73,13 @@ export function startTrackingLongTasks(): void {
       return;
     }
 
-    const { op: parentOp, start_timestamp: parentStartTimestamp } = spanToJSON(parent);
+    const { attributes: parentAttributes, start_timestamp: parentStartTimestamp } = spanToStreamedSpanJSON(parent);
 
     for (const entry of entries) {
       const startTime = msToSec((browserPerformanceTimeOrigin() as number) + entry.startTime);
       const duration = msToSec(entry.duration);
 
-      if (parentOp === 'navigation' && parentStartTimestamp && startTime < parentStartTimestamp) {
+      if (parentAttributes[SENTRY_OP] === 'navigation' && parentStartTimestamp && startTime < parentStartTimestamp) {
         // Skip adding a span if the long task started before the navigation started.
         // `startAndEndSpan` will otherwise adjust the parent's start time to the span's start
         // time, potentially skewing the duration of the actual navigation as reported via our
@@ -117,7 +117,10 @@ export function startTrackingLongAnimationFrames(): void {
 
       const startTime = msToSec((browserPerformanceTimeOrigin() as number) + entry.startTime);
 
-      const { start_timestamp: parentStartTimestamp, op: parentOp } = spanToJSON(parent);
+      const {
+        start_timestamp: parentStartTimestamp,
+        attributes: { [SENTRY_OP]: parentOp },
+      } = spanToStreamedSpanJSON(parent);
 
       if (parentOp === 'navigation' && parentStartTimestamp && startTime < parentStartTimestamp) {
         // Skip adding the span if the long animation frame started before the navigation started.
@@ -220,7 +223,7 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
 
   const performanceEntries = performance.getEntries();
 
-  const { op, start_timestamp: transactionStartTime } = spanToJSON(span);
+  const { attributes, start_timestamp: transactionStartTime } = spanToStreamedSpanJSON(span);
 
   performanceEntries.slice(_performanceCursor).forEach(entry => {
     const startTime = msToSec(entry.startTime);
@@ -232,7 +235,11 @@ export function addPerformanceEntries(span: Span, options: AddPerformanceEntries
       Math.max(0, entry.duration),
     );
 
-    if (op === 'navigation' && transactionStartTime && timeOrigin + startTime < transactionStartTime) {
+    if (
+      attributes[SENTRY_OP] === 'navigation' &&
+      transactionStartTime &&
+      timeOrigin + startTime < transactionStartTime
+    ) {
       return;
     }
 
@@ -479,7 +486,7 @@ function _trackNavigator(span: Span, spanStreamingEnabled: boolean | undefined):
     if (isMeasurementValue(connection.rtt)) {
       if (spanStreamingEnabled) {
         span.setAttribute('network.connection.rtt', connection.rtt);
-      } else if (spanToJSON(span).op === 'pageload') {
+      } else if (spanToStreamedSpanJSON(span).attributes[SENTRY_OP] === 'pageload') {
         // Measurements are only recorded on the pageload span, matching the historical
         // behavior where `connection.rtt` was only flushed for pageload transactions.
         setMeasurement('connection.rtt', connection.rtt, 'millisecond');

--- a/packages/browser-utils/src/performance/userTiming.ts
+++ b/packages/browser-utils/src/performance/userTiming.ts
@@ -1,10 +1,10 @@
-import { SENTRY_ORIGIN } from '@sentry/conventions/attributes';
+import { SENTRY_OP, SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 import type { IntegrationFn, Span, SpanAttributes, SpanAttributeValue } from '@sentry/core';
 import {
   browserPerformanceTimeOrigin,
   defineIntegration,
   isPrimitive,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   stringMatchesSomePattern,
 } from '@sentry/core';
 import { getBrowserPerformanceAPI, msToSec, startAndEndSpan } from './utils';
@@ -34,7 +34,9 @@ const _userTimingIntegration = ((options: UserTimingOptions = {}) => {
       let performanceCursor = 0;
 
       client.on('beforeIdleSpanEnd', idleSpan => {
-        const { op: parentOp, start_timestamp: parentStartTimestamp } = spanToJSON(idleSpan);
+        const { attributes, start_timestamp: parentStartTimestamp } = spanToStreamedSpanJSON(idleSpan);
+        const parentOp = attributes[SENTRY_OP];
+
         if (parentOp !== 'pageload' && parentOp !== 'navigation') {
           return;
         }

--- a/packages/browser-utils/src/web-vitals/spans.ts
+++ b/packages/browser-utils/src/web-vitals/spans.ts
@@ -105,7 +105,7 @@ export function _emitWebVitalSpan(options: WebVitalSpanOptions): void {
     ...passedAttributes,
   };
 
-  if (parentSpan && spanToStreamedSpanJSON(parentSpan).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'pageload') {
+  if (parentSpan && spanToStreamedSpanJSON(parentSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'pageload') {
     // for LCP and CLS, we collect the pageload span id as an attribute
     attributes['sentry.pageload.span_id'] = parentSpan.spanContext().spanId;
   }

--- a/packages/browser-utils/src/web-vitals/tracking.ts
+++ b/packages/browser-utils/src/web-vitals/tracking.ts
@@ -1,5 +1,6 @@
 import type { Client, Measurements, Span } from '@sentry/core';
-import { browserPerformanceTimeOrigin, debug, setMeasurement, spanToJSON } from '@sentry/core';
+import { browserPerformanceTimeOrigin, debug, setMeasurement, spanToStreamedSpanJSON } from '@sentry/core';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 import { DEBUG_BUILD } from '../debug-build';
 import { htmlTreeAsString } from '../htmlTreeAsString';
 import {
@@ -150,7 +151,7 @@ export function addWebVitalsToSpan(span: Span, options: AddWebVitalsToSpanOption
   const timeOrigin = msToSec(origin);
 
   // Measurements are only available for pageload transactions
-  if (spanToJSON(span).op === 'pageload') {
+  if (spanToStreamedSpanJSON(span).attributes[SENTRY_OP] === 'pageload') {
     _addTtfbRequestTimeToMeasurements(_measurements);
 
     if (spanStreamingEnabled) {

--- a/packages/browser-utils/test/browser/utils.test.ts
+++ b/packages/browser-utils/test/browser/utils.test.ts
@@ -1,4 +1,4 @@
-import { getMainCarrier, SentrySpan, setCurrentClient, spanToJSON } from '@sentry/core';
+import { getMainCarrier, SentrySpan, setCurrentClient, spanToStreamedSpanJSON } from '@sentry/core';
 import { beforeEach, describe, expect, it, test } from 'vitest';
 import { extractNetworkProtocol, startAndEndSpan } from '../../src/performance/utils';
 import { getDefaultClientOptions, TestClient } from '../utils/TestClient';
@@ -25,9 +25,9 @@ describe('startAndEndSpan()', () => {
 
     expect(span).toBeDefined();
     expect(span).toBeInstanceOf(SentrySpan);
-    expect(spanToJSON(span).description).toBe('evaluation');
-    expect(spanToJSON(span).op).toBe('script');
-    expect(spanToJSON(span).op).toBe('script');
+    expect(spanToStreamedSpanJSON(span).name).toBe('evaluation');
+    expect(spanToStreamedSpanJSON(span).attributes['sentry.op']).toBe('script');
+    expect(spanToStreamedSpanJSON(span).attributes['sentry.op']).toBe('script');
   });
 
   it('adjusts the start timestamp if child span starts before transaction', () => {
@@ -38,8 +38,8 @@ describe('startAndEndSpan()', () => {
     })!;
 
     expect(span).toBeDefined();
-    expect(spanToJSON(parentSpan).start_timestamp).toEqual(spanToJSON(span).start_timestamp);
-    expect(spanToJSON(parentSpan).start_timestamp).toEqual(100);
+    expect(spanToStreamedSpanJSON(parentSpan).start_timestamp).toEqual(spanToStreamedSpanJSON(span).start_timestamp);
+    expect(spanToStreamedSpanJSON(parentSpan).start_timestamp).toEqual(100);
   });
 
   it('does not adjust start timestamp if child span starts after transaction', () => {
@@ -50,8 +50,10 @@ describe('startAndEndSpan()', () => {
     })!;
 
     expect(span).toBeDefined();
-    expect(spanToJSON(parentSpan).start_timestamp).not.toEqual(spanToJSON(span).start_timestamp);
-    expect(spanToJSON(parentSpan).start_timestamp).toEqual(123);
+    expect(spanToStreamedSpanJSON(parentSpan).start_timestamp).not.toEqual(
+      spanToStreamedSpanJSON(span).start_timestamp,
+    );
+    expect(spanToStreamedSpanJSON(parentSpan).start_timestamp).toEqual(123);
   });
 });
 

--- a/packages/browser-utils/test/performance/browserMetrics.test.ts
+++ b/packages/browser-utils/test/performance/browserMetrics.test.ts
@@ -6,7 +6,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SentrySpan,
   setCurrentClient,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { _addNavigationSpans, _addResourceSpans, _setResourceRequestAttributes } from '../../src/performance/entries';
@@ -132,8 +132,8 @@ describe('addWebVitalsToSpan', () => {
       spanStreamingEnabled: true,
     });
 
-    expect(spanToJSON(nextPageloadSpan).data['browser.web_vital.fp.value']).toBeUndefined();
-    expect(spanToJSON(nextPageloadSpan).data['browser.web_vital.fcp.value']).toBeUndefined();
+    expect(spanToStreamedSpanJSON(nextPageloadSpan).attributes['browser.web_vital.fp.value']).toBeUndefined();
+    expect(spanToStreamedSpanJSON(nextPageloadSpan).attributes['browser.web_vital.fcp.value']).toBeUndefined();
   });
 });
 
@@ -235,14 +235,12 @@ describe('_addResourceSpans', () => {
     _addResourceSpans(span, entry, resourceEntryName, startTime, duration, timeOrigin);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!)).toEqual(
+    expect(spanToStreamedSpanJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        description: '/assets/to/css',
+        name: '/assets/to/css',
         start_timestamp: timeOrigin + startTime,
-        timestamp: timeOrigin + startTime + duration,
-        op: 'resource.css',
-        origin: 'auto.resource.browser.metrics',
-        data: {
+        end_timestamp: timeOrigin + startTime + duration,
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           ['http.decoded_response_content_length']: entry.decodedBodySize,
@@ -288,9 +286,9 @@ describe('_addResourceSpans', () => {
     _addResourceSpans(span, entry, 'https://example.com/assets/app.js?v=42#main', 100, 23, 345);
 
     expect(spans).toHaveLength(1);
-    const json = spanToJSON(spans[0]!);
-    expect(json.description).toBe('/assets/app.js?v=42#main');
-    expect(json.data['url.full']).toBe('https://example.com/assets/app.js?v=42#main');
+    const json = spanToStreamedSpanJSON(spans[0]!);
+    expect(json.name).toBe('/assets/app.js?v=42#main');
+    expect(json.attributes['url.full']).toBe('https://example.com/assets/app.js?v=42#main');
   });
 
   it('sets url.full to the full cross-origin URL', () => {
@@ -308,10 +306,10 @@ describe('_addResourceSpans', () => {
     _addResourceSpans(span, entry, 'https://cdn.example.org/static/logo.png', 100, 23, 345);
 
     expect(spans).toHaveLength(1);
-    const json = spanToJSON(spans[0]!);
-    expect(json.description).toBe('https://cdn.example.org/static/logo.png');
-    expect(json.data['url.full']).toBe('https://cdn.example.org/static/logo.png');
-    expect(json.data['url.same_origin']).toBe(false);
+    const json = spanToStreamedSpanJSON(spans[0]!);
+    expect(json.name).toBe('https://cdn.example.org/static/logo.png');
+    expect(json.attributes['url.full']).toBe('https://cdn.example.org/static/logo.png');
+    expect(json.attributes['url.same_origin']).toBe(false);
   });
 
   it('creates a variety of resource spans', () => {
@@ -352,7 +350,9 @@ describe('_addResourceSpans', () => {
       _addResourceSpans(span, entry, 'https://example.com/assets/to/me', 123, 234, 465);
 
       expect(spans).toHaveLength(i + 1);
-      expect(spanToJSON(spans[i]!)).toEqual(expect.objectContaining({ op }));
+      expect(spanToStreamedSpanJSON(spans[i]!).attributes).toEqual(
+        expect.objectContaining({ [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op }),
+      );
     }
   });
 
@@ -397,7 +397,7 @@ describe('_addResourceSpans', () => {
     expect(spans).toHaveLength(table.length - ignoredResourceSpans.length);
     const spanOps = new Set(
       spans.map(s => {
-        return spanToJSON(s).op;
+        return spanToStreamedSpanJSON(s).attributes['sentry.op'];
       }),
     );
     expect(spanOps).toEqual(new Set(['resource.css', 'resource.image']));
@@ -422,9 +422,9 @@ describe('_addResourceSpans', () => {
     _addResourceSpans(span, entry, resourceEntryName, 100, 23, 345);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!)).toEqual(
+    expect(spanToStreamedSpanJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        data: expect.objectContaining({
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           ['http.decoded_response_content_length']: entry.decodedBodySize,
@@ -460,9 +460,9 @@ describe('_addResourceSpans', () => {
     _addResourceSpans(span, entry, resourceEntryName, 100, 23, 345);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!)).toEqual(
+    expect(spanToStreamedSpanJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        data: expect.objectContaining({
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           'server.address': 'example.com',
@@ -472,10 +472,8 @@ describe('_addResourceSpans', () => {
           ['network.protocol.name']: 'http',
           ['network.protocol.version']: '3',
         }),
-        description: '/assets/to/css',
-        timestamp: 468,
-        op: 'resource.css',
-        origin: 'auto.resource.browser.metrics',
+        name: '/assets/to/css',
+        end_timestamp: 468,
         start_timestamp: 445,
       }),
     );
@@ -513,9 +511,9 @@ describe('_addResourceSpans', () => {
     _addResourceSpans(span, entry, resourceEntryName, 100, 23, 345);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!)).toEqual(
+    expect(spanToStreamedSpanJSON(spans[0]!)).toEqual(
       expect.objectContaining({
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'resource.css',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
           'server.address': 'example.com',
@@ -538,10 +536,8 @@ describe('_addResourceSpans', () => {
           'http.request.time_to_first_byte': 1.008,
           'http.request.worker_start': expect.any(Number),
         },
-        description: '/assets/to/css',
-        timestamp: 468,
-        op: 'resource.css',
-        origin: 'auto.resource.browser.metrics',
+        name: '/assets/to/css',
+        end_timestamp: 468,
         start_timestamp: 445,
       }),
     );
@@ -570,7 +566,9 @@ describe('_addResourceSpans', () => {
       _addResourceSpans(span, entry, resourceEntryName, 100, 23, 345);
 
       expect(spans).toHaveLength(1);
-      expect(spanToJSON(spans[0]!).data).toMatchObject({ 'http.response_delivery_type': deliveryType });
+      expect(spanToStreamedSpanJSON(spans[0]!).attributes).toMatchObject({
+        'http.response_delivery_type': deliveryType,
+      });
     },
   );
 });
@@ -649,105 +647,87 @@ describe('_addNavigationSpans', () => {
     const parent_span_id = pageloadSpan.spanContext().spanId;
 
     expect(spans).toHaveLength(9);
-    expect(spans.map(spanToJSON)).toEqual(
+    expect(spans.map(spanToStreamedSpanJSON)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.dom_content_loaded_event',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.dom_content_loaded_event',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.load_event',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.load_event',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.connect',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.connect',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.tls_ssl',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.tls_ssl',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.cache',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.cache',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.dns',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.dns',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.request',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.request',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'sentry.op': 'browser.response',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.response',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),
         expect.objectContaining({
-          data: {
+          attributes: {
             'http.redirect_count': 2,
             'sentry.op': 'browser.redirect',
             'sentry.origin': 'auto.ui.browser.metrics',
           },
-          description: 'https://santry.com/test',
-          op: 'browser.redirect',
-          origin: 'auto.ui.browser.metrics',
+          name: 'https://santry.com/test',
           parent_span_id,
           trace_id,
         }),

--- a/packages/browser-utils/test/performance/userTiming.test.ts
+++ b/packages/browser-utils/test/performance/userTiming.test.ts
@@ -1,5 +1,5 @@
 import type { Span } from '@sentry/core';
-import { getMainCarrier, SentrySpan, setCurrentClient, spanToJSON } from '@sentry/core';
+import { getMainCarrier, SentrySpan, setCurrentClient, spanToStreamedSpanJSON } from '@sentry/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { _addUserTimingSpan, userTimingIntegration } from '../../src/performance/userTiming';
 import * as utils from '../../src/performance/utils';
@@ -41,11 +41,13 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(2);
-    expect(spans.map(span => spanToJSON(span).description)).toEqual(['app-ready', 'hydrate']);
-    expect(spans.map(span => spanToJSON(span).op)).toEqual(['mark', 'measure']);
-    expect(spanToJSON(spans[0]!).timestamp).toBe(spanToJSON(spans[0]!).start_timestamp);
-    expect(spanToJSON(spans[1]!).timestamp! - spanToJSON(spans[1]!).start_timestamp).toBeCloseTo(0.025);
-    expect(spanToJSON(spans[1]!).parent_span_id).toBe(parentSpan.spanContext().spanId);
+    expect(spans.map(span => spanToStreamedSpanJSON(span).name)).toEqual(['app-ready', 'hydrate']);
+    expect(spans.map(span => spanToStreamedSpanJSON(span).attributes['sentry.op'])).toEqual(['mark', 'measure']);
+    expect(spanToStreamedSpanJSON(spans[0]!).end_timestamp).toBe(spanToStreamedSpanJSON(spans[0]!).start_timestamp);
+    expect(
+      spanToStreamedSpanJSON(spans[1]!).end_timestamp - spanToStreamedSpanJSON(spans[1]!).start_timestamp,
+    ).toBeCloseTo(0.025);
+    expect(spanToStreamedSpanJSON(spans[1]!).parent_span_id).toBe(parentSpan.spanContext().spanId);
   });
 
   it('captures only entries added since the previous idle span ended', () => {
@@ -65,7 +67,7 @@ describe('userTimingIntegration', () => {
     );
 
     expect(spans).toHaveLength(2);
-    expect(spans.map(span => spanToJSON(span).description)).toEqual(['initial-render', 'route-render']);
+    expect(spans.map(span => spanToStreamedSpanJSON(span).name)).toEqual(['initial-render', 'route-render']);
   });
 
   it('reads the latest entries immediately before the segment ends', () => {
@@ -76,7 +78,7 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!).description).toBe('last-moment-work');
+    expect(spanToStreamedSpanJSON(spans[0]!).name).toBe('last-moment-work');
   });
 
   it('does not capture entries for unrelated idle spans', () => {
@@ -102,7 +104,7 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(2);
-    expect(spans.map(span => spanToJSON(span).description)).toEqual(['application-mark', 'application-render']);
+    expect(spans.map(span => spanToStreamedSpanJSON(span).name)).toEqual(['application-mark', 'application-render']);
   });
 
   it('does not attach entries preceding a navigation span', () => {
@@ -122,7 +124,7 @@ describe('userTimingIntegration', () => {
     client.emit('beforeIdleSpanEnd', parentSpan);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!).description).toBe('current-route');
+    expect(spanToStreamedSpanJSON(spans[0]!).name).toBe('current-route');
   });
 });
 
@@ -157,7 +159,7 @@ describe('_addUserTimingSpan', () => {
     _addUserTimingSpan(parentSpan, entry, 0.012, 0.01, 100, 0, []);
 
     expect(spans).toHaveLength(1);
-    expect(spanToJSON(spans[0]!).data).toEqual({
+    expect(spanToStreamedSpanJSON(spans[0]!).attributes).toEqual({
       'sentry.browser.measure.detail.phase': 'client',
       'sentry.browser.measure.detail.counts': '{"components":4}',
       'sentry.op': 'measure',

--- a/packages/browser-utils/test/web-vitals/spans.test.ts
+++ b/packages/browser-utils/test/web-vitals/spans.test.ts
@@ -23,7 +23,6 @@ vi.mock('@sentry/core', async () => {
     startInactiveSpan: vi.fn(),
     getActiveSpan: vi.fn(),
     getRootSpan: vi.fn(),
-    spanToJSON: vi.fn(),
     spanToStreamedSpanJSON: vi.fn(),
   };
 });

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -67,6 +67,7 @@ export {
   captureSession,
   endSession,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,

--- a/packages/browser/src/integrations/graphqlClient.ts
+++ b/packages/browser/src/integrations/graphqlClient.ts
@@ -4,13 +4,12 @@ import {
   isObjectLike,
   isString,
   SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   stringMatchesSomePattern,
 } from '@sentry/core/browser';
 import type { FetchHint, XhrHint } from '@sentry/browser-utils';
 import { getBodyString, getFetchRequestArgBody, SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
-import { GRAPHQL_DOCUMENT, URL_FULL } from '@sentry/conventions/attributes';
+import { GRAPHQL_DOCUMENT, HTTP_METHOD, SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
 
 interface GraphQLClientOptions {
   endpoints: Array<string | RegExp>;
@@ -57,10 +56,10 @@ const _graphqlClientIntegration = ((options: GraphQLClientOptions) => {
 
 function _updateSpanWithGraphQLData(client: Client, options: GraphQLClientOptions): void {
   client.on('beforeOutgoingRequestSpan', (span, hint) => {
-    const spanJSON = spanToJSON(span);
+    const spanJSON = spanToStreamedSpanJSON(span);
 
-    const spanAttributes = spanJSON.data || {};
-    const spanOp = spanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_OP];
+    const spanAttributes = spanJSON.attributes;
+    const spanOp = spanAttributes[SENTRY_OP];
 
     const isHttpClientSpan = spanOp === 'http.client';
 
@@ -69,7 +68,8 @@ function _updateSpanWithGraphQLData(client: Client, options: GraphQLClientOption
     }
 
     const httpUrl = spanAttributes[URL_FULL];
-    const httpMethod = spanAttributes[SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD] || spanAttributes['http.method'];
+    // oxlint-disable-next-line typescript/no-deprecated
+    const httpMethod = spanAttributes[SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD] || spanAttributes[HTTP_METHOD];
 
     if (!isString(httpUrl) || !isString(httpMethod)) {
       return;

--- a/packages/browser/src/tracing/backgroundtab.ts
+++ b/packages/browser/src/tracing/backgroundtab.ts
@@ -1,6 +1,7 @@
-import { debug, getActiveSpan, getRootSpan, SPAN_STATUS_ERROR, spanToJSON } from '@sentry/core/browser';
+import { debug, getActiveSpan, getRootSpan, SPAN_STATUS_ERROR, spanToStreamedSpanJSON } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 /**
  * Add a listener that cancels and finishes a transaction when the global
@@ -19,7 +20,10 @@ export function registerBackgroundTabDetection(): void {
       if (WINDOW.document.hidden && rootSpan) {
         const cancelledStatus = 'cancelled';
 
-        const { op, status } = spanToJSON(rootSpan);
+        const {
+          attributes: { [SENTRY_OP]: op },
+          status,
+        } = spanToStreamedSpanJSON(rootSpan);
 
         if (DEBUG_BUILD) {
           debug.log(`[Tracing] Transaction: ${cancelledStatus} -> since tab moved to the background, op: ${op}`);

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -31,7 +31,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   spanIsSampled,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startIdleSpan,
   startInactiveSpan,
   timestampInSeconds,
@@ -51,7 +51,7 @@ import { WEB_VITALS_INTEGRATION_NAME, webVitalsIntegration } from '../integratio
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
-import { URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
 
 export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 
@@ -472,8 +472,11 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       function maybeEndActiveSpan(): void {
         const activeSpan = getActiveIdleSpan(client);
 
-        if (activeSpan && !spanToJSON(activeSpan).timestamp) {
-          DEBUG_BUILD && debug.log(`[Tracing] Finishing current active span with op: ${spanToJSON(activeSpan).op}`);
+        if (activeSpan && !spanToStreamedSpanJSON(activeSpan).end_timestamp) {
+          DEBUG_BUILD &&
+            debug.log(
+              `[Tracing] Finishing current active span with op: ${spanToStreamedSpanJSON(activeSpan).attributes[SENTRY_OP]}`,
+            );
           // If there's an open active span, we need to finish it before creating an new one.
           activeSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON, 'cancelled');
           activeSpan.end();
@@ -799,7 +802,7 @@ function registerInteractionListener(
 
     const activeIdleSpan = getActiveIdleSpan(client);
     if (activeIdleSpan) {
-      const currentRootSpanOp = spanToJSON(activeIdleSpan).op;
+      const currentRootSpanOp = spanToStreamedSpanJSON(activeIdleSpan).attributes[SENTRY_OP];
       if (['navigation', 'pageload'].includes(currentRootSpanOp as string)) {
         DEBUG_BUILD &&
           debug.warn(`[Tracing] Did not create ${op} span because a pageload or navigation span is in progress.`);
@@ -853,7 +856,7 @@ function setActiveIdleSpan(client: Client, span: Span | undefined): void {
 const REDIRECT_THRESHOLD = 1.5;
 
 function isRedirect(activeSpan: Span, lastInteractionTimestamp: number | undefined): boolean {
-  const spanData = spanToJSON(activeSpan);
+  const spanData = spanToStreamedSpanJSON(activeSpan);
 
   const now = dateTimestampInSeconds();
 

--- a/packages/browser/src/tracing/linkedTraces.ts
+++ b/packages/browser/src/tracing/linkedTraces.ts
@@ -6,10 +6,11 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_PREVIOUS_TRACE_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../exports';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 export interface PreviousTraceInfo {
   /**
@@ -137,12 +138,12 @@ export function addPreviousTraceSpanLink(
   span: Span,
   oldPropagationContext: PropagationContext,
 ): PreviousTraceInfo {
-  const spanJson = spanToJSON(span);
+  const spanJson = spanToStreamedSpanJSON(span);
 
   function getSampleRate(): number {
     try {
       const oldSampleRate = Number(
-        spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] ?? oldPropagationContext.dsc?.sample_rate,
+        spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] ?? oldPropagationContext.dsc?.sample_rate,
       );
       return Number.isNaN(oldSampleRate) ? 0 : oldSampleRate;
     } catch {
@@ -178,7 +179,7 @@ export function addPreviousTraceSpanLink(
     if (DEBUG_BUILD) {
       debug.log(
         `Adding previous_trace \`${JSON.stringify(previousTraceSpanCtx)}\` link to span \`${JSON.stringify({
-          op: spanJson.op,
+          op: spanJson.attributes[SENTRY_OP],
           ...span.spanContext(),
         })}\``,
       );

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -25,7 +25,7 @@ import {
   SentryNonRecordingSpan,
   setHttpStatus,
   spanIsIgnored,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startInactiveSpan,
   stringMatchesSomePattern,
   stripDataUrlContent,
@@ -212,7 +212,7 @@ const HTTP_TIMING_WAIT_MS = 300;
  * @param span A span that has yet to be finished, must contain `url.full` on data.
  */
 function addHTTPTimings(span: Span, client: Client): void {
-  const url = spanToJSON(span).data[URL_FULL];
+  const url = spanToStreamedSpanJSON(span).attributes[URL_FULL];
 
   if (!url || typeof url !== 'string') {
     return;

--- a/packages/browser/test/integrations/graphqlClient.test.ts
+++ b/packages/browser/test/integrations/graphqlClient.test.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Client } from '@sentry/core/browser';
-import { SentrySpan, spanToJSON } from '@sentry/core/browser';
+import { SentrySpan, spanToStreamedSpanJSON } from '@sentry/core/browser';
 import type { FetchHint, XhrHint } from '@sentry/browser-utils';
 import { SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
 import { URL_FULL } from '@sentry/conventions/attributes';
@@ -367,9 +367,9 @@ describe('GraphqlClient', () => {
 
       handler(span, makeFetchHint('http://localhost:4000/graphql', requestBody));
 
-      const json = spanToJSON(span);
-      expect(json.description).toBe('POST http://localhost:4000/graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBe(requestBody.query);
+      const json = spanToStreamedSpanJSON(span);
+      expect(json.name).toBe('POST http://localhost:4000/graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBe(requestBody.query);
     });
 
     test('enriches http.client span when only url.full is present', () => {
@@ -385,9 +385,9 @@ describe('GraphqlClient', () => {
 
       handler(span, makeFetchHint('http://localhost:4000/graphql', requestBody));
 
-      const json = spanToJSON(span);
-      expect(json.description).toBe('POST http://localhost:4000/graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBe(requestBody.query);
+      const json = spanToStreamedSpanJSON(span);
+      expect(json.name).toBe('POST http://localhost:4000/graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBe(requestBody.query);
     });
 
     test('enriches http.client span for relative URLs', () => {
@@ -403,9 +403,9 @@ describe('GraphqlClient', () => {
 
       handler(span, makeFetchHint('/graphql', requestBody));
 
-      const json = spanToJSON(span);
-      expect(json.description).toBe('POST /graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBe(requestBody.query);
+      const json = spanToStreamedSpanJSON(span);
+      expect(json.name).toBe('POST /graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBe(requestBody.query);
     });
 
     test('does nothing when no URL attribute is present', () => {
@@ -420,9 +420,9 @@ describe('GraphqlClient', () => {
 
       handler(span, makeFetchHint('/graphql', requestBody));
 
-      const json = spanToJSON(span);
-      expect(json.description).toBe('POST');
-      expect(json.data['graphql.document']).toBeUndefined();
+      const json = spanToStreamedSpanJSON(span);
+      expect(json.name).toBe('POST');
+      expect(json.attributes['graphql.document']).toBeUndefined();
     });
 
     test('does nothing when span op is not http.client', () => {
@@ -438,9 +438,9 @@ describe('GraphqlClient', () => {
 
       handler(span, makeFetchHint('/graphql', requestBody));
 
-      const json = spanToJSON(span);
-      expect(json.description).toBe('custom span');
-      expect(json.data['graphql.document']).toBeUndefined();
+      const json = spanToStreamedSpanJSON(span);
+      expect(json.name).toBe('custom span');
+      expect(json.attributes['graphql.document']).toBeUndefined();
     });
 
     test('omits graphql.document when dataCollection.graphQL.document is false', () => {
@@ -457,10 +457,10 @@ describe('GraphqlClient', () => {
 
       handler(span, makeFetchHint('http://localhost:4000/graphql', requestBody));
 
-      const json = spanToJSON(span);
+      const json = spanToStreamedSpanJSON(span);
       // The span is still renamed with the operation, but the document is not attached.
-      expect(json.description).toBe('POST http://localhost:4000/graphql (query GetHello)');
-      expect(json.data['graphql.document']).toBeUndefined();
+      expect(json.name).toBe('POST http://localhost:4000/graphql (query GetHello)');
+      expect(json.attributes['graphql.document']).toBeUndefined();
     });
   });
 });

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -14,7 +14,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCurrentClient,
   spanIsSampled,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startInactiveSpan,
   TRACING_DEFAULTS,
   browserPerformanceTimeOrigin,
@@ -170,12 +170,10 @@ describe('browserTracingIntegration', () => {
     const span = getActiveSpan();
     expect(span).toBeDefined();
     expect(spanIsSampled(span!)).toBe(true);
-    expect(spanToJSON(span!)).toEqual({
-      description: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.browser',
+    expect(spanToStreamedSpanJSON(span!)).toEqual({
+      name: '/',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -186,6 +184,10 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
+      links: undefined,
     });
   });
 
@@ -257,12 +259,10 @@ describe('browserTracingIntegration', () => {
     expect(span).toBeDefined();
     expect(spanIsSampled(span)).toBe(true);
     expect(span.isRecording()).toBe(true);
-    expect(spanToJSON(span)).toEqual({
-      description: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.browser',
+    expect(spanToStreamedSpanJSON(span)).toEqual({
+      name: '/',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -273,6 +273,10 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
+      links: undefined,
     });
 
     // this is what is used to get the span name - JSDOM does not update this on it's own!
@@ -288,12 +292,10 @@ describe('browserTracingIntegration', () => {
     expect(span2).toBeDefined();
     expect(spanIsSampled(span2)).toBe(true);
     expect(span2.isRecording()).toBe(true);
-    expect(spanToJSON(span2)).toEqual({
-      description: '/test',
-      op: 'navigation',
-      origin: 'auto.navigation.browser',
+    expect(spanToStreamedSpanJSON(span2)).toEqual({
+      name: '/test',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -315,6 +317,9 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
     });
 
     // this is what is used to get the span name - JSDOM does not update this on it's own!
@@ -330,12 +335,10 @@ describe('browserTracingIntegration', () => {
     expect(span3).toBeDefined();
     expect(spanIsSampled(span3)).toBe(true);
     expect(span3.isRecording()).toBe(true);
-    expect(spanToJSON(span3)).toEqual({
-      description: '/test2',
-      op: 'navigation',
-      origin: 'auto.navigation.browser',
+    expect(spanToStreamedSpanJSON(span3)).toEqual({
+      name: '/test2',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -357,6 +360,9 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
     });
   });
 
@@ -374,12 +380,10 @@ describe('browserTracingIntegration', () => {
     expect(span).toBeDefined();
     expect(spanIsSampled(span)).toBe(true);
     expect(span.isRecording()).toBe(true);
-    expect(spanToJSON(span)).toEqual({
-      description: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.browser',
+    expect(spanToStreamedSpanJSON(span)).toEqual({
+      name: '/',
       status: 'ok',
-      data: {
+      attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
         [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -390,6 +394,10 @@ describe('browserTracingIntegration', () => {
       span_id: expect.stringMatching(/[a-f0-9]{16}/),
       start_timestamp: expect.any(Number),
       trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      end_timestamp: undefined,
+      is_segment: true,
+      parent_span_id: undefined,
+      links: undefined,
     });
 
     // this is what is used to get the span name - JSDOM does not update this on it's own!
@@ -408,18 +416,16 @@ describe('browserTracingIntegration', () => {
     expect(getActiveSpan()).toBe(span);
 
     // span has connected redirect span
-    expect(getSpanDescendants(span).map(span => spanToJSON(span))).toContainEqual(
+    expect(getSpanDescendants(span).map(span => spanToStreamedSpanJSON(span))).toContainEqual(
       expect.objectContaining({
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation.redirect',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.browser',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [URL_FULL]: 'https://example.com/test',
           [URL_PATH]: '/test',
         },
-        description: '/test',
-        op: 'navigation.redirect',
-        origin: 'auto.navigation.browser',
+        name: '/test',
         parent_span_id: span.spanContext().spanId,
       }),
     );
@@ -469,12 +475,10 @@ describe('browserTracingIntegration', () => {
       const span = startBrowserTracingPageLoadSpan(client, { name: 'test span' });
 
       expect(span).toBeDefined();
-      expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'pageload',
-        origin: 'manual',
+      expect(spanToStreamedSpanJSON(span!)).toEqual({
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -485,6 +489,10 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
+        links: undefined,
       });
       expect(spanIsSampled(span!)).toBe(true);
     });
@@ -508,12 +516,10 @@ describe('browserTracingIntegration', () => {
       });
 
       expect(span).toBeDefined();
-      expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'pageload',
-        origin: 'auto.test',
+      expect(spanToStreamedSpanJSON(span!)).toEqual({
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -525,6 +531,10 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
+        links: undefined,
       });
     });
 
@@ -577,7 +587,7 @@ describe('browserTracingIntegration', () => {
 
       const pageloadSpan = getActiveSpan();
 
-      expect(spanToJSON(pageloadSpan!).op).toBe('test op');
+      expect(spanToStreamedSpanJSON(pageloadSpan!).attributes['sentry.op']).toBe('test op');
     });
 
     it('sets the pageload span name on `scope.transactionName`', () => {
@@ -671,8 +681,8 @@ describe('browserTracingIntegration', () => {
 
     const pageloadSpan = getActiveSpan();
 
-    expect(spanToJSON(pageloadSpan!).description).toBe('changed');
-    expect(spanToJSON(pageloadSpan!).data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+    expect(spanToStreamedSpanJSON(pageloadSpan!).name).toBe('changed');
+    expect(spanToStreamedSpanJSON(pageloadSpan!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
   });
 
   it('sets source to "custom" if name is changed in-place in beforeStartSpan', () => {
@@ -703,8 +713,8 @@ describe('browserTracingIntegration', () => {
 
     const pageloadSpan = getActiveSpan();
 
-    expect(spanToJSON(pageloadSpan!).description).toBe('changed');
-    expect(spanToJSON(pageloadSpan!).data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+    expect(spanToStreamedSpanJSON(pageloadSpan!).name).toBe('changed');
+    expect(spanToStreamedSpanJSON(pageloadSpan!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
   });
 
   describe('startBrowserTracingNavigationSpan', () => {
@@ -751,12 +761,10 @@ describe('browserTracingIntegration', () => {
       const span = startBrowserTracingNavigationSpan(client, { name: 'test span' });
 
       expect(span).toBeDefined();
-      expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'navigation',
-        origin: 'manual',
+      expect(spanToStreamedSpanJSON(span!)).toEqual({
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'manual',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -778,6 +786,9 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
       });
       expect(spanIsSampled(span!)).toBe(true);
     });
@@ -807,12 +818,10 @@ describe('browserTracingIntegration', () => {
       });
 
       expect(span).toBeDefined();
-      expect(spanToJSON(span!)).toEqual({
-        description: 'test span',
-        op: 'navigation',
-        origin: 'auto.test',
+      expect(spanToStreamedSpanJSON(span!)).toEqual({
+        name: 'test span',
         status: 'ok',
-        data: {
+        attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.test',
           [SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE]: 1,
@@ -824,6 +833,10 @@ describe('browserTracingIntegration', () => {
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
         start_timestamp: expect.any(Number),
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        end_timestamp: undefined,
+        is_segment: true,
+        parent_span_id: undefined,
+        links: undefined,
       });
     });
 
@@ -880,7 +893,7 @@ describe('browserTracingIntegration', () => {
 
       const navigationSpan = getActiveSpan();
 
-      expect(spanToJSON(navigationSpan!).op).toBe('test op');
+      expect(spanToStreamedSpanJSON(navigationSpan!).attributes['sentry.op']).toBe('test op');
     });
 
     it('sets source to "custom" if name is changed in beforeStartSpan', () => {
@@ -908,8 +921,8 @@ describe('browserTracingIntegration', () => {
 
       const pageloadSpan = getActiveSpan();
 
-      expect(spanToJSON(pageloadSpan!).description).toBe('changed');
-      expect(spanToJSON(pageloadSpan!).data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
+      expect(spanToStreamedSpanJSON(pageloadSpan!).name).toBe('changed');
+      expect(spanToStreamedSpanJSON(pageloadSpan!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toBe('custom');
     });
 
     it('sets the navigation span name on `scope.transactionName`', () => {
@@ -1086,9 +1099,9 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
-      expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
-      expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
+      expect(spanToStreamedSpanJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
+      expect(spanToStreamedSpanJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
+      expect(spanToStreamedSpanJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(false);
 
       expect(dynamicSamplingContext).toBeDefined();
@@ -1124,9 +1137,9 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
-      expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
-      expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
+      expect(spanToStreamedSpanJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
+      expect(spanToStreamedSpanJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
+      expect(spanToStreamedSpanJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(false);
 
       expect(dynamicSamplingContext).toBeDefined();
@@ -1168,9 +1181,9 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('navigation');
-      expect(spanToJSON(idleSpan).trace_id).not.toEqual('12312012123120121231201212312012');
-      expect(spanToJSON(idleSpan).parent_span_id).not.toEqual('1121201211212012');
+      expect(spanToStreamedSpanJSON(idleSpan).attributes['sentry.op']).toBe('navigation');
+      expect(spanToStreamedSpanJSON(idleSpan).trace_id).not.toEqual('12312012123120121231201212312012');
+      expect(spanToStreamedSpanJSON(idleSpan).parent_span_id).not.toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(true);
 
       expect(dynamicSamplingContext).toBeDefined();
@@ -1225,9 +1238,9 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
-      expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312011');
-      expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212011');
+      expect(spanToStreamedSpanJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
+      expect(spanToStreamedSpanJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312011');
+      expect(spanToStreamedSpanJSON(idleSpan).parent_span_id).toEqual('1121201211212011');
       expect(spanIsSampled(idleSpan)).toBe(true);
 
       expect(dynamicSamplingContext).toBeDefined();
@@ -1334,9 +1347,9 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span is correct
-      expect(spanToJSON(idleSpan).op).toBe('pageload');
-      expect(spanToJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
-      expect(spanToJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
+      expect(spanToStreamedSpanJSON(idleSpan).attributes['sentry.op']).toBe('pageload');
+      expect(spanToStreamedSpanJSON(idleSpan).trace_id).toEqual('12312012123120121231201212312012');
+      expect(spanToStreamedSpanJSON(idleSpan).parent_span_id).toEqual('1121201211212012');
       expect(spanIsSampled(idleSpan)).toBe(false);
 
       expect(dynamicSamplingContext).toBeDefined();
@@ -1382,8 +1395,8 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span should use meta tag data, not Server-Timing data
-      expect(spanToJSON(idleSpan).trace_id).toEqual('11111111111111111111111111111111');
-      expect(spanToJSON(idleSpan).parent_span_id).toEqual('2222222222222222');
+      expect(spanToStreamedSpanJSON(idleSpan).trace_id).toEqual('11111111111111111111111111111111');
+      expect(spanToStreamedSpanJSON(idleSpan).parent_span_id).toEqual('2222222222222222');
       expect(spanIsSampled(idleSpan)).toBe(true);
 
       expect(dynamicSamplingContext).toStrictEqual({ release: '3.0.0', sample_rand: '0.999' });
@@ -1434,8 +1447,8 @@ describe('browserTracingIntegration', () => {
       const propagationContext = getCurrentScope().getPropagationContext();
 
       // Span should use passed-in data, not Server-Timing data
-      expect(spanToJSON(idleSpan).trace_id).toEqual('99999999999999999999999999999999');
-      expect(spanToJSON(idleSpan).parent_span_id).toEqual('8888888888888888');
+      expect(spanToStreamedSpanJSON(idleSpan).trace_id).toEqual('99999999999999999999999999999999');
+      expect(spanToStreamedSpanJSON(idleSpan).parent_span_id).toEqual('8888888888888888');
       expect(spanIsSampled(idleSpan)).toBe(true);
 
       expect(dynamicSamplingContext).toStrictEqual({ release: '4.0.0', sample_rand: '0.777' });
@@ -1527,7 +1540,7 @@ describe('browserTracingIntegration', () => {
 
       const span1 = startInactiveSpan({ name: 'test span 1', forceTransaction: true });
       span1.end();
-      const span1Json = spanToJSON(span1);
+      const span1Json = spanToStreamedSpanJSON(span1);
 
       expect(span1Json.links).toBeUndefined();
 
@@ -1536,7 +1549,7 @@ describe('browserTracingIntegration', () => {
 
       const span2 = startInactiveSpan({ name: 'test span 2', forceTransaction: true });
       span2.end();
-      const spanJson2 = spanToJSON(span2);
+      const spanJson2 = spanToStreamedSpanJSON(span2);
 
       expect(spanJson2.links).toEqual([
         {
@@ -1568,7 +1581,7 @@ describe('browserTracingIntegration', () => {
 
       const span1 = startInactiveSpan({ name: 'test span 1', forceTransaction: true });
       span1.end();
-      const span1Json = spanToJSON(span1);
+      const span1Json = spanToStreamedSpanJSON(span1);
 
       expect(span1Json.links).toBeUndefined();
 
@@ -1577,7 +1590,7 @@ describe('browserTracingIntegration', () => {
 
       const span2 = startInactiveSpan({ name: 'test span 2', forceTransaction: true });
       span2.end();
-      const spanJson2 = spanToJSON(span2);
+      const spanJson2 = spanToStreamedSpanJSON(span2);
 
       expect(spanJson2.links).toBeUndefined();
     });

--- a/packages/browser/test/tracing/linkedTraces.test.ts
+++ b/packages/browser/test/tracing/linkedTraces.test.ts
@@ -4,7 +4,7 @@ import {
   debug,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SentrySpan,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   timestampInSeconds,
 } from '@sentry/core/browser';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -66,7 +66,7 @@ describe('linkTraces', () => {
 
       spanStartCb(childSpan);
 
-      expect(spanToJSON(childSpan).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(childSpan).links).toBeUndefined();
     });
 
     it('adds a link from the first trace root span to the second trace root span', () => {
@@ -80,7 +80,7 @@ describe('linkTraces', () => {
 
       spanStartCb(rootSpanTrace1);
 
-      expect(spanToJSON(rootSpanTrace1).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rootSpanTrace1).links).toBeUndefined();
 
       const rootSpanTrace2 = new SentrySpan({
         name: 'test',
@@ -92,7 +92,7 @@ describe('linkTraces', () => {
 
       spanStartCb(rootSpanTrace2);
 
-      expect(spanToJSON(rootSpanTrace2).links).toEqual([
+      expect(spanToStreamedSpanJSON(rootSpanTrace2).links).toEqual([
         {
           attributes: {
             'sentry.link.type': 'previous_trace',
@@ -115,7 +115,7 @@ describe('linkTraces', () => {
 
       spanStartCb(rootSpanTrace1);
 
-      expect(spanToJSON(rootSpanTrace1).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rootSpanTrace1).links).toBeUndefined();
 
       const rootSpan2Trace = new SentrySpan({
         name: 'test',
@@ -127,7 +127,7 @@ describe('linkTraces', () => {
 
       spanStartCb(rootSpan2Trace);
 
-      expect(spanToJSON(rootSpan2Trace).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rootSpan2Trace).links).toBeUndefined();
     });
   });
 
@@ -183,7 +183,7 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(previousTraceInfo, currentSpan, oldPropagationContext);
 
-    const spanJson = spanToJSON(currentSpan);
+    const spanJson = spanToStreamedSpanJSON(currentSpan);
 
     expect(spanJson.links).toEqual([
       {
@@ -196,7 +196,7 @@ describe('addPreviousTraceSpanLink', () => {
       },
     ]);
 
-    expect(spanJson.data).toMatchObject({
+    expect(spanJson.attributes).toMatchObject({
       [PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE]: '123-456-1',
     });
 
@@ -394,11 +394,11 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(previousTraceInfo, currentSpan, oldPropagationContext);
 
-    const spanJson = spanToJSON(currentSpan);
+    const spanJson = spanToStreamedSpanJSON(currentSpan);
 
     expect(spanJson.links).toBeUndefined();
 
-    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
+    expect(Object.keys(spanJson.attributes)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     // but still updates the previousTraceInfo to the current span
     expect(updatedPreviousTraceInfo).toEqual({
@@ -449,7 +449,7 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(previousTraceInfo, currentSpan, oldPropagationContext);
 
-    expect(spanToJSON(currentSpan).links).toEqual([
+    expect(spanToStreamedSpanJSON(currentSpan).links).toEqual([
       {
         trace_id: '789',
         span_id: '101',
@@ -489,9 +489,9 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(undefined, currentSpan, oldPropagationContext);
 
-    const spanJson = spanToJSON(currentSpan);
+    const spanJson = spanToStreamedSpanJSON(currentSpan);
     expect(spanJson.links).toBeUndefined();
-    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
+    expect(Object.keys(spanJson.attributes)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     expect(updatedPreviousTraceInfo).toEqual({
       sampleRand: 0.0126,
@@ -530,9 +530,9 @@ describe('addPreviousTraceSpanLink', () => {
 
     const updatedPreviousTraceInfo = addPreviousTraceSpanLink(previousTraceInfo, currentSpan, oldPropagationContext);
 
-    const spanJson = spanToJSON(currentSpan);
+    const spanJson = spanToStreamedSpanJSON(currentSpan);
     expect(spanJson.links).toBeUndefined();
-    expect(Object.keys(spanJson.data)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
+    expect(Object.keys(spanJson.attributes)).not.toContain(PREVIOUS_TRACE_TMP_SPAN_ATTRIBUTE);
 
     expect(updatedPreviousTraceInfo).toBe(previousTraceInfo);
   });

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -143,6 +143,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   trpcMiddleware,

--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -1,5 +1,5 @@
 import http from 'node:http';
-import { getActiveSpan, getCurrentScope, getTraceData, spanToJSON } from '@sentry/core';
+import { getActiveSpan, getCurrentScope, getTraceData, spanToStreamedSpanJSON } from '@sentry/core';
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { init } from '../../src';
 
@@ -37,11 +37,11 @@ describe('Bun HTTP Server Integration', () => {
   });
 
   test('creates an http.server span for incoming requests', async () => {
-    let span: ReturnType<typeof spanToJSON> | undefined;
+    let span: ReturnType<typeof spanToStreamedSpanJSON> | undefined;
 
     const { port, close } = await startServer((_req, res) => {
       const activeSpan = getActiveSpan();
-      span = activeSpan ? spanToJSON(activeSpan) : undefined;
+      span = activeSpan ? spanToStreamedSpanJSON(activeSpan) : undefined;
       res.end('ok');
     });
 
@@ -50,9 +50,9 @@ describe('Bun HTTP Server Integration', () => {
     await close();
 
     expect(span).toBeDefined();
-    expect(span?.op).toBe('http.server');
-    expect(span?.description).toBe('GET /users');
-    expect(span?.data['sentry.origin']).toBe('auto.http.server');
+    expect(span?.attributes['sentry.op']).toBe('http.server');
+    expect(span?.name).toBe('GET /users');
+    expect(span?.attributes['sentry.origin']).toBe('auto.http.server');
   });
 
   test('isolates each incoming request with a distinct trace id', async () => {

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -93,6 +93,7 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   trpcMiddleware,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -10,6 +10,7 @@ export type { OfflineStore, OfflineTransportOptions } from './transports/offline
 export type { IntegrationIndex } from './integration';
 export * from './tracing';
 export * from './semanticAttributes';
+export type { RawAttributes } from './attributes';
 export { createEventEnvelope, createSessionEnvelope } from './envelope';
 export {
   captureException,

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -12,6 +12,7 @@ import {
   getSpanDescendants,
   removeChildSpanFromSpan,
   spanTimeInputToSeconds,
+  spanToStreamedSpanJSON,
   spanToJSON,
 } from '../utils/spanUtils';
 import { timestampInSeconds } from '../utils/time';
@@ -359,7 +360,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       if (
         _finished ||
         startedSpan === span ||
-        !!spanToJSON(startedSpan).timestamp ||
+        !!spanToStreamedSpanJSON(startedSpan).end_timestamp ||
         (startedSpan instanceof SentrySpan && startedSpan.isStandaloneSpan())
       ) {
         return;

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -271,7 +271,7 @@ export class SentrySpan implements Span {
    * @hidden
    * @internal This method is purely for internal purposes and should not be used outside
    * of SDK code. If you need to get a JSON representation of a span,
-   * use `spanToJSON(span)` instead.
+   * use `spanToStreamedSpanJSON(span)` instead.
    */
   public getSpanJSON(): SpanJSON {
     return {
@@ -307,8 +307,7 @@ export class SentrySpan implements Span {
       trace_id: this._traceId,
       parent_span_id: this._parentSpanId,
       start_timestamp: this._startTime,
-      // just in case _endTime is not set, we use the start time (i.e. duration 0)
-      end_timestamp: this._endTime ?? this._startTime,
+      end_timestamp: this._endTime,
       is_segment: this === getRootSpan(this),
       status: getSimpleStatus(this._status),
       attributes: addStatusMessageAttribute(this._attributes, this._status),

--- a/packages/core/src/tracing/spans/captureSpan.ts
+++ b/packages/core/src/tracing/spans/captureSpan.ts
@@ -83,7 +83,7 @@ export function captureSpan(span: Span, client: Client): SerializedStreamedSpanW
       ? applyBeforeSendSpanCallback(spanJSON, beforeSendSpan)
       : spanJSON;
 
-  const spanNameSource = processedSpan.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+  const spanNameSource = processedSpan.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
   if (spanJSON.is_segment && spanNameSource) {
     // Backfill sentry.segment.name.source from sentry.source.
     // TODO(v11): Remove this backfill once we removed setting SEMANTIC_ATTRIBUTE_SENTRY_SOURCE in favour of

--- a/packages/core/src/tracing/spans/spanJsonToStreamedSpan.ts
+++ b/packages/core/src/tracing/spans/spanJsonToStreamedSpan.ts
@@ -12,7 +12,7 @@ export function spanJsonToSerializedStreamedSpan(span: SpanJSON): SerializedStre
     parent_span_id: span.parent_span_id,
     name: span.description || '',
     start_timestamp: span.start_timestamp,
-    end_timestamp: span.timestamp || span.start_timestamp,
+    end_timestamp: span.timestamp,
     status: !span.status || span.status === 'ok' || span.status === 'cancelled' ? 'ok' : 'error',
     is_segment: false,
     attributes: { ...(span.data as RawAttributes<Record<string, unknown>>) },

--- a/packages/core/src/types/samplingcontext.ts
+++ b/packages/core/src/types/samplingcontext.ts
@@ -1,6 +1,6 @@
+import type { RawAttributes } from '../attributes';
 import type { RequestEventData } from '../types/request';
 import type { WorkerLocation } from './misc';
-import type { SpanAttributes } from './span';
 
 /**
  * Context data passed by the user when starting a transaction, to be used by the tracesSampler method.
@@ -38,7 +38,7 @@ export interface SamplingContext extends CustomSamplingContext {
   name: string;
 
   /** Initial attributes that have been passed to the span being sampled. */
-  attributes?: SpanAttributes;
+  attributes?: RawAttributes<Record<string, unknown>>;
 }
 
 /**

--- a/packages/core/src/types/span.ts
+++ b/packages/core/src/types/span.ts
@@ -49,10 +49,11 @@ export interface StreamedSpanJSON {
   span_id: string;
   name: string;
   start_timestamp: number;
-  end_timestamp: number;
+  /** Only set once the span has ended. */
+  end_timestamp?: number;
   status: 'ok' | 'error';
   is_segment: boolean;
-  attributes?: RawAttributes<Record<string, unknown>>;
+  attributes: RawAttributes<Record<string, unknown>>;
   links?: SpanLinkJSON<RawAttributes<Record<string, unknown>>>[];
 }
 
@@ -60,9 +61,11 @@ export interface StreamedSpanJSON {
  * Serialized span item.
  * This is the final, serialized span format that is sent to Sentry.
  * The intermediate representation is {@link StreamedSpanJSON}.
- * Main difference: Attributes are converted to {@link Attributes}, thus including the `type` annotation.
+ * Main differences: Attributes are converted to {@link Attributes}, thus including the `type`
+ * annotation, and `end_timestamp` is guaranteed to be set (we only ever send ended spans).
  */
-export type SerializedStreamedSpan = Omit<StreamedSpanJSON, 'attributes' | 'links'> & {
+export type SerializedStreamedSpan = Omit<StreamedSpanJSON, 'attributes' | 'links' | 'end_timestamp'> & {
+  end_timestamp: number;
   attributes: Attributes;
   links?: SpanLinkJSON<Attributes>[];
 };

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -167,8 +167,8 @@ function ensureTimestampInSeconds(timestamp: number): number {
  * Convert a span to a JSON representation.
  */
 // Note: Because of this, we currently have a circular type dependency (which we opted out of in package.json).
-// This is not avoidable as we need `spanToJSON` in `spanUtils.ts`, which in turn is needed by `span.ts` for backwards compatibility.
-// And `spanToJSON` needs the Span class from `span.ts` to check here.
+// This is not avoidable as we need `spanToStreamedSpanJSON` in `spanUtils.ts`, which in turn is needed by `span.ts` for backwards compatibility.
+// And `spanToStreamedSpanJSON` needs the Span class from `span.ts` to check here.
 export function spanToJSON(span: Span): SpanJSON {
   if (spanIsSentrySpan(span)) {
     return span.getSpanJSON();
@@ -227,7 +227,8 @@ export function spanToStreamedSpanJSON(span: Span): StreamedSpanJSON {
       trace_id,
       parent_span_id: getOtelParentSpanId(span),
       start_timestamp: spanTimeInputToSeconds(startTime),
-      end_timestamp: spanTimeInputToSeconds(endTime),
+      // This is [0,0] by default in OTEL, in which case we want to interpret this as no end time
+      end_timestamp: spanTimeInputToSeconds(endTime) || undefined,
       is_segment: span === INTERNAL_getSegmentSpan(span),
       status: getSimpleStatus(status),
       attributes: addStatusMessageAttribute(attributes, status),
@@ -242,9 +243,9 @@ export function spanToStreamedSpanJSON(span: Span): StreamedSpanJSON {
     trace_id,
     start_timestamp: 0,
     name: '',
-    end_timestamp: 0,
     status: 'ok',
     is_segment: span === INTERNAL_getSegmentSpan(span),
+    attributes: {},
   };
 }
 
@@ -270,6 +271,9 @@ function getOtelParentSpanId(span: OpenTelemetrySdkTraceBaseSpan): string | unde
 export function streamedSpanJsonToSerializedSpan(spanJson: StreamedSpanJSON): SerializedStreamedSpan {
   return {
     ...spanJson,
+    // We only ever send ended spans, but fall back to the start time (i.e. duration 0) so that
+    // sent spans always carry an end timestamp.
+    end_timestamp: spanJson.end_timestamp ?? spanJson.start_timestamp,
     attributes: serializeAttributes(spanJson.attributes),
     links: spanJson.links?.map(link => ({
       ...link,

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { setCurrentClient, spanToJSON, startInactiveSpan, startSpan } from '../../../src';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
+  setCurrentClient,
+  spanToStreamedSpanJSON,
+  startInactiveSpan,
+  startSpan,
+} from '../../../src';
 import * as globalErrorModule from '../../../src/instrument/globalError';
 import * as globalUnhandledRejectionModule from '../../../src/instrument/globalUnhandledRejection';
 import { _resetErrorsInstrumented, registerSpanErrorInstrumentation } from '../../../src/tracing/errors';
@@ -43,13 +49,13 @@ describe('registerErrorHandlers()', () => {
     registerSpanErrorInstrumentation();
 
     const transaction = startInactiveSpan({ name: 'test' })!;
-    expect(spanToJSON(transaction).status).toBe('ok');
+    expect(spanToStreamedSpanJSON(transaction).status).toBe('ok');
 
     mockErrorCallback({} as HandlerDataError);
-    expect(spanToJSON(transaction).status).toBe('ok');
+    expect(spanToStreamedSpanJSON(transaction).status).toBe('ok');
 
     mockUnhandledRejectionCallback({});
-    expect(spanToJSON(transaction).status).toBe('ok');
+    expect(spanToStreamedSpanJSON(transaction).status).toBe('ok');
 
     transaction.end();
   });
@@ -59,7 +65,9 @@ describe('registerErrorHandlers()', () => {
 
     startSpan({ name: 'test' }, span => {
       mockErrorCallback({} as HandlerDataError);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      const { status, attributes } = spanToStreamedSpanJSON(span);
+      expect(status).toBe('error');
+      expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('internal_error');
     });
   });
 
@@ -68,7 +76,9 @@ describe('registerErrorHandlers()', () => {
 
     startSpan({ name: 'test' }, span => {
       mockUnhandledRejectionCallback({});
-      expect(spanToJSON(span).status).toBe('internal_error');
+      const { status, attributes } = spanToStreamedSpanJSON(span);
+      expect(status).toBe('error');
+      expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('internal_error');
     });
   });
 });

--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -9,11 +9,12 @@ import {
   getTraceData,
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
   SentryNonRecordingSpan,
   SentrySpan,
   setCurrentClient,
   spanToBaggageHeader,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startInactiveSpan,
   startSpan,
   startSpanManual,
@@ -262,7 +263,7 @@ describe('startIdleSpan', () => {
     vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout + 1);
     vi.runOnlyPendingTimers();
 
-    expect(spanToJSON(idleSpan).data).toEqual(
+    expect(spanToStreamedSpanJSON(idleSpan).attributes).toEqual(
       expect.objectContaining({
         foo: 'bar',
       }),
@@ -287,7 +288,7 @@ describe('startIdleSpan', () => {
   it('runs beforeIdleSpanEnd before trimming the idle span', () => {
     const baseTimeInSeconds = Math.floor(Date.now() / 1000) - 9999;
     const beforeIdleSpanEnd = vi.fn((span: Span) => {
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeUndefined();
       const childSpan = startInactiveSpan({ name: 'last-moment child', startTime: baseTimeInSeconds });
       childSpan.end(baseTimeInSeconds + 1);
     });
@@ -299,7 +300,7 @@ describe('startIdleSpan', () => {
 
     expect(beforeIdleSpanEnd).toHaveBeenCalledOnce();
     expect(beforeIdleSpanEnd).toHaveBeenCalledWith(idleSpan);
-    expect(spanToJSON(idleSpan).timestamp).toBe(baseTimeInSeconds + 1);
+    expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBe(baseTimeInSeconds + 1);
   });
 
   it('filters spans on end', () => {
@@ -474,7 +475,7 @@ describe('startIdleSpan', () => {
     expect(hookSpans).toEqual([{ span: idleSpan, hook: 'spanStart' }]);
 
     vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-    expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
 
     expect(hookSpans).toEqual([
       { span: idleSpan, hook: 'spanStart' },
@@ -622,7 +623,7 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('does not finish if a activity is started', () => {
@@ -632,7 +633,7 @@ describe('startIdleSpan', () => {
       startInactiveSpan({ name: 'span' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
     });
 
     it('does not finish when idleTimeout is not exceed after last activity finished', () => {
@@ -648,7 +649,7 @@ describe('startIdleSpan', () => {
 
       vi.advanceTimersByTime(8);
 
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
     });
 
     it('finish when idleTimeout is exceeded after last activity finished', () => {
@@ -664,7 +665,7 @@ describe('startIdleSpan', () => {
 
       vi.advanceTimersByTime(10);
 
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
   });
 
@@ -676,18 +677,24 @@ describe('startIdleSpan', () => {
       // Start any span to cancel idle timeout
       startInactiveSpan({ name: 'span' });
 
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait some time
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait for timeout to exceed
       vi.advanceTimersByTime(1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('resets after new activities are added', () => {
@@ -697,32 +704,42 @@ describe('startIdleSpan', () => {
       // Start any span to cancel idle timeout
       startInactiveSpan({ name: 'span' });
 
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait some time
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // New span resets the timeout
       startInactiveSpan({ name: 'span' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // New span resets the timeout
       startInactiveSpan({ name: 'span' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Wait for timeout to exceed
       vi.advanceTimersByTime(1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it("doesn't reset the timeout for standalone spans", () => {
@@ -734,8 +751,10 @@ describe('startIdleSpan', () => {
 
       // Wait some time
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout - 1000);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // new standalone span should not reset the timeout
       const standaloneSpan = startInactiveSpan({ name: 'standalone span', experimental: { standalone: true } });
@@ -743,8 +762,10 @@ describe('startIdleSpan', () => {
 
       // Wait for timeout to exceed
       vi.advanceTimersByTime(1001);
-      expect(spanToJSON(idleSpan).status).not.toEqual('deadline_exceeded');
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).not.toEqual(
+        'deadline_exceeded',
+      );
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
   });
 
@@ -754,16 +775,16 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Now emit a signal
       getClient()!.emit('idleSpanEnableAutoFinish', idleSpan);
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('skips span timeout if disableAutoFinish=true', () => {
@@ -773,16 +794,16 @@ describe('startIdleSpan', () => {
       startInactiveSpan({ name: 'inner' });
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Now emit a signal
       getClient()!.emit('idleSpanEnableAutoFinish', idleSpan);
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.childSpanTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('times out at final timeout if disableAutoFinish=true', () => {
@@ -790,7 +811,7 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.finalTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeDefined();
     });
 
     it('ignores it if hook is emitted with other span', () => {
@@ -799,17 +820,17 @@ describe('startIdleSpan', () => {
       expect(idleSpan).toBeDefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
 
       // Now emit a signal, but with a different span
       getClient()!.emit('idleSpanEnableAutoFinish', span);
 
       // This doesn't affect us!
       vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
-      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeUndefined();
     });
   });
 
@@ -831,7 +852,7 @@ describe('startIdleSpan', () => {
 
       vi.runAllTimers();
 
-      expect(spanToJSON(idleSpan).timestamp).toBe(1100);
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBe(1100);
     });
 
     it('trims end to final timeout', () => {
@@ -851,7 +872,7 @@ describe('startIdleSpan', () => {
 
       vi.runAllTimers();
 
-      expect(spanToJSON(idleSpan).timestamp).toBe(1030);
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBe(1030);
     });
 
     it('keeps lower span endTime than highest child span end', () => {
@@ -871,8 +892,8 @@ describe('startIdleSpan', () => {
 
       vi.runAllTimers();
 
-      expect(spanToJSON(idleSpan).timestamp).toBeLessThan(999_999_999);
-      expect(spanToJSON(idleSpan).timestamp).toBeGreaterThan(1060);
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeLessThan(999_999_999);
+      expect(spanToStreamedSpanJSON(idleSpan).end_timestamp).toBeGreaterThan(1060);
     });
   });
 });

--- a/packages/core/test/lib/tracing/spanstatus.test.ts
+++ b/packages/core/test/lib/tracing/spanstatus.test.ts
@@ -1,30 +1,36 @@
 import { describe, expect, it } from 'vitest';
-import { SentrySpan, setHttpStatus, spanToJSON } from '../../../src/index';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
+  SentrySpan,
+  setHttpStatus,
+  spanToStreamedSpanJSON,
+} from '../../../src/index';
 
 describe('setHttpStatus', () => {
   it.each([
-    [200, 'ok'],
-    [300, 'ok'],
-    [401, 'unauthenticated'],
-    [403, 'permission_denied'],
-    [404, 'not_found'],
-    [409, 'already_exists'],
-    [413, 'failed_precondition'],
-    [429, 'resource_exhausted'],
-    [455, 'invalid_argument'],
-    [501, 'unimplemented'],
-    [503, 'unavailable'],
-    [504, 'deadline_exceeded'],
-    [520, 'internal_error'],
-  ])('applies the correct span status and http status code to the span (%s - $%s)', (code, status) => {
+    [200, 'ok', undefined],
+    [300, 'ok', undefined],
+    [401, 'error', 'unauthenticated'],
+    [403, 'error', 'permission_denied'],
+    [404, 'error', 'not_found'],
+    [409, 'error', 'already_exists'],
+    [413, 'error', 'failed_precondition'],
+    [429, 'error', 'resource_exhausted'],
+    [455, 'error', 'invalid_argument'],
+    [501, 'error', 'unimplemented'],
+    [503, 'error', 'unavailable'],
+    [504, 'error', 'deadline_exceeded'],
+    [520, 'error', 'internal_error'],
+  ])('applies the correct span status and http status code to the span (%s - $%s)', (code, status, statusMessage) => {
     const span = new SentrySpan({ name: 'test' });
 
-    setHttpStatus(span, code);
+    setHttpStatus(span, code as number);
 
-    const { status: spanStatus, data } = spanToJSON(span);
+    const { status: spanStatus, attributes } = spanToStreamedSpanJSON(span);
 
     expect(spanStatus).toBe(status);
-    expect(data).toMatchObject({ 'http.response.status_code': code });
+    expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe(statusMessage);
+    expect(attributes).toMatchObject({ 'http.response.status_code': code });
   });
 
   it('defaults to internal_error', () => {
@@ -32,9 +38,10 @@ describe('setHttpStatus', () => {
 
     setHttpStatus(span, 600);
 
-    const { status: spanStatus, data } = spanToJSON(span);
+    const { status: spanStatus, attributes } = spanToStreamedSpanJSON(span);
 
-    expect(spanStatus).toBe('internal_error');
-    expect(data).toMatchObject({ 'http.response.status_code': 600 });
+    expect(spanStatus).toBe('error');
+    expect(attributes[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('internal_error');
+    expect(attributes).toMatchObject({ 'http.response.status_code': 600 });
   });
 });

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -11,7 +11,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setAsyncContextStrategy,
   setCurrentClient,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   withScope,
 } from '../../../src';
 import { getAsyncContextStrategy } from '../../../src/asyncContext';
@@ -102,8 +102,8 @@ describe('startSpan', () => {
       }
       expect(_span).toBeDefined();
 
-      expect(spanToJSON(_span!).description).toEqual('GET users/[id]');
-      expect(spanToJSON(_span!).status).toEqual(isError ? 'internal_error' : 'ok');
+      expect(spanToStreamedSpanJSON(_span!).name).toEqual('GET users/[id]');
+      expect(spanToStreamedSpanJSON(_span!).status).toEqual(isError ? 'error' : 'ok');
     });
 
     it('allows for transaction to be mutated', async () => {
@@ -120,7 +120,7 @@ describe('startSpan', () => {
         //
       }
 
-      expect(spanToJSON(_span!).op).toEqual('http.server');
+      expect(spanToStreamedSpanJSON(_span!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual('http.server');
     });
 
     it('creates a span with correct description', async () => {
@@ -144,9 +144,9 @@ describe('startSpan', () => {
       const spans = getSpanDescendants(_span!);
 
       expect(spans).toHaveLength(2);
-      expect(spanToJSON(spans[1]!).description).toEqual('SELECT * from users');
-      expect(spanToJSON(spans[1]!).parent_span_id).toEqual(_span!.spanContext().spanId);
-      expect(spanToJSON(spans[1]!).status).toEqual(isError ? 'internal_error' : 'ok');
+      expect(spanToStreamedSpanJSON(spans[1]!).name).toEqual('SELECT * from users');
+      expect(spanToStreamedSpanJSON(spans[1]!).parent_span_id).toEqual(_span!.spanContext().spanId);
+      expect(spanToStreamedSpanJSON(spans[1]!).status).toEqual(isError ? 'error' : 'ok');
     });
 
     it('allows for span to be mutated', async () => {
@@ -171,7 +171,7 @@ describe('startSpan', () => {
       const spans = getSpanDescendants(_span!);
 
       expect(spans).toHaveLength(2);
-      expect(spanToJSON(spans[1]!).op).toEqual('db.query');
+      expect(spanToStreamedSpanJSON(spans[1]!).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP]).toEqual('db.query');
     });
 
     it('correctly sets the span origin', async () => {
@@ -194,19 +194,22 @@ describe('startSpan', () => {
       }
 
       expect(_span).toBeDefined();
-      const jsonSpan = spanToJSON(_span!);
+      const jsonSpan = spanToStreamedSpanJSON(_span!);
       expect(jsonSpan).toEqual({
-        data: {
+        attributes: {
           'sentry.origin': 'auto.http.browser',
           'sentry.sample_rate': 1,
           'sentry.source': 'custom',
+          ...(isError && { 'sentry.status.message': 'internal_error' }),
         },
-        origin: 'auto.http.browser',
-        description: 'GET users/[id]',
+        name: 'GET users/[id]',
         span_id: expect.stringMatching(/[a-f0-9]{16}/),
+        parent_span_id: undefined,
         start_timestamp: expect.any(Number),
-        status: isError ? 'internal_error' : 'ok',
-        timestamp: expect.any(Number),
+        end_timestamp: expect.any(Number),
+        is_segment: true,
+        status: isError ? 'error' : 'ok',
+        links: undefined,
         trace_id: expect.stringMatching(/[a-f0-9]{32}/),
       });
     });
@@ -306,17 +309,17 @@ describe('startSpan', () => {
     const span = startSpan({ name: 'GET users/[id]' }, span => {
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeUndefined();
       return span;
     });
 
     expect(span).toBeDefined();
-    expect(spanToJSON(span).timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
   });
 
   it('allows to pass a `startTime`', () => {
     const start = startSpan({ name: 'outer', startTime: [1234, 0] }, span => {
-      return spanToJSON(span).start_timestamp;
+      return spanToStreamedSpanJSON(span).start_timestamp;
     });
 
     expect(start).toEqual(1234);
@@ -353,7 +356,7 @@ describe('startSpan', () => {
       expect(getActiveSpan()).toBe(span);
 
       // span has the correct parent span
-      expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
+      expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('parent-span-id');
 
       // scope data modifications
       getCurrentScope().setTag('cats', 'great');
@@ -390,7 +393,7 @@ describe('startSpan', () => {
         expect(getCurrentScope()).not.toBe(customScope);
 
         expect(getActiveSpan()).toBe(span1);
-        expect(spanToJSON(span1).parent_span_id).toBe('parent-span-id');
+        expect(spanToStreamedSpanJSON(span1).parent_span_id).toBe('parent-span-id');
       });
 
       // active span on customScope is reset
@@ -405,7 +408,7 @@ describe('startSpan', () => {
 
         expect(getActiveSpan()).toBe(span2);
         // both, span1 and span2 are children of the parent span
-        expect(spanToJSON(span2).parent_span_id).toBe('parent-span-id');
+        expect(spanToStreamedSpanJSON(span2).parent_span_id).toBe('parent-span-id');
       });
 
       withScope(customScope, () => {
@@ -460,7 +463,7 @@ describe('startSpan', () => {
 
     startSpan({ name: 'GET users/[id]', parentSpan }, span => {
       expect(getActiveSpan()).toBe(span);
-      expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
+      expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('parent-span-id');
     });
 
     expect(getActiveSpan()).toBe(undefined);
@@ -469,7 +472,7 @@ describe('startSpan', () => {
   it('allows to pass parentSpan=null', () => {
     startSpan({ name: 'GET users/[id]' }, () => {
       startSpan({ name: 'GET users/[id]', parentSpan: null }, span => {
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
       });
     });
   });
@@ -480,7 +483,7 @@ describe('startSpan', () => {
     // @ts-expect-error _links exists on span
     expect(rawSpan1?._links).toEqual(undefined);
 
-    const span1JSON = spanToJSON(rawSpan1);
+    const span1JSON = spanToStreamedSpanJSON(rawSpan1);
 
     startSpan({ name: '/users/:id' }, rawSpan2 => {
       rawSpan2.addLink({
@@ -490,7 +493,7 @@ describe('startSpan', () => {
         },
       });
 
-      const span2LinkJSON = spanToJSON(rawSpan2).links?.[0];
+      const span2LinkJSON = spanToStreamedSpanJSON(rawSpan2).links?.[0];
 
       expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
 
@@ -682,11 +685,11 @@ describe('startSpan', () => {
       client.init();
 
       startSpan({ name: 'parent span' }, span => {
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         startSpan({ name: 'child span' }, childSpan => {
-          expect(spanToJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
           startSpan({ name: 'grand child span' }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(span.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(span.spanContext().spanId);
           });
         });
       });
@@ -702,11 +705,11 @@ describe('startSpan', () => {
       client.init();
 
       startSpan({ name: 'parent span' }, span => {
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         startSpan({ name: 'child span' }, childSpan => {
-          expect(spanToJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
           startSpan({ name: 'grand child span' }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(childSpan.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(childSpan.spanContext().spanId);
           });
         });
       });
@@ -726,7 +729,7 @@ describe('startSpan', () => {
       startSpan({ name: 'parent span' }, () => {
         startSpan({ name: 'child span' }, () => {
           startSpan({ name: 'grand child span', parentSpan }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(parentSpan.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(parentSpan.spanContext().spanId);
           });
         });
       });
@@ -744,7 +747,7 @@ describe('startSpan', () => {
       startSpan({ name: 'parent span' }, () => {
         startSpan({ name: 'child span' }, () => {
           startSpan({ name: 'grand child span', parentSpan: null }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(undefined);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(undefined);
           });
         });
       });
@@ -933,9 +936,9 @@ describe('startSpanManual', () => {
     startSpanManual({ name: 'GET users/[id]' }, (span, finish) => {
       expect(span).toBeDefined();
       expect(span).toBeInstanceOf(SentrySpan);
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeUndefined();
       finish();
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
     });
   });
 
@@ -970,7 +973,7 @@ describe('startSpanManual', () => {
         // current scope is forked from the customScope
         expect(getCurrentScope()).not.toBe(initialScope);
         expect(getCurrentScope()).not.toBe(customScope);
-        expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('parent-span-id');
 
         // span is active span
         expect(getActiveSpan()).toBe(span);
@@ -994,7 +997,7 @@ describe('startSpanManual', () => {
         // current scope is forked from the customScope
         expect(getCurrentScope()).not.toBe(initialScope);
         expect(getCurrentScope()).not.toBe(customScope);
-        expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('parent-span-id');
 
         // scope data modification from customScope in previous callback is persisted
         expect(getCurrentScope().getScopeData().tags).toEqual({ dogs: 'great', bears: 'great' });
@@ -1057,7 +1060,7 @@ describe('startSpanManual', () => {
 
     startSpanManual({ name: 'GET users/[id]', parentSpan }, span => {
       expect(getActiveSpan()).toBe(span);
-      expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
+      expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('parent-span-id');
 
       span.end();
     });
@@ -1068,7 +1071,7 @@ describe('startSpanManual', () => {
   it('allows to pass parentSpan=null', () => {
     startSpan({ name: 'GET users/[id]' }, () => {
       startSpanManual({ name: 'child', parentSpan: null }, span => {
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         span.end();
       });
     });
@@ -1080,7 +1083,7 @@ describe('startSpanManual', () => {
     // @ts-expect-error _links exists on span
     expect(rawSpan1?._links).toEqual(undefined);
 
-    const span1JSON = spanToJSON(rawSpan1);
+    const span1JSON = spanToStreamedSpanJSON(rawSpan1);
 
     startSpanManual({ name: '/users/:id' }, rawSpan2 => {
       rawSpan2.addLink({
@@ -1090,7 +1093,7 @@ describe('startSpanManual', () => {
         },
       });
 
-      const span2LinkJSON = spanToJSON(rawSpan2).links?.[0];
+      const span2LinkJSON = spanToStreamedSpanJSON(rawSpan2).links?.[0];
 
       expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
 
@@ -1221,7 +1224,7 @@ describe('startSpanManual', () => {
   it('allows to pass a `startTime`', () => {
     const start = startSpanManual({ name: 'outer', startTime: [1234, 0] }, span => {
       span.end();
-      return spanToJSON(span).start_timestamp;
+      return spanToStreamedSpanJSON(span).start_timestamp;
     });
 
     expect(start).toEqual(1234);
@@ -1296,11 +1299,11 @@ describe('startSpanManual', () => {
       client.init();
 
       startSpanManual({ name: 'parent span' }, span => {
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         startSpanManual({ name: 'child span' }, childSpan => {
-          expect(spanToJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
           startSpanManual({ name: 'grand child span' }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(span.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(span.spanContext().spanId);
             grandChildSpan.end();
           });
           childSpan.end();
@@ -1319,11 +1322,11 @@ describe('startSpanManual', () => {
       client.init();
 
       startSpanManual({ name: 'parent span' }, span => {
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         startSpanManual({ name: 'child span' }, childSpan => {
-          expect(spanToJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(childSpan).parent_span_id).toBe(span.spanContext().spanId);
           startSpanManual({ name: 'grand child span' }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(childSpan.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(childSpan.spanContext().spanId);
             grandChildSpan.end();
           });
           childSpan.end();
@@ -1346,7 +1349,7 @@ describe('startSpanManual', () => {
       startSpan({ name: 'parent span' }, () => {
         startSpan({ name: 'child span' }, () => {
           startSpanManual({ name: 'grand child span', parentSpan }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(parentSpan.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(parentSpan.spanContext().spanId);
             grandChildSpan.end();
           });
         });
@@ -1365,7 +1368,7 @@ describe('startSpanManual', () => {
       startSpan({ name: 'parent span' }, () => {
         startSpan({ name: 'child span' }, () => {
           startSpanManual({ name: 'grand child span', parentSpan: null }, grandChildSpan => {
-            expect(spanToJSON(grandChildSpan).parent_span_id).toBe(undefined);
+            expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(undefined);
             grandChildSpan.end();
           });
         });
@@ -1447,11 +1450,11 @@ describe('startInactiveSpan', () => {
 
     expect(span).toBeDefined();
     expect(span).toBeInstanceOf(SentrySpan);
-    expect(spanToJSON(span).timestamp).toBeUndefined();
+    expect(spanToStreamedSpanJSON(span).end_timestamp).toBeUndefined();
 
     span.end();
 
-    expect(spanToJSON(span).timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
   });
 
   it('does not set span on scope', () => {
@@ -1482,8 +1485,8 @@ describe('startInactiveSpan', () => {
     const currentTraceId = getCurrentScope().getPropagationContext().traceId;
     const span = startInactiveSpan({ name: 'GET users/[id]' });
 
-    expect(spanToJSON(span).trace_id).toBe(currentTraceId);
-    expect(spanToJSON(span).parent_span_id).toBeUndefined();
+    expect(spanToStreamedSpanJSON(span).trace_id).toBe(currentTraceId);
+    expect(spanToStreamedSpanJSON(span).parent_span_id).toBeUndefined();
     expect(getDynamicSamplingContextFromSpan(span)).toEqual(
       expect.objectContaining({ trace_id: currentTraceId, transaction: 'GET users/[id]' }),
     );
@@ -1499,7 +1502,7 @@ describe('startInactiveSpan', () => {
     const span = startInactiveSpan({ name: 'GET users/[id]', scope: manualScope });
 
     expect(span).toBeDefined();
-    expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
+    expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('parent-span-id');
     expect(getActiveSpan()).toBeUndefined();
 
     span.end();
@@ -1512,7 +1515,7 @@ describe('startInactiveSpan', () => {
 
     const span = startInactiveSpan({ name: 'GET users/[id]', parentSpan });
 
-    expect(spanToJSON(span).parent_span_id).toBe('parent-span-id');
+    expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('parent-span-id');
     expect(getActiveSpan()).toBe(undefined);
 
     span.end();
@@ -1523,7 +1526,7 @@ describe('startInactiveSpan', () => {
   it('allows to pass parentSpan=null', () => {
     startSpan({ name: 'outer' }, () => {
       const span = startInactiveSpan({ name: 'GET users/[id]', parentSpan: null });
-      expect(spanToJSON(span).parent_span_id).toBe(undefined);
+      expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
       span.end();
     });
   });
@@ -1544,8 +1547,8 @@ describe('startInactiveSpan', () => {
       ],
     });
 
-    const span1JSON = spanToJSON(rawSpan1);
-    const span2JSON = spanToJSON(rawSpan2);
+    const span1JSON = spanToStreamedSpanJSON(rawSpan1);
+    const span2JSON = spanToStreamedSpanJSON(rawSpan2);
     const span2LinkJSON = span2JSON.links?.[0];
 
     expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
@@ -1563,7 +1566,7 @@ describe('startInactiveSpan', () => {
     expect(span2LinkJSON?.span_id).toBe(span1JSON.span_id);
 
     // sampling decision is inherited
-    expect(span2LinkJSON?.sampled).toBe(Boolean(spanToJSON(rawSpan1).data['sentry.sample_rate']));
+    expect(span2LinkJSON?.sampled).toBe(Boolean(spanToStreamedSpanJSON(rawSpan1).attributes['sentry.sample_rate']));
   });
 
   it('allows to force a transaction with forceTransaction=true', async () => {
@@ -1671,7 +1674,7 @@ describe('startInactiveSpan', () => {
 
   it('allows to pass a `startTime`', () => {
     const span = startInactiveSpan({ name: 'outer', startTime: [1234, 0] });
-    expect(spanToJSON(span).start_timestamp).toEqual(1234);
+    expect(spanToStreamedSpanJSON(span).start_timestamp).toEqual(1234);
   });
 
   it("picks up the trace id off the parent scope's propagation context", () => {
@@ -1736,19 +1739,19 @@ describe('startInactiveSpan', () => {
       client.init();
 
       const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-      expect(spanToJSON(inactiveSpan).parent_span_id).toBe(undefined);
+      expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(undefined);
 
       startSpan({ name: 'parent span' }, span => {
         const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-        expect(spanToJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
+        expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
 
         startSpan({ name: 'child span' }, () => {
           const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-          expect(spanToJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
 
           startSpan({ name: 'grand child span' }, () => {
             const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-            expect(spanToJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
           });
         });
       });
@@ -1764,19 +1767,19 @@ describe('startInactiveSpan', () => {
       client.init();
 
       const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-      expect(spanToJSON(inactiveSpan).parent_span_id).toBe(undefined);
+      expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(undefined);
 
       startSpan({ name: 'parent span' }, span => {
         const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-        expect(spanToJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
+        expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(span.spanContext().spanId);
 
         startSpan({ name: 'child span' }, childSpan => {
           const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-          expect(spanToJSON(inactiveSpan).parent_span_id).toBe(childSpan.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(childSpan.spanContext().spanId);
 
           startSpan({ name: 'grand child span' }, grandChildSpan => {
             const inactiveSpan = startInactiveSpan({ name: 'inactive span' });
-            expect(spanToJSON(inactiveSpan).parent_span_id).toBe(grandChildSpan.spanContext().spanId);
+            expect(spanToStreamedSpanJSON(inactiveSpan).parent_span_id).toBe(grandChildSpan.spanContext().spanId);
           });
         });
       });
@@ -1796,7 +1799,7 @@ describe('startInactiveSpan', () => {
       startSpan({ name: 'parent span' }, () => {
         startSpan({ name: 'child span' }, () => {
           const grandChildSpan = startInactiveSpan({ name: 'grand child span', parentSpan });
-          expect(spanToJSON(grandChildSpan).parent_span_id).toBe(parentSpan.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(parentSpan.spanContext().spanId);
           grandChildSpan.end();
         });
       });
@@ -1814,7 +1817,7 @@ describe('startInactiveSpan', () => {
       startSpan({ name: 'parent span' }, () => {
         startSpan({ name: 'child span' }, () => {
           const grandChildSpan = startInactiveSpan({ name: 'grand child span', parentSpan: null });
-          expect(spanToJSON(grandChildSpan).parent_span_id).toBe(undefined);
+          expect(spanToStreamedSpanJSON(grandChildSpan).parent_span_id).toBe(undefined);
           grandChildSpan.end();
         });
       });
@@ -2209,7 +2212,7 @@ describe('continueTrace', () => {
         },
         () => {
           startSpan({ name: 'inner' }, span => {
-            const innerSpanJson = spanToJSON(span);
+            const innerSpanJson = spanToStreamedSpanJSON(span);
             const innerTraceId = innerSpanJson.trace_id;
             const innerParentSpanId = innerSpanJson.parent_span_id;
 
@@ -2309,7 +2312,7 @@ describe('withActiveSpan()', () => {
 
     const parentSpanId = withActiveSpan(inactiveSpan, () => {
       return startSpan({ name: 'child-span' }, childSpan => {
-        return spanToJSON(childSpan).parent_span_id;
+        return spanToStreamedSpanJSON(childSpan).parent_span_id;
       });
     });
 
@@ -2369,11 +2372,11 @@ describe('span hooks', () => {
     const endedSpans: string[] = [];
 
     client.on('spanStart', span => {
-      startedSpans.push(spanToJSON(span).description || '');
+      startedSpans.push(spanToStreamedSpanJSON(span).name);
     });
 
     client.on('spanEnd', span => {
-      endedSpans.push(spanToJSON(span).description || '');
+      endedSpans.push(spanToStreamedSpanJSON(span).name);
     });
 
     startSpan({ name: 'span1' }, () => {
@@ -2710,7 +2713,7 @@ describe('ignoreSpans (core path, streaming)', () => {
         expect(getActiveSpan()).toBe(rootSpan);
 
         startSpan({ name: 'grandchild' }, grandchildSpan => {
-          const json = spanToJSON(grandchildSpan);
+          const json = spanToStreamedSpanJSON(grandchildSpan);
           expect(json.parent_span_id).toBe(rootSpan.spanContext().spanId);
         });
       });

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -8,6 +8,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
   SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE,
+  SentryNonRecordingSpan,
   SentrySpan,
   setCurrentClient,
   SPAN_STATUS_ERROR,
@@ -317,7 +318,7 @@ describe('spanTimeInputToSeconds', () => {
   });
 });
 
-describe('spanToJSON', () => {
+describe('spanToStreamedSpanJSON', () => {
   describe('SentrySpan', () => {
     it('works with a simple span', () => {
       const span = new SentrySpan();
@@ -432,7 +433,7 @@ describe('spanToJSON', () => {
           trace_id: expect.stringMatching(/^[0-9a-f]{32}$/),
           name: '',
           start_timestamp: expect.any(Number),
-          end_timestamp: expect.any(Number),
+          end_timestamp: undefined,
           status: 'ok',
           is_segment: true,
           attributes: {
@@ -565,7 +566,7 @@ describe('spanToJSON', () => {
           trace_id: 'TRACE-1',
           parent_span_id: undefined,
           start_timestamp: 123,
-          end_timestamp: 0,
+          end_timestamp: undefined,
           name: 'test span',
           is_segment: true,
           status: 'ok',
@@ -755,6 +756,38 @@ describe('spanIsSampled', () => {
   test('not sampled', () => {
     const span = new SentrySpan({ sampled: false });
     expect(spanIsSampled(span)).toBe(false);
+  });
+});
+
+// `end_timestamp` is what call sites use to tell an open span from an ended one, so it must stay
+// unset until the span actually ends — across all span implementations.
+describe('spanToStreamedSpanJSON end_timestamp', () => {
+  test('SentrySpan', () => {
+    const span = new SentrySpan({ name: 'test' });
+    expect(spanToStreamedSpanJSON(span).end_timestamp).toBeUndefined();
+
+    span.end();
+    expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+  });
+
+  test('unsampled SentrySpan', () => {
+    const span = new SentrySpan({ name: 'test', sampled: false });
+    expect(spanToStreamedSpanJSON(span).end_timestamp).toBeUndefined();
+
+    span.end();
+    expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+  });
+
+  test('OpenTelemetry span', () => {
+    const openSpan = createMockedOtelSpan({ spanId: 'SPAN-1', traceId: 'TRACE-1', endTime: [0, 0] });
+    expect(spanToStreamedSpanJSON(openSpan).end_timestamp).toBeUndefined();
+
+    const endedSpan = createMockedOtelSpan({ spanId: 'SPAN-1', traceId: 'TRACE-1', endTime: 456 });
+    expect(spanToStreamedSpanJSON(endedSpan).end_timestamp).toBe(456);
+  });
+
+  test('SentryNonRecordingSpan', () => {
+    expect(spanToStreamedSpanJSON(new SentryNonRecordingSpan()).end_timestamp).toBeUndefined();
   });
 });
 

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -89,6 +89,7 @@ export {
   captureSession,
   endSession,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -120,6 +120,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   trpcMiddleware,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -123,6 +123,7 @@ export {
   spotlightIntegration,
   initOpenTelemetry,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   trpcMiddleware,

--- a/packages/nestjs/test/integrations/orchestrion-subscriber.test.ts
+++ b/packages/nestjs/test/integrations/orchestrion-subscriber.test.ts
@@ -12,7 +12,7 @@ import {
   initAndBind,
   resolvedSyncPromise,
   setAsyncContextStrategy,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { nestjsChannels as CHANNELS } from '@sentry/server-utils/orchestrion';
@@ -139,18 +139,18 @@ describe('NestJS orchestrion subscriber: app_creation', () => {
 
     const span = getSpan();
     expect(span).toBeDefined();
-    const json = spanToJSON(span!);
-    expect(json.description).toBe('Create Nest App');
-    expect(json.op).toBe('function');
-    expect(json.origin).toBe('auto.http.nestjs');
-    expect(json.data).toMatchObject({
+    const json = spanToStreamedSpanJSON(span!);
+    expect(json.name).toBe('Create Nest App');
+    expect(json.attributes['sentry.op']).toBe('function');
+    expect(json.attributes['sentry.origin']).toBe('auto.http.nestjs');
+    expect(json.attributes).toMatchObject({
       component: '@nestjs/core',
       'nestjs.type': 'app_creation',
       'nestjs.version': '10.4.1',
       'nestjs.module': 'AppModule',
     });
     // Span was ended on `asyncEnd`.
-    expect(json.timestamp).toBeDefined();
+    expect(json.end_timestamp).toBeDefined();
   });
 
   it('omits optional attributes when version/module are absent', async () => {
@@ -163,10 +163,10 @@ describe('NestJS orchestrion subscriber: app_creation', () => {
 
     await channel.tracePromise(async () => ({ app: true }), { arguments: [] });
 
-    const json = spanToJSON(getSpan()!);
-    expect(json.data['nestjs.version']).toBeUndefined();
-    expect(json.data['nestjs.module']).toBeUndefined();
-    expect(json.data['nestjs.type']).toBe('app_creation');
+    const json = spanToStreamedSpanJSON(getSpan()!);
+    expect(json.attributes['nestjs.version']).toBeUndefined();
+    expect(json.attributes['nestjs.module']).toBeUndefined();
+    expect(json.attributes['nestjs.type']).toBe('app_creation');
   });
 });
 
@@ -213,12 +213,12 @@ describe('NestJS orchestrion subscriber: request_context / request_handler', () 
       return 'cats';
     }
 
-    let contextSpanJson: ReturnType<typeof spanToJSON> | undefined;
+    let contextSpanJson: ReturnType<typeof spanToStreamedSpanJSON> | undefined;
     const { effectiveHandler } = driveCreate(instance, getCats, '10.4.1', () => {
       // The per-request handler `create` returns. Capture the active span
       // here: when invoked it runs inside the request_context span.
       return function perRequest(): unknown {
-        contextSpanJson = spanToJSON(getActiveSpan()!);
+        contextSpanJson = spanToStreamedSpanJSON(getActiveSpan()!);
         return 'ok';
       };
     });
@@ -231,10 +231,10 @@ describe('NestJS orchestrion subscriber: request_context / request_handler', () 
     });
 
     expect(contextSpanJson).toBeDefined();
-    expect(contextSpanJson!.description).toBe('CatsController.getCats');
-    expect(contextSpanJson!.op).toBe('function');
-    expect(contextSpanJson!.origin).toBe('auto.http.nestjs');
-    expect(contextSpanJson!.data).toMatchObject({
+    expect(contextSpanJson!.name).toBe('CatsController.getCats');
+    expect(contextSpanJson!.attributes['sentry.op']).toBe('function');
+    expect(contextSpanJson!.attributes['sentry.origin']).toBe('auto.http.nestjs');
+    expect(contextSpanJson!.attributes).toMatchObject({
       component: '@nestjs/core',
       'nestjs.type': 'request_context',
       'nestjs.controller': 'CatsController',
@@ -253,9 +253,9 @@ describe('NestJS orchestrion subscriber: request_context / request_handler', () 
 
     class CatsController {}
     const instance = new CatsController();
-    let handlerSpanJson: ReturnType<typeof spanToJSON> | undefined;
+    let handlerSpanJson: ReturnType<typeof spanToStreamedSpanJSON> | undefined;
     function getCats(): string {
-      handlerSpanJson = spanToJSON(getActiveSpan()!);
+      handlerSpanJson = spanToStreamedSpanJSON(getActiveSpan()!);
       return 'cats';
     }
 
@@ -268,10 +268,10 @@ describe('NestJS orchestrion subscriber: request_context / request_handler', () 
     wrappedCallback.call(instance);
 
     expect(handlerSpanJson).toBeDefined();
-    expect(handlerSpanJson!.description).toBe('getCats');
-    expect(handlerSpanJson!.op).toBe('handler');
-    expect(handlerSpanJson!.origin).toBe('auto.http.nestjs');
-    expect(handlerSpanJson!.data).toMatchObject({
+    expect(handlerSpanJson!.name).toBe('getCats');
+    expect(handlerSpanJson!.attributes['sentry.op']).toBe('handler');
+    expect(handlerSpanJson!.attributes['sentry.origin']).toBe('auto.http.nestjs');
+    expect(handlerSpanJson!.attributes).toMatchObject({
       component: '@nestjs/core',
       'nestjs.type': 'handler',
       'nestjs.callback': 'getCats',
@@ -289,7 +289,7 @@ describe('NestJS orchestrion subscriber: request_context / request_handler', () 
     let contextSpanId: string | undefined;
     let handlerParentSpanId: string | undefined;
     function getCats(): string {
-      handlerParentSpanId = spanToJSON(getActiveSpan()!).parent_span_id;
+      handlerParentSpanId = spanToStreamedSpanJSON(getActiveSpan()!).parent_span_id;
       return 'cats';
     }
 
@@ -340,12 +340,12 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     new LoggerMiddleware().use({ url: '/' }, {}, next);
 
     expect(next).toHaveBeenCalledTimes(1);
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('LoggerMiddleware');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs');
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('LoggerMiddleware');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs');
     // startSpanManual span ends when the proxied `next` is called.
-    expect(json.timestamp).toBeDefined();
+    expect(json.end_timestamp).toBeDefined();
   });
 
   it('guard: wraps `canActivate` in a span and preserves its return value', () => {
@@ -363,10 +363,10 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     applyInjectable(AuthGuard);
 
     expect(new AuthGuard().canActivate({ ctx: true })).toBe(true);
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('AuthGuard');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.guard');
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('AuthGuard');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.guard');
   });
 
   it('pipe: wraps `transform` in a span and preserves its return value', () => {
@@ -384,10 +384,10 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     applyInjectable(ParseIntPipe);
 
     expect(new ParseIntPipe().transform('42', { type: 'param' })).toBe(42);
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('ParseIntPipe');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.pipe');
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('ParseIntPipe');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.pipe');
   });
 
   it('interceptor: opens a before-span (ended at next.handle) and instruments the returned observable', () => {
@@ -418,12 +418,12 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     // Passthrough: same observable is returned (with `subscribe` proxied).
     expect(returned).toBe(observable);
 
-    const beforeJson = spanToJSON(beforeSpan!);
-    expect(beforeJson.description).toBe('LoggingInterceptor');
-    expect(beforeJson.op).toBe('middleware');
-    expect(beforeJson.origin).toBe('auto.middleware.nestjs.interceptor');
+    const beforeJson = spanToStreamedSpanJSON(beforeSpan!);
+    expect(beforeJson.name).toBe('LoggingInterceptor');
+    expect(beforeJson.attributes['sentry.op']).toBe('middleware');
+    expect(beforeJson.attributes['sentry.origin']).toBe('auto.middleware.nestjs.interceptor');
     // before-span ends when `next.handle()` is called.
-    expect(beforeJson.timestamp).toBeDefined();
+    expect(beforeJson.end_timestamp).toBeDefined();
 
     // The returned observable was instrumented: subscribing registers an
     // after-span teardown (proving the after-span was created).
@@ -461,7 +461,7 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
 
     expect(returned).toBe(observable);
     // before-span ended (when `next.handle()` ran, post-await)
-    expect(spanToJSON(beforeSpan!).timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(beforeSpan!).end_timestamp).toBeDefined();
     // after-span was created AND the observable instrumented despite the await
     returned.subscribe();
     expect(teardowns).toHaveLength(1);
@@ -497,7 +497,7 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     expect(next.handle).not.toHaveBeenCalled();
     // before-span is closed even though `next.handle()` (which normally
     // ends it) never ran
-    expect(spanToJSON(beforeSpan!).timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(beforeSpan!).end_timestamp).toBeDefined();
     // no after-span, so the observable is left un-instrumented
     returned.subscribe();
     expect(teardowns).toHaveLength(0);
@@ -533,7 +533,7 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     expect(next.handle).not.toHaveBeenCalled();
     // before-span is closed even though `next.handle()` (which normally
     // ends it) never ran
-    expect(spanToJSON(beforeSpan!).timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(beforeSpan!).end_timestamp).toBeDefined();
     // no after-span, so the observable is left un-instrumented
     returned.subscribe();
     expect(teardowns).toHaveLength(0);
@@ -585,8 +585,8 @@ describe('NestJS orchestrion subscriber: @Injectable (middleware/guard/pipe/inte
     expect(returned).toBe(observable);
     // Each interceptor opened and ended its own distinct before-span.
     expect(outerBefore).not.toBe(innerBefore);
-    expect(spanToJSON(outerBefore!).timestamp).toBeDefined();
-    expect(spanToJSON(innerBefore!).timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(outerBefore!).end_timestamp).toBeDefined();
+    expect(spanToStreamedSpanJSON(innerBefore!).end_timestamp).toBeDefined();
     // Exactly one "Interceptors - After Route" span was created for the
     // shared context.
     returned.subscribe();
@@ -642,10 +642,10 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
     const ret = new HttpExceptionFilter().catch('boom', { switchToHttp: () => ({}) });
     expect(ret).toBe('handled:boom');
 
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('HttpExceptionFilter');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.exception_filter');
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('HttpExceptionFilter');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.exception_filter');
   });
 
   it('does not open a span when exception or host is absent', () => {
@@ -697,10 +697,10 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
     const ret = new HttpExceptionFilter().catch('boom', { switchToHttp: () => ({}) });
     expect(ret).toBe('handled:boom');
 
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('HttpExceptionFilter');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.exception_filter');
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('HttpExceptionFilter');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.exception_filter');
   });
 
   it('still wraps `catch` when the @Catch channel fired first (dual @Injectable @Catch filter)', () => {
@@ -721,10 +721,10 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
     const ret = new HttpExceptionFilter().catch('boom', { switchToHttp: () => ({}) });
     expect(ret).toBe('handled:boom');
 
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('HttpExceptionFilter');
-    expect(json.op).toBe('middleware');
-    expect(json.origin).toBe('auto.middleware.nestjs.exception_filter');
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('HttpExceptionFilter');
+    expect(json.attributes['sentry.op']).toBe('middleware');
+    expect(json.attributes['sentry.origin']).toBe('auto.middleware.nestjs.exception_filter');
   });
 
   // A (contrived) class that is BOTH a guard (`canActivate`) and an
@@ -761,8 +761,10 @@ describe('NestJS orchestrion subscriber: @Catch (exception filter)', () => {
       expect(new GuardAndFilter().canActivate({ ctx: true })).toBe(true);
       expect(new GuardAndFilter().catch('boom', { switchToHttp: () => ({}) })).toBe('handled:boom');
 
-      expect(spanToJSON(guardSpan!).origin).toBe('auto.middleware.nestjs.guard');
-      expect(spanToJSON(filterSpan!).origin).toBe('auto.middleware.nestjs.exception_filter');
+      expect(spanToStreamedSpanJSON(guardSpan!).attributes['sentry.origin']).toBe('auto.middleware.nestjs.guard');
+      expect(spanToStreamedSpanJSON(filterSpan!).attributes['sentry.origin']).toBe(
+        'auto.middleware.nestjs.exception_filter',
+      );
     });
   }
 });
@@ -852,10 +854,10 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
 
     await (descriptor.value as AnyFn)();
 
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('event user.created');
-    expect(json.op).toBe('function');
-    expect(json.origin).toBe('auto.event.nestjs');
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('event user.created');
+    expect(json.attributes['sentry.op']).toBe('function');
+    expect(json.attributes['sentry.origin']).toBe('auto.event.nestjs');
   });
 
   it('bullmq @Processor: patches `process` into a queue.process transaction (string queue name)', async () => {
@@ -882,11 +884,11 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
     expect(EmailProcessor.prototype.process).not.toBe(originalProcess);
 
     await new EmailProcessor().process({});
-    const json = spanToJSON(spanInside!);
-    expect(json.description).toBe('emails process');
-    expect(json.op).toBe('queue.process');
-    expect(json.origin).toBe('auto.queue.nestjs.bullmq');
-    expect(json.data).toMatchObject({
+    const json = spanToStreamedSpanJSON(spanInside!);
+    expect(json.name).toBe('emails process');
+    expect(json.attributes['sentry.op']).toBe('queue.process');
+    expect(json.attributes['sentry.origin']).toBe('auto.queue.nestjs.bullmq');
+    expect(json.attributes).toMatchObject({
       'messaging.system': 'bullmq',
       'messaging.destination.name': 'emails',
     });
@@ -907,7 +909,7 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
     }
     wrappedDecorator(ReportsProcessor);
     return new ReportsProcessor().process().then(() => {
-      expect(spanToJSON(spanInside!).description).toBe('reports process');
+      expect(spanToStreamedSpanJSON(spanInside!).name).toBe('reports process');
     });
   });
 
@@ -972,7 +974,7 @@ describe('NestJS orchestrion subscriber: schedule / event / bullmq', () => {
 
     await (descriptor.value as AnyFn)();
 
-    expect(spanToJSON(spanInside!).description).toBe(expected);
+    expect(spanToStreamedSpanJSON(spanInside!).name).toBe(expected);
   });
 
   it('bullmq @Processor: skips wrapping when the class is flagged __SENTRY_INTERNAL__', () => {

--- a/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
+++ b/packages/nextjs/src/common/utils/dropMiddlewareTunnelRequests.ts
@@ -1,12 +1,6 @@
 import { HTTP_TARGET, URL_FULL } from '@sentry/conventions/attributes';
-import {
-  getClient,
-  GLOBAL_OBJ,
-  isSentryRequestUrl,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  type Span,
-  type SpanAttributes,
-} from '@sentry/core';
+import type { RawAttributes } from '@sentry/core';
+import { getClient, GLOBAL_OBJ, isSentryRequestUrl, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, type Span } from '@sentry/core';
 import { ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
 import { isPathnameUnderSentryTunnelRoute } from './tunnelPathnameMatch';
 import { TRANSACTION_ATTR_SHOULD_DROP_TRANSACTION } from '../span-attributes-with-logic-attached';
@@ -21,7 +15,10 @@ const globalWithInjectedValues = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
  * 1. Requests to the local tunnel route (before rewrite) via middleware or BaseServer.handleRequest
  * 2. Requests to Sentry ingest (after rewrite) via fetch spans
  */
-export function dropMiddlewareTunnelRequests(span: Span, attrs: SpanAttributes | undefined): void {
+export function dropMiddlewareTunnelRequests(
+  span: Span,
+  attrs: RawAttributes<Record<string, unknown>> | undefined,
+): void {
   // When the user brings their own OTel setup (enableOpenTelemetrySetup: false), we should not
   // mutate their spans with Sentry-internal attributes as it pollutes their tracing backends.
   if (
@@ -53,7 +50,7 @@ export function dropMiddlewareTunnelRequests(span: Span, attrs: SpanAttributes |
   }
 }
 
-function isSentryRequestSpan(attrs: SpanAttributes): boolean {
+function isSentryRequestSpan(attrs: RawAttributes<Record<string, unknown>>): boolean {
   const httpUrl = attrs[URL_FULL];
 
   if (!httpUrl) {

--- a/packages/nextjs/src/common/utils/forkIsolationScopeForRootSpan.ts
+++ b/packages/nextjs/src/common/utils/forkIsolationScopeForRootSpan.ts
@@ -1,5 +1,5 @@
 import { context } from '@opentelemetry/api';
-import type { Span, SpanAttributes } from '@sentry/core';
+import type { RawAttributes, Span } from '@sentry/core';
 import {
   getCapturedScopesOnSpan,
   getCurrentScope,
@@ -14,7 +14,10 @@ import { ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
  * Forks the isolation scope for `BaseServer.handleRequest` / `Middleware.execute` root spans so that request-scoped
  * data (e.g. `normalizedRequest`) stays isolated per request.
  */
-export function maybeForkIsolationScopeForRootSpan(span: Span, spanAttributes: SpanAttributes | undefined): void {
+export function maybeForkIsolationScopeForRootSpan(
+  span: Span,
+  spanAttributes: RawAttributes<Record<string, unknown>> | undefined,
+): void {
   const spanType = spanAttributes?.[ATTR_NEXT_SPAN_TYPE];
   if (spanType !== 'BaseServer.handleRequest' && spanType !== 'Middleware.execute') {
     return;

--- a/packages/nextjs/src/common/utils/tracingUtils.ts
+++ b/packages/nextjs/src/common/utils/tracingUtils.ts
@@ -1,6 +1,6 @@
 import { HTTP_ROUTE, SENTRY_OP } from '@sentry/conventions/attributes';
 import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
-import type { PropagationContext, Span, SpanAttributes } from '@sentry/core';
+import type { PropagationContext, RawAttributes, Span } from '@sentry/core';
 import { isObjectLike, Scope, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { ATTR_NEXT_SEGMENT, ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
 
@@ -61,7 +61,7 @@ export function commonObjectToIsolationScope(commonObject: unknown): Scope {
  * @param spanAttributes The attributes of the span to check.
  * @returns True if the span is a resolve segment span, false otherwise.
  */
-export function isResolveSegmentSpan(spanAttributes: SpanAttributes): boolean {
+export function isResolveSegmentSpan(spanAttributes: RawAttributes<Record<string, unknown>>): boolean {
   return (
     spanAttributes[ATTR_NEXT_SPAN_TYPE] === 'NextNodeServer.getLayoutOrPageModule' &&
     spanAttributes[ATTR_NEXT_SPAN_NAME] === 'resolve segment modules' &&
@@ -96,8 +96,8 @@ export function getEnhancedResolveSegmentSpanName({ segment, route }: { segment:
  */
 export function maybeEnhanceServerComponentSpanName(
   activeSpan: Span,
-  spanAttributes: SpanAttributes,
-  rootSpanAttributes: SpanAttributes,
+  spanAttributes: RawAttributes<Record<string, unknown>>,
+  rootSpanAttributes: RawAttributes<Record<string, unknown>>,
 ): void {
   if (!isResolveSegmentSpan(spanAttributes)) {
     return;
@@ -109,7 +109,7 @@ export function maybeEnhanceServerComponentSpanName(
   activeSpan.updateName(enhancedName);
   activeSpan.setAttributes({
     'sentry.nextjs.ssr.function.type': segment === PAGE_SEGMENT ? 'Page' : 'Layout',
-    'sentry.nextjs.ssr.function.route': route,
+    'sentry.nextjs.ssr.function.route': route as string | undefined,
     [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
     [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
   });

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -11,7 +11,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import type { VercelEdgeOptions } from '@sentry/vercel-edge';
 import { getDefaultIntegrations, init as vercelEdgeInit } from '@sentry/vercel-edge';
@@ -128,7 +128,7 @@ export function init(options: VercelEdgeOptions = {}): void {
   });
 
   client.on('spanStart', span => {
-    const spanAttributes = spanToJSON(span).data;
+    const spanAttributes = spanToStreamedSpanJSON(span).attributes;
     const rootSpan = getRootSpan(span);
     const isRootSpan = span === rootSpan;
 

--- a/packages/nextjs/src/server/handleOnSpanStart.ts
+++ b/packages/nextjs/src/server/handleOnSpanStart.ts
@@ -5,7 +5,7 @@ import {
   getRootSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import { ATTR_NEXT_ROUTE, ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../common/nextSpanAttributes';
 import { addHeadersAsAttributes } from '../common/utils/addHeadersAsAttributes';
@@ -22,9 +22,9 @@ import { maybeEnrichQueueConsumerSpan, maybeEnrichQueueProducerSpan } from './ve
  * @param span The span that is starting.
  */
 export function handleOnSpanStart(span: Span): void {
-  const spanAttributes = spanToJSON(span).data;
+  const spanAttributes = spanToStreamedSpanJSON(span).attributes;
   const rootSpan = getRootSpan(span);
-  const rootSpanAttributes = spanToJSON(rootSpan).data;
+  const rootSpanAttributes = spanToStreamedSpanJSON(rootSpan).attributes;
   const isRootSpan = span === rootSpan;
 
   dropMiddlewareTunnelRequests(span, spanAttributes);

--- a/packages/nextjs/src/server/vercelCronsMonitoring.ts
+++ b/packages/nextjs/src/server/vercelCronsMonitoring.ts
@@ -1,5 +1,5 @@
 import type { Span } from '@sentry/core';
-import { _INTERNAL_safeDateNow, captureCheckIn, debug, getIsolationScope, spanToJSON } from '@sentry/core';
+import { _INTERNAL_safeDateNow, captureCheckIn, debug, getIsolationScope, spanToStreamedSpanJSON } from '@sentry/core';
 import { DEBUG_BUILD } from '../common/debug-build';
 import type { VercelCronsConfig } from '../common/types';
 
@@ -86,7 +86,7 @@ export function maybeStartCronCheckIn(span: Span, route: string | undefined): vo
  * Should be called from the spanEnd event handler.
  */
 export function maybeCompleteCronCheckIn(span: Span): void {
-  const spanData = spanToJSON(span).data;
+  const spanData = spanToStreamedSpanJSON(span).attributes;
   const checkInId = spanData?.[ATTR_SENTRY_CRON_CHECK_IN_ID];
   const monitorSlug = spanData?.[ATTR_SENTRY_CRON_MONITOR_SLUG];
   const startTime = spanData?.[ATTR_SENTRY_CRON_START_TIME];
@@ -97,7 +97,7 @@ export function maybeCompleteCronCheckIn(span: Span): void {
   }
 
   const duration = _INTERNAL_safeDateNow() / 1000 - startTime;
-  const spanStatus = spanToJSON(span).status;
+  const spanStatus = spanToStreamedSpanJSON(span).status;
   // Span status is 'ok' for success, undefined for unset, or an error message like 'internal_error'
   const checkInStatus = spanStatus && spanStatus !== 'ok' ? 'error' : 'ok';
 

--- a/packages/nextjs/src/server/vercelQueuesMonitoring.ts
+++ b/packages/nextjs/src/server/vercelQueuesMonitoring.ts
@@ -1,6 +1,6 @@
 import { URL_FULL } from '@sentry/conventions/attributes';
 import type { Span } from '@sentry/core';
-import { getIsolationScope, spanToJSON } from '@sentry/core';
+import { getIsolationScope, spanToStreamedSpanJSON } from '@sentry/core';
 
 // OTel Messaging semantic convention attribute keys
 const ATTR_MESSAGING_SYSTEM = 'messaging.system';
@@ -74,7 +74,7 @@ export function maybeEnrichQueueConsumerSpan(span: Span): void {
  * We use domain-based detection to avoid false positives from user routes.
  */
 export function maybeEnrichQueueProducerSpan(span: Span): void {
-  const spanData = spanToJSON(span).data;
+  const spanData = spanToStreamedSpanJSON(span).attributes;
 
   // http.client spans have url.full attribute
   const urlFull = spanData?.[URL_FULL] as string | undefined;
@@ -113,7 +113,7 @@ export function maybeEnrichQueueProducerSpan(span: Span): void {
  * Cleans up the internal marker attribute from enriched queue spans on end.
  */
 export function maybeCleanupQueueSpan(span: Span): void {
-  const spanData = spanToJSON(span).data;
+  const spanData = spanToStreamedSpanJSON(span).attributes;
   if (spanData?.[ATTR_SENTRY_QUEUE_ENRICHED]) {
     span.setAttribute(ATTR_SENTRY_QUEUE_ENRICHED, undefined);
   }

--- a/packages/nextjs/test/server/vercelQueuesMonitoring.test.ts
+++ b/packages/nextjs/test/server/vercelQueuesMonitoring.test.ts
@@ -10,8 +10,8 @@ vi.mock('@sentry/core', () => ({
       },
     }),
   }),
-  spanToJSON: (span: { _data: Record<string, unknown> }) => ({
-    data: span._data,
+  spanToStreamedSpanJSON: (span: { _data: Record<string, unknown> }) => ({
+    attributes: span._data,
   }),
 }));
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -136,6 +136,7 @@ export {
   withActiveSpan,
   getRootSpan,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   trpcMiddleware,

--- a/packages/node/src/integrations/tracing/redis/cache.ts
+++ b/packages/node/src/integrations/tracing/redis/cache.ts
@@ -5,7 +5,7 @@ import {
   SEMANTIC_ATTRIBUTE_CACHE_KEY,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   truncate,
 } from '@sentry/core';
 import type { IORedisCommandArgs } from '../../../utils/redisCache';
@@ -19,6 +19,14 @@ import {
   shouldConsiderForCache,
 } from '../../../utils/redisCache';
 import type { IORedisResponseCustomAttributeFunction } from './vendored/types';
+import {
+  NET_PEER_NAME,
+  NET_PEER_PORT,
+  NETWORK_PEER_ADDRESS,
+  NETWORK_PEER_PORT,
+  SERVER_ADDRESS,
+  SERVER_PORT,
+} from '@sentry/conventions/attributes';
 
 // This module deliberately does NOT import the vendored OTel `IORedisInstrumentation`/
 // `RedisInstrumentation`, so the orchestrion opt-in can pull `cacheResponseHook`
@@ -74,11 +82,14 @@ export const cacheResponseHook: IORedisResponseCustomAttributeFunction = (
   // Fall back to stable semconv attributes (server.address/server.port) when
   // old-semconv ones are absent, eg OTEL_SEMCONV_STABILITY_OPT_IN=database
   // set for node-redis v4/v5.
-  const spanData = spanToJSON(span).data;
-  const networkPeerAddress = spanData['net.peer.name'] ?? spanData['server.address'];
-  const networkPeerPort = spanData['net.peer.port'] ?? spanData['server.port'];
+  const attributes = spanToStreamedSpanJSON(span).attributes;
+  // oxlint-disable-next-line typescript/no-deprecated
+  const networkPeerAddress = (attributes[NET_PEER_NAME] ?? attributes[SERVER_ADDRESS]) as string | undefined;
+  // oxlint-disable-next-line typescript/no-deprecated
+  const networkPeerPort = (attributes[NET_PEER_PORT] ?? attributes[SERVER_PORT]) as number | undefined;
+
   if (networkPeerPort && networkPeerAddress) {
-    span.setAttributes({ 'network.peer.address': networkPeerAddress, 'network.peer.port': networkPeerPort });
+    span.setAttributes({ [NETWORK_PEER_ADDRESS]: networkPeerAddress, [NETWORK_PEER_PORT]: networkPeerPort });
   }
 
   // A remove response is a delete-count, not a cached value, so its size is meaningless.

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -13,7 +13,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   withScope,
 } from '@sentry/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -333,7 +333,7 @@ describe('trace', () => {
 
       startSpan({ name: 'GET users/[id]', parentSpan: parentSpan! }, span => {
         expect(getActiveSpan()).toBe(span);
-        expect(spanToJSON(span).parent_span_id).toBe(parentSpan.spanContext().spanId);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(parentSpan.spanContext().spanId);
       });
 
       expect(getActiveSpan()).toBe(undefined);
@@ -342,7 +342,7 @@ describe('trace', () => {
     it('allows to pass parentSpan=null', () => {
       startSpan({ name: 'GET users/[id' }, () => {
         startSpan({ name: 'child', parentSpan: null }, span => {
-          expect(spanToJSON(span).parent_span_id).toBe(undefined);
+          expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         });
       });
     });
@@ -350,9 +350,9 @@ describe('trace', () => {
     it('allows to add span links', () => {
       const rawSpan1 = startInactiveSpan({ name: 'pageload_span' });
 
-      expect(spanToJSON(rawSpan1).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rawSpan1).links).toBeUndefined();
 
-      const span1JSON = spanToJSON(rawSpan1);
+      const span1JSON = spanToStreamedSpanJSON(rawSpan1);
 
       startSpan({ name: '/users/:id' }, rawSpan2 => {
         rawSpan2.addLink({
@@ -362,7 +362,7 @@ describe('trace', () => {
           },
         });
 
-        const span2LinkJSON = spanToJSON(rawSpan2).links?.[0];
+        const span2LinkJSON = spanToStreamedSpanJSON(rawSpan2).links?.[0];
 
         expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
 
@@ -377,9 +377,9 @@ describe('trace', () => {
     it('allows to pass span links in span options', () => {
       const rawSpan1 = startInactiveSpan({ name: 'pageload_span' });
 
-      expect(spanToJSON(rawSpan1).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rawSpan1).links).toBeUndefined();
 
-      const span1JSON = spanToJSON(rawSpan1);
+      const span1JSON = spanToStreamedSpanJSON(rawSpan1);
 
       startSpan(
         {
@@ -392,7 +392,7 @@ describe('trace', () => {
           ],
         },
         rawSpan2 => {
-          const span2LinkJSON = spanToJSON(rawSpan2).links?.[0];
+          const span2LinkJSON = spanToStreamedSpanJSON(rawSpan2).links?.[0];
 
           expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
 
@@ -692,7 +692,7 @@ describe('trace', () => {
       const span = startInactiveSpan({ name: 'GET users/[id]', parentSpan: parentSpan! });
 
       expect(getActiveSpan()).toBe(undefined);
-      expect(spanToJSON(span).parent_span_id).toBe(parentSpan!.spanContext().spanId);
+      expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(parentSpan!.spanContext().spanId);
 
       expect(getActiveSpan()).toBe(undefined);
     });
@@ -700,7 +700,7 @@ describe('trace', () => {
     it('allows to pass parentSpan=null', () => {
       startSpan({ name: 'outer' }, () => {
         const span = startInactiveSpan({ name: 'test span', parentSpan: null });
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         span.end();
       });
     });
@@ -708,7 +708,7 @@ describe('trace', () => {
     it('allows to pass span links in span options', () => {
       const rawSpan1 = startInactiveSpan({ name: 'pageload_span' });
 
-      expect(spanToJSON(rawSpan1).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rawSpan1).links).toBeUndefined();
 
       const rawSpan2 = startInactiveSpan({
         name: 'GET users/[id]',
@@ -720,8 +720,8 @@ describe('trace', () => {
         ],
       });
 
-      const span1JSON = spanToJSON(rawSpan1);
-      const span2JSON = spanToJSON(rawSpan2);
+      const span1JSON = spanToStreamedSpanJSON(rawSpan1);
+      const span2JSON = spanToStreamedSpanJSON(rawSpan2);
       const span2LinkJSON = span2JSON.links?.[0];
 
       expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
@@ -733,7 +733,7 @@ describe('trace', () => {
       expect(span2LinkJSON?.span_id).toBe(span1JSON.span_id);
 
       // sampling decision is inherited
-      expect(span2LinkJSON?.sampled).toBe(Boolean(spanToJSON(rawSpan1).data['sentry.sample_rate']));
+      expect(span2LinkJSON?.sampled).toBe(Boolean(spanToStreamedSpanJSON(rawSpan1).attributes['sentry.sample_rate']));
     });
 
     it('allows to force a transaction with forceTransaction=true', async () => {
@@ -1039,7 +1039,7 @@ describe('trace', () => {
 
       startSpanManual({ name: 'GET users/[id]', parentSpan: parentSpan! }, span => {
         expect(getActiveSpan()).toBe(span);
-        expect(spanToJSON(span).parent_span_id).toBe(parentSpan.spanContext().spanId);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(parentSpan.spanContext().spanId);
 
         span.end();
       });
@@ -1050,7 +1050,7 @@ describe('trace', () => {
     it('allows to pass parentSpan=null', () => {
       startSpan({ name: 'outer' }, () => {
         startSpanManual({ name: 'GET users/[id]', parentSpan: null }, span => {
-          expect(spanToJSON(span).parent_span_id).toBe(undefined);
+          expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
           span.end();
         });
       });
@@ -1059,9 +1059,9 @@ describe('trace', () => {
     it('allows to add span links', () => {
       const rawSpan1 = startInactiveSpan({ name: 'pageload_span' });
 
-      expect(spanToJSON(rawSpan1).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rawSpan1).links).toBeUndefined();
 
-      const span1JSON = spanToJSON(rawSpan1);
+      const span1JSON = spanToStreamedSpanJSON(rawSpan1);
 
       startSpanManual({ name: '/users/:id' }, rawSpan2 => {
         rawSpan2.addLink({
@@ -1071,7 +1071,7 @@ describe('trace', () => {
           },
         });
 
-        const span2LinkJSON = spanToJSON(rawSpan2).links?.[0];
+        const span2LinkJSON = spanToStreamedSpanJSON(rawSpan2).links?.[0];
 
         expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
 
@@ -1086,9 +1086,9 @@ describe('trace', () => {
     it('allows to pass span links in span options', () => {
       const rawSpan1 = startInactiveSpan({ name: 'pageload_span' });
 
-      expect(spanToJSON(rawSpan1).links).toBeUndefined();
+      expect(spanToStreamedSpanJSON(rawSpan1).links).toBeUndefined();
 
-      const span1JSON = spanToJSON(rawSpan1);
+      const span1JSON = spanToStreamedSpanJSON(rawSpan1);
 
       startSpanManual(
         {
@@ -1101,7 +1101,7 @@ describe('trace', () => {
           ],
         },
         rawSpan2 => {
-          const span2LinkJSON = spanToJSON(rawSpan2).links?.[0];
+          const span2LinkJSON = spanToStreamedSpanJSON(rawSpan2).links?.[0];
 
           expect(span2LinkJSON?.attributes?.['sentry.link.type']).toBe('previous_trace');
 
@@ -1285,12 +1285,12 @@ describe('trace', () => {
         const span = startInactiveSpan({ name: 'test span' });
 
         expect(span).toBeDefined();
-        const traceId = spanToJSON(span).trace_id;
+        const traceId = spanToStreamedSpanJSON(span).trace_id;
         expect(traceId).toMatch(/[a-f0-9]{32}/);
-        expect(spanToJSON(span).parent_span_id).toBe(undefined);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe(undefined);
         // A root span without a parent continues the current scope's propagation context trace,
         // matching the core SDK behavior.
-        expect(spanToJSON(span).trace_id).toEqual(propagationContext.traceId);
+        expect(spanToStreamedSpanJSON(span).trace_id).toEqual(propagationContext.traceId);
 
         expect(getDynamicSamplingContextFromSpan(span)).toEqual({
           trace_id: traceId,
@@ -1311,12 +1311,12 @@ describe('trace', () => {
         const span = startInactiveSpan({ name: 'test span' });
 
         expect(span).toBeDefined();
-        const traceId = spanToJSON(span).trace_id;
+        const traceId = spanToStreamedSpanJSON(span).trace_id;
         expect(traceId).toMatch(/[a-f0-9]{32}/);
         // The root span continues the scope's trace and inherits the propagation context's
         // parentSpanId as its parent, matching the core SDK behavior.
-        expect(spanToJSON(span).parent_span_id).toBe('1121201211212012');
-        expect(spanToJSON(span).trace_id).toEqual(propagationContext.traceId);
+        expect(spanToStreamedSpanJSON(span).parent_span_id).toBe('1121201211212012');
+        expect(spanToStreamedSpanJSON(span).trace_id).toEqual(propagationContext.traceId);
 
         expect(getDynamicSamplingContextFromSpan(span)).toEqual({
           environment: 'production',
@@ -1338,8 +1338,8 @@ describe('trace', () => {
           const span = startInactiveSpan({ name: 'test span' });
 
           expect(span).toBeDefined();
-          expect(spanToJSON(span).trace_id).toEqual(parentSpan.spanContext().traceId);
-          expect(spanToJSON(span).parent_span_id).toEqual(parentSpan.spanContext().spanId);
+          expect(spanToStreamedSpanJSON(span).trace_id).toEqual(parentSpan.spanContext().traceId);
+          expect(spanToStreamedSpanJSON(span).parent_span_id).toEqual(parentSpan.spanContext().spanId);
           expect(getDynamicSamplingContextFromSpan(span)).toEqual({
             ...getDynamicSamplingContextFromClient(propagationContext.traceId, getClient()!),
             trace_id: parentSpan.spanContext().traceId,
@@ -1371,8 +1371,8 @@ describe('trace', () => {
           const span = startInactiveSpan({ name: 'test span' });
 
           expect(span).toBeDefined();
-          expect(spanToJSON(span).trace_id).toEqual('12312012123120121231201212312012');
-          expect(spanToJSON(span).parent_span_id).toEqual('1121201211212012');
+          expect(spanToStreamedSpanJSON(span).trace_id).toEqual('12312012123120121231201212312012');
+          expect(spanToStreamedSpanJSON(span).parent_span_id).toEqual('1121201211212012');
           expect(getDynamicSamplingContextFromSpan(span)).toEqual({
             release: '1.0',
             environment: 'production',
@@ -1400,8 +1400,8 @@ describe('trace', () => {
           const span = startInactiveSpan({ name: 'test span' });
 
           expect(span).toBeDefined();
-          expect(spanToJSON(span).trace_id).toEqual('12312012123120121231201212312012');
-          expect(spanToJSON(span).parent_span_id).toEqual('1121201211212012');
+          expect(spanToStreamedSpanJSON(span).trace_id).toEqual('12312012123120121231201212312012');
+          expect(spanToStreamedSpanJSON(span).parent_span_id).toEqual('1121201211212012');
           expect(getDynamicSamplingContextFromSpan(span)).toEqual({
             release: '1.0',
             environment: 'production',
@@ -1904,7 +1904,7 @@ describe('span.end() timestamp conversion', () => {
 });
 
 function getSpanName(span: Span): string | undefined {
-  return spanToJSON(span).description;
+  return spanToStreamedSpanJSON(span).name;
 }
 
 // Native Sentry spans store timestamps in seconds; the tests assert HrTime `[seconds, nanoseconds]`.
@@ -1917,19 +1917,19 @@ function hrTimeFromSeconds(seconds: number): [number, number] {
 }
 
 function getSpanEndTime(span: Span): [number, number] | undefined {
-  const timestamp = spanToJSON(span).timestamp;
-  return typeof timestamp === 'number' ? hrTimeFromSeconds(timestamp) : [0, 0];
+  const endTimestamp = spanToStreamedSpanJSON(span).end_timestamp;
+  return typeof endTimestamp === 'number' ? hrTimeFromSeconds(endTimestamp) : [0, 0];
 }
 
 function getSpanStartTime(span: Span): [number, number] | undefined {
-  const startTimestamp = spanToJSON(span).start_timestamp;
+  const startTimestamp = spanToStreamedSpanJSON(span).start_timestamp;
   return typeof startTimestamp === 'number' ? hrTimeFromSeconds(startTimestamp) : undefined;
 }
 
 function getSpanAttributes(span: Span): Record<string, unknown> | undefined {
-  return spanToJSON(span).data;
+  return spanToStreamedSpanJSON(span).attributes;
 }
 
 function getSpanParentSpanId(span: Span): string | undefined {
-  return spanToJSON(span).parent_span_id;
+  return spanToStreamedSpanJSON(span).parent_span_id;
 }

--- a/packages/opentelemetry/test/tracerProvider.test.ts
+++ b/packages/opentelemetry/test/tracerProvider.test.ts
@@ -4,7 +4,7 @@ import {
   getActiveSpan,
   getCapturedScopesOnSpan,
   getRootSpan,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startSpanManual,
   type Span,
   withIsolationScope,
@@ -25,27 +25,22 @@ describe('SentryTracerProvider', () => {
       },
     });
 
-    expect(spanToJSON(span as Span)).toEqual({
-      data: {
+    expect(spanToStreamedSpanJSON(span as Span)).toEqual({
+      attributes: {
         'sentry.origin': 'manual',
         'sentry.sample_rate': 1,
         'db.system.name': 'postgresql',
         'db.statement': 'SELECT * FROM users',
         'sentry.source': 'custom',
       },
-      description: 'SELECT users',
-      origin: 'manual',
+      name: 'SELECT users',
       parent_span_id: undefined,
       span_id: span.spanContext().spanId,
       start_timestamp: expect.any(Number),
+      end_timestamp: undefined,
+      is_segment: true,
       status: 'ok',
-      timestamp: undefined,
       trace_id: span.spanContext().traceId,
-      profile_id: undefined,
-      exclusive_time: undefined,
-      measurements: undefined,
-      is_segment: undefined,
-      segment_id: undefined,
       links: undefined,
     });
   });
@@ -54,7 +49,7 @@ describe('SentryTracerProvider', () => {
     trace.getTracer('test').startActiveSpan('parent', parent => {
       const child = trace.getTracer('test').startSpan('child');
 
-      expect(spanToJSON(child as Span).parent_span_id).toBe(parent.spanContext().spanId);
+      expect(spanToStreamedSpanJSON(child as Span).parent_span_id).toBe(parent.spanContext().spanId);
     });
   });
 
@@ -64,7 +59,7 @@ describe('SentryTracerProvider', () => {
       const child = trace.getTracer('test').startSpan('child', {}, suppressedContext);
 
       expect(child.isRecording()).toBe(false);
-      expect(spanToJSON(child as Span).trace_id).toBe(parent.spanContext().traceId);
+      expect(spanToStreamedSpanJSON(child as Span).trace_id).toBe(parent.spanContext().traceId);
       // Non-recording spans no longer carry a `parent_span_id` under the scope-based
       // sampling model; the child is instead linked to the parent's span tree.
       expect(getRootSpan(child as Span)).toBe(getRootSpan(parent as unknown as Span));
@@ -110,7 +105,7 @@ describe('SentryTracerProvider', () => {
   it('parents core spans to the active OpenTelemetry span', () => {
     trace.getTracer('test').startActiveSpan('parent', parent => {
       startSpanManual({ name: 'child' }, child => {
-        expect(spanToJSON(child).parent_span_id).toBe(parent.spanContext().spanId);
+        expect(spanToStreamedSpanJSON(child).parent_span_id).toBe(parent.spanContext().spanId);
         child.end();
       });
     });
@@ -125,10 +120,10 @@ describe('SentryTracerProvider', () => {
     });
 
     const span = trace.getTracer('test').startSpan('server', { kind: SpanKind.SERVER }, remoteContext);
-    const json = spanToJSON(span as Span);
+    const json = spanToStreamedSpanJSON(span as Span);
 
     expect(json.trace_id).toBe('12312012123120121231201212312012');
     expect(json.parent_span_id).toBe('1121201211212012');
-    expect(json.data?.['sentry.kind']).toBe('server');
+    expect(json.attributes['sentry.kind']).toBe('server');
   });
 });

--- a/packages/react-router/src/client/createClientInstrumentation.ts
+++ b/packages/react-router/src/client/createClientInstrumentation.ts
@@ -10,7 +10,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   SPAN_STATUS_ERROR,
   startSpan,
   updateSpanName,
@@ -378,7 +378,8 @@ function updateRootSpanRoute(routeName: string, hasPattern: boolean): void {
     return;
   }
 
-  const { op } = spanToJSON(rootSpan);
+  const { attributes } = spanToStreamedSpanJSON(rootSpan);
+  const op = attributes[SENTRY_OP];
   if (op !== 'navigation' && op !== 'pageload') {
     return;
   }

--- a/packages/react-router/src/client/hydratedRouter.ts
+++ b/packages/react-router/src/client/hydratedRouter.ts
@@ -10,7 +10,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import type { DataRouter } from 'react-router';
 import { DEBUG_BUILD } from '../common/debug-build';
@@ -22,7 +22,7 @@ import {
   resolveNavigateAbsoluteUrl,
   resolveNavigateArg,
 } from './utils';
-import { URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 const GLOBAL_OBJ_WITH_DATA_ROUTER = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __reactRouterDataRouter?: DataRouter;
@@ -49,7 +49,7 @@ export function instrumentHydratedRouter(): void {
       const pageloadSpan = getActiveRootSpan();
 
       if (pageloadSpan) {
-        const pageloadName = spanToJSON(pageloadSpan).description;
+        const pageloadName = spanToStreamedSpanJSON(pageloadSpan).name;
         const parameterizePageloadRoute = getParameterizedRoute(router.state);
         if (
           pageloadName &&
@@ -125,21 +125,22 @@ export function instrumentHydratedRouter(): void {
           return;
         }
 
-        const rootSpanJson = spanToJSON(rootSpan);
+        const rootSpanJson = spanToStreamedSpanJSON(rootSpan);
+        const rootSpanAttributes = rootSpanJson.attributes;
 
         // When the instrumentation API is active, navigation roots are parameterized
         // by the native route hooks
         if (
-          rootSpanJson.op === 'navigation' &&
+          rootSpanAttributes[SENTRY_OP] === 'navigation' &&
           isClientInstrumentationApiUsed() &&
-          rootSpanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'route'
+          rootSpanAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] === 'route'
         ) {
           return;
         }
 
-        const rootSpanName = rootSpanJson.description;
+        const rootSpanName = rootSpanJson.name;
         const parameterizedRoute = getParameterizedRoute(newState);
-        const spanPathname = rootSpanJson.data?.[URL_PATH] as string | undefined;
+        const spanPathname = rootSpanAttributes[URL_PATH] as string | undefined;
         const destinationPathname = normalizePathname(newState.location.pathname);
 
         if (
@@ -207,7 +208,7 @@ function getActiveRootSpan(): Span | undefined {
 
   const rootSpan = getRootSpan(activeSpan);
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToStreamedSpanJSON(rootSpan).attributes[SENTRY_OP];
 
   // Only use this root span if it is a pageload or navigation span
   return op === 'navigation' || op === 'pageload' ? rootSpan : undefined;

--- a/packages/react-router/test/client/createClientInstrumentation.test.ts
+++ b/packages/react-router/test/client/createClientInstrumentation.test.ts
@@ -16,7 +16,7 @@ vi.mock('@sentry/core', async () => {
     getClient: vi.fn(),
     getActiveSpan: vi.fn(),
     getRootSpan: vi.fn(),
-    spanToJSON: vi.fn(),
+    spanToStreamedSpanJSON: vi.fn(),
     updateSpanName: vi.fn(),
     GLOBAL_OBJ: globalThis,
     SEMANTIC_ATTRIBUTE_SENTRY_OP: 'sentry.op',
@@ -901,7 +901,7 @@ describe('navigation root parameterization', () => {
     const mockRootSpan = { setAttributes: vi.fn() };
     (core.getActiveSpan as any).mockReturnValue({});
     (core.getRootSpan as any).mockReturnValue(mockRootSpan);
-    (core.spanToJSON as any).mockReturnValue({ op: 'navigation' });
+    (core.spanToStreamedSpanJSON as any).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } });
 
     const mockInstrument = vi.fn();
     const instrumentation = createSentryClientInstrumentation();
@@ -923,7 +923,7 @@ describe('navigation root parameterization', () => {
     const mockRootSpan = { setAttributes: vi.fn() };
     (core.getActiveSpan as any).mockReturnValue({});
     (core.getRootSpan as any).mockReturnValue(mockRootSpan);
-    (core.spanToJSON as any).mockReturnValue({ op: 'navigation' });
+    (core.spanToStreamedSpanJSON as any).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } });
 
     const mockInstrument = vi.fn();
     const instrumentation = createSentryClientInstrumentation();
@@ -942,7 +942,7 @@ describe('navigation root parameterization', () => {
   it('does not rename root spans that are not pageload/navigation', async () => {
     (core.getActiveSpan as any).mockReturnValue({});
     (core.getRootSpan as any).mockReturnValue({ setAttribute: vi.fn() });
-    (core.spanToJSON as any).mockReturnValue({ op: 'http.server' });
+    (core.spanToStreamedSpanJSON as any).mockReturnValue({ attributes: { 'sentry.op': 'http.server' } });
 
     const mockInstrument = vi.fn();
     const instrumentation = createSentryClientInstrumentation();

--- a/packages/react-router/test/client/hydratedRouter.test.ts
+++ b/packages/react-router/test/client/hydratedRouter.test.ts
@@ -10,7 +10,7 @@ vi.mock('@sentry/core', async () => {
     ...actual,
     getActiveSpan: vi.fn(),
     getRootSpan: vi.fn(),
-    spanToJSON: vi.fn(),
+    spanToStreamedSpanJSON: vi.fn(),
     getClient: vi.fn(),
     debug: {
       warn: vi.fn(),
@@ -62,10 +62,10 @@ describe('instrumentHydratedRouter', () => {
 
     (core.getActiveSpan as any).mockReturnValue(mockPageloadSpan);
     (core.getRootSpan as any).mockImplementation((span: any) => span);
-    (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: '/foo/bar',
+    (core.spanToStreamedSpanJSON as any).mockImplementation((span: any) => ({
+      name: '/foo/bar',
       // Distinguish so the subscribe callback can branch on op (pageload vs. navigation).
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
+      attributes: { 'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload' },
     }));
     (core.getClient as any).mockReturnValue({});
     (browser.startBrowserTracingNavigationSpan as any).mockReturnValue(mockNavigationSpan);
@@ -143,10 +143,9 @@ describe('instrumentHydratedRouter', () => {
     // Routes without a loader/action never trigger a route hook, so the navigation root is still
     // source:url. The heuristic must still parameterize it instead of leaving the raw URL.
     (globalThis as any).__sentryReactRouterClientInstrumentationUsed = true;
-    (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: '/foo/bar',
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
-      data: { source: 'url' },
+    (core.spanToStreamedSpanJSON as any).mockImplementation((span: any) => ({
+      name: '/foo/bar',
+      attributes: { 'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload', source: 'url' },
     }));
 
     instrumentHydratedRouter();
@@ -230,10 +229,12 @@ describe('instrumentHydratedRouter', () => {
     mockRouter.navigate('settings');
 
     (core.getActiveSpan as any).mockReturnValue(mockNavigationSpan);
-    (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: 'settings',
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
-      data: { 'url.path': '/foo/bar/settings' },
+    (core.spanToStreamedSpanJSON as any).mockImplementation((span: any) => ({
+      name: 'settings',
+      attributes: {
+        'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload',
+        'url.path': '/foo/bar/settings',
+      },
     }));
 
     const callback = mockRouter.subscribe.mock.calls[0][0];
@@ -339,10 +340,9 @@ describe('instrumentHydratedRouter', () => {
     });
 
     (core.getActiveSpan as any).mockReturnValue(mockNavigationSpan);
-    (core.spanToJSON as any).mockImplementation((span: any) => ({
-      description: '/foo/bar',
-      op: span === mockNavigationSpan ? 'navigation' : 'pageload',
-      data: { 'url.path': '/foo' },
+    (core.spanToStreamedSpanJSON as any).mockImplementation((span: any) => ({
+      name: '/foo/bar',
+      attributes: { 'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload', 'url.path': '/foo' },
     }));
 
     const callback = mockRouter.subscribe.mock.calls[0][0];

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,6 +1,11 @@
 import { startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON, timestampInSeconds, withActiveSpan } from '@sentry/core';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  spanToStreamedSpanJSON,
+  timestampInSeconds,
+  withActiveSpan,
+} from '@sentry/core';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
 import { BROWSER_UI_RENDER_SPAN_OP } from '@sentry/conventions/op';
 import * as React from 'react';
@@ -110,7 +115,7 @@ class Profiler extends React.Component<ProfilerProps> {
     const { name, includeRender = true } = this.props;
 
     if (this._mountSpan && includeRender) {
-      const startTime = spanToJSON(this._mountSpan).timestamp;
+      const startTime = spanToStreamedSpanJSON(this._mountSpan).end_timestamp;
       withActiveSpan(this._mountSpan, () => {
         const renderSpan = startInactiveSpan({
           onlyIfParent: true,
@@ -213,7 +218,7 @@ function useProfiler(
 
     return (): void => {
       if (mountSpan && options.hasRenderSpan) {
-        const startTime = spanToJSON(mountSpan).timestamp;
+        const startTime = spanToStreamedSpanJSON(mountSpan).end_timestamp;
         const endTimestamp = timestampInSeconds();
 
         const renderSpan = startInactiveSpan({

--- a/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
+++ b/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
@@ -17,7 +17,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import * as React from 'react';
 import { DEBUG_BUILD } from '../debug-build';
@@ -47,7 +47,7 @@ import {
   setNavigationContext,
   transactionNameHasWildcard,
 } from './utils';
-import { URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
 
 let _useEffect: UseEffect;
 let _useLocation: UseLocation;
@@ -320,15 +320,15 @@ export function processResolvedRoutes(
   // Use captured span if provided, otherwise fall back to current active span
   const targetSpan = capturedSpan ?? getActiveRootSpan();
   if (targetSpan) {
-    const spanJson = spanToJSON(targetSpan);
+    const { end_timestamp, attributes } = spanToStreamedSpanJSON(targetSpan);
 
-    // Skip update if span has already ended (timestamp is set when span.end() is called)
-    if (spanJson.timestamp) {
+    // Skip update if span has already ended (end_timestamp is set when span.end() is called)
+    if (end_timestamp) {
       DEBUG_BUILD && debug.warn('[React Router] Lazy handler resolved after span ended - skipping update');
       return;
     }
 
-    const spanOp = spanJson.op;
+    const spanOp = attributes[SENTRY_OP];
 
     // Use captured location for route matching (ensures we match against the correct route)
     // Fall back to window.location only if no captured location and no captured span
@@ -370,14 +370,13 @@ export function updateNavigationSpan(
   forceUpdate = false,
   matchRoutes: MatchRoutes,
 ): void {
-  const spanJson = spanToJSON(activeRootSpan);
-  const currentName = spanJson.description;
+  const { name: currentName, end_timestamp, attributes } = spanToStreamedSpanJSON(activeRootSpan);
 
   const hasBeenNamed = (activeRootSpan as { __sentry_navigation_name_set__?: boolean })?.__sentry_navigation_name_set__;
   const currentNameHasWildcard = currentName && transactionNameHasWildcard(currentName);
   const shouldUpdate = !hasBeenNamed || forceUpdate || currentNameHasWildcard;
 
-  if (shouldUpdate && !spanJson.timestamp) {
+  if (shouldUpdate && !end_timestamp) {
     const currentBranches = matchRoutes(allRoutes, location);
     const [name, source] = resolveRouteNameAndSource(
       location,
@@ -389,7 +388,7 @@ export function updateNavigationSpan(
       _enableAsyncRouteHandlers,
     );
 
-    const currentSource = spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+    const currentSource = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
     const isImprovement =
       name &&
       (!currentName || // No current name - always set
@@ -419,7 +418,8 @@ function setupRouterSubscription(
   activeRootSpan: Span | undefined,
 ): void {
   let isInitialPageloadComplete = false;
-  let hasSeenPageloadSpan = !!activeRootSpan && spanToJSON(activeRootSpan).op === 'pageload';
+  let hasSeenPageloadSpan =
+    !!activeRootSpan && spanToStreamedSpanJSON(activeRootSpan).attributes[SENTRY_OP] === 'pageload';
   let hasSeenPopAfterPageload = false;
   let scheduledNavigationHandler: number | null = null;
   let lastHandledPathname: string | null = null;
@@ -427,7 +427,8 @@ function setupRouterSubscription(
   router.subscribe((state: RouterState) => {
     if (!isInitialPageloadComplete) {
       const currentRootSpan = getActiveRootSpan();
-      const isCurrentlyInPageload = currentRootSpan && spanToJSON(currentRootSpan).op === 'pageload';
+      const isCurrentlyInPageload =
+        currentRootSpan && spanToStreamedSpanJSON(currentRootSpan).attributes[SENTRY_OP] === 'pageload';
 
       if (isCurrentlyInPageload) {
         hasSeenPageloadSpan = true;
@@ -865,15 +866,15 @@ function wrapPatchRoutesOnNavigation(
 
             // Use the captured activeRootSpan instead of getActiveRootSpan() to avoid race conditions
             // where user navigates away during lazy route loading and we'd update the wrong span
-            const spanJson = activeRootSpan ? spanToJSON(activeRootSpan) : undefined;
+            const spanJson = activeRootSpan ? spanToStreamedSpanJSON(activeRootSpan) : undefined;
             // Only update if we have a valid targetPath (patchRoutesOnNavigation can be called without path),
             // the captured span exists, hasn't ended, and is a navigation span
             if (
               targetPath &&
               activeRootSpan &&
               spanJson &&
-              !spanJson.timestamp && // Span hasn't ended yet
-              spanJson.op === 'navigation'
+              !spanJson.end_timestamp && // Span hasn't ended yet
+              spanJson.attributes[SENTRY_OP] === 'navigation'
             ) {
               updateNavigationSpan(
                 activeRootSpan,
@@ -905,12 +906,12 @@ function wrapPatchRoutesOnNavigation(
 
         // Use the captured activeRootSpan instead of getActiveRootSpan() to avoid race conditions
         // where user navigates away during lazy route loading and we'd update the wrong span
-        const spanJson = activeRootSpan ? spanToJSON(activeRootSpan) : undefined;
+        const spanJson = activeRootSpan ? spanToStreamedSpanJSON(activeRootSpan) : undefined;
         if (
           activeRootSpan &&
           spanJson &&
-          !spanJson.timestamp && // Span hasn't ended yet
-          spanJson.op === 'navigation'
+          !spanJson.end_timestamp && // Span hasn't ended yet
+          spanJson.attributes[SENTRY_OP] === 'navigation'
         ) {
           // Use targetPath consistently - don't fall back to WINDOW.location which may have changed
           // if the user navigated away during async loading
@@ -958,7 +959,11 @@ export function handleNavigation(opts: {
   }
 
   const activeRootSpan = getActiveRootSpan();
-  if (activeRootSpan && spanToJSON(activeRootSpan).op === 'pageload' && navigationType === 'POP') {
+  if (
+    activeRootSpan &&
+    spanToStreamedSpanJSON(activeRootSpan).attributes[SENTRY_OP] === 'pageload' &&
+    navigationType === 'POP'
+  ) {
     return;
   }
 
@@ -978,7 +983,7 @@ export function handleNavigation(opts: {
 
     // Determine if this navigation should be skipped as a duplicate
     const trackedSpanHasEnded =
-      trackedNav && !trackedNav.isPlaceholder ? !!spanToJSON(trackedNav.span).timestamp : false;
+      trackedNav && !trackedNav.isPlaceholder ? !!spanToStreamedSpanJSON(trackedNav.span).end_timestamp : false;
     const { skip, shouldUpdate } = shouldSkipNavigation(trackedNav, locationKey, name, trackedSpanHasEnded);
 
     if (skip) {
@@ -1194,7 +1199,7 @@ function shouldUpdateWildcardSpanName(
 
 function tryUpdateSpanNameBeforeEnd(
   span: Span,
-  spanJson: ReturnType<typeof spanToJSON>,
+  spanJson: ReturnType<typeof spanToStreamedSpanJSON>,
   currentName: string | undefined,
   location: Location,
   routes: RouteObject[],
@@ -1203,7 +1208,7 @@ function tryUpdateSpanNameBeforeEnd(
   allRoutes: Set<RouteObject>,
 ): void {
   try {
-    const currentSource = spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+    const currentSource = spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as string | undefined;
 
     if (currentSource === 'route' && currentName && !transactionNameHasWildcard(currentName)) {
       return;
@@ -1228,7 +1233,7 @@ function tryUpdateSpanNameBeforeEnd(
     );
 
     const isImprovement = shouldUpdateWildcardSpanName(currentName, currentSource, name, source, true);
-    const spanNotEnded = spanType === 'pageload' || !spanJson.timestamp;
+    const spanNotEnded = spanType === 'pageload' || !spanJson.end_timestamp;
 
     if (isImprovement && spanNotEnded) {
       span.updateName(name);
@@ -1275,9 +1280,9 @@ function patchSpanEnd(
     // If no timestamp was provided, capture the current time now
     const endTimestamp = args.length > 0 ? args[0] : Date.now() / 1000;
 
-    const spanJson = spanToJSON(span);
-    const currentName = spanJson.description;
-    const currentSource = spanJson.data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+    const spanJson = spanToStreamedSpanJSON(span);
+    const currentName = spanJson.name;
+    const currentSource = spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
 
     // Helper to clean up activeNavigationSpans after span ends
     const cleanupNavigationSpan = (): void => {
@@ -1328,11 +1333,11 @@ function patchSpanEnd(
 
       waitPromise
         .then(() => {
-          const updatedSpanJson = spanToJSON(span);
+          const updatedSpanJson = spanToStreamedSpanJSON(span);
           tryUpdateSpanNameBeforeEnd(
             span,
             updatedSpanJson,
-            updatedSpanJson.description,
+            updatedSpanJson.name,
             location,
             routes,
             basename,

--- a/packages/react/src/reactrouter-compat-utils/utils.ts
+++ b/packages/react/src/reactrouter-compat-utils/utils.ts
@@ -1,8 +1,9 @@
 import type { Span, TransactionSource } from '@sentry/core/browser';
-import { debug, getActiveSpan, getRootSpan, spanToJSON } from '@sentry/core/browser';
+import { debug, getActiveSpan, getRootSpan, spanToStreamedSpanJSON } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
 import type { Location, MatchRoutes, RouteMatch, RouteObject } from '../types';
 import { matchRouteManifest, stripBasenameFromPathname } from './route-manifest';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 
 // Global variables that these utilities depend on
 let _matchRoutes: MatchRoutes;
@@ -375,7 +376,7 @@ export function getActiveRootSpan(): Span | undefined {
     return undefined;
   }
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToStreamedSpanJSON(rootSpan).attributes[SENTRY_OP];
 
   // Only use this root span if it is a pageload or navigation span
   return op === 'navigation' || op === 'pageload' ? rootSpan : undefined;

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -12,7 +12,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import type { ReactElement } from 'react';
 import * as React from 'react';
@@ -266,7 +266,7 @@ function getActiveRootSpan(): Span | undefined {
     return undefined;
   }
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToStreamedSpanJSON(rootSpan).attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP];
 
   // Only use this root span if it is a pageload or navigation span
   return op === 'navigation' || op === 'pageload' ? rootSpan : undefined;

--- a/packages/react/test/reactrouter-compat-utils/instrumentation.test.tsx
+++ b/packages/react/test/reactrouter-compat-utils/instrumentation.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import type { Client, Span } from '@sentry/core';
-import { addNonEnumerableProperty, spanToJSON } from '@sentry/core';
+import { addNonEnumerableProperty, spanToStreamedSpanJSON } from '@sentry/core';
 import * as React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -32,7 +32,7 @@ vi.mock('@sentry/core', async requireActual => {
     getActiveSpan: vi.fn(() => mockSpan),
     getClient: vi.fn(() => mockClient),
     getRootSpan: vi.fn(() => mockSpan),
-    spanToJSON: vi.fn(() => ({ op: 'navigation' })),
+    spanToStreamedSpanJSON: vi.fn(() => ({ attributes: { 'sentry.op': 'navigation' } })),
   };
 });
 
@@ -426,10 +426,9 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   it('should upgrade from URL source to route source (regression fix)', async () => {
     // Setup: Current span has URL source and non-parameterized name
-    vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/123',
-      data: { 'sentry.source': 'url' },
+    vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+      name: '/users/123',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'url' },
     } as any);
 
     // Target: Resolves to route source with parameterized name
@@ -460,10 +459,9 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   it('should not downgrade from route source to URL source', async () => {
     // Setup: Current span has route source with parameterized name (no wildcard)
-    vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/:id',
-      data: { 'sentry.source': 'route' },
+    vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+      name: '/users/:id',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
     } as any);
 
     // Target: Would resolve to URL source (downgrade attempt)
@@ -495,10 +493,9 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   it('should upgrade wildcard names to specific routes', async () => {
     // Setup: Current span has route source with wildcard
-    vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/*',
-      data: { 'sentry.source': 'route' },
+    vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+      name: '/users/*',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
     } as any);
 
     // Mock wildcard detection: current name has wildcard, new name doesn't
@@ -532,10 +529,9 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   it('should not downgrade from wildcard route to URL', async () => {
     // Setup: Current span has route source with wildcard
-    vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/*',
-      data: { 'sentry.source': 'route' },
+    vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+      name: '/users/*',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
     } as any);
 
     // Mock wildcard detection: current name has wildcard, new name doesn't
@@ -571,9 +567,9 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   it('should set name when no current name exists', async () => {
     // Setup: Current span has no name (undefined)
-    vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: undefined,
+    vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+      name: undefined,
+      attributes: { 'sentry.op': 'navigation' },
     } as any);
 
     // Target: Resolves to route
@@ -602,10 +598,9 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   it('should not update when same source and no improvement', async () => {
     // Setup: Current span has URL source
-    vi.mocked(spanToJSON).mockReturnValue({
-      op: 'navigation',
-      description: '/users/123',
-      data: { 'sentry.source': 'url' },
+    vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+      name: '/users/123',
+      attributes: { 'sentry.op': 'navigation', 'sentry.source': 'url' },
     } as any);
 
     // Target: Resolves to same URL source (no improvement)
@@ -899,8 +894,10 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       // Mock startBrowserTracingNavigationSpan to return our mock span
       vi.mocked(browserModule.startBrowserTracingNavigationSpan).mockReturnValue(mockNavigationSpan);
 
-      // Mock spanToJSON to return different values for different calls
-      vi.mocked(coreModule.spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      // Mock spanToStreamedSpanJSON to return different values for different calls
+      vi.mocked(coreModule.spanToStreamedSpanJSON).mockReturnValue({
+        attributes: { 'sentry.op': 'navigation' },
+      } as any);
 
       // Mock getActiveRootSpan to return undefined (no pageload span)
       vi.mocked(coreModule.getActiveSpan).mockReturnValue(undefined);
@@ -956,7 +953,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
     it('blocks duplicate navigation for exact same locationKey (pathname+query+hash)', async () => {
       const { handleNavigation } = await import('../../src/reactrouter-compat-utils/instrumentation');
       const { startBrowserTracingNavigationSpan } = await import('@sentry/browser');
-      const { spanToJSON } = await import('@sentry/core');
+      const { spanToStreamedSpanJSON } = await import('@sentry/core');
 
       const location: Location = {
         pathname: '/search',
@@ -984,8 +981,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
         matches: matches as any,
       });
 
-      // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      // Mock spanToStreamedSpanJSON to indicate span hasn't ended yet
+      vi.mocked(spanToStreamedSpanJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second navigation - exact same location, should be blocked
       handleNavigation({
@@ -1003,7 +1000,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
     it('allows navigation for same pathname but different query string', async () => {
       const { handleNavigation } = await import('../../src/reactrouter-compat-utils/instrumentation');
       const { startBrowserTracingNavigationSpan } = await import('@sentry/browser');
-      const { spanToJSON } = await import('@sentry/core');
+      const { spanToStreamedSpanJSON } = await import('@sentry/core');
 
       const location1: Location = {
         pathname: '/search',
@@ -1031,8 +1028,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
         matches: matches as any,
       });
 
-      // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      // Mock spanToStreamedSpanJSON to indicate span hasn't ended yet
+      vi.mocked(spanToStreamedSpanJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second navigation - same pathname, different query
       const location2: Location = {
@@ -1058,7 +1055,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
     it('allows navigation for same pathname but different hash', async () => {
       const { handleNavigation } = await import('../../src/reactrouter-compat-utils/instrumentation');
       const { startBrowserTracingNavigationSpan } = await import('@sentry/browser');
-      const { spanToJSON } = await import('@sentry/core');
+      const { spanToStreamedSpanJSON } = await import('@sentry/core');
 
       const location1: Location = {
         pathname: '/page',
@@ -1086,8 +1083,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
         matches: matches as any,
       });
 
-      // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      // Mock spanToStreamedSpanJSON to indicate span hasn't ended yet
+      vi.mocked(spanToStreamedSpanJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second navigation - same pathname, different hash
       const location2: Location = {
@@ -1113,7 +1110,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
     it('updates wildcard span when better parameterized name becomes available', async () => {
       const { handleNavigation } = await import('../../src/reactrouter-compat-utils/instrumentation');
       const { startBrowserTracingNavigationSpan } = await import('@sentry/browser');
-      const { spanToJSON } = await import('@sentry/core');
+      const { spanToStreamedSpanJSON } = await import('@sentry/core');
       const { transactionNameHasWildcard, resolveRouteNameAndSource } =
         await import('../../src/reactrouter-compat-utils/utils');
 
@@ -1152,11 +1149,10 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       const firstSpan = mockNavigationSpan;
       expect(startBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1);
 
-      // Mock spanToJSON to indicate span hasn't ended yet and has wildcard name
-      vi.mocked(spanToJSON).mockReturnValue({
-        op: 'navigation',
-        description: '/users/*',
-        data: { 'sentry.source': 'route' },
+      // Mock spanToStreamedSpanJSON to indicate span hasn't ended yet and has wildcard name
+      vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+        name: '/users/*',
+        attributes: { 'sentry.op': 'navigation', 'sentry.source': 'route' },
       } as any);
 
       // Second navigation - same location but better parameterized name available
@@ -1183,7 +1179,7 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
       // causing duplicate navigation spans.
       const { handleNavigation } = await import('../../src/reactrouter-compat-utils/instrumentation');
       const { startBrowserTracingNavigationSpan } = await import('@sentry/browser');
-      const { spanToJSON } = await import('@sentry/core');
+      const { spanToStreamedSpanJSON } = await import('@sentry/core');
       const { resolveRouteNameAndSource } = await import('../../src/reactrouter-compat-utils/utils');
 
       // Mock resolveRouteNameAndSource to return consistent route name
@@ -1218,8 +1214,8 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
       expect(startBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1);
 
-      // Mock spanToJSON to indicate span hasn't ended yet
-      vi.mocked(spanToJSON).mockReturnValue({ op: 'navigation' } as any);
+      // Mock spanToStreamedSpanJSON to indicate span hasn't ended yet
+      vi.mocked(spanToStreamedSpanJSON).mockReturnValue({ attributes: { 'sentry.op': 'navigation' } } as any);
 
       // Second call: Full location (from router.state)
       // React Router provides location with empty string search and hash
@@ -1399,12 +1395,10 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
 
   describe('wrapPatchRoutesOnNavigation race condition fix', () => {
     it('should use captured span instead of current active span in args.patch callback', () => {
-      const endedSpanJson = {
-        op: 'navigation',
-        timestamp: 1234567890, // Span has ended
-      };
-
-      vi.mocked(spanToJSON).mockReturnValue(endedSpanJson as any);
+      vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+        attributes: { 'sentry.op': 'navigation' },
+        end_timestamp: 1234567890, // Span has ended
+      } as any);
 
       const endedSpan = {
         updateName: vi.fn(),
@@ -1424,12 +1418,10 @@ describe('tryUpdateSpanNameBeforeEnd - source upgrade logic', () => {
     });
 
     it('should not fall back to WINDOW.location.pathname after async operations', () => {
-      const validSpanJson = {
-        op: 'navigation',
-        timestamp: undefined, // Span hasn't ended
-      };
-
-      vi.mocked(spanToJSON).mockReturnValue(validSpanJson as any);
+      vi.mocked(spanToStreamedSpanJSON).mockReturnValue({
+        attributes: { 'sentry.op': 'navigation' },
+        end_timestamp: undefined, // Span hasn't ended
+      } as any);
 
       const validSpan = {
         updateName: vi.fn(),

--- a/packages/react/test/reactrouter-cross-usage.test.tsx
+++ b/packages/react/test/reactrouter-cross-usage.test.tsx
@@ -47,6 +47,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouter-descendant-routes.test.tsx
+++ b/packages/react/test/reactrouter-descendant-routes.test.tsx
@@ -42,6 +42,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -26,6 +26,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv4.test.tsx
+++ b/packages/react/test/reactrouterv4.test.tsx
@@ -29,6 +29,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv5.test.tsx
+++ b/packages/react/test/reactrouterv5.test.tsx
@@ -29,6 +29,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/react/test/reactrouterv6.test.tsx
+++ b/packages/react/test/reactrouterv6.test.tsx
@@ -47,6 +47,9 @@ const mockRootSpan = {
   getSpanJSON() {
     return { op: 'pageload' };
   },
+  getStreamedSpanJSON() {
+    return { attributes: { 'sentry.op': 'pageload' } };
+  },
 };
 
 vi.mock('@sentry/browser', async requireActual => {

--- a/packages/remix/src/cloudflare/index.ts
+++ b/packages/remix/src/cloudflare/index.ts
@@ -112,6 +112,7 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   trpcMiddleware,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,

--- a/packages/remix/src/server/index.ts
+++ b/packages/remix/src/server/index.ts
@@ -101,6 +101,7 @@ export {
   setUser,
   spanToBaggageHeader,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spotlightIntegration,
   startInactiveSpan,

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -29,7 +29,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setHttpStatus,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startSpan,
   winterCGHeadersToDict,
   winterCGRequestToRequestData,
@@ -125,7 +125,7 @@ function makeWrappedDocumentRequestFunction(instrumentTracing?: boolean) {
       if (instrumentTracing) {
         const activeSpan = getActiveSpan();
         const rootSpan = activeSpan && getRootSpan(activeSpan);
-        const name = rootSpan ? spanToJSON(rootSpan).description : undefined;
+        const name = rootSpan ? spanToStreamedSpanJSON(rootSpan).name : undefined;
 
         response = await startSpan(
           {
@@ -177,7 +177,7 @@ function updateSpanWithRoute(args: DataFunctionArgs, build: ServerBuild): void {
 
     // Preserve the HTTP method prefix if the span already has one
     const method = args.request.method.toUpperCase();
-    const currentSpanName = spanToJSON(rootSpan).description;
+    const currentSpanName = spanToStreamedSpanJSON(rootSpan).name;
     const newSpanName = currentSpanName?.startsWith(method) ? `${method} ${transactionName}` : transactionName;
 
     rootSpan.updateName(newSpanName);

--- a/packages/remix/src/server/integrations/tracing-channel.ts
+++ b/packages/remix/src/server/integrations/tracing-channel.ts
@@ -9,7 +9,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startInactiveSpan,
   waitForTracingChannelBinding,
   filterCollectedUrl,
@@ -131,7 +131,7 @@ function enrichActiveSpanWithRoute(result: unknown): void {
     // oxlint-disable-next-line typescript/no-deprecated
     span.setAttribute(HTTP_ROUTE, route.path);
     // oxlint-disable-next-line typescript/no-deprecated
-    const method = spanToJSON(span).data[HTTP_METHOD];
+    const method = spanToStreamedSpanJSON(span).attributes[HTTP_METHOD];
     span.updateName(typeof method === 'string' ? `${method} ${route.path}` : route.path);
     span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
   }

--- a/packages/remix/test/server/instrumentServer.test.ts
+++ b/packages/remix/test/server/instrumentServer.test.ts
@@ -17,7 +17,7 @@ describe('instrumentBuild', () => {
     } as unknown as Span;
     vi.spyOn(SentryCore, 'getActiveSpan').mockReturnValue(rootSpan);
     vi.spyOn(SentryCore, 'getRootSpan').mockReturnValue(rootSpan);
-    vi.spyOn(SentryCore, 'spanToJSON').mockReturnValue({ description: 'GET /users/42' });
+    vi.spyOn(SentryCore, 'spanToStreamedSpanJSON').mockReturnValue({ name: 'GET /users/42' });
     const build = {
       entry: { module: {} },
       routes: {

--- a/packages/remix/test/server/tracing-channel-test-utils.ts
+++ b/packages/remix/test/server/tracing-channel-test-utils.ts
@@ -73,6 +73,7 @@ export function makeSpan(data: Record<string, unknown> = {}): Span {
     setAttribute: vi.fn(),
     updateName: vi.fn(),
     getSpanJSON: () => ({ data }),
+    getStreamedSpanJSON: () => ({ attributes: data }),
   } as unknown as Span;
 }
 

--- a/packages/replay-internal/src/replay.ts
+++ b/packages/replay-internal/src/replay.ts
@@ -1,6 +1,12 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
 import type { ReplayRecordingMode, ReplayStopReason, Span } from '@sentry/core';
-import { getActiveSpan, getClient, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON } from '@sentry/core';
+import {
+  getActiveSpan,
+  getClient,
+  getRootSpan,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  spanToStreamedSpanJSON,
+} from '@sentry/core';
 import { EventType, record } from '@sentry/rrweb';
 import {
   BUFFER_CHECKOUT_TIME,
@@ -839,14 +845,17 @@ export class ReplayContainer implements ReplayContainerInterface {
   public getCurrentRoute(): string | undefined {
     const lastActiveSpan = this.lastActiveSpan || getActiveSpan();
     const lastRootSpan = lastActiveSpan && getRootSpan(lastActiveSpan);
-
-    const attributes = (lastRootSpan && spanToJSON(lastRootSpan).data) || {};
-    const source = attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
-    if (!lastRootSpan || !source || !['route', 'custom'].includes(source)) {
+    if (!lastRootSpan) {
       return undefined;
     }
 
-    return spanToJSON(lastRootSpan).description;
+    const spanJson = spanToStreamedSpanJSON(lastRootSpan);
+    const source = spanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as string | undefined;
+    if (!source || !['route', 'custom'].includes(source)) {
+      return undefined;
+    }
+
+    return spanJson.name;
   }
 
   /**

--- a/packages/server-utils/src/graphql/utils.ts
+++ b/packages/server-utils/src/graphql/utils.ts
@@ -1,6 +1,12 @@
 import { SENTRY_GRAPHQL_OPERATION } from '@sentry/conventions/attributes';
-import type { Span } from '@sentry/core';
-import { getClient, isObjectLike, getRootSpan, spanToJSON, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
+import type { Span, SpanAttributeValue } from '@sentry/core';
+import {
+  getClient,
+  isObjectLike,
+  getRootSpan,
+  spanToStreamedSpanJSON,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from '@sentry/core';
 
 // Same key the OTel path uses, so renames stay consistent across both.
 const ORIGINAL_DESCRIPTION_ATTRIBUTE = 'original-description';
@@ -36,12 +42,12 @@ export function renameRootSpanWithOperation(span: Span, operationType: string, o
     return;
   }
 
-  const rootSpanJson = spanToJSON(rootSpan);
+  const rootSpanJson = spanToStreamedSpanJSON(rootSpan);
 
   const newOperation = operationName ? `${operationType} ${operationName}` : operationType;
 
   // A single operation is stored as a string, multiple as an array.
-  const existingOperations = rootSpanJson.data[SENTRY_GRAPHQL_OPERATION];
+  const existingOperations = rootSpanJson.attributes[SENTRY_GRAPHQL_OPERATION];
   let operations: string | string[];
   if (Array.isArray(existingOperations)) {
     operations = [...(existingOperations as string[]), newOperation];
@@ -54,15 +60,15 @@ export function renameRootSpanWithOperation(span: Span, operationType: string, o
 
   // Keep the pre-rename name so repeated renames don't compound.
   const originalDescription =
-    (rootSpanJson.data[ORIGINAL_DESCRIPTION_ATTRIBUTE] as string | undefined) ?? rootSpanJson.description;
-  if (!rootSpanJson.data[ORIGINAL_DESCRIPTION_ATTRIBUTE]) {
+    (rootSpanJson.attributes[ORIGINAL_DESCRIPTION_ATTRIBUTE] as string | undefined) ?? rootSpanJson.name;
+  if (!rootSpanJson.attributes[ORIGINAL_DESCRIPTION_ATTRIBUTE]) {
     rootSpan.setAttribute(ORIGINAL_DESCRIPTION_ATTRIBUTE, originalDescription);
   }
 
   // `updateName` stamps `source: 'custom'`, so re-set the original source afterwards to preserve it.
-  const source = rootSpanJson.data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
+  const source = rootSpanJson.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
   rootSpan.updateName(`${originalDescription} (${getGraphqlOperationNamesFromAttribute(operations)})`);
-  rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
+  rootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source as SpanAttributeValue);
 }
 
 /** Format the accumulated operations for the root span name: up to 5 sorted names, then `+N`. */

--- a/packages/server-utils/src/integrations/tracing-channel/google-genai.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/google-genai.ts
@@ -1,4 +1,4 @@
-import { GEN_AI_REQUEST_MODEL } from '@sentry/conventions/attributes';
+import { GEN_AI_REQUEST_MODEL, SENTRY_OP, SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Span } from '@sentry/core';
 import {
@@ -6,7 +6,7 @@ import {
   defineIntegration,
   getActiveSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startInactiveSpan,
 } from '@sentry/core';
 import { getGenAiSpanOp, resolveAIRecordingOptions } from '../../ai/core/utils';
@@ -91,7 +91,9 @@ function createGenAiSpan(
   if (operation !== 'chat') {
     const activeSpan = getActiveSpan();
     if (activeSpan) {
-      const { op, origin } = spanToJSON(activeSpan);
+      const {
+        attributes: { [SENTRY_OP]: op, [SENTRY_ORIGIN]: origin },
+      } = spanToStreamedSpanJSON(activeSpan);
       if (origin === ORIGIN && op === 'gen_ai.chat') {
         return undefined;
       }

--- a/packages/server-utils/src/utils/setHttpServerSpanRouteAttribute.ts
+++ b/packages/server-utils/src/utils/setHttpServerSpanRouteAttribute.ts
@@ -1,11 +1,5 @@
-import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_ROUTE } from '@sentry/conventions/attributes';
-import {
-  getActiveSpan,
-  getRootSpan,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
-} from '@sentry/core';
+import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_ROUTE, SENTRY_OP } from '@sentry/conventions/attributes';
+import { getActiveSpan, getRootSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToStreamedSpanJSON } from '@sentry/core';
 
 /**
  * Set the `http.route` attribute on the root HTTP server span for the current trace.
@@ -24,8 +18,8 @@ export function setHttpServerSpanRouteAttribute(route: string): void {
     return;
   }
 
-  const attributes = spanToJSON(rootSpan).data;
-  if (attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] !== 'http.server') {
+  const attributes = spanToStreamedSpanJSON(rootSpan).attributes;
+  if (attributes[SENTRY_OP] !== 'http.server') {
     return;
   }
 

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import {
+  GEN_AI_CONVERSATION_ID,
   GEN_AI_EMBEDDINGS_INPUT,
   GEN_AI_FUNCTION_ID,
   GEN_AI_INPUT_MESSAGES,
@@ -24,12 +25,11 @@ import type { Span, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_skipAiProviderWrapping,
   captureException,
-  GEN_AI_CONVERSATION_ID_ATTRIBUTE,
   getClient,
   isObjectLike,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceContext,
   startInactiveSpan,
   stringify,
@@ -336,7 +336,7 @@ function addTokensToSpan(span: Span, attribute: string, value: number | undefine
   if (value === undefined) {
     return;
   }
-  const current = spanToJSON(span).data[attribute];
+  const current = spanToStreamedSpanJSON(span).attributes[attribute];
   span.setAttribute(attribute, (typeof current === 'number' ? current : 0) + value);
 }
 
@@ -554,12 +554,9 @@ export function enrichSpanOnEnd(
   const providerAttributes = getProviderMetadataAttributes(providerMetadata);
   // Don't overwrite a conversation id already set on span start (e.g. by `conversationIdIntegration`
   // from a user-set scope value); the provider-derived id is only a fallback. Matches the OTel path.
-  if (
-    GEN_AI_CONVERSATION_ID_ATTRIBUTE in providerAttributes &&
-    spanToJSON(span).data[GEN_AI_CONVERSATION_ID_ATTRIBUTE]
-  ) {
+  if (GEN_AI_CONVERSATION_ID in providerAttributes && spanToStreamedSpanJSON(span).attributes[GEN_AI_CONVERSATION_ID]) {
     // oxlint-disable-next-line typescript/no-dynamic-delete
-    delete providerAttributes[GEN_AI_CONVERSATION_ID_ATTRIBUTE];
+    delete providerAttributes[GEN_AI_CONVERSATION_ID];
   }
   span.setAttributes(providerAttributes);
 

--- a/packages/server-utils/test/mysql2/mysql2-dc-subscriber.test.ts
+++ b/packages/server-utils/test/mysql2/mysql2-dc-subscriber.test.ts
@@ -14,7 +14,7 @@ import {
   initAndBind,
   resolvedSyncPromise,
   setAsyncContextStrategy,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startSpan,
 } from '@sentry/core';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -118,7 +118,7 @@ async function traceOperation(
     const run = channel.tracePromise(async () => {
       span = getActiveSpan();
       startSpan({ name: 'child' }, child => {
-        childParentSpanId = spanToJSON(child).parent_span_id;
+        childParentSpanId = spanToStreamedSpanJSON(child).parent_span_id;
       });
       if (outcome.error) {
         throw outcome.error;
@@ -193,16 +193,16 @@ describe('subscribeMysql2DiagnosticChannels', () => {
       );
 
       expect(span).toBeDefined();
-      const json = spanToJSON(span!);
-      expect(json.description).toBe('SELECT solution FROM maths');
-      expect(json.op).toBe('db');
-      expect(json.origin).toBe('auto.db.mysql2.diagnostic_channel');
-      expect(json.data['db.system.name']).toBe('mysql');
-      expect(json.data['db.operation.name']).toBe('SELECT');
-      expect(json.data['db.namespace']).toBe('test');
-      expect(json.data['server.address']).toBe('127.0.0.1');
-      expect(json.data['server.port']).toBe(3306);
-      expect(json.timestamp).toBeDefined();
+      const json = spanToStreamedSpanJSON(span!);
+      expect(json.name).toBe('SELECT solution FROM maths');
+      expect(json.attributes['sentry.op']).toBe('db');
+      expect(json.attributes['sentry.origin']).toBe('auto.db.mysql2.diagnostic_channel');
+      expect(json.attributes['db.system.name']).toBe('mysql');
+      expect(json.attributes['db.operation.name']).toBe('SELECT');
+      expect(json.attributes['db.namespace']).toBe('test');
+      expect(json.attributes['server.address']).toBe('127.0.0.1');
+      expect(json.attributes['server.port']).toBe(3306);
+      expect(spanToStreamedSpanJSON(span!).end_timestamp).toBeDefined();
     });
 
     it('sanitizes inlined values out of db.query.text and the span name', async () => {
@@ -213,13 +213,13 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: [] },
       );
 
-      const json = spanToJSON(span!);
-      const queryText = json.data['db.query.text'] as string;
+      const json = spanToStreamedSpanJSON(span!);
+      const queryText = json.attributes['db.query.text'] as string;
       expect(queryText).toBe('SELECT * FROM users WHERE email = ? AND age = ?');
       expect(queryText).not.toContain('a@b.com');
       expect(queryText).not.toContain('21');
       // the span name is the sanitized statement too — no raw values leak there either
-      expect(json.description).toBe('SELECT * FROM users WHERE email = ? AND age = ?');
+      expect(json.name).toBe('SELECT * FROM users WHERE email = ? AND age = ?');
     });
 
     it('does not attach raw values to the span', async () => {
@@ -229,7 +229,7 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: [] },
       );
 
-      expect(JSON.stringify(spanToJSON(span!).data)).not.toContain('secret');
+      expect(JSON.stringify(spanToStreamedSpanJSON(span!).attributes)).not.toContain('secret');
     });
 
     it('sets error status and does NOT capture an exception on failure', async () => {
@@ -239,8 +239,8 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { error: new Error('table missing') },
       );
 
-      expect(spanToJSON(span!).status).toBe('internal_error');
-      expect(spanToJSON(span!).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span!).status).toBe('error');
+      expect(spanToStreamedSpanJSON(span!).end_timestamp).toBeDefined();
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -251,7 +251,7 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: [] },
       );
 
-      expect(spanToJSON(span!).parent_span_id).toBe(enclosingSpanId);
+      expect(spanToStreamedSpanJSON(span!).parent_span_id).toBe(enclosingSpanId);
       expect(childParentSpanId).toBe(span!.spanContext().spanId);
     });
   });
@@ -264,9 +264,9 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: [] },
       );
 
-      const json = spanToJSON(span!);
-      expect(json.data['db.query.text']).toBe('SELECT * FROM users WHERE id = ?');
-      expect(json.data['db.operation.name']).toBe('SELECT');
+      const json = spanToStreamedSpanJSON(span!);
+      expect(json.attributes['db.query.text']).toBe('SELECT * FROM users WHERE id = ?');
+      expect(json.attributes['db.operation.name']).toBe('SELECT');
     });
   });
 
@@ -278,15 +278,15 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: undefined },
       );
 
-      const json = spanToJSON(span!);
-      expect(json.description).toBe('mysql2.connect');
-      expect(json.op).toBe('db');
-      expect(json.origin).toBe('auto.db.mysql2.diagnostic_channel');
-      expect(json.data['db.system.name']).toBe('mysql');
-      expect(json.data['db.namespace']).toBe('test');
-      expect(json.data['server.address']).toBe('127.0.0.1');
-      expect(json.data['server.port']).toBe(3306);
-      expect(json.data['db.query.text']).toBeUndefined();
+      const json = spanToStreamedSpanJSON(span!);
+      expect(json.name).toBe('mysql2.connect');
+      expect(json.attributes['sentry.op']).toBe('db');
+      expect(json.attributes['sentry.origin']).toBe('auto.db.mysql2.diagnostic_channel');
+      expect(json.attributes['db.system.name']).toBe('mysql');
+      expect(json.attributes['db.namespace']).toBe('test');
+      expect(json.attributes['server.address']).toBe('127.0.0.1');
+      expect(json.attributes['server.port']).toBe(3306);
+      expect(json.attributes['db.query.text']).toBeUndefined();
     });
 
     it('names the pool connect span distinctly', async () => {
@@ -296,7 +296,7 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: undefined },
       );
 
-      expect(spanToJSON(span!).description).toBe('mysql2.pool.connect');
+      expect(spanToStreamedSpanJSON(span!).name).toBe('mysql2.pool.connect');
     });
 
     it('omits server.port for unix-socket connections', async () => {
@@ -306,9 +306,9 @@ describe('subscribeMysql2DiagnosticChannels', () => {
         { result: undefined },
       );
 
-      const json = spanToJSON(span!);
-      expect(json.data['server.address']).toBe('/var/run/mysqld/mysqld.sock');
-      expect(json.data['server.port']).toBeUndefined();
+      const json = spanToStreamedSpanJSON(span!);
+      expect(json.attributes['server.address']).toBe('/var/run/mysqld/mysqld.sock');
+      expect(json.attributes['server.port']).toBeUndefined();
     });
   });
 });

--- a/packages/server-utils/test/tracing-channel.test.ts
+++ b/packages/server-utils/test/tracing-channel.test.ts
@@ -13,7 +13,6 @@ import {
   initAndBind,
   resolvedSyncPromise,
   setAsyncContextStrategy,
-  spanToJSON,
   spanToStreamedSpanJSON,
   startInactiveSpan,
   startSpan,
@@ -162,7 +161,7 @@ describe('bindTracingChannelToSpan', () => {
     channel.traceSync(
       () => {
         startSpan({ name: 'child-span' }, child => {
-          childParentSpanId = spanToJSON(child).parent_span_id;
+          childParentSpanId = spanToStreamedSpanJSON(child).parent_span_id;
         });
       },
       { operation: 'read' },
@@ -202,7 +201,7 @@ describe('bindTracingChannelToSpan', () => {
           undefined,
           () => {
             startSpan({ name: 'child-span' }, child => {
-              childParentSpanId = spanToJSON(child).parent_span_id;
+              childParentSpanId = spanToStreamedSpanJSON(child).parent_span_id;
             });
             done();
           },
@@ -236,7 +235,7 @@ describe('bindTracingChannelToSpan', () => {
       otherRequestSpanId = other.spanContext().spanId;
       channel.asyncStart.runStores(ctx, () => {
         startSpan({ name: 'child-span' }, child => {
-          childParentSpanId = spanToJSON(child).parent_span_id;
+          childParentSpanId = spanToStreamedSpanJSON(child).parent_span_id;
         });
       });
     });
@@ -269,8 +268,8 @@ describe('bindTracingChannelToSpan', () => {
       channel.traceSync(() => undefined, { operation: 'read' });
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).status).toBe('ok');
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).status).toBe('ok');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -288,7 +287,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -333,8 +332,8 @@ describe('bindTracingChannelToSpan', () => {
       await promise;
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).status).toBe('ok');
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).status).toBe('ok');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -357,7 +356,7 @@ describe('bindTracingChannelToSpan', () => {
       await expect(promise).rejects.toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -375,7 +374,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -395,8 +394,8 @@ describe('bindTracingChannelToSpan', () => {
       });
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).status).toBe('ok');
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).status).toBe('ok');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -417,7 +416,7 @@ describe('bindTracingChannelToSpan', () => {
       });
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -438,7 +437,7 @@ describe('bindTracingChannelToSpan', () => {
       ).toThrow(error);
 
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
       expect(captureExceptionSpy).not.toHaveBeenCalled();
     });
 
@@ -457,10 +456,10 @@ describe('bindTracingChannelToSpan', () => {
 
         // The transaction status field is normalized to a valid value; the raw message survives on
         // the streamed span as `sentry.status.message`.
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(spanToStreamedSpanJSON(span).attributes?.['sentry.status.message']).toBe('bad input');
-        expect(data['error.type']).toBe('TypeError');
+        const { status, attributes } = spanToStreamedSpanJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['sentry.status.message']).toBe('bad input');
+        expect(attributes['error.type']).toBe('TypeError');
       });
 
       it('stringifies a thrown primitive and marks the type unknown', () => {
@@ -475,10 +474,10 @@ describe('bindTracingChannelToSpan', () => {
           ),
         ).toThrow('plain failure');
 
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(spanToStreamedSpanJSON(span).attributes?.['sentry.status.message']).toBe('plain failure');
-        expect(data['error.type']).toBe('unknown');
+        const { status, attributes } = spanToStreamedSpanJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['sentry.status.message']).toBe('plain failure');
+        expect(attributes['error.type']).toBe('unknown');
       });
 
       it('falls back to internal_error for an error-like object without `name` or `message`', () => {
@@ -494,9 +493,9 @@ describe('bindTracingChannelToSpan', () => {
         ).toThrow();
 
         // No usable message → no status message set → `getStatusMessage` defaults to `internal_error`.
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(data['error.type']).toBe('unknown');
+        const { status, attributes } = spanToStreamedSpanJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['error.type']).toBe('unknown');
       });
 
       it('falls back to internal_error when a falsy value is thrown', () => {
@@ -515,9 +514,9 @@ describe('bindTracingChannelToSpan', () => {
         }
 
         expect(threw).toBe(true);
-        const { status, data } = spanToJSON(span);
-        expect(status).toBe('internal_error');
-        expect(data['error.type']).toBe('unknown');
+        const { status, attributes } = spanToStreamedSpanJSON(span);
+        expect(status).toBe('error');
+        expect(attributes['error.type']).toBe('unknown');
       });
     });
   });
@@ -546,8 +545,8 @@ describe('bindTracingChannelToSpan', () => {
       ).rejects.toThrow(error);
 
       expect(captureExceptionSpy).not.toHaveBeenCalled();
-      expect(spanToJSON(span).status).toBe('internal_error');
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
     });
 
     it('captures the exception with the default mechanism when `captureError` is true', async () => {
@@ -576,7 +575,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
     });
 
     it('captures the exception on the synchronous error path when `captureError` is true', () => {
@@ -605,7 +604,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
     });
 
     it('captures the exception on the callback error path when `captureError` is true', async () => {
@@ -637,7 +636,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.diagnostic_channels.bind_span', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
     });
 
     it('captures the exception with the hint returned by a `captureError` function, passing it the thrown error', async () => {
@@ -669,7 +668,7 @@ describe('bindTracingChannelToSpan', () => {
       expect(captureExceptionSpy).toHaveBeenCalledWith(error, {
         mechanism: { type: 'auto.http.custom', handled: false },
       });
-      expect(spanToJSON(span).status).toBe('internal_error');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
     });
 
     it('uses the default mechanism when `captureError` is a function on the synchronous error path', () => {
@@ -714,7 +713,7 @@ describe('bindTracingChannelToSpan', () => {
         {
           beforeSpanEnd(s, data) {
             receivedSpan = s;
-            openWhenCalled = spanToJSON(s).timestamp === undefined;
+            openWhenCalled = spanToStreamedSpanJSON(s).end_timestamp === undefined;
             expect(data._sentrySpan).toBe(s);
             expect('result' in data).toBe(true);
             s.setAttribute('enriched', true);
@@ -726,8 +725,8 @@ describe('bindTracingChannelToSpan', () => {
 
       expect(receivedSpan).toBe(span);
       expect(openWhenCalled).toBe(true);
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).data.enriched).toBe(true);
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).attributes.enriched).toBe(true);
     });
 
     it('runs before the span is ended on async completion', async () => {
@@ -740,7 +739,7 @@ describe('bindTracingChannelToSpan', () => {
         () => span,
         {
           beforeSpanEnd(s) {
-            expect(spanToJSON(s).timestamp).toBeUndefined();
+            expect(spanToStreamedSpanJSON(s).end_timestamp).toBeUndefined();
             s.setAttribute('enriched', true);
           },
         },
@@ -748,8 +747,8 @@ describe('bindTracingChannelToSpan', () => {
 
       await channel.tracePromise(async () => 'ok', { operation: 'read' });
 
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).data.enriched).toBe(true);
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).attributes.enriched).toBe(true);
     });
 
     it('runs on the error path with the error on the context object', async () => {
@@ -780,7 +779,7 @@ describe('bindTracingChannelToSpan', () => {
       ).rejects.toThrow(error);
 
       expect(sawError).toBe(error);
-      expect(spanToJSON(span).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
     });
   });
 
@@ -812,22 +811,22 @@ describe('bindTracingChannelToSpan', () => {
     it('does not end the span while deferred', () => {
       const { span, endSpy } = setupDeferred('test:defer:open');
       expect(endSpy).not.toHaveBeenCalled();
-      expect(spanToJSON(span).timestamp).toBeUndefined();
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeUndefined();
     });
 
     it('`end()` ends the span once with no error status', () => {
       const { span, endSpy, end } = setupDeferred('test:defer:ok');
       end();
       expect(endSpy).toHaveBeenCalledTimes(1);
-      expect(spanToJSON(span).timestamp).toBeDefined();
-      expect(spanToJSON(span).status).toBe('ok');
+      expect(spanToStreamedSpanJSON(span).end_timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(span).status).toBe('ok');
     });
 
     it('`end(error)` sets error status and the `error.type` attribute, then ends', () => {
       const { span, endSpy, end } = setupDeferred('test:defer:error');
       end(new TypeError('stream blew up'));
-      expect(spanToJSON(span).status).toBe('internal_error');
-      expect(spanToJSON(span).data['error.type']).toBe('TypeError');
+      expect(spanToStreamedSpanJSON(span).status).toBe('error');
+      expect(spanToStreamedSpanJSON(span).attributes['error.type']).toBe('TypeError');
       expect(endSpy).toHaveBeenCalledTimes(1);
     });
 
@@ -917,7 +916,7 @@ describe('bindTracingChannelToSpan', () => {
         channel.traceSync(
           () => {
             startSpan({ name: 'child-span' }, child => {
-              childParentSpanId = spanToJSON(child).parent_span_id;
+              childParentSpanId = spanToStreamedSpanJSON(child).parent_span_id;
             });
           },
           { operation: 'read' },

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -3,7 +3,7 @@ import {
   getAbsoluteUrl,
   getActiveSpan,
   getRootSpan,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startBrowserTracingNavigationSpan,
 } from '@sentry/browser';
 import {
@@ -145,8 +145,8 @@ function withSentryRouterRoot(Root: Component<RouteSectionProps>): Component<Rou
         }
       } else {
         // No matched route - update back-button navigations and set source to url
-        const { op, description } = spanToJSON(rootSpan);
-        if (op === 'navigation' && description === '-1') {
+        const { attributes, name: spanName } = spanToStreamedSpanJSON(rootSpan);
+        if (attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'navigation' && spanName === '-1') {
           rootSpan.updateName(name);
         }
         rootSpan.setAttributes({ [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url', ...urlAttributes });

--- a/packages/solid/test/solidrouter.test.tsx
+++ b/packages/solid/test/solidrouter.test.tsx
@@ -1,4 +1,4 @@
-import { spanToJSON } from '@sentry/browser';
+import { spanToStreamedSpanJSON } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import {
   createTransport,
@@ -63,7 +63,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     const client = createMockBrowserClient();
     setCurrentClient(client);
 
-    client.on('spanStart', span => spanStartMock(spanToJSON(span)));
+    client.on('spanStart', span => spanStartMock(spanToStreamedSpanJSON(span)));
     client.addIntegration(solidRouterBrowserTracingIntegration());
 
     const history = createMemoryHistory();
@@ -71,9 +71,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -88,7 +87,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     const client = createMockBrowserClient();
     setCurrentClient(client);
 
-    client.on('spanStart', span => spanStartMock(spanToJSON(span)));
+    client.on('spanStart', span => spanStartMock(spanToStreamedSpanJSON(span)));
     client.addIntegration(
       solidRouterBrowserTracingIntegration({
         instrumentPageLoad: false,
@@ -103,9 +102,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -145,20 +143,20 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
       // Wait for the router transition to complete (Navigate redirects are async)
       await waitFor(() => {
-        const navSpan = spans.find(s => spanToJSON(s).op === 'navigation');
+        const navSpan = spans.find(s => spanToStreamedSpanJSON(s).attributes['sentry.op'] === 'navigation');
         expect(navSpan).toBeDefined();
 
-        const span = spanToJSON(navSpan!);
-        expect(span.description).toBe(parametrizedRoute);
-        expect(span.data).toMatchObject({
+        const span = spanToStreamedSpanJSON(navSpan!);
+        expect(span.name).toBe(parametrizedRoute);
+        expect(span.attributes).toMatchObject({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.solidrouter',
         });
 
         for (const [key, value] of Object.entries(expectedParams as Record<string, string>)) {
-          expect(span.data![`url.path.parameter.${key}`]).toBe(value);
-          expect(span.data![`params.${key}`]).toBe(value);
+          expect(span.attributes![`url.path.parameter.${key}`]).toBe(value);
+          expect(span.attributes![`params.${key}`]).toBe(value);
         }
       });
     },
@@ -170,7 +168,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     const client = createMockBrowserClient();
     setCurrentClient(client);
 
-    client.on('spanStart', span => spanStartMock(spanToJSON(span)));
+    client.on('spanStart', span => spanStartMock(spanToStreamedSpanJSON(span)));
     client.addIntegration(
       solidRouterBrowserTracingIntegration({
         instrumentNavigation: false,
@@ -185,9 +183,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'navigation',
-        description: '/about',
-        data: expect.objectContaining({
+        name: '/about',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.solidrouter',
@@ -203,7 +200,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     setCurrentClient(client);
 
     client.on('spanStart', span => {
-      spanStartMock(spanToJSON(span));
+      spanStartMock(spanToStreamedSpanJSON(span));
     });
     client.addIntegration(solidRouterBrowserTracingIntegration());
     const SentryRouter = withSentryRouterRouting(MemoryRouter);

--- a/packages/solidstart/src/server/index.ts
+++ b/packages/solidstart/src/server/index.ts
@@ -105,6 +105,7 @@ export {
   setUser,
   spanToBaggageHeader,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spotlightIntegration,
   startInactiveSpan,

--- a/packages/solidstart/src/server/withServerActionInstrumentation.ts
+++ b/packages/solidstart/src/server/withServerActionInstrumentation.ts
@@ -4,7 +4,13 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
 } from '@sentry/core';
-import { captureException, getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON, startSpan } from '@sentry/node';
+import {
+  captureException,
+  getActiveSpan,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  spanToStreamedSpanJSON,
+  startSpan,
+} from '@sentry/node';
 import { isRedirect } from './utils';
 import { HTTP_ROUTE, HTTP_TARGET, SENTRY_OP, URL_PATH } from '@sentry/conventions/attributes';
 import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
@@ -21,7 +27,7 @@ export async function withServerActionInstrumentation<A extends (...args: unknow
   const activeSpan = getActiveSpan();
 
   if (activeSpan) {
-    const spanData = spanToJSON(activeSpan).data;
+    const spanData = spanToStreamedSpanJSON(activeSpan).attributes;
 
     // In solid start, server function calls are made to `/_server` which doesn't tell us
     // a lot. We rewrite the span's route to be that of the sever action name but only

--- a/packages/solidstart/test/client/solidrouter.test.tsx
+++ b/packages/solidstart/test/client/solidrouter.test.tsx
@@ -1,4 +1,4 @@
-import { spanToJSON } from '@sentry/browser';
+import { spanToStreamedSpanJSON } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import {
   createTransport,
@@ -63,7 +63,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     const client = createMockBrowserClient();
     setCurrentClient(client);
 
-    client.on('spanStart', span => spanStartMock(spanToJSON(span)));
+    client.on('spanStart', span => spanStartMock(spanToStreamedSpanJSON(span)));
     client.addIntegration(solidRouterBrowserTracingIntegration());
 
     const history = createMemoryHistory();
@@ -71,9 +71,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -88,7 +87,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     const client = createMockBrowserClient();
     setCurrentClient(client);
 
-    client.on('spanStart', span => spanStartMock(spanToJSON(span)));
+    client.on('spanStart', span => spanStartMock(spanToStreamedSpanJSON(span)));
     client.addIntegration(
       solidRouterBrowserTracingIntegration({
         instrumentPageLoad: false,
@@ -103,9 +102,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'pageload',
-        description: '/',
-        data: expect.objectContaining({
+        name: '/',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.browser',
@@ -145,20 +143,20 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
       // Wait for the router transition to complete (Navigate redirects are async)
       await waitFor(() => {
-        const navSpan = spans.find(s => spanToJSON(s).op === 'navigation');
+        const navSpan = spans.find(s => spanToStreamedSpanJSON(s).attributes['sentry.op'] === 'navigation');
         expect(navSpan).toBeDefined();
 
-        const span = spanToJSON(navSpan!);
-        expect(span.description).toBe(parametrizedRoute);
-        expect(span.data).toMatchObject({
+        const span = spanToStreamedSpanJSON(navSpan!);
+        expect(span.name).toBe(parametrizedRoute);
+        expect(span.attributes).toMatchObject({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solidstart.solidrouter',
         });
 
         for (const [key, value] of Object.entries(expectedParams as Record<string, string>)) {
-          expect(span.data![`url.path.parameter.${key}`]).toBe(value);
-          expect(span.data![`params.${key}`]).toBe(value);
+          expect(span.attributes![`url.path.parameter.${key}`]).toBe(value);
+          expect(span.attributes![`params.${key}`]).toBe(value);
         }
       });
     },
@@ -170,7 +168,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     const client = createMockBrowserClient();
     setCurrentClient(client);
 
-    client.on('spanStart', span => spanStartMock(spanToJSON(span)));
+    client.on('spanStart', span => spanStartMock(spanToStreamedSpanJSON(span)));
     client.addIntegration(
       solidRouterBrowserTracingIntegration({
         instrumentNavigation: false,
@@ -185,9 +183,8 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'navigation',
-        description: '/about',
-        data: expect.objectContaining({
+        name: '/about',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solidstart.solidrouter',
@@ -203,7 +200,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
     setCurrentClient(client);
 
     client.on('spanStart', span => {
-      spanStartMock(spanToJSON(span));
+      spanStartMock(spanToStreamedSpanJSON(span));
     });
     client.addIntegration(solidRouterBrowserTracingIntegration());
     const SentryRouter = withSentryRouterRouting(MemoryRouter);

--- a/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
+++ b/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
@@ -7,7 +7,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setCurrentClient,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/node';
 import { redirect } from '@solidjs/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -93,14 +93,13 @@ describe('withServerActionInstrumentation', () => {
     const client = createMockNodeClient();
     setCurrentClient(client);
 
-    client.on('spanStart', span => spanStartMock(spanToJSON(span)));
+    client.on('spanStart', span => spanStartMock(spanToStreamedSpanJSON(span)));
 
     await serverActionGetPrefecture();
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        op: 'function',
-        description: 'getPrefecture',
-        data: expect.objectContaining({
+        name: 'getPrefecture',
+        attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.solidstart',

--- a/packages/sveltekit/src/server-common/handle.ts
+++ b/packages/sveltekit/src/server-common/handle.ts
@@ -13,7 +13,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   setHttpStatus,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   startSpan,
   updateSpanName,
   winterCGHeadersToDict,
@@ -167,11 +167,11 @@ async function instrumentHandle(
         // We're doing this here instead of an event processor to ensure we update the
         // span name as early as possible (for dynamic sampling, et al.)
         // Other spans are enhanced in the `processKitSpans` integration.
-        const spanJson = spanToJSON(kitRootSpan);
-        const kitRootSpanAttributes = spanJson.data;
-        const originalName = spanJson.description;
+        const spanJson = spanToStreamedSpanJSON(kitRootSpan);
+        const kitRootSpanAttributes = spanJson.attributes;
+        const originalName = spanJson.name;
 
-        const kitRoute = kitRootSpanAttributes[HTTP_ROUTE];
+        const kitRoute = kitRootSpanAttributes[HTTP_ROUTE] as string | undefined;
         const routeName = typeof kitRoute === 'string' ? kitRoute : routeId;
         if (routeName && typeof routeName === 'string') {
           updateSpanName(kitRootSpan, `${event.request.method ?? 'GET'} ${routeName}`);
@@ -182,8 +182,8 @@ async function instrumentHandle(
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.sveltekit',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeName ? 'route' : 'url',
           'sveltekit.tracing.original_name': originalName,
-          [URL_FULL]: kitRootSpanAttributes[URL_FULL] ?? filterCollectedUrl(event.url.href),
-          [URL_PATH]: kitRootSpanAttributes[URL_PATH] ?? event.url.pathname,
+          [URL_FULL]: (kitRootSpanAttributes[URL_FULL] as string | undefined) ?? filterCollectedUrl(event.url.href),
+          [URL_PATH]: (kitRootSpanAttributes[URL_PATH] as string | undefined) ?? event.url.pathname,
           ...(routeName && {
             [HTTP_ROUTE]: routeName,
           }),

--- a/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
+++ b/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
@@ -62,13 +62,13 @@ export function _enhanceKitSpanStreamed(span: StreamedSpanJSON): void {
     return;
   }
 
-  const previousOrigin = span.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined;
+  const previousOrigin = span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined;
 
   safeSetSpanJSONAttributes(span, { [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP });
 
   if (previousOrigin === 'manual') {
     // `safeSetSpanJSONAttributes` skips existing keys, so overwrite the 'manual' sentinel directly.
-    span.attributes![SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] = origin;
+    span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] = origin;
   } else {
     safeSetSpanJSONAttributes(span, { [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: origin });
   }

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -102,6 +102,7 @@ export {
   setUser,
   spanToBaggageHeader,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spotlightIntegration,
   startInactiveSpan,

--- a/packages/sveltekit/src/worker/index.ts
+++ b/packages/sveltekit/src/worker/index.ts
@@ -70,6 +70,7 @@ export {
   setUser,
   spanToBaggageHeader,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   startInactiveSpan,
   startNewTrace,

--- a/packages/sveltekit/test/server-common/handle.test.ts
+++ b/packages/sveltekit/test/server-common/handle.test.ts
@@ -6,7 +6,7 @@ import {
   getSpanDescendants,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   spanIsSampled,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 import * as SentryCore from '@sentry/core';
 import { NodeClient, setCurrentClient } from '@sentry/node';
@@ -141,13 +141,13 @@ describe('sentryHandle', () => {
 
       expect(_span!).toBeDefined();
 
-      expect(spanToJSON(_span!).description).toEqual('GET /users/[id]');
-      expect(spanToJSON(_span!).op).toEqual('http.server');
-      expect(spanToJSON(_span!).status).toEqual(isError ? 'internal_error' : 'ok');
-      expect(spanToJSON(_span!).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
-      expect(spanToJSON(_span!).data?.[HTTP_ROUTE]).toEqual('/users/[id]');
+      expect(spanToStreamedSpanJSON(_span!).name).toEqual('GET /users/[id]');
+      expect(spanToStreamedSpanJSON(_span!).attributes['sentry.op']).toEqual('http.server');
+      expect(spanToStreamedSpanJSON(_span!).status).toEqual(isError ? 'error' : 'ok');
+      expect(spanToStreamedSpanJSON(_span!).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+      expect(spanToStreamedSpanJSON(_span!).attributes?.[HTTP_ROUTE]).toEqual('/users/[id]');
 
-      expect(spanToJSON(_span!).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(_span!).end_timestamp).toBeDefined();
 
       const spans = getSpanDescendants(_span!);
       expect(spans).toHaveLength(1);
@@ -172,9 +172,9 @@ describe('sentryHandle', () => {
       }
 
       expect(_span).toBeUndefined();
-      expect(spanToJSON(kitRootSpan).description).toEqual('GET /users/[id]');
-      expect(spanToJSON(kitRootSpan).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
-      expect(spanToJSON(kitRootSpan).data?.[HTTP_ROUTE]).toEqual('/users/[id]');
+      expect(spanToStreamedSpanJSON(kitRootSpan).name).toEqual('GET /users/[id]');
+      expect(spanToStreamedSpanJSON(kitRootSpan).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+      expect(spanToStreamedSpanJSON(kitRootSpan).attributes?.[HTTP_ROUTE]).toEqual('/users/[id]');
       kitRootSpan.end();
     });
 
@@ -207,20 +207,26 @@ describe('sentryHandle', () => {
       expect(txnCount).toEqual(1);
       expect(_span!).toBeDefined();
 
-      expect(spanToJSON(_span!).description).toEqual('GET /users/[id]');
-      expect(spanToJSON(_span!).op).toEqual('http.server');
-      expect(spanToJSON(_span!).status).toEqual(isError ? 'internal_error' : 'ok');
-      expect(spanToJSON(_span!).data?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
+      expect(spanToStreamedSpanJSON(_span!).name).toEqual('GET /users/[id]');
+      expect(spanToStreamedSpanJSON(_span!).attributes['sentry.op']).toEqual('http.server');
+      expect(spanToStreamedSpanJSON(_span!).status).toEqual(isError ? 'error' : 'ok');
+      expect(spanToStreamedSpanJSON(_span!).attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]).toEqual('route');
 
-      expect(spanToJSON(_span!).timestamp).toBeDefined();
+      expect(spanToStreamedSpanJSON(_span!).end_timestamp).toBeDefined();
 
-      const spans = getSpanDescendants(_span!).map(spanToJSON);
+      const spans = getSpanDescendants(_span!).map(spanToStreamedSpanJSON);
 
       expect(spans).toHaveLength(2);
       expect(spans).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ op: 'http.server', description: 'GET /users/[id]' }),
-          expect.objectContaining({ op: 'http.server', description: 'GET api/users/details/[id]' }),
+          expect.objectContaining({
+            name: 'GET /users/[id]',
+            attributes: expect.objectContaining({ 'sentry.op': 'http.server' }),
+          }),
+          expect.objectContaining({
+            name: 'GET api/users/details/[id]',
+            attributes: expect.objectContaining({ 'sentry.op': 'http.server' }),
+          }),
         ]),
       );
     });
@@ -264,7 +270,7 @@ describe('sentryHandle', () => {
 
       expect(_span).toBeDefined();
       expect(_span!.spanContext().traceId).toEqual('1234567890abcdef1234567890abcdef');
-      expect(spanToJSON(_span!).parent_span_id).toEqual('1234567890abcdef');
+      expect(spanToStreamedSpanJSON(_span!).parent_span_id).toEqual('1234567890abcdef');
       expect(spanIsSampled(_span!)).toEqual(true);
       // Continuing a trace without incoming baggage does not populate a new DSC, but the scope's
       // `sample_rand` is still propagated so downstream sampling decisions stay consistent. Assert it

--- a/packages/tanstackstart-react/src/server/globalMiddleware.ts
+++ b/packages/tanstackstart-react/src/server/globalMiddleware.ts
@@ -3,11 +3,12 @@ import {
   addNonEnumerableProperty,
   captureException,
   getActiveSpan,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   updateSpanName,
 } from '@sentry/core';
 import type { SentryGlobalFunctionMiddleware, SentryGlobalRequestMiddleware } from '../common/types';
 import { SENTRY_INTERNAL } from './middleware';
+import { SENTRY_ORIGIN } from '@sentry/conventions/attributes';
 
 type ServerFnMeta = {
   id?: string;
@@ -37,10 +38,10 @@ function createSentryFunctionMiddlewareHandler(mechanismType: string) {
     serverFnMeta?: ServerFnMeta;
   }): Promise<unknown> {
     const activeSpan = getActiveSpan();
-    const spanData = activeSpan ? spanToJSON(activeSpan) : undefined;
-    if (activeSpan && spanData?.origin === 'auto.function.tanstackstart.server') {
+    const spanData = activeSpan ? spanToStreamedSpanJSON(activeSpan) : undefined;
+    if (activeSpan && spanData?.attributes[SENTRY_ORIGIN] === 'auto.function.tanstackstart.server') {
       if (serverFnMeta?.name) {
-        const method = spanData.description?.split(' ')[0] || 'GET';
+        const method = spanData.name.split(' ')[0] || 'GET';
         updateSpanName(activeSpan, `${method} /_serverFn/${serverFnMeta.name}`);
         activeSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'route');
       }

--- a/packages/tanstackstart-react/src/server/routeParametrization.ts
+++ b/packages/tanstackstart-react/src/server/routeParametrization.ts
@@ -5,7 +5,7 @@ import {
   getCurrentScope,
   getRootSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
   updateSpanName,
 } from '@sentry/core';
 
@@ -53,7 +53,7 @@ export function updateSpanWithRouteParametrization(method: string, pathname: str
   }
 
   const rootSpan = getRootSpan(activeSpan);
-  const rootSpanData = spanToJSON(rootSpan).data;
+  const rootSpanData = spanToStreamedSpanJSON(rootSpan).attributes;
   if (rootSpanData?.[HTTP_ROUTE]) {
     return;
   }

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -89,6 +89,7 @@ export {
   SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE,
   trpcMiddleware,
   spanToJSON,
+  spanToStreamedSpanJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
   wrapMcpServerWithSentry,

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -2,6 +2,7 @@ import { captureException, getAbsoluteUrl } from '@sentry/browser';
 import {
   NAVIGATION_ROUTE_ID,
   PARAMS_KEY_BASE,
+  SENTRY_OP,
   URL_PATH_PARAMETER_KEY_BASE,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
@@ -12,7 +13,7 @@ import {
   getRootSpan,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-  spanToJSON,
+  spanToStreamedSpanJSON,
 } from '@sentry/core';
 
 // The following type is an intersection of the Route type from VueRouter v2, v3, and v4.
@@ -114,7 +115,7 @@ export function instrumentVueRouter(
 
     // Update the existing page load span with parametrized route information
     if (options.instrumentPageLoad && activePageLoadSpan) {
-      const existingAttributes = spanToJSON(activePageLoadSpan).data;
+      const existingAttributes = spanToStreamedSpanJSON(activePageLoadSpan).attributes;
       if (existingAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom') {
         activePageLoadSpan.updateName(spanName);
         activePageLoadSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, transactionSource);
@@ -167,7 +168,7 @@ function getActivePageLoadSpan(): Span | undefined {
     return undefined;
   }
 
-  const op = spanToJSON(rootSpan).op;
+  const op = spanToStreamedSpanJSON(rootSpan).attributes[SENTRY_OP];
 
   return op === 'pageload' ? rootSpan : undefined;
 }

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -146,7 +146,8 @@ describe('instrumentVueRouter()', () => {
     (fromKey, toKey, transactionName, transactionSource) => {
       const mockRootSpan = {
         ...MOCK_SPAN,
-        getSpanJSON: vi.fn().mockReturnValue({ op: 'pageload', data: {} }),
+        getSpanJSON: () => ({}),
+        getStreamedSpanJSON: () => ({ attributes: { 'sentry.op': 'pageload' } }),
         updateName: vi.fn(),
         setAttribute: vi.fn(),
         setAttributes: vi.fn(),
@@ -252,9 +253,10 @@ describe('instrumentVueRouter()', () => {
       setAttribute: vi.fn(),
       setAttributes: vi.fn(),
       name: '',
-      getSpanJSON: () => ({
-        op: 'pageload',
-        data: {
+      getSpanJSON: () => ({}),
+      getStreamedSpanJSON: () => ({
+        attributes: {
+          'sentry.op': 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         },
       }),
@@ -276,9 +278,9 @@ describe('instrumentVueRouter()', () => {
     // now we give the transaction a custom name, thereby simulating what would
     // happen when users use the `beforeNavigate` hook
     mockRootSpan.name = 'customTxnName';
-    mockRootSpan.getSpanJSON = () => ({
-      op: 'pageload',
-      data: {
+    mockRootSpan.getStreamedSpanJSON = () => ({
+      attributes: {
+        'sentry.op': 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
       },
     });
@@ -341,9 +343,10 @@ describe('instrumentVueRouter()', () => {
         setAttribute: vi.fn(),
         setAttributes: vi.fn(),
         name: '',
-        getSpanJSON: () => ({
-          op: 'pageload',
-          data: {
+        getSpanJSON: () => ({}),
+        getStreamedSpanJSON: () => ({
+          attributes: {
+            'sentry.op': 'pageload',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           },
         }),


### PR DESCRIPTION
This PR is prework for #23238:

- Moves every SDK-internal `spanToJSON` call to the already-exported `spanToStreamedSpanJSON` function.
- `op`, `origin` and `description` become attribute lookups (`sentry.op`, `sentry.origin`) and `name`
- `timestamp` becomes `end_timestamp`.

Three type/behavior changes are included because the migration depends on them:

- `StreamedSpanJSON.attributes` is now always set (so we/users don't need optional chaining)
- `end_timestamp` became optional since we depend on checking the end timestamp for un-ended spans
- `SerializedStreamedSpan` re-requires `end_timestamp` with a `start_timestamp` fallback so spans on the wire always carry one.

Minor additional changes:

- `RawAttributes` is exported from `@sentry/core` for typing attribute bags
- Redis cache and `setHttpServerSpanRouteAttribute` use `@sentry/conventions` constants instead of string literals
- Fixes a stale mock in the Remix `instrumentServer` test that returned `description` where the code reads `name`, which silently dropped the method-prefix branch from coverage
