### PR TITLE
fix(sveltekit)!: Move `sentrySvelteKit` off the runtime entry to `@sentry/sveltekit/vite`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -967,7 +967,23 @@ Sentry.init({
 
 The same applies when looking the integration up by name, e.g. via `client.getIntegrationByName('OtlpIntegration')`.
 
-## 6. Type Changes
+### `sentrySvelteKit` moved to the `@sentry/sveltekit/vite` subpath export
+
+Affected SDKs: `@sentry/sveltekit`.
+
+The `sentrySvelteKit` Vite plugin is no longer re-exported from the main `@sentry/sveltekit` entry. Import it from `@sentry/sveltekit/vite` in your `vite.config.ts` instead:
+
+```ts
+// vite.config.ts
+
+// before
+import { sentrySvelteKit } from '@sentry/sveltekit';
+
+// after
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
+```
+
+The main entry re-exported the build plugin statically, which pulled the whole build-time module graph (`@sentry/vite-plugin`, and through it `@babel/core`) into the server runtime graph whenever the SDK was imported in server code. Serverless bundlers that trace by reachability (e.g. `@vercel/nft`) then copied all of it into the function. Moving the plugin behind its own subpath keeps it off the runtime entry so it is never reachable from server code.
 
 - Several public types that used `any` now use `unknown` — including `StackFrame`, `SamplingContext`,
   `SentryError`, and `User`. You may need to narrow types explicitly where you previously relied on

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/vite.config.ts
@@ -1,4 +1,4 @@
-import { sentrySvelteKit } from '@sentry/sveltekit';
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-orchestrion/vite.config.ts
@@ -1,4 +1,4 @@
-import { sentrySvelteKit } from '@sentry/sveltekit';
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/vite.config.ts
@@ -1,4 +1,4 @@
-import { sentrySvelteKit } from '@sentry/sveltekit';
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/vite.config.ts
@@ -1,4 +1,4 @@
-import { sentrySvelteKit } from '@sentry/sveltekit';
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/vite.config.js
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/vite.config.js
@@ -1,4 +1,4 @@
-import { sentrySvelteKit } from '@sentry/sveltekit';
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/vite.config.js
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/vite.config.js
@@ -1,5 +1,5 @@
 import adapter from '@sveltejs/adapter-node';
-import { sentrySvelteKit } from '@sentry/sveltekit';
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig } from 'vite';

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/vite.config.js
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/vite.config.js
@@ -1,4 +1,4 @@
-import { sentrySvelteKit } from '@sentry/sveltekit';
+import { sentrySvelteKit } from '@sentry/sveltekit/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -41,6 +41,11 @@
         "import": "./build/esm/index.server.js",
         "require": "./build/cjs/index.server.js"
       }
+    },
+    "./vite": {
+      "types": "./build/types/vite/index.d.ts",
+      "import": "./build/esm/vite/index.js",
+      "require": "./build/cjs/vite/index.js"
     }
   },
   "publishConfig": {

--- a/packages/sveltekit/rollup.npm.config.mjs
+++ b/packages/sveltekit/rollup.npm.config.mjs
@@ -13,6 +13,7 @@ export default makeNPMConfigVariants(
       'src/client/svelte5BrowserTracing.ts',
       'src/server/index.ts',
       'src/worker/index.ts',
+      'src/vite/index.ts',
     ],
     packageSpecificConfig: {
       // Keep the variant subpath external so the transpiled output preserves the import for the

--- a/packages/sveltekit/src/index.server.ts
+++ b/packages/sveltekit/src/index.server.ts
@@ -1,2 +1,1 @@
 export * from './server';
-export * from './vite';

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -11,7 +11,6 @@ import type * as clientSdk from './client';
 import type * as serverSdk from './server';
 
 export * from './client';
-export * from './vite';
 export * from './server';
 export * from './worker';
 


### PR DESCRIPTION
Moves the `sentrySvelteKit` Vite plugin off the main `@sentry/sveltekit` entry and behind a dedicated `@sentry/sveltekit/vite` subpath export.

This matches the layout `@sentry/solidstart` and `@sentry/tanstackstart-react` already use.

This is a breaking change to the public API, so I added an entry into the v11 migration guide.

closes getsentry/sentry-javascript#23243