### PR TITLE
ref(core): Type metric units with MetricUnit

### DIFF
--- a/packages/core/src/metrics/public-api.ts
+++ b/packages/core/src/metrics/public-api.ts
@@ -1,4 +1,5 @@
 import type { Scope } from '../scope';
+import type { MetricUnit } from '../types/measurement';
 import type { Metric, MetricType } from '../types/metric';
 import { _INTERNAL_captureMetric } from './internal';
 
@@ -9,7 +10,7 @@ export interface MetricOptions {
   /**
    * The unit of the metric value.
    */
-  unit?: string;
+  unit?: MetricUnit;
 
   /**
    * Arbitrary structured data that stores information about the metric.

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -487,6 +487,7 @@ export type {
   InformationUnit,
   FractionUnit,
   MeasurementUnit,
+  MetricUnit,
   NoneUnit,
   Measurements,
 } from './types/measurement';

--- a/packages/core/src/types/measurement.ts
+++ b/packages/core/src/types/measurement.ts
@@ -43,3 +43,7 @@ type LiteralUnion<T extends string> = T | Omit<T, T>;
 export type MeasurementUnit = LiteralUnion<DurationUnit | InformationUnit | FractionUnit | NoneUnit>;
 
 export type Measurements = Record<string, { value: number; unit: MeasurementUnit }>;
+
+// Unlike MeasurementUnit, metric units have no NoneUnit: a unitless metric omits the unit field
+// rather than sending 'none'. See https://develop.sentry.dev/sdk/telemetry/attributes/#units
+export type MetricUnit = LiteralUnion<DurationUnit | InformationUnit | FractionUnit>;

--- a/packages/core/src/types/metric.ts
+++ b/packages/core/src/types/metric.ts
@@ -1,4 +1,5 @@
 import type { Attributes, TypedAttributeValue } from '../attributes';
+import type { MetricUnit } from './measurement';
 
 export type MetricType = 'counter' | 'gauge' | 'distribution';
 
@@ -21,7 +22,7 @@ export interface Metric {
   /**
    * The unit of the metric value.
    */
-  unit?: string;
+  unit?: MetricUnit;
 
   /**
    * Arbitrary structured data that stores information about the metric.
@@ -63,7 +64,7 @@ export interface SerializedMetric {
   /**
    * The unit of the metric value.
    */
-  unit?: string;
+  unit?: MetricUnit;
 
   /**
    * The value of the metric.


### PR DESCRIPTION
Types the `unit` field on the metrics API (`MetricOptions`, `Metric`, `SerializedMetric`) instead of leaving it as a bare `string`.

It reuses the existing `LiteralUnion` helper so the canonical units that match the develop docs get autocomplete while arbitrary strings still pass through, which the spec requires ("SDKs MUST NOT restrict unit values").

I did not reuse `MeasurementUnit` here as it carries a `NoneUnit` (`'' | 'none'`) that is a leftover from the old transaction-measurement system and is not a valid metric unit.

This doesn't change anything about the API, is still accepts `string` but just provides autocomplete on the common values we use throughout our codebase, it's mostly a DX change for us.