### PR TITLE
ref(server-utils): Remove unused AI integration interface types

### DIFF
--- a/packages/server-utils/src/ai/anthropic-ai/types.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/types.ts
@@ -49,14 +49,6 @@ type SuccessfulResponse = {
 export type AnthropicAiResponse = SuccessfulResponse | MessageError;
 
 /**
- * Anthropic AI Integration interface for type safety
- */
-export interface AnthropicAiIntegration {
-  name: string;
-  options: AnthropicAiOptions;
-}
-
-/**
  * Message type for Anthropic AI
  */
 export type AnthropicAiMessage = {

--- a/packages/server-utils/src/ai/langchain/types.ts
+++ b/packages/server-utils/src/ai/langchain/types.ts
@@ -91,14 +91,6 @@ export interface LangChainLLMResult {
 }
 
 /**
- * Integration interface for type safety
- */
-export interface LangChainIntegration {
-  name: string;
-  options: LangChainOptions;
-}
-
-/**
  * LangChain callback handler interface
  * Compatible with both BaseCallbackHandlerMethodsClass and BaseCallbackHandler from @langchain/core
  * Uses general types and index signature for maximum compatibility across LangChain versions

--- a/packages/server-utils/src/ai/langgraph/types.ts
+++ b/packages/server-utils/src/ai/langgraph/types.ts
@@ -69,11 +69,3 @@ export interface CompiledGraph {
   };
   builder?: StateGraphBuilder;
 }
-
-/**
- * LangGraph Integration interface for type safety
- */
-export interface LangGraphIntegration {
-  name: string;
-  options: LangGraphOptions;
-}

--- a/packages/server-utils/src/ai/openai/types.ts
+++ b/packages/server-utils/src/ai/openai/types.ts
@@ -332,11 +332,3 @@ export interface ChatCompletionChunk {
 export interface OpenAIStream<T> extends AsyncIterable<T> {
   [Symbol.asyncIterator](): AsyncIterator<T>;
 }
-
-/**
- * OpenAI Integration interface for type safety
- */
-export interface OpenAiIntegration {
-  name: string;
-  options: OpenAiOptions;
-}


### PR DESCRIPTION
Removes the unused `AnthropicAiIntegration`, `OpenAiIntegration`, `LangChainIntegration`, and `LangGraphIntegration` interfaces, whose last consumers were dropped in earlier refactors and which are already absent from the public API since the v11 move to `@sentry/server-utils`.