### PR TITLE
deps(nuxt): Bump `@nuxt/kit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-Work in this release was contributed by @psh4607, @trinitiwowka, @nehaprasad-dev, @JealousGx, @Jxxunnn, @eddie333016, @davidmurdoch, and @yashschandra. Thank you for your contributions!
+Work in this release was contributed by @psh4607, @thijsw, @trinitiwowka, @nehaprasad-dev, @JealousGx, @Jxxunnn, @eddie333016, @davidmurdoch, and @yashschandra. Thank you for your contributions!
 
 - feat(deno)!: Rename several default integrations to match the other SDKs ([#22404](https://github.com/getsentry/sentry-javascript/pull/22404)). The `deno*Integration` exports are kept as deprecated aliases. If you were relying on the names (for example, to disable them), then note that these have changed:
   - `DenoAmqplib` => `Amqplib`

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@nuxt/kit": "^3.13.2",
+    "@nuxt/kit": "^4.5.2",
     "@sentry/browser": "10.67.0",
     "@sentry/cloudflare": "10.67.0",
     "@sentry/conventions": "^0.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5885,7 +5885,7 @@
     which "^6.0.1"
     ws "^8.21.1"
 
-"@nuxt/kit@3.21.11", "@nuxt/kit@^3.13.2":
+"@nuxt/kit@3.21.11":
   version "3.21.11"
   resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-3.21.11.tgz#983c40f57ce222149dce212485c64bc56f663cc8"
   integrity sha512-0Xi3tgwN77w43Q8GCPIrvWmF1J7Peehkts44E0uKNIml9lB8WoUn8YxyUjxBv47XtVR86NWoWALAT+/IEMHJEA==
@@ -5912,7 +5912,7 @@
     unctx "^2.5.0"
     untyped "^2.0.0"
 
-"@nuxt/kit@^4.5.1":
+"@nuxt/kit@^4.5.1", "@nuxt/kit@^4.5.2":
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/@nuxt/kit/-/kit-4.5.2.tgz#fa338b169d14d9e66f973ded551d2376edb72398"
   integrity sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==


### PR DESCRIPTION

See this PR (contributed by @thijsw):
- https://github.com/getsentry/sentry-javascript/pull/22713

Bumping`@nuxt/kit` to v4 was suggested by the Nuxt maintainers. This is backwards compatible with Nuxt v3.

Closes https://github.com/getsentry/sentry-javascript/issues/22679
