### PR TITLE
ref(server-utils): Remove unused AI client types

### DIFF
--- a/packages/server-utils/src/ai/anthropic-ai/types.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/types.ts
@@ -49,19 +49,6 @@ type SuccessfulResponse = {
 export type AnthropicAiResponse = SuccessfulResponse | MessageError;
 
 /**
- * Basic interface for Anthropic AI client with only the instrumented methods
- * This provides type safety while being generic enough to work with different client implementations
- */
-export interface AnthropicAiClient {
-  messages?: {
-    create: (...args: unknown[]) => Promise<AnthropicAiResponse>;
-  };
-  completions?: {
-    create: (...args: unknown[]) => Promise<AnthropicAiResponse>;
-  };
-}
-
-/**
  * Anthropic AI Integration interface for type safety
  */
 export interface AnthropicAiIntegration {

--- a/packages/server-utils/src/ai/google-genai/types.ts
+++ b/packages/server-utils/src/ai/google-genai/types.ts
@@ -145,33 +145,5 @@ type GenerateContentResponse = {
   usageMetadata?: GenerateContentResponseUsageMetadata;
 };
 
-/**
- * Basic interface for Google GenAI client with only the instrumented methods
- * This provides type safety while being generic enough to work with different client implementations
- */
-export interface GoogleGenAIClient {
-  models: {
-    generateContent: (...args: unknown[]) => Promise<GenerateContentResponse>;
-    // https://googleapis.github.io/js-genai/release_docs/classes/models.Models.html#generatecontentstream
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    generateContentStream: (...args: unknown[]) => Promise<AsyncGenerator<GenerateContentResponse, any, unknown>>;
-    // https://googleapis.github.io/js-genai/release_docs/classes/models.Models.html#embedcontent
-    embedContent: (...args: unknown[]) => Promise<unknown>;
-  };
-  chats: {
-    create: (...args: unknown[]) => GoogleGenAIChat;
-  };
-}
-
-/**
- * Google GenAI Chat interface for chat instances created via chats.create()
- */
-export interface GoogleGenAIChat {
-  sendMessage: (...args: unknown[]) => Promise<GenerateContentResponse>;
-  // https://googleapis.github.io/js-genai/release_docs/classes/chats.Chat.html#sendmessagestream
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sendMessageStream: (...args: unknown[]) => Promise<AsyncGenerator<GenerateContentResponse, any, unknown>>;
-}
-
 // Export the response type for use in instrumentation
 export type GoogleGenAIResponse = GenerateContentResponse;

--- a/packages/server-utils/src/ai/openai/types.ts
+++ b/packages/server-utils/src/ai/openai/types.ts
@@ -16,17 +16,6 @@ export type AttributeValue =
 /** Options for the OpenAI integration. */
 export type OpenAiOptions = GenAiOptions;
 
-export interface OpenAiClient {
-  responses?: {
-    create: (...args: unknown[]) => Promise<unknown>;
-  };
-  chat?: {
-    completions?: {
-      create: (...args: unknown[]) => Promise<unknown>;
-    };
-  };
-}
-
 /**
  * @see https://platform.openai.com/docs/api-reference/chat/object
  */

--- a/packages/server-utils/src/ai/workers-ai/types.ts
+++ b/packages/server-utils/src/ai/workers-ai/types.ts
@@ -4,16 +4,6 @@ import type { GenAiOptions } from '../core/utils';
 export type WorkersAiOptions = GenAiOptions;
 
 /**
- * Minimal shape of the Cloudflare Workers AI binding (`env.AI`).
- * We only rely on the `run` method, everything else is passed through untouched.
- * @see https://developers.cloudflare.com/workers-ai/configuration/bindings/
- */
-export interface WorkersAiClient {
-  run: (model: string, inputs: Record<string, unknown>, options?: Record<string, unknown>) => Promise<unknown>;
-  [key: string]: unknown;
-}
-
-/**
  * The token usage reported by Workers AI text generation models.
  */
 export interface WorkersAiUsage {

--- a/packages/server-utils/test/ai/tracing/openai-integration-functions.test.ts
+++ b/packages/server-utils/test/ai/tracing/openai-integration-functions.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import type { OpenAiClient } from '../../../src/ai/openai/types';
 import { instrumentOpenAiClient } from '../../../src/ai/openai';
 
 interface FullOpenAIClient {
@@ -103,12 +102,11 @@ class MockOpenAIClient implements FullOpenAIClient {
 
 describe('OpenAI Integration Private Field Fix', () => {
   let mockClient: MockOpenAIClient;
-  let instrumentedClient: FullOpenAIClient & OpenAiClient;
+  let instrumentedClient: FullOpenAIClient;
 
   beforeEach(() => {
     mockClient = new MockOpenAIClient();
-    instrumentedClient = instrumentOpenAiClient(mockClient as unknown as OpenAiClient) as FullOpenAIClient &
-      OpenAiClient;
+    instrumentedClient = instrumentOpenAiClient(mockClient as unknown as object) as FullOpenAIClient;
   });
 
   it('should work with instrumented methods (chat.completions.create)', async () => {


### PR DESCRIPTION
Removes the unused `AnthropicAiClient`, `OpenAiClient`, `GoogleGenAIClient`, and `WorkersAiClient` interfaces (plus the now-orphaned `GoogleGenAIChat`), which aren't referenced by the generic `instrument*Client` functions and are already absent from the public API since the v11 move to `@sentry/server-utils`.