### PR TITLE
ref(server-utils): Remove unused AI `*InstrumentedMethod` types

### DIFF
--- a/packages/server-utils/src/ai/anthropic-ai/types.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/types.ts
@@ -1,5 +1,4 @@
 import type { GenAiOptions } from '../core/utils';
-import type { ANTHROPIC_METHOD_REGISTRY } from './constants';
 
 /** Options for the Anthropic AI integration. */
 export type AnthropicAiOptions = GenAiOptions;
@@ -69,11 +68,6 @@ export interface AnthropicAiIntegration {
   name: string;
   options: AnthropicAiOptions;
 }
-
-/**
- * @deprecated This type is no longer used and will be removed in the next major version.
- */
-export type AnthropicAiInstrumentedMethod = keyof typeof ANTHROPIC_METHOD_REGISTRY;
 
 /**
  * Message type for Anthropic AI

--- a/packages/server-utils/src/ai/google-genai/types.ts
+++ b/packages/server-utils/src/ai/google-genai/types.ts
@@ -1,5 +1,4 @@
 import type { GenAiOptions } from '../core/utils';
-import type { GOOGLE_GENAI_METHOD_REGISTRY } from './constants';
 
 /** Options for the Google GenAI integration. */
 export type GoogleGenAIOptions = GenAiOptions;
@@ -173,15 +172,6 @@ export interface GoogleGenAIChat {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   sendMessageStream: (...args: unknown[]) => Promise<AsyncGenerator<GenerateContentResponse, any, unknown>>;
 }
-
-export type GoogleGenAIInstrumentedMethod = keyof typeof GOOGLE_GENAI_METHOD_REGISTRY;
-
-/**
- * @deprecated Use {@link GoogleGenAIInstrumentedMethod} instead. This alias
- * preserves backwards compatibility with the misspelled name and will be
- * removed in the next major version.
- */
-export type GoogleGenAIIstrumentedMethod = GoogleGenAIInstrumentedMethod;
 
 // Export the response type for use in instrumentation
 export type GoogleGenAIResponse = GenerateContentResponse;

--- a/packages/server-utils/src/ai/openai/types.ts
+++ b/packages/server-utils/src/ai/openai/types.ts
@@ -1,5 +1,4 @@
 import type { GenAiOptions } from '../core/utils';
-import type { OPENAI_METHOD_REGISTRY } from './constants';
 
 /**
  * Attribute values may be any non-nullish primitive value except an object.
@@ -352,8 +351,3 @@ export interface OpenAiIntegration {
   name: string;
   options: OpenAiOptions;
 }
-
-/**
- * @deprecated This type is no longer used and will be removed in the next major version.
- */
-export type InstrumentedMethod = keyof typeof OPENAI_METHOD_REGISTRY;


### PR DESCRIPTION
Removes the `*InstrumentedMethod` AI types (Anthropic, OpenAI, Google GenAI) which are unused internally and already absent from the public API since the v11 move to `@sentry/server-utils`.