### PR TITLE
feat(nextjs): Unify reactComponentAnnotation across webpack and Turbopack

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/next.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/next.config.ts
@@ -9,10 +9,10 @@ const nextConfig: NextConfig = {};
 export default withSentryConfig(nextConfig, {
   silent: true,
   applicationKey: 'nextjs-16-streaming-e2e',
+  reactComponentAnnotation: {
+    enabled: true,
+  },
   _experimental: {
     vercelCronsMonitoring: true,
-    turbopackReactComponentAnnotation: {
-      enabled: true,
-    },
   },
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/next.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/next.config.ts
@@ -15,10 +15,10 @@ const nextConfig: NextConfig = {
 export default withSentryConfig(nextConfig, {
   silent: true,
   applicationKey: 'nextjs-16-e2e',
+  reactComponentAnnotation: {
+    enabled: true,
+  },
   _experimental: {
     vercelCronsMonitoring: true,
-    turbopackReactComponentAnnotation: {
-      enabled: true,
-    },
   },
 });

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -635,6 +635,28 @@ The `console` option of `breadcrumbsIntegration` was removed. Use the `consoleIn
 
 **Tracing removed from generated templates:** Tracing was removed from the generated Pages Router API handler, Edge API handler, and Middleware wrapper templates. Route handlers and middleware are still instrumented automatically, so no action is required for most users.
 
+**Unified `reactComponentAnnotation` option:** React component annotation is now configured through a single top-level `reactComponentAnnotation` option that applies to both webpack and Turbopack builds:
+
+```js
+export default withSentryConfig(nextConfig, {
+  reactComponentAnnotation: {
+    enabled: true,
+    ignoredComponents: ['MyComponent'],
+  },
+});
+```
+
+The two bundler-specific options it replaces are deprecated but still work, and will be removed in v12:
+
+- `webpack.reactComponentAnnotation`
+- `_experimental.turbopackReactComponentAnnotation`
+
+If both a bundler-specific option and the top-level one are set, the bundler-specific one wins for that bundler.
+
+Note that v10.30.0 deprecated a top-level `reactComponentAnnotation` in favour of `webpack.reactComponentAnnotation`, and v11 removed it. This reinstates the top-level option with broader meaning: it now drives Turbopack builds as well, which the old one never did. If you moved to `webpack.reactComponentAnnotation` for v10, moving back to the top level is the forward path.
+
+On Turbopack, component annotation requires Next.js 16+. The SDK now warns at build time if annotation is enabled on an older Next.js version, where it previously did nothing silently.
+
 ### Cloudflare: `nodejs_compat` compatibility flag is now required
 
 Affected SDKs: `@sentry/cloudflare`.

--- a/packages/nextjs/src/config/getBuildPluginOptions.ts
+++ b/packages/nextjs/src/config/getBuildPluginOptions.ts
@@ -332,6 +332,8 @@ export function getBuildPluginOptions({
     reactComponentAnnotation: buildTool.startsWith('after-production-compile')
       ? undefined
       : {
+          ...sentryBuildOptions.reactComponentAnnotation,
+          // eslint-disable-next-line typescript/no-deprecated
           ...sentryBuildOptions.webpack?.reactComponentAnnotation,
           ...sentryBuildOptions.webpack?.unstable_sentryWebpackPluginOptions?.reactComponentAnnotation,
         },

--- a/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
+++ b/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
@@ -97,24 +97,39 @@ export function constructTurbopackConfig({
   }
 
   // Add component annotation loader for react component name annotation in Turbopack builds.
-  // This is only added when turbopackReactComponentAnnotation.enabled is set AND the Next.js
-  // version supports the `condition` field in Turbopack rules (Next.js 16+).
-  const turbopackReactComponentAnnotation = userSentryOptions?._experimental?.turbopackReactComponentAnnotation;
-  if (turbopackReactComponentAnnotation?.enabled && nextJsVersion && supportsTurbopackRuleCondition(nextJsVersion)) {
-    newConfig.rules = safelyAddTurbopackRule(newConfig.rules, {
-      matcher: '*.{tsx,jsx}',
-      rule: {
-        condition: { not: 'foreign' },
-        loaders: [
-          {
-            loader: path.resolve(__dirname, '..', 'loaders', 'componentAnnotationLoader.js'),
-            options: {
-              ignoredComponents: turbopackReactComponentAnnotation.ignoredComponents ?? [],
+  // This is only added when annotation is enabled AND the Next.js version supports the
+  // `condition` field in Turbopack rules (Next.js 16+).
+  const reactComponentAnnotation = {
+    ...userSentryOptions?.reactComponentAnnotation,
+    // eslint-disable-next-line typescript/no-deprecated
+    ...userSentryOptions?._experimental?.turbopackReactComponentAnnotation,
+  };
+  if (reactComponentAnnotation.enabled) {
+    if (nextJsVersion && supportsTurbopackRuleCondition(nextJsVersion)) {
+      newConfig.rules = safelyAddTurbopackRule(newConfig.rules, {
+        matcher: '*.{tsx,jsx}',
+        rule: {
+          condition: { not: 'foreign' },
+          loaders: [
+            {
+              loader: path.resolve(__dirname, '..', 'loaders', 'componentAnnotationLoader.js'),
+              options: {
+                ignoredComponents: reactComponentAnnotation.ignoredComponents ?? [],
+              },
             },
-          },
-        ],
-      },
-    });
+          ],
+        },
+      });
+    } else {
+      // Without this warning the option silently no-ops, which is indistinguishable from
+      // annotation being broken.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[@sentry/nextjs] \`reactComponentAnnotation\` is enabled but React component annotation requires Next.js 16+ on Turbopack builds${
+          nextJsVersion ? ` (detected ${nextJsVersion})` : ''
+        }. Your components will not be annotated.`,
+      );
+    }
   }
 
   newConfig.rules = maybeAddOrchestrionRule(newConfig.rules, userSentryOptions, nextJsVersion);

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -160,6 +160,8 @@ export type SentryBuildWebpackOptions = {
    * When enabled, your app's DOM will automatically be annotated during build-time with their respective component names.
    * This will unlock the capability to search for Replays in Sentry by component name, as well as see component names in breadcrumbs and performance monitoring.
    * Please note that this feature is not currently supported by the esbuild bundler plugins, and will only annotate React components
+   *
+   * @deprecated Use the top-level `reactComponentAnnotation` option instead, which works for both webpack and Turbopack builds.
    */
   reactComponentAnnotation?: {
     /**
@@ -171,7 +173,7 @@ export type SentryBuildWebpackOptions = {
      * A list of strings representing the names of components to ignore. The plugin will not apply `data-sentry` annotations on the DOM element for these components.
      */
     ignoredComponents?: string[];
-  };
+  }; // TODO(v12): remove this option
 };
 
 export type SentryBuildOptions = {
@@ -488,6 +490,28 @@ export type SentryBuildOptions = {
   applicationKey?: string;
 
   /**
+   * Options related to react component name annotations.
+   * Disabled by default, unless a value is set for this option.
+   * When enabled, your app's DOM will automatically be annotated during build-time with their respective component names.
+   * This will unlock the capability to search for Replays in Sentry by component name, as well as see component names in
+   * breadcrumbs and performance monitoring.
+   *
+   * For webpack builds, this is forwarded to `@sentry/bundler-plugins/webpack`.
+   * For Turbopack builds, this applies the annotations via a custom loader and requires Next.js 16+.
+   */
+  reactComponentAnnotation?: {
+    /**
+     * Whether the component name annotate plugin should be enabled or not.
+     */
+    enabled?: boolean;
+
+    /**
+     * A list of strings representing the names of components to ignore. The plugin will not apply `data-sentry` annotations on the DOM element for these components.
+     */
+    ignoredComponents?: string[];
+  };
+
+  /**
    * Options to configure various bundle size optimizations related to the Sentry SDK.
    */
   bundleSizeOptimizations?: {
@@ -655,11 +679,13 @@ export type SentryBuildOptions = {
      * When enabled, JSX elements are annotated with `data-sentry-component`,
      * `data-sentry-element`, and `data-sentry-source-file` attributes.
      * Requires Next.js 16+.
+     *
+     * @deprecated Use the top-level `reactComponentAnnotation` option instead, which works for both webpack and Turbopack builds.
      */
     turbopackReactComponentAnnotation?: {
       enabled?: boolean;
       ignoredComponents?: string[];
-    };
+    }; // TODO(v12): remove this option
   }>;
 
   /**

--- a/packages/nextjs/test/config/getBuildPluginOptions.test.ts
+++ b/packages/nextjs/test/config/getBuildPluginOptions.test.ts
@@ -849,6 +849,58 @@ describe('getBuildPluginOptions', () => {
   });
 
   describe('react component annotation', () => {
+    it('forwards the top-level option to the webpack plugin', () => {
+      const sentryBuildOptions: SentryBuildOptions = {
+        org: 'test-org',
+        project: 'test-project',
+        reactComponentAnnotation: {
+          enabled: true,
+          ignoredComponents: ['Header'],
+        },
+      };
+
+      const result = getBuildPluginOptions({
+        sentryBuildOptions,
+        releaseName: mockReleaseName,
+        distDirAbsPath: mockDistDirAbsPath,
+        buildTool: 'webpack-client',
+      });
+
+      expect(result.reactComponentAnnotation).toEqual({
+        enabled: true,
+        ignoredComponents: ['Header'],
+      });
+    });
+
+    it('lets the deprecated webpack-scoped option override the top-level one', () => {
+      const sentryBuildOptions: SentryBuildOptions = {
+        org: 'test-org',
+        project: 'test-project',
+        reactComponentAnnotation: {
+          enabled: true,
+          ignoredComponents: ['TopLevel'],
+        },
+        webpack: {
+          reactComponentAnnotation: {
+            ignoredComponents: ['Scoped'],
+          },
+        },
+      };
+
+      const result = getBuildPluginOptions({
+        sentryBuildOptions,
+        releaseName: mockReleaseName,
+        distDirAbsPath: mockDistDirAbsPath,
+        buildTool: 'webpack-client',
+      });
+
+      // Merged field-wise: `enabled` comes from the top level, `ignoredComponents` from the scoped option
+      expect(result.reactComponentAnnotation).toEqual({
+        enabled: true,
+        ignoredComponents: ['Scoped'],
+      });
+    });
+
     it('merges react component annotation options correctly for webpack builds', () => {
       const sentryBuildOptions: SentryBuildOptions = {
         org: 'test-org',

--- a/packages/nextjs/test/config/turbopack/constructTurbopackConfig.test.ts
+++ b/packages/nextjs/test/config/turbopack/constructTurbopackConfig.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { RouteManifest } from '../../../src/config/manifest/types';
 import {
   constructTurbopackConfig,
@@ -1286,6 +1286,168 @@ describe('componentAnnotation with turbopackReactComponentAnnotation', () => {
     expect(result.rules!['*.{ts,tsx,js,jsx,mjs,cjs}']).toBeDefined();
     // Component annotation loader should be present
     expect(result.rules!['*.{tsx,jsx}']).toBeDefined();
+  });
+});
+
+describe('componentAnnotation with top-level reactComponentAnnotation', () => {
+  function mockLoaderPaths(): void {
+    const pathResolveSpy = vi.spyOn(path, 'resolve');
+    pathResolveSpy.mockImplementation((...args: string[]) => {
+      const lastArg = args[args.length - 1];
+      if (lastArg === 'componentAnnotationLoader.js') {
+        return '/mocked/path/to/componentAnnotationLoader.js';
+      }
+      if (lastArg === 'moduleMetadataInjectionLoader.js') {
+        return '/mocked/path/to/moduleMetadataInjectionLoader.js';
+      }
+      return '/mocked/path/to/valueInjectionLoader.js';
+    });
+  }
+
+  function getIgnoredComponents(result: ReturnType<typeof constructTurbopackConfig>): string[] {
+    const rule = result.rules!['*.{tsx,jsx}'] as {
+      loaders: Array<{ loader: string; options: { ignoredComponents: string[] } }>;
+    };
+    return rule.loaders[0]!.options.ignoredComponents;
+  }
+
+  it('adds the component annotation loader rule when enabled and Next.js >= 16', () => {
+    mockLoaderPaths();
+
+    const result = constructTurbopackConfig({
+      userNextConfig: {},
+      userSentryOptions: { reactComponentAnnotation: { enabled: true, ignoredComponents: ['Header'] } },
+      nextJsVersion: '16.0.0',
+    });
+
+    expect(result.rules!['*.{tsx,jsx}']).toEqual({
+      condition: { not: 'foreign' },
+      loaders: [
+        {
+          loader: '/mocked/path/to/componentAnnotationLoader.js',
+          options: {
+            ignoredComponents: ['Header'],
+          },
+        },
+      ],
+    });
+  });
+
+  it('does not add the rule when enabled is false', () => {
+    const result = constructTurbopackConfig({
+      userNextConfig: {},
+      userSentryOptions: { reactComponentAnnotation: { enabled: false } },
+      nextJsVersion: '16.0.0',
+    });
+
+    expect(result.rules!['*.{tsx,jsx}']).toBeUndefined();
+  });
+
+  it('lets the deprecated experimental option override the top-level one', () => {
+    mockLoaderPaths();
+
+    const result = constructTurbopackConfig({
+      userNextConfig: {},
+      userSentryOptions: {
+        reactComponentAnnotation: { enabled: true, ignoredComponents: ['TopLevel'] },
+        _experimental: {
+          turbopackReactComponentAnnotation: { enabled: true, ignoredComponents: ['Experimental'] },
+        },
+      },
+      nextJsVersion: '16.0.0',
+    });
+
+    expect(getIgnoredComponents(result)).toEqual(['Experimental']);
+  });
+
+  it('merges field-wise so the top-level option fills gaps the experimental one leaves', () => {
+    mockLoaderPaths();
+
+    const result = constructTurbopackConfig({
+      userNextConfig: {},
+      userSentryOptions: {
+        reactComponentAnnotation: { enabled: true, ignoredComponents: ['TopLevel'] },
+        _experimental: {
+          turbopackReactComponentAnnotation: { enabled: true },
+        },
+      },
+      nextJsVersion: '16.0.0',
+    });
+
+    expect(getIgnoredComponents(result)).toEqual(['TopLevel']);
+  });
+
+  it('lets the deprecated experimental option disable annotation enabled at the top level', () => {
+    const result = constructTurbopackConfig({
+      userNextConfig: {},
+      userSentryOptions: {
+        reactComponentAnnotation: { enabled: true },
+        _experimental: {
+          turbopackReactComponentAnnotation: { enabled: false },
+        },
+      },
+      nextJsVersion: '16.0.0',
+    });
+
+    expect(result.rules!['*.{tsx,jsx}']).toBeUndefined();
+  });
+
+  describe('Next.js < 16 warning', () => {
+    let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('warns and skips the rule when the Next.js version is too old', () => {
+      const result = constructTurbopackConfig({
+        userNextConfig: {},
+        userSentryOptions: { reactComponentAnnotation: { enabled: true } },
+        nextJsVersion: '15.4.1',
+      });
+
+      expect(result.rules!['*.{tsx,jsx}']).toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('requires Next.js 16+'));
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('detected 15.4.1'));
+    });
+
+    it('warns without a version when the Next.js version could not be detected', () => {
+      const result = constructTurbopackConfig({
+        userNextConfig: {},
+        userSentryOptions: { reactComponentAnnotation: { enabled: true } },
+        nextJsVersion: undefined,
+      });
+
+      expect(result.rules!['*.{tsx,jsx}']).toBeUndefined();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('requires Next.js 16+'));
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('detected'));
+    });
+
+    it('does not warn when annotation is not enabled', () => {
+      constructTurbopackConfig({
+        userNextConfig: {},
+        userSentryOptions: { reactComponentAnnotation: { enabled: false } },
+        nextJsVersion: '15.4.1',
+      });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not warn on a supported Next.js version', () => {
+      mockLoaderPaths();
+
+      constructTurbopackConfig({
+        userNextConfig: {},
+        userSentryOptions: { reactComponentAnnotation: { enabled: true } },
+        nextJsVersion: '16.0.0',
+      });
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
Unifies React component annotation into a single top-level `reactComponentAnnotation` for both webpack and Turbopack, mirroring `applicationKey` (#20794).

Removing the top-level option in #23221 was an oversight - it was deprecated back when annotation was webpack-only, but Turbopack supports it now.

`webpack.reactComponentAnnotation` and `_experimental.turbopackReactComponentAnnotation` are deprecated but still work, removal in v12. We only moved users onto the webpack one in 10.30.0, so removing it now would mean two migrations in a row.

Also warns when annotation is enabled on Turbopack + Next.js < 16, where it previously no-opped
silently.