### PR TITLE
chore(effect): sentry-conventions dep verison drift

### DIFF
--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.16.0",
+    "@sentry/conventions": "^0.19.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0"
   },


### PR DESCRIPTION
Fixes failing checks on develop, the `effect` SDK somehow drifted with its own conventions version where we bumped it to `0.19.0` recently.
