### PR TITLE
ref(server-utils): Alias AI integration option types to shared `GenAiOptions`

### DIFF
--- a/packages/server-utils/src/ai/anthropic-ai/types.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/types.ts
@@ -1,15 +1,13 @@
+import type { GenAiOptions } from '../core/utils';
 import type { ANTHROPIC_METHOD_REGISTRY } from './constants';
 
-export interface AnthropicAiOptions {
-  /**
-   * Enable or disable input recording.
-   */
-  recordInputs?: boolean;
-  /**
-   * Enable or disable output recording.
-   */
-  recordOutputs?: boolean;
-}
+/**
+ * Options for the Anthropic AI integration.
+ *
+ * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Anthropic-specific
+ * options can be added here in the future without a breaking signature change.
+ */
+export type AnthropicAiOptions = GenAiOptions;
 
 export type Message = {
   role: 'user' | 'assistant';

--- a/packages/server-utils/src/ai/anthropic-ai/types.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/types.ts
@@ -1,12 +1,7 @@
 import type { GenAiOptions } from '../core/utils';
 import type { ANTHROPIC_METHOD_REGISTRY } from './constants';
 
-/**
- * Options for the Anthropic AI integration.
- *
- * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Anthropic-specific
- * options can be added here in the future without a breaking signature change.
- */
+/** Options for the Anthropic AI integration. */
 export type AnthropicAiOptions = GenAiOptions;
 
 export type Message = {

--- a/packages/server-utils/src/ai/core/utils.ts
+++ b/packages/server-utils/src/ai/core/utils.ts
@@ -17,8 +17,16 @@ import {
 } from '@sentry/conventions/attributes';
 import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
 
-export interface AIRecordingOptions {
+export interface GenAiOptions {
+  /**
+   * Record input messages/prompts on gen_ai spans. Defaults to the global
+   * `dataCollection.genAI.inputs` setting; an explicit value here takes precedence.
+   */
   recordInputs?: boolean;
+  /**
+   * Record output text/responses on gen_ai spans. Defaults to the global
+   * `dataCollection.genAI.outputs` setting; an explicit value here takes precedence.
+   */
   recordOutputs?: boolean;
 }
 
@@ -60,13 +68,13 @@ export function getGenAiSpanOp(operationName: string): string {
  * Resolves AI recording options by falling back to the client's `dataCollection.genAI` settings.
  * Precedence: explicit option > dataCollection.genAI > true (genAI data collected by default)
  */
-export function resolveAIRecordingOptions<T extends AIRecordingOptions>(options?: T): T & Required<AIRecordingOptions> {
+export function resolveAIRecordingOptions<T extends GenAiOptions>(options?: T): T & Required<GenAiOptions> {
   const genAI = getClient()?.getDataCollectionOptions().genAI;
   return {
     ...options,
     recordInputs: options?.recordInputs ?? genAI?.inputs ?? true,
     recordOutputs: options?.recordOutputs ?? genAI?.outputs ?? true,
-  } as T & Required<AIRecordingOptions>;
+  } as T & Required<GenAiOptions>;
 }
 
 /**

--- a/packages/server-utils/src/ai/google-genai/types.ts
+++ b/packages/server-utils/src/ai/google-genai/types.ts
@@ -1,15 +1,13 @@
+import type { GenAiOptions } from '../core/utils';
 import type { GOOGLE_GENAI_METHOD_REGISTRY } from './constants';
 
-export interface GoogleGenAIOptions {
-  /**
-   * Enable or disable input recording.
-   */
-  recordInputs?: boolean;
-  /**
-   * Enable or disable output recording.
-   */
-  recordOutputs?: boolean;
-}
+/**
+ * Options for the Google GenAI integration.
+ *
+ * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Google-GenAI-specific
+ * options can be added here in the future without a breaking signature change.
+ */
+export type GoogleGenAIOptions = GenAiOptions;
 
 /**
  * Google GenAI Content Part

--- a/packages/server-utils/src/ai/google-genai/types.ts
+++ b/packages/server-utils/src/ai/google-genai/types.ts
@@ -1,12 +1,7 @@
 import type { GenAiOptions } from '../core/utils';
 import type { GOOGLE_GENAI_METHOD_REGISTRY } from './constants';
 
-/**
- * Options for the Google GenAI integration.
- *
- * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Google-GenAI-specific
- * options can be added here in the future without a breaking signature change.
- */
+/** Options for the Google GenAI integration. */
 export type GoogleGenAIOptions = GenAiOptions;
 
 /**

--- a/packages/server-utils/src/ai/langchain/types.ts
+++ b/packages/server-utils/src/ai/langchain/types.ts
@@ -1,19 +1,12 @@
-/**
- * Options for LangChain integration
- */
-export interface LangChainOptions {
-  /**
-   * Whether to record input messages/prompts
-   * @default false (respects `dataCollection.genAI.inputs`)
-   */
-  recordInputs?: boolean;
+import type { GenAiOptions } from '../core/utils';
 
-  /**
-   * Whether to record output text and responses
-   * @default false (respects `dataCollection.genAI.outputs`)
-   */
-  recordOutputs?: boolean;
-}
+/**
+ * Options for the LangChain integration.
+ *
+ * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so LangChain-specific
+ * options can be added here in the future without a breaking signature change.
+ */
+export type LangChainOptions = GenAiOptions;
 
 /**
  * LangChain Serialized type (compatible with @langchain/core)

--- a/packages/server-utils/src/ai/langchain/types.ts
+++ b/packages/server-utils/src/ai/langchain/types.ts
@@ -1,11 +1,6 @@
 import type { GenAiOptions } from '../core/utils';
 
-/**
- * Options for the LangChain integration.
- *
- * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so LangChain-specific
- * options can be added here in the future without a breaking signature change.
- */
+/** Options for the LangChain integration. */
 export type LangChainOptions = GenAiOptions;
 
 /**

--- a/packages/server-utils/src/ai/langgraph/types.ts
+++ b/packages/server-utils/src/ai/langgraph/types.ts
@@ -1,11 +1,6 @@
 import type { GenAiOptions } from '../core/utils';
 
-/**
- * Options for the LangGraph integration.
- *
- * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so LangGraph-specific
- * options can be added here in the future without a breaking signature change.
- */
+/** Options for the LangGraph integration. */
 export type LangGraphOptions = GenAiOptions;
 
 /**

--- a/packages/server-utils/src/ai/langgraph/types.ts
+++ b/packages/server-utils/src/ai/langgraph/types.ts
@@ -1,13 +1,12 @@
-export interface LangGraphOptions {
-  /**
-   * Enable or disable input recording.
-   */
-  recordInputs?: boolean;
-  /**
-   * Enable or disable output recording.
-   */
-  recordOutputs?: boolean;
-}
+import type { GenAiOptions } from '../core/utils';
+
+/**
+ * Options for the LangGraph integration.
+ *
+ * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so LangGraph-specific
+ * options can be added here in the future without a breaking signature change.
+ */
+export type LangGraphOptions = GenAiOptions;
 
 /**
  * LangGraph Tool definition from lc_kwargs

--- a/packages/server-utils/src/ai/openai/types.ts
+++ b/packages/server-utils/src/ai/openai/types.ts
@@ -14,12 +14,7 @@ export type AttributeValue =
   | Array<null | undefined | number>
   | Array<null | undefined | boolean>;
 
-/**
- * Options for the OpenAI integration.
- *
- * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so OpenAI-specific
- * options can be added here in the future without a breaking signature change.
- */
+/** Options for the OpenAI integration. */
 export type OpenAiOptions = GenAiOptions;
 
 export interface OpenAiClient {

--- a/packages/server-utils/src/ai/openai/types.ts
+++ b/packages/server-utils/src/ai/openai/types.ts
@@ -1,3 +1,4 @@
+import type { GenAiOptions } from '../core/utils';
 import type { OPENAI_METHOD_REGISTRY } from './constants';
 
 /**
@@ -13,16 +14,13 @@ export type AttributeValue =
   | Array<null | undefined | number>
   | Array<null | undefined | boolean>;
 
-export interface OpenAiOptions {
-  /**
-   * Enable or disable input recording.
-   */
-  recordInputs?: boolean;
-  /**
-   * Enable or disable output recording.
-   */
-  recordOutputs?: boolean;
-}
+/**
+ * Options for the OpenAI integration.
+ *
+ * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so OpenAI-specific
+ * options can be added here in the future without a breaking signature change.
+ */
+export type OpenAiOptions = GenAiOptions;
 
 export interface OpenAiClient {
   responses?: {

--- a/packages/server-utils/src/ai/workers-ai/types.ts
+++ b/packages/server-utils/src/ai/workers-ai/types.ts
@@ -1,11 +1,6 @@
 import type { GenAiOptions } from '../core/utils';
 
-/**
- * Options for the Workers AI integration.
- *
- * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Workers-AI-specific
- * options can be added here in the future without a breaking signature change.
- */
+/** Options for the Workers AI integration. */
 export type WorkersAiOptions = GenAiOptions;
 
 /**

--- a/packages/server-utils/src/ai/workers-ai/types.ts
+++ b/packages/server-utils/src/ai/workers-ai/types.ts
@@ -1,6 +1,12 @@
-import type { AIRecordingOptions } from '../core/utils';
+import type { GenAiOptions } from '../core/utils';
 
-export interface WorkersAiOptions extends AIRecordingOptions {}
+/**
+ * Options for the Workers AI integration.
+ *
+ * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Workers-AI-specific
+ * options can be added here in the future without a breaking signature change.
+ */
+export type WorkersAiOptions = GenAiOptions;
 
 /**
  * Minimal shape of the Cloudflare Workers AI binding (`env.AI`).

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -25,7 +25,6 @@ export type {
   TracingChannelPayloadWithSpan,
 } from './tracing-channel';
 export type { InstrumentationConfig } from './orchestrion';
-export type { GenAiOptions } from './ai/core/utils';
 export { vercelAiIntegration, type VercelAiOptions } from './vercel-ai';
 export {
   fastifyIntegration,

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -25,6 +25,7 @@ export type {
   TracingChannelPayloadWithSpan,
 } from './tracing-channel';
 export type { InstrumentationConfig } from './orchestrion';
+export type { GenAiOptions } from './ai/core/utils';
 export { vercelAiIntegration, type VercelAiOptions } from './vercel-ai';
 export {
   fastifyIntegration,

--- a/packages/server-utils/src/vercel-ai/index.ts
+++ b/packages/server-utils/src/vercel-ai/index.ts
@@ -1,22 +1,15 @@
 import { defineIntegration, waitForTracingChannelBinding, type IntegrationFn } from '@sentry/core';
+import type { GenAiOptions } from '../ai/core/utils';
 import { subscribeVercelAiTracingChannel } from './vercel-ai-dc-subscriber';
 import * as dc from 'node:diagnostics_channel';
 
-export interface VercelAiOptions {
-  /**
-   * Enable or disable input recording. Enabled if `dataCollection.genAI.inputs` is `true`
-   * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
-   * Integration-level options take precedence over global `dataCollection` config.
-   */
-  recordInputs?: boolean;
-
-  /**
-   * Enable or disable output recording. Enabled if `dataCollection.genAI.outputs` is `true`
-   * or if you set `isEnabled` to `true` in your ai SDK method telemetry settings.
-   * Integration-level options take precedence over global `dataCollection` config.
-   */
-  recordOutputs?: boolean;
-}
+/**
+ * Options for the Vercel AI integration.
+ *
+ * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Vercel-AI-specific
+ * options can be added here in the future without a breaking signature change.
+ */
+export type VercelAiOptions = GenAiOptions;
 
 const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {
   return {

--- a/packages/server-utils/src/vercel-ai/index.ts
+++ b/packages/server-utils/src/vercel-ai/index.ts
@@ -3,12 +3,7 @@ import type { GenAiOptions } from '../ai/core/utils';
 import { subscribeVercelAiTracingChannel } from './vercel-ai-dc-subscriber';
 import * as dc from 'node:diagnostics_channel';
 
-/**
- * Options for the Vercel AI integration.
- *
- * Currently an alias of {@link GenAiOptions}; kept as a distinct named type so Vercel-AI-specific
- * options can be added here in the future without a breaking signature change.
- */
+/** Options for the Vercel AI integration. */
 export type VercelAiOptions = GenAiOptions;
 
 const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {

--- a/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -36,6 +36,7 @@ import {
   withScope,
 } from '@sentry/core';
 import type { TracingChannel } from 'node:diagnostics_channel';
+import type { GenAiOptions } from '../ai/core/utils';
 import { getProviderMetadataAttributes } from '../ai/vercel-ai';
 import { WORKERS_AI_INTEGRATION_NAME } from '../ai/workers-ai/constants';
 import { bindTracingChannelToSpan } from '../tracing-channel';
@@ -198,10 +199,7 @@ export interface VercelAiChannelMessage {
 export type VercelAiTracingChannelFactory = <T extends object>(name: string) => TracingChannel<T, T>;
 
 /** Integration-level recording options, pinned at subscribe time so we never look the integration up per event. */
-export interface VercelAiChannelOptions {
-  recordInputs?: boolean;
-  recordOutputs?: boolean;
-}
+export type VercelAiChannelOptions = GenAiOptions;
 
 /**
  * Subscribe Sentry span handlers to the `ai` SDK's native telemetry tracing channel (`ai:telemetry`,


### PR DESCRIPTION
All our specific options types for the AI integrations (`AnthropicAiOptions` etc.) expose exactly the same options. This pulls them together into a shared type.

We could probably drop these altogether but for now I opted to keep the old exports as an alias to the shared type. This saves us a breaking change (e.g. the workers options are exported on cloudflare) and keeps this easily extensible if there is a need in the future.