### PR TITLE
ref(server-utils): Remove dead Vercel AI tool-call span-context tracking

### DIFF
--- a/packages/server-utils/src/ai/vercel-ai/constants.ts
+++ b/packages/server-utils/src/ai/vercel-ai/constants.ts
@@ -1,10 +1,3 @@
-import type { ToolCallSpanContext } from './types';
-
-// Global map to track tool call IDs to their corresponding span contexts.
-// This allows us to capture tool errors and link them to the correct span
-// without keeping full Span objects (and their potentially large attributes) alive.
-export const toolCallSpanContextMap = new Map<string, ToolCallSpanContext>();
-
 // Used to make tool descriptions available to execute_tool spans in the span streaming path.
 // Streamed spans are processed individually, so execute_tool spans cannot look up descriptions
 // from their sibling doGenerate span on span end (as we do for transactions).

--- a/packages/server-utils/src/ai/vercel-ai/index.ts
+++ b/packages/server-utils/src/ai/vercel-ai/index.ts
@@ -33,7 +33,7 @@ import {
 } from '@sentry/conventions/attributes';
 import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
 import { GEN_AI_TOOL_CALL_ID_ATTRIBUTE } from '../core/gen-ai-attributes';
-import { SPAN_TO_OPERATION_NAME, toolCallSpanContextMap, toolDescriptionMap } from './constants';
+import { SPAN_TO_OPERATION_NAME, toolDescriptionMap } from './constants';
 import type { TokenSummary } from './types';
 import {
   accumulateTokensForParent,
@@ -410,15 +410,6 @@ function processToolCallSpan(span: Span, attributes: SpanAttributes): void {
   span.setAttribute(GEN_AI_OPERATION_NAME, 'execute_tool');
   renameAttributeKey(attributes, AI_TOOL_CALL_NAME_ATTRIBUTE, GEN_AI_TOOL_NAME);
   renameAttributeKey(attributes, AI_TOOL_CALL_ID_ATTRIBUTE, GEN_AI_TOOL_CALL_ID_ATTRIBUTE);
-
-  // Store the span context in our global map using the tool call ID.
-  // This allows us to capture tool errors and link them to the correct span
-  // without retaining the full Span object in memory.
-  const toolCallId = attributes[GEN_AI_TOOL_CALL_ID_ATTRIBUTE];
-
-  if (typeof toolCallId === 'string') {
-    toolCallSpanContextMap.set(toolCallId, span.spanContext());
-  }
 
   const toolName = attributes[GEN_AI_TOOL_NAME];
   if (toolName) {

--- a/packages/server-utils/src/ai/vercel-ai/types.ts
+++ b/packages/server-utils/src/ai/vercel-ai/types.ts
@@ -2,8 +2,3 @@ export interface TokenSummary {
   inputTokens: number;
   outputTokens: number;
 }
-
-export interface ToolCallSpanContext {
-  traceId: string;
-  spanId: string;
-}

--- a/packages/server-utils/src/ai/vercel-ai/utils.ts
+++ b/packages/server-utils/src/ai/vercel-ai/utils.ts
@@ -11,8 +11,7 @@ import {
   GEN_AI_USAGE_OUTPUT_TOKENS,
 } from '@sentry/conventions/attributes';
 import { extractSystemInstructions } from '../core/utils';
-import { toolCallSpanContextMap } from './constants';
-import type { TokenSummary, ToolCallSpanContext } from './types';
+import type { TokenSummary } from './types';
 import { AI_PROMPT_ATTRIBUTE, AI_PROMPT_MESSAGES_ATTRIBUTE } from './vercel-ai-attributes';
 
 /**
@@ -121,20 +120,6 @@ export function applyToolDescriptionsAndTokens(spans: SpanJSON[], tokenAccumulat
       applyAccumulatedTokens(span, tokenAccumulator);
     }
   }
-}
-
-/**
- * Get the span context associated with a tool call ID.
- */
-export function _INTERNAL_getSpanContextForToolCallId(toolCallId: string): ToolCallSpanContext | undefined {
-  return toolCallSpanContextMap.get(toolCallId);
-}
-
-/**
- * Clean up the span mapping for a tool call ID
- */
-export function _INTERNAL_cleanupToolCallSpanContext(toolCallId: string): void {
-  toolCallSpanContextMap.delete(toolCallId);
 }
 
 /**


### PR DESCRIPTION
This mechanism is no longer needed but we still had these leftovers. We need to remove this because the map still gets filled with entries but these get never deleted resulting in a memory leak.