### PR TITLE
ref(opentelemetry): Remove `OpenTelemetrySpanContext`

### DIFF
--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -1,7 +1,7 @@
 import type { Context, Span, SpanContext, SpanOptions, TimeInput, Tracer } from '@opentelemetry/api';
 import { context, SpanStatusCode, trace, TraceFlags } from '@opentelemetry/api';
 import { isTracingSuppressed, suppressTracing } from './utils/suppressTracing';
-import type { Client, Scope, Span as SentrySpan } from '@sentry/core';
+import type { Client, Scope, Span as SentrySpan, StartSpanOptions } from '@sentry/core';
 import {
   getClient,
   getCurrentScope,
@@ -13,7 +13,6 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   spanToStaticSpanJSON,
 } from '@sentry/core';
-import type { OpenTelemetrySpanContext } from './types';
 import { getContextFromScope } from './utils/contextData';
 import { getSamplingDecision } from './utils/getSamplingDecision';
 import { makeTraceState } from './utils/makeTraceState';
@@ -26,7 +25,7 @@ import { SENTRY_TRACE_STATE_DSC } from './constants';
  * @param callback - The callback to execute with the span
  * @param autoEnd - Whether to automatically end the span after the callback completes
  */
-function _startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span) => T, autoEnd: boolean): T {
+function _startSpan<T>(options: StartSpanOptions, callback: (span: Span) => T, autoEnd: boolean): T {
   const tracer = getTracer();
 
   const { name, parentSpan: customParentSpan } = options;
@@ -106,7 +105,7 @@ function _startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span)
  * You'll always get a span passed to the callback,
  * it may just be a non-recording span if the span is not sampled or if tracing is disabled.
  */
-export function startSpan<T>(options: OpenTelemetrySpanContext, callback: (span: Span) => T): T {
+export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) => T): T {
   return _startSpan(options, callback, true);
 }
 
@@ -120,10 +119,7 @@ export function startSpan<T>(options: OpenTelemetrySpanContext, callback: (span:
  * You'll always get a span passed to the callback,
  * it may just be a non-recording span if the span is not sampled or if tracing is disabled.
  */
-export function startSpanManual<T>(
-  options: OpenTelemetrySpanContext,
-  callback: (span: Span, finish: () => void) => T,
-): T {
+export function startSpanManual<T>(options: StartSpanOptions, callback: (span: Span, finish: () => void) => T): T {
   return _startSpan(options, span => callback(span, () => span.end()), false);
 }
 
@@ -136,7 +132,7 @@ export function startSpanManual<T>(
  * This function will always return a span,
  * it may just be a non-recording span if the span is not sampled or if tracing is disabled.
  */
-export function startInactiveSpan(options: OpenTelemetrySpanContext): Span {
+export function startInactiveSpan(options: StartSpanOptions): Span {
   const tracer = getTracer();
 
   const { name, parentSpan: customParentSpan } = options;
@@ -185,8 +181,8 @@ function getTracer(): Tracer {
   return client?.tracer || trace.getTracer('@sentry/opentelemetry', SDK_VERSION);
 }
 
-function getSpanOptions(options: OpenTelemetrySpanContext): SpanOptions {
-  const { startTime, attributes, kind, op, links } = options;
+function getSpanOptions(options: StartSpanOptions): SpanOptions {
+  const { startTime, attributes, op, links } = options;
 
   // OTEL expects timestamps in ms, not seconds
   const fixedStartTime = typeof startTime === 'number' ? ensureTimestampInMilliseconds(startTime) : startTime;
@@ -198,7 +194,6 @@ function getSpanOptions(options: OpenTelemetrySpanContext): SpanOptions {
           ...attributes,
         }
       : attributes,
-    kind,
     links,
     startTime: fixedStartTime,
   };

--- a/packages/opentelemetry/src/types.ts
+++ b/packages/opentelemetry/src/types.ts
@@ -1,10 +1,4 @@
-import type { SpanKind } from '@opentelemetry/api';
-import type { Scope, StartSpanOptions } from '@sentry/core';
-
-export interface OpenTelemetrySpanContext extends StartSpanOptions {
-  // Additional otel-only option, for now...?
-  kind?: SpanKind;
-}
+import type { Scope } from '@sentry/core';
 
 export interface CurrentScopes {
   scope: Scope;


### PR DESCRIPTION
The type is no longer needed, we handle the kind separately already in the tracer.