### PR TITLE
feat(hono): Support `.query()` handlers

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hono-4/deno.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/deno.json
@@ -5,7 +5,7 @@
     "@sentry/deno": "npm:@sentry/deno",
     "@sentry/core": "npm:@sentry/core",
     "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0",
-    "hono": "npm:hono@^4.12.14"
+    "hono": "npm:hono@^4.13.1"
   },
   "nodeModulesDir": "manual"
 }

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -19,7 +19,7 @@
     "@sentry/hono": "latest || *",
     "@sentry/node": "latest || *",
     "@hono/node-server": "^2.0.5",
-    "hono": "^4.12.14"
+    "hono": "^4.13.1"
   },
   "devDependencies": {
     "@playwright/test": "~1.56.0",

--- a/dev-packages/e2e-tests/test-applications/hono-4/src/routes.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/src/routes.ts
@@ -66,6 +66,16 @@ export function addRoutes(app: HonoType<{ Bindings?: { E2E_TEST_DSN: string } }>
     },
     c => c.text('main inline all'),
   );
+  app.query(
+    '/test-main-inline/query',
+    async function mainInlineQuery(_c, next) {
+      await next();
+    },
+    async c => {
+      const body = await c.req.json<{ value: string }>();
+      return c.json({ method: c.req.method, value: body.value });
+    },
+  );
 
   // Combined: .use() middleware + inline middleware via .get() on the same path.
   app.use('/test-main-inline/combined/*', middlewareA);

