### PR TITLE
ref(core): Remove OTel span handling from `spanToJSON`

### DIFF
--- a/packages/core/src/tracing/sentryNonRecordingSpan.ts
+++ b/packages/core/src/tracing/sentryNonRecordingSpan.ts
@@ -6,6 +6,7 @@ import type {
   SpanAttributeValue,
   SpanContextData,
   SpanTimeInput,
+  StreamedSpanJSON,
 } from '../types/span';
 import type { SpanStatus } from '../types/spanStatus';
 import { addNonEnumerableProperty } from '../utils/object';
@@ -107,6 +108,18 @@ export class SentryNonRecordingSpan implements Span {
    */
   public recordException(_exception: unknown, _time?: SpanTimeInput | undefined): void {
     // noop
+  }
+
+  public getSpanJSON(): StreamedSpanJSON {
+    return {
+      name: '',
+      is_segment: false,
+      span_id: this._spanId,
+      trace_id: this._traceId,
+      start_timestamp: 0,
+      status: 'ok',
+      attributes: {},
+    };
   }
 }
 

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -279,14 +279,7 @@ export class SentrySpan implements Span {
     };
   }
 
-  /**
-   * Get {@link StreamedSpanJSON} representation of this span.
-   *
-   * @hidden
-   * @internal This method is purely for internal purposes and should not be used outside
-   * of SDK code. If you need to get a JSON representation of a span,
-   * use `spanToJSON(span)` instead.
-   */
+  /** @inheritdoc */
   public getSpanJSON(): StreamedSpanJSON {
     return {
       name: this._name ?? '',

--- a/packages/core/src/types/span.ts
+++ b/packages/core/src/types/span.ts
@@ -320,4 +320,9 @@ export interface Span {
    * NOT USED IN SENTRY, only added for compliance with OTEL Span interface
    */
   recordException(exception: unknown, time?: SpanTimeInput): void;
+
+  /**
+   * Get a {@link StreamedSpanJSON} representation of this span.
+   */
+  getSpanJSON(): StreamedSpanJSON;
 }

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -7,8 +7,6 @@ import { getCurrentScope } from '../currentScopes';
 import type { Scope } from '../scope';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_CUSTOM_SPAN_NAME,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE,
 } from '../semanticAttributes';
@@ -22,7 +20,6 @@ import type {
   Span,
   SpanAttributes,
   SpanJSON,
-  SpanOrigin,
   SpanTimeInput,
   StreamedSpanJSON,
 } from '../types/span';
@@ -167,40 +164,20 @@ function ensureTimestampInSeconds(timestamp: number): number {
  * Convert a span to a static JSON representation.
  */
 // Note: Because of this, we currently have a circular type dependency (which we opted out of in package.json).
-// This is not avoidable as we need `spanToJSON` in `spanUtils.ts`, which in turn is needed by `span.ts` for backwards compatibility.
+// This is not avoidable as we need `spanToJSON` in `spanUtils.ts`, which in turn is needed by `sentrySpan.ts` for backwards compatibility.
 // And `spanToJSON` needs the Span class from `span.ts` to check here.
 export function spanToStaticSpanJSON(span: Span): SpanJSON {
   if (spanIsSentrySpan(span)) {
     return span.getStaticSpanJSON();
   }
 
-  const { spanId: span_id, traceId: trace_id } = span.spanContext();
-
-  // Handle a span from @opentelemetry/sdk-base-trace's `Span` class
-  if (spanIsOpenTelemetrySdkTraceBaseSpan(span)) {
-    const { attributes, startTime, name, endTime, status, links } = span;
-
-    return {
-      span_id,
-      trace_id,
-      data: attributes,
-      description: name,
-      parent_span_id: getOtelParentSpanId(span),
-      start_timestamp: spanTimeInputToSeconds(startTime),
-      // This is [0,0] by default in OTEL, in which case we want to interpret this as no end time
-      timestamp: spanTimeInputToSeconds(endTime) || undefined,
-      status: getStatusMessage(status),
-      op: attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP],
-      origin: attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined,
-      links: convertSpanLinksForEnvelope(links),
-    };
-  }
-
-  // Finally, at least we have `spanContext()`....
+  // because `spanToJSON` accepts a `Span` interface rather than a `SentrySpan` instance,
+  // we need to handle the case where the span is not a Sentry span.
   // This should not actually happen in reality, but we need to handle it for type safety.
+  const ctx = span.spanContext();
   return {
-    span_id,
-    trace_id,
+    span_id: ctx.spanId,
+    trace_id: ctx.traceId,
     start_timestamp: 0,
     status: 'ok',
     data: {},
@@ -217,26 +194,8 @@ export function spanToJSON(span: Span): StreamedSpanJSON {
 
   const { spanId: span_id, traceId: trace_id } = span.spanContext();
 
-  // Handle a span from @opentelemetry/sdk-base-trace's `Span` class
-  if (spanIsOpenTelemetrySdkTraceBaseSpan(span)) {
-    const { attributes, startTime, name, endTime, status, links } = span;
-
-    return {
-      name,
-      span_id,
-      trace_id,
-      parent_span_id: getOtelParentSpanId(span),
-      start_timestamp: spanTimeInputToSeconds(startTime),
-      // This is [0,0] by default in OTEL, in which case we want to interpret this as no end time
-      end_timestamp: spanTimeInputToSeconds(endTime) || undefined,
-      is_segment: span === INTERNAL_getSegmentSpan(span),
-      status: getSimpleStatus(status),
-      attributes: addStatusMessageAttribute(attributes, status),
-      links: getStreamedSpanLinks(links),
-    };
-  }
-
-  // Finally, as a fallback, at least we have `spanContext()`....
+  // Because `spanToJSON` accepts a `Span` interface rather than a `SentrySpan` instance,
+  // we need to handle the case where the span is not a Sentry span.
   // This should not actually happen in reality, but we need to handle it for type safety.
   return {
     span_id,
@@ -247,20 +206,6 @@ export function spanToJSON(span: Span): StreamedSpanJSON {
     is_segment: span === INTERNAL_getSegmentSpan(span),
     attributes: {},
   };
-}
-
-/**
- * In preparation for the next major of OpenTelemetry, we want to support
- * looking up the parent span id according to the new API
- * In OTel v1, the parent span id is accessed as `parentSpanId`
- * In OTel v2, the parent span id is accessed as `spanId` on the `parentSpanContext`
- */
-function getOtelParentSpanId(span: OpenTelemetrySdkTraceBaseSpan): string | undefined {
-  return 'parentSpanId' in span
-    ? span.parentSpanId
-    : 'parentSpanContext' in span
-      ? (span.parentSpanContext as { spanId?: string } | undefined)?.spanId
-      : undefined;
 }
 
 /**
@@ -280,22 +225,6 @@ export function streamedSpanJsonToSerializedSpan(spanJson: StreamedSpanJSON): Se
       attributes: serializeAttributes(link.attributes),
     })),
   };
-}
-
-function spanIsOpenTelemetrySdkTraceBaseSpan(span: Span): span is OpenTelemetrySdkTraceBaseSpan {
-  const castSpan = span as Partial<OpenTelemetrySdkTraceBaseSpan>;
-  return !!castSpan.attributes && !!castSpan.startTime && !!castSpan.name && !!castSpan.endTime && !!castSpan.status;
-}
-
-/** Exported only for tests. */
-export interface OpenTelemetrySdkTraceBaseSpan extends Span {
-  attributes: SpanAttributes;
-  startTime: SpanTimeInput;
-  name: string;
-  status: SpanStatus;
-  endTime: SpanTimeInput;
-  parentSpanId?: string;
-  links?: SpanLink[];
 }
 
 /**

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -188,24 +188,7 @@ export function spanToStaticSpanJSON(span: Span): SpanJSON {
  * Convert a span to a JSON representation.
  */
 export function spanToJSON(span: Span): StreamedSpanJSON {
-  if (spanIsSentrySpan(span)) {
-    return span.getSpanJSON();
-  }
-
-  const { spanId: span_id, traceId: trace_id } = span.spanContext();
-
-  // Because `spanToJSON` accepts a `Span` interface rather than a `SentrySpan` instance,
-  // we need to handle the case where the span is not a Sentry span.
-  // This should not actually happen in reality, but we need to handle it for type safety.
-  return {
-    span_id,
-    trace_id,
-    start_timestamp: 0,
-    name: '',
-    status: 'ok',
-    is_segment: span === INTERNAL_getSegmentSpan(span),
-    attributes: {},
-  };
+  return span.getSpanJSON();
 }
 
 /**
@@ -232,7 +215,7 @@ export function streamedSpanJsonToSerializedSpan(spanJson: StreamedSpanJSON): Se
  * :( So instead we approximate this by checking if it has the `getSpanJSON` method.
  */
 export function spanIsSentrySpan(span: Span): span is SentrySpan {
-  return typeof (span as SentrySpan).getSpanJSON === 'function';
+  return typeof (span as SentrySpan).getStaticSpanJSON === 'function';
 }
 
 /**

--- a/packages/core/test/lib/tracing/spans/captureSpan.test.ts
+++ b/packages/core/test/lib/tracing/spans/captureSpan.test.ts
@@ -423,7 +423,10 @@ describe('captureSpan', () => {
       client.on('processSpan', processSpanFn);
       client.on('processSegmentSpan', processSegmentSpanFn);
 
-      const span = startInactiveSpan({ name: 'my-span', attributes: { 'sentry.op': 'http.client' } });
+      const span = withScope(scope => {
+        scope.setClient(client);
+        return startInactiveSpan({ name: 'my-span', attributes: { 'sentry.op': 'http.client' } });
+      });
 
       captureSpan(span, client);
 

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -13,7 +13,6 @@ import {
   setCurrentClient,
   SPAN_STATUS_ERROR,
   SPAN_STATUS_OK,
-  SPAN_STATUS_UNSET,
   spanToTraceHeader,
   startInactiveSpan,
   startSpan,
@@ -22,10 +21,8 @@ import {
   withScope,
 } from '../../../src';
 import type { SpanLink } from '../../../src/types/link';
-import type { Span, SpanAttributes, SpanTimeInput, StreamedSpanJSON } from '../../../src/types/span';
-import type { SpanStatus } from '../../../src/types/spanStatus';
+import type { Span, StreamedSpanJSON } from '../../../src/types/span';
 import { _setSpanForScope } from '../../../src/utils/spanOnScope';
-import type { OpenTelemetrySdkTraceBaseSpan } from '../../../src/utils/spanUtils';
 import {
   addChildSpanToSpan,
   getActiveSpan,
@@ -42,47 +39,6 @@ import {
   updateSpanName,
 } from '../../../src/utils/spanUtils';
 import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
-
-function createMockedOtelSpan({
-  spanId,
-  traceId,
-  isRemote,
-  attributes = {},
-  startTime = Date.now(),
-  name = 'test span',
-  status = { code: SPAN_STATUS_UNSET },
-  endTime = Date.now(),
-  parentSpanId,
-  links = undefined,
-}: {
-  spanId: string;
-  traceId: string;
-  attributes?: SpanAttributes;
-  startTime?: SpanTimeInput;
-  isRemote?: boolean;
-  name?: string;
-  status?: SpanStatus;
-  endTime?: SpanTimeInput;
-  parentSpanId?: string;
-  links?: SpanLink[];
-}): Span {
-  return {
-    spanContext: () => {
-      return {
-        spanId,
-        traceId,
-        isRemote,
-      };
-    },
-    attributes,
-    startTime,
-    name,
-    status,
-    endTime,
-    parentSpanId,
-    links,
-  } as OpenTelemetrySdkTraceBaseSpan;
-}
 
 describe('spanToTraceHeader', () => {
   test('simple', () => {
@@ -116,63 +72,6 @@ describe('spanToTraceContext', () => {
       span_id: '1234',
       trace_id: 'ABCD',
       parent_span_id: '5678',
-    });
-  });
-
-  it('works with a local OTEL span', () => {
-    const span = createMockedOtelSpan({
-      spanId: '1234',
-      traceId: 'ABCD',
-      isRemote: false,
-    });
-
-    expect(spanToTraceContext(span)).toEqual({
-      span_id: '1234',
-      trace_id: 'ABCD',
-    });
-  });
-
-  it('works with a local OTEL span with parentSpanId', () => {
-    const span = createMockedOtelSpan({
-      spanId: '1234',
-      traceId: 'ABCD',
-      isRemote: false,
-      parentSpanId: 'XYZ',
-    });
-
-    expect(spanToTraceContext(span)).toEqual({
-      parent_span_id: 'XYZ',
-      span_id: '1234',
-      trace_id: 'ABCD',
-    });
-  });
-
-  it('works with a remote OTEL span', () => {
-    const span = createMockedOtelSpan({
-      spanId: '1234',
-      traceId: 'ABCD',
-      isRemote: true,
-    });
-
-    expect(spanToTraceContext(span)).toEqual({
-      parent_span_id: '1234',
-      span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
-      trace_id: 'ABCD',
-    });
-  });
-
-  it('works with a remote OTEL span with parentSpanId', () => {
-    const span = createMockedOtelSpan({
-      spanId: '1234',
-      traceId: 'ABCD',
-      isRemote: true,
-      parentSpanId: 'XYZ',
-    });
-
-    expect(spanToTraceContext(span)).toEqual({
-      parent_span_id: '1234',
-      span_id: expect.stringMatching(/^[0-9a-f]{16}$/),
-      trace_id: 'ABCD',
     });
   });
 });
@@ -369,64 +268,7 @@ describe('spanToStaticSpanJSON', () => {
     });
   });
 
-  describe('OpenTelemetry Span', () => {
-    it('works with a simple span', () => {
-      const span = createMockedOtelSpan({
-        spanId: 'SPAN-1',
-        traceId: 'TRACE-1',
-        name: 'test span',
-        startTime: 123,
-        endTime: [0, 0],
-        attributes: {},
-        status: { code: SPAN_STATUS_UNSET },
-      });
-
-      expect(spanToStaticSpanJSON(span)).toEqual({
-        span_id: 'SPAN-1',
-        trace_id: 'TRACE-1',
-        start_timestamp: 123,
-        description: 'test span',
-        data: {},
-        status: 'ok',
-      });
-    });
-
-    it('works with a full span', () => {
-      const span = createMockedOtelSpan({
-        spanId: 'SPAN-1',
-        traceId: 'TRACE-1',
-        name: 'test span',
-        startTime: 123,
-        endTime: 456,
-        attributes: {
-          attr1: 'value1',
-          attr2: 2,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'test op',
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto',
-        },
-        status: { code: SPAN_STATUS_ERROR, message: 'unknown_error' },
-      });
-
-      expect(spanToStaticSpanJSON(span)).toEqual({
-        span_id: 'SPAN-1',
-        trace_id: 'TRACE-1',
-        start_timestamp: 123,
-        timestamp: 456,
-        description: 'test span',
-        op: 'test op',
-        origin: 'auto',
-        data: {
-          attr1: 'value1',
-          attr2: 2,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'test op',
-          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto',
-        },
-        status: 'unknown_error',
-      });
-    });
-  });
-
-  describe('spanToJSON', () => {
+  describe('spanToStreamedSpanJSON', () => {
     describe('SentrySpan', () => {
       it('converts a minimal span', () => {
         const span = new SentrySpan();
@@ -551,121 +393,6 @@ describe('spanToStaticSpanJSON', () => {
         expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('explicit message');
       });
     });
-    describe('OpenTelemetry Span', () => {
-      it('converts a simple span', () => {
-        const span = createMockedOtelSpan({
-          spanId: 'SPAN-1',
-          traceId: 'TRACE-1',
-          name: 'test span',
-          startTime: 123,
-          endTime: [0, 0],
-          attributes: {},
-          status: { code: SPAN_STATUS_UNSET },
-        });
-
-        expect(spanToJSON(span)).toEqual({
-          span_id: 'SPAN-1',
-          trace_id: 'TRACE-1',
-          parent_span_id: undefined,
-          start_timestamp: 123,
-          end_timestamp: undefined,
-          name: 'test span',
-          is_segment: true,
-          status: 'ok',
-          attributes: {},
-        });
-      });
-
-      it('converts a full span', () => {
-        const span = createMockedOtelSpan({
-          spanId: 'SPAN-1',
-          traceId: 'TRACE-1',
-          parentSpanId: 'PARENT-1',
-          name: 'test span',
-          startTime: 123,
-          endTime: 456,
-          attributes: {
-            attr1: 'value1',
-            attr2: 2,
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'test op',
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto',
-          },
-          links: [
-            {
-              context: {
-                spanId: 'span1',
-                traceId: 'trace1',
-                traceFlags: TRACE_FLAG_SAMPLED,
-              },
-              attributes: {
-                [SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE]: 'previous_trace',
-              },
-            },
-          ],
-          status: { code: SPAN_STATUS_ERROR, message: 'unknown_error' },
-        });
-
-        expect(spanToJSON(span)).toEqual({
-          span_id: 'SPAN-1',
-          trace_id: 'TRACE-1',
-          parent_span_id: 'PARENT-1',
-          start_timestamp: 123,
-          end_timestamp: 456,
-          name: 'test span',
-          is_segment: true,
-          status: 'error',
-          attributes: {
-            attr1: 'value1',
-            attr2: 2,
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'test op',
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto',
-            [SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]: 'unknown_error',
-          },
-          links: [
-            {
-              span_id: 'span1',
-              trace_id: 'trace1',
-              sampled: true,
-              attributes: {
-                [SEMANTIC_LINK_ATTRIBUTE_LINK_TYPE]: 'previous_trace',
-              },
-            },
-          ],
-        });
-      });
-
-      it('preserves a custom error status message as the sentry.status.message attribute', () => {
-        const span = createMockedOtelSpan({
-          spanId: 'SPAN-1',
-          traceId: 'TRACE-1',
-          name: 'test span',
-          startTime: 123,
-          endTime: 456,
-          attributes: {},
-          status: { code: SPAN_STATUS_ERROR, message: 'Connection Refused' },
-        });
-
-        const json = spanToJSON(span);
-        expect(json.status).toBe('error');
-        expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBe('Connection Refused');
-      });
-
-      it('does not set a status message for ok/unset spans', () => {
-        const span = createMockedOtelSpan({
-          spanId: 'SPAN-1',
-          traceId: 'TRACE-1',
-          name: 'test span',
-          startTime: 123,
-          endTime: 456,
-          attributes: {},
-          status: { code: SPAN_STATUS_UNSET },
-        });
-
-        const json = spanToJSON(span);
-        expect(json.status).toBe('ok');
-        expect(json.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_STATUS_MESSAGE]).toBeUndefined();
-      });
-    });
   });
 
   describe('streamedSpanJsonToSerializedSpan', () => {
@@ -778,14 +505,6 @@ describe('spanToJSON end_timestamp', () => {
 
     span.end();
     expect(spanToJSON(span).end_timestamp).toBeDefined();
-  });
-
-  test('OpenTelemetry span', () => {
-    const openSpan = createMockedOtelSpan({ spanId: 'SPAN-1', traceId: 'TRACE-1', endTime: [0, 0] });
-    expect(spanToJSON(openSpan).end_timestamp).toBeUndefined();
-
-    const endedSpan = createMockedOtelSpan({ spanId: 'SPAN-1', traceId: 'TRACE-1', endTime: 456 });
-    expect(spanToJSON(endedSpan).end_timestamp).toBe(456);
   });
 
   test('SentryNonRecordingSpan', () => {


### PR DESCRIPTION
WIP: needs https://github.com/getsentry/sentry-javascript/pull/23198

Now that our SDK only emits `SentrySpan`, even when our tracer provider is used, we can streamline the `spanToJSON` helper, to no longer handle OTel spans. This should reduce some bytes and complexity.