--- a/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/hono-4/tests/middleware.test.ts
@@ -253,6 +253,37 @@ const MAIN_INLINE_CASES = [
 ] as const;
 
 test.describe('inline middleware spans (main app)', () => {
+  test('creates middleware span for inline middleware via .query()', async ({ baseURL }) => {
+    const fullPath = `${MAIN_INLINE_PREFIX}/query`;
+    const transactionPromise = waitForTransaction(APP_NAME, event => {
+      return event.contexts?.trace?.op === 'http.server' && event.transaction === `QUERY ${fullPath}`;
+    });
+
+    const response = await fetch(`${baseURL}${fullPath}`, {
+      method: 'QUERY',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: 'query-body' }),
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ method: 'QUERY', value: 'query-body' });
+
+    const transaction = await transactionPromise;
+    expect(transaction.transaction).toBe(`QUERY ${fullPath}`);
+    expect(transaction.contexts?.trace?.op).toBe('http.server');
+    expect(transaction.transaction_info?.source).toBe('route');
+    expect(transaction.request?.method).toBe('QUERY');
+
+    const middlewareSpans = (transaction.spans || []).filter(span => span.op === 'middleware');
+    expect(middlewareSpans).toHaveLength(1);
+    expect(middlewareSpans[0]).toEqual(
+      expect.objectContaining({
+        description: 'mainInlineQuery',
+        op: 'middleware',
+        origin: 'auto.middleware.hono',
+      }),
+    );
+  });
+
   MAIN_INLINE_CASES.forEach(({ name, path, method, expectedMiddlewareName }) => {
     test(`creates middleware span for inline middleware via ${name}`, async ({ baseURL }) => {
       const fullPath = `${MAIN_INLINE_PREFIX}${path}`;

--- a/packages/hono/src/shared/patchAppUse.ts
+++ b/packages/hono/src/shared/patchAppUse.ts
@@ -8,7 +8,7 @@ const patchedUseInstances = new WeakSet<Hono<any>>();
 // oxlint-disable-next-line typescript/no-explicit-any
 const patchedMethodInstances = new WeakSet<Hono<any>>();
 
-const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'options', 'patch', 'all'] as const;
+const HTTP_METHODS = ['get', 'post', 'put', 'delete', 'options', 'patch', 'all', 'query'] as const;
 
 /**
  * Patches `app.use` (instance own property) on a Hono instance to instrument middleware at registration time.
@@ -40,7 +40,7 @@ export function patchAppUse<E extends Env>(app: Hono<E>): void {
 }
 
 /**
- * Patches HTTP method class fields (get, post, put, delete, options, patch, all) to instrument inline middleware at registration time.
+ * Patches HTTP method class fields to instrument inline middleware at registration time.
  *
  * For `app.get('/path', mw1, mw2, handler)`, all handlers except the last are middleware and get wrapped with spans.
  * The final handler (the route handler) is already covered by the root http.server transaction.
@@ -54,19 +54,13 @@ export function patchHttpMethodHandlers<E extends Env>(app: Hono<E>): void {
   patchedMethodInstances.add(app);
 
   for (const method of HTTP_METHODS) {
-    app[method] = new Proxy(app[method], {
-      apply(target, thisArg, args: unknown[]) {
-        return Reflect.apply(target, thisArg, wrapInlineMiddleware(args));
-      },
-    });
+    patchRegistrationMethod(app, method, wrapInlineMiddleware);
   }
 
-  app.on = new Proxy(app.on, {
-    apply(target, thisArg, args: unknown[]) {
-      // .on(method, path, ...handlers) — first two args are method and path
-      const [method, path, ...handlers] = args;
-      return Reflect.apply(target, thisArg, [method, path, ...wrapInlineMiddleware(handlers)]);
-    },
+  patchRegistrationMethod(app, 'on', args => {
+    // .on(method, path, ...handlers) — first two args are method and path
+    const [method, path, ...handlers] = args;
+    return [method, path, ...wrapInlineMiddleware(handlers)];
   });
 }
 
@@ -88,4 +82,18 @@ function wrapInlineMiddleware(args: unknown[]): unknown[] {
     wrapped[i] = wrapMiddlewareWithSpan(wrapped[i] as MiddlewareHandler);
   }
   return wrapped;
+}
+
+function patchRegistrationMethod(app: object, method: string, transformArgs: (args: unknown[]) => unknown[]): void {
+  const registration: unknown = Reflect.get(app, method);
+  if (typeof registration !== 'function') {
+    return;
+  }
+
+  const patchedRegistration = new Proxy(registration, {
+    apply(target, thisArg, args: unknown[]) {
+      return Reflect.apply(target, thisArg, transformArgs(args));
+    },
+  });
+  Reflect.set(app, method, patchedRegistration);
 }

--- a/packages/hono/test/shared/patchAppUse.test.ts
+++ b/packages/hono/test/shared/patchAppUse.test.ts
@@ -278,7 +278,7 @@ describe('patchHttpMethodHandlers (inline middleware spans on main app)', () => 
     patchHttpMethodHandlers(app);
 
     app.on(
-      'GET',
+      'QUERY',
       '/test',
       async function onMw(_c: unknown, next: () => Promise<void>) {
         await next();
@@ -288,12 +288,67 @@ describe('patchHttpMethodHandlers (inline middleware spans on main app)', () => 
       },
     );
 
-    await app.fetch(new Request('http://localhost/test'));
+    await app.fetch(new Request('http://localhost/test', { method: 'QUERY' }));
 
     const spanNames = startInactiveSpanMock.mock.calls.map((c: unknown[]) => (c[0] as { name: string }).name);
     expect(spanNames).toHaveLength(1);
     expect(spanNames).toContain('onMw');
     expect(spanNames).not.toContain('onHandler');
+  });
+
+  it('wraps app.query middleware when query is available (from 4.13.0)', async () => {
+    const context = { value: 'context' };
+    const result = { value: 'result' };
+    let registeredMiddleware: ((context: unknown, next: () => Promise<void>) => Promise<void>) | undefined;
+    let registeredHandler: ((context: unknown) => unknown) | undefined;
+    const query = vi.fn(function (
+      this: unknown,
+      path: string,
+      middleware: (context: unknown, next: () => Promise<void>) => Promise<void>,
+      handler: (context: unknown) => unknown,
+    ) {
+      expect(this).toBe(fakeApp);
+      expect(path).toBe('/test');
+      registeredMiddleware = middleware;
+      registeredHandler = handler;
+      return result;
+    });
+    const fakeApp = Object.assign(new Hono(), { query });
+    async function queryMiddleware(receivedContext: unknown, next: () => Promise<void>) {
+      expect(receivedContext).toBe(context);
+      await next();
+    }
+    const middleware = vi.fn(queryMiddleware);
+    const handler = vi.fn((receivedContext: unknown) => {
+      expect(receivedContext).toBe(context);
+      return 'handled';
+    });
+
+    patchHttpMethodHandlers(fakeApp as unknown as Parameters<typeof patchHttpMethodHandlers>[0]);
+    const registrationResult = fakeApp.query('/test', middleware, handler);
+
+    expect(registrationResult).toBe(result);
+    if (!registeredMiddleware || !registeredHandler) {
+      throw new Error('query handlers were not registered');
+    }
+    expect(registeredHandler).toBe(handler);
+
+    const next = vi.fn(async () => undefined);
+    await registeredMiddleware(context, next);
+    const handlerResult = registeredHandler(context);
+
+    expect(startInactiveSpanMock).toHaveBeenCalledTimes(1);
+    expect(startInactiveSpanMock).toHaveBeenCalledWith(expect.objectContaining({ name: 'queryMiddleware' }));
+    expect(middleware).toHaveBeenCalledWith(context, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(context);
+    expect(handlerResult).toBe('handled');
+  });
+
+  it('patches apps without app.query', () => {
+    const app = new Hono();
+
+    expect(() => patchHttpMethodHandlers(app)).not.toThrow();
   });
 
   it('does not wrap sole handler in app.on(method, path, handler)', async () => {


### PR DESCRIPTION
Adds support for `.query` handlers added in hono 4.13.0
- https://github.com/honojs/hono/releases/tag/v4.13.0
