### PR TITLE
fix(deno)!: Enable sessions for HTTP requests and align option names

### DIFF
--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -542,6 +542,21 @@ Sentry.httpIntegration({
 
 `httpIntegration`'s `instrumentation` option is still honored for **outgoing** request spans.
 
+### Deno `node:http` server requests are tracked as sessions
+
+Affected SDKs: `@sentry/deno`.
+
+`denoHttpIntegration` now creates [Sessions](https://docs.sentry.io/product/releases/health/#sessions) for incoming `node:http` requests, matching the other server SDKs. In v10 it disabled them unconditionally, so release health reported no session data for Deno servers. If you have a `release` configured, you will start seeing session aggregates for incoming requests. Pass `sessions: false` to restore the previous behavior:
+
+```js
+Sentry.init({
+  dsn: '__DSN__',
+  integrations: [Sentry.denoHttpIntegration({ sessions: false })],
+});
+```
+
+`sessionFlushingDelayMS` is also configurable now, and defaults to `60000` (60s) as in the other SDKs.
+
 ### Node HTTP transport `keepAlive` defaults to `true`
 
 Affected SDKs: `@sentry/node` and dependents.
@@ -1267,6 +1282,33 @@ Several default integrations were renamed to match the names used by the other S
 - `DenoMongoose` => `Mongoose`
 - `DenoMysql` => `Mysql`
 - `DenoPostgres` => `Postgres`
+
+### `denoHttpIntegration` incoming span hooks renamed
+
+Affected SDKs: `@sentry/deno`.
+
+The incoming-span hooks on `denoHttpIntegration` were renamed to match `httpIntegration` in the other server SDKs. Their arguments are typed as `HttpIncomingMessage` / `HttpServerResponse` now, instead of `unknown`.
+
+| Removed option          | Replacement     |
+| ----------------------- | --------------- |
+| `onIncomingSpanCreated` | `onSpanCreated` |
+| `onIncomingSpanEnd`     | `onSpanEnd`     |
+
+```js
+// before
+Sentry.denoHttpIntegration({
+  onIncomingSpanCreated: (span, req, res) => {
+    span.setAttribute('custom', true);
+  },
+});
+
+// after
+Sentry.denoHttpIntegration({
+  onSpanCreated: (span, req, res) => {
+    span.setAttribute('custom', true);
+  },
+});
+```
 
 ### `OtlpIntegration` integration renamed to `Otlp`
 

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -97,14 +97,15 @@ const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
     setupOnce() {
       const { [HTTP_ON_SERVER_REQUEST]: onHttpServerRequest } = getHttpServerSubscriptions({
         ...options,
+        // TODO: consolidate confusingly named HTTP instrumentation options
+        onSpanCreated: options.onIncomingSpanCreated,
+        onSpanEnd: options.onIncomingSpanEnd,
         errorMonitor,
       });
       subscribe(HTTP_ON_SERVER_REQUEST, onHttpServerRequest);
 
       const { [HTTP_ON_CLIENT_REQUEST]: onHttpClientRequest } = getHttpClientSubscriptions({
-        ...options,
         breadcrumbs,
-        // TODO: consolidate confusingly named HTTP instrumentation options
         propagateTrace: tracePropagation,
         ignoreOutgoingRequests: options.ignoreOutgoingRequests
           ? (url, request) => options.ignoreOutgoingRequests!(url, getRequestOptions(request))

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -104,7 +104,6 @@ const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
         onSpanCreated: options.onIncomingSpanCreated,
         onSpanEnd: options.onIncomingSpanEnd,
         errorMonitor,
-        sessions: false,
       });
       subscribe(HTTP_ON_SERVER_REQUEST, onHttpServerRequest);
 

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -105,6 +105,7 @@ const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
       subscribe(HTTP_ON_SERVER_REQUEST, onHttpServerRequest);
 
       const { [HTTP_ON_CLIENT_REQUEST]: onHttpClientRequest } = getHttpClientSubscriptions({
+        ...options,
         breadcrumbs,
         propagateTrace: tracePropagation,
         ignoreOutgoingRequests: options.ignoreOutgoingRequests

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -1,7 +1,7 @@
 import { subscribe } from 'node:diagnostics_channel';
 import { errorMonitor } from 'node:events';
 import type { RequestOptions } from 'node:http';
-import type { HttpIncomingMessage, Integration, IntegrationFn, Span } from '@sentry/core';
+import type { HttpIncomingMessage, HttpServerResponse, Integration, IntegrationFn, Span } from '@sentry/core';
 import {
   defineIntegration,
   getHttpClientSubscriptions,
@@ -9,12 +9,11 @@ import {
   getRequestOptions,
   HTTP_ON_CLIENT_REQUEST,
   HTTP_ON_SERVER_REQUEST,
-  type HttpInstrumentationOptions,
 } from '@sentry/core';
 
 const INTEGRATION_NAME = 'DenoHttp' as const;
 
-export interface DenoHttpIntegrationOptions extends HttpInstrumentationOptions {
+export interface DenoHttpIntegrationOptions {
   /**
    * Whether breadcrumbs should be recorded for outgoing requests.
    *
@@ -27,6 +26,21 @@ export interface DenoHttpIntegrationOptions extends HttpInstrumentationOptions {
    * Defaults to the client's tracing configuration (`hasSpansEnabled`).
    */
   spans?: boolean;
+
+  /**
+   * Whether the integration should create [Sessions](https://docs.sentry.io/product/releases/health/#sessions) for
+   * incoming requests to track the health and crash-free rate of your releases in Sentry.
+   *
+   * @default `true`
+   */
+  sessions?: boolean;
+
+  /**
+   * Number of milliseconds until sessions are flushed as a session aggregate.
+   *
+   * @default `60000` (60s)
+   */
+  sessionFlushingDelayMS?: number;
 
   /**
    * Whether to inject trace propagation headers (sentry-trace, baggage) into outgoing HTTP requests.
@@ -78,14 +92,15 @@ export interface DenoHttpIntegrationOptions extends HttpInstrumentationOptions {
   ignoreOutgoingRequests?: (url: string, request: RequestOptions) => boolean;
 
   /**
-   * Hook invoked after the server span is created but before the request is handled.
+   * A hook that can be used to mutate the span for incoming requests.
+   * This is triggered after the span is created, but before it is recorded.
    */
-  onIncomingSpanCreated?: (span: Span, request: unknown, response: unknown) => void;
+  onSpanCreated?: (span: Span, request: HttpIncomingMessage, response: HttpServerResponse) => void;
 
   /**
-   * Hook invoked when the server span ends, before it is recorded.
+   * A hook that can be used to mutate the span one last time when the response is finished.
    */
-  onIncomingSpanEnd?: (span: Span, request: unknown, response: unknown) => void;
+  onSpanEnd?: (span: Span, request: HttpIncomingMessage, response: HttpServerResponse) => void;
 }
 
 const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
@@ -97,9 +112,6 @@ const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
     setupOnce() {
       const { [HTTP_ON_SERVER_REQUEST]: onHttpServerRequest } = getHttpServerSubscriptions({
         ...options,
-        // TODO: consolidate confusingly named HTTP instrumentation options
-        onSpanCreated: options.onIncomingSpanCreated,
-        onSpanEnd: options.onIncomingSpanEnd,
         errorMonitor,
       });
       subscribe(HTTP_ON_SERVER_REQUEST, onHttpServerRequest);

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -9,11 +9,12 @@ import {
   getRequestOptions,
   HTTP_ON_CLIENT_REQUEST,
   HTTP_ON_SERVER_REQUEST,
+  type HttpInstrumentationOptions,
 } from '@sentry/core';
 
 const INTEGRATION_NAME = 'DenoHttp' as const;
 
-export interface DenoHttpIntegrationOptions {
+export interface DenoHttpIntegrationOptions extends HttpInstrumentationOptions {
   /**
    * Whether breadcrumbs should be recorded for outgoing requests.
    *
@@ -95,21 +96,15 @@ const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
     name: INTEGRATION_NAME,
     setupOnce() {
       const { [HTTP_ON_SERVER_REQUEST]: onHttpServerRequest } = getHttpServerSubscriptions({
-        // `spans` falls through to the client's tracing config when unset.
-        spans: options.spans,
-        ignoreStaticAssets: options.ignoreStaticAssets,
-        ignoreIncomingRequests: options.ignoreIncomingRequests,
-        maxRequestBodySize: options.maxRequestBodySize,
-        ignoreRequestBody: options.ignoreRequestBody,
-        onSpanCreated: options.onIncomingSpanCreated,
-        onSpanEnd: options.onIncomingSpanEnd,
+        ...options,
         errorMonitor,
       });
       subscribe(HTTP_ON_SERVER_REQUEST, onHttpServerRequest);
 
       const { [HTTP_ON_CLIENT_REQUEST]: onHttpClientRequest } = getHttpClientSubscriptions({
-        spans: options.spans,
+        ...options,
         breadcrumbs,
+        // TODO: consolidate confusingly named HTTP instrumentation options
         propagateTrace: tracePropagation,
         ignoreOutgoingRequests: options.ignoreOutgoingRequests
           ? (url, request) => options.ignoreOutgoingRequests!(url, getRequestOptions(request))

--- a/packages/deno/test/deno-http-sessions-disabled.test.ts
+++ b/packages/deno/test/deno-http-sessions-disabled.test.ts
@@ -1,0 +1,64 @@
+// <reference lib="deno.ns" />
+
+/**
+ * Lives in its own file because `setupOnce` runs once per process
+ * (`installedIntegrations` guards it) and the diagnostics channel
+ * subscription is global. Deno gives each test file a fresh module graph,
+ * so this is the only way to install `denoHttpIntegration` with
+ * non-default options after `deno-http.test.ts` has installed it with
+ * the defaults.
+ */
+
+import * as http from 'node:http';
+import type { Envelope } from '@sentry/core';
+import { forEachEnvelopeItem, getIsolationScope, getMainCarrier } from '@sentry/core';
+import { assert } from 'https://deno.land/std@0.212.0/assert/assert.ts';
+import { assertEquals } from 'https://deno.land/std@0.212.0/assert/assert_equals.ts';
+import { denoHttpIntegration, init } from '../build/esm/index.js';
+import { makeTestTransport } from './transport.ts';
+
+Deno.test({
+  name: 'denoHttpIntegration: node:http incoming request records no session when sessions: false',
+  async fn() {
+    getMainCarrier().__SENTRY__ = undefined;
+
+    const envelopes: Envelope[] = [];
+    const client = init({
+      dsn: 'https://username@domain/123',
+      release: '1.0.0',
+      integrations: [denoHttpIntegration({ sessions: false })],
+      transport: makeTestTransport(envelope => {
+        envelopes.push(envelope);
+      }),
+    });
+
+    // Captured inside the handler so we can tell "sessions were disabled"
+    // apart from "the request was never instrumented at all".
+    let isolatedTransactionName: string | undefined;
+    const server = http.createServer((_req, res) => {
+      isolatedTransactionName = getIsolationScope().getScopeData().transactionName;
+      res.end('ok');
+    });
+    const port: number = await new Promise(resolve => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve((server.address() as { port: number }).port);
+      });
+    });
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    assertEquals(await response.text(), 'ok');
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    await client.flush(2_000);
+
+    const itemTypes: string[] = [];
+    for (const envelope of envelopes) {
+      forEachEnvelopeItem(envelope, ([headers]) => {
+        itemTypes.push(headers.type);
+      });
+    }
+
+    assertEquals(isolatedTransactionName, 'GET /health');
+    assert(!itemTypes.includes('sessions'), `expected no session envelope item, got: ${itemTypes.join(', ')}`);
+    assert(!itemTypes.includes('session'), `expected no session envelope item, got: ${itemTypes.join(', ')}`);
+  },
+});

--- a/packages/deno/test/deno-http-spans-disabled.test.ts
+++ b/packages/deno/test/deno-http-spans-disabled.test.ts
@@ -15,6 +15,7 @@ import type { TransactionEvent } from '@sentry/core';
 import { getIsolationScope, getMainCarrier } from '@sentry/core';
 import { assert } from 'https://deno.land/std@0.212.0/assert/assert.ts';
 import { assertEquals } from 'https://deno.land/std@0.212.0/assert/assert_equals.ts';
+import type { DenoClient } from '../build/esm/index.js';
 import { denoHttpIntegration, init, startSpan } from '../build/esm/index.js';
 
 /**
@@ -22,9 +23,9 @@ import { denoHttpIntegration, init, startSpan } from '../build/esm/index.js';
  * everywhere except the HTTP integration. Without it the option would be
  * indistinguishable from tracing being off.
  */
-function initWithSpansDisabled(transactions: TransactionEvent[]): void {
+function initWithSpansDisabled(transactions: TransactionEvent[]): DenoClient {
   getMainCarrier().__SENTRY__ = undefined;
-  init({
+  return init({
     dsn: 'https://username@domain/123',
     tracesSampleRate: 1,
     traceLifecycle: 'static',
@@ -33,14 +34,14 @@ function initWithSpansDisabled(transactions: TransactionEvent[]): void {
       transactions.push(event);
       return null;
     },
-  });
+  }) as DenoClient;
 }
 
 Deno.test({
   name: 'denoHttpIntegration: node:http outgoing request creates no http.client span when spans: false',
   async fn() {
     const transactions: TransactionEvent[] = [];
-    initWithSpansDisabled(transactions);
+    const client = initWithSpansDisabled(transactions);
 
     // Deno.serve for the target so this does not depend on the node:http
     // server instrumentation.
@@ -74,6 +75,10 @@ Deno.test({
     abortController.abort();
     await target.finished;
 
+    // Event capture runs through the client's async processing queue, so
+    // drain it before reading the sink -- otherwise these assertions race.
+    await client.flush(5_000);
+
     // The parent span proves tracing itself is live, so an absent
     // http.client span is the option working rather than tracing being off.
     assert(sentryTraceHeader, 'expected an injected sentry-trace header, so the client was instrumented');
@@ -92,7 +97,7 @@ Deno.test({
   name: 'denoHttpIntegration: node:http incoming request creates no http.server transaction when spans: false',
   async fn() {
     const transactions: TransactionEvent[] = [];
-    initWithSpansDisabled(transactions);
+    const client = initWithSpansDisabled(transactions);
 
     // Captured inside the handler so we can tell "spans were disabled" apart
     // from "the request was never instrumented at all".
@@ -110,6 +115,11 @@ Deno.test({
     const response = await fetch(`http://127.0.0.1:${port}/users/42`);
     assertEquals(await response.text(), 'ok');
     await new Promise<void>(resolve => server.close(() => resolve()));
+
+    // Drain the async processing queue first. Without this, "no http.server
+    // transaction yet" and "no http.server transaction at all" look alike,
+    // so the assertion below could pass while spans were still enabled.
+    await client.flush(5_000);
 
     // Request isolation still runs with spans off, so this proves the
     // instrumentation saw the request.

--- a/packages/deno/test/deno-http-spans-disabled.test.ts
+++ b/packages/deno/test/deno-http-spans-disabled.test.ts
@@ -1,0 +1,120 @@
+// <reference lib="deno.ns" />
+
+/**
+ * Lives in its own file because `setupOnce` runs once per process
+ * (`installedIntegrations` guards it) and the diagnostics channel
+ * subscription is global. Deno gives each test file a fresh module graph,
+ * so this is the only way to install `denoHttpIntegration` with
+ * `spans: false` after another file has installed it with the defaults.
+ *
+ * Both tests below share that single `spans: false` subscription.
+ */
+
+import * as http from 'node:http';
+import type { TransactionEvent } from '@sentry/core';
+import { getIsolationScope, getMainCarrier } from '@sentry/core';
+import { assert } from 'https://deno.land/std@0.212.0/assert/assert.ts';
+import { assertEquals } from 'https://deno.land/std@0.212.0/assert/assert_equals.ts';
+import { denoHttpIntegration, init, startSpan } from '../build/esm/index.js';
+
+/**
+ * `spans: false` must win over `tracesSampleRate: 1`, so tracing is on
+ * everywhere except the HTTP integration. Without it the option would be
+ * indistinguishable from tracing being off.
+ */
+function initWithSpansDisabled(transactions: TransactionEvent[]): void {
+  getMainCarrier().__SENTRY__ = undefined;
+  init({
+    dsn: 'https://username@domain/123',
+    tracesSampleRate: 1,
+    traceLifecycle: 'static',
+    integrations: [denoHttpIntegration({ spans: false })],
+    beforeSendTransaction: (event: TransactionEvent) => {
+      transactions.push(event);
+      return null;
+    },
+  });
+}
+
+Deno.test({
+  name: 'denoHttpIntegration: node:http outgoing request creates no http.client span when spans: false',
+  async fn() {
+    const transactions: TransactionEvent[] = [];
+    initWithSpansDisabled(transactions);
+
+    // Deno.serve for the target so this does not depend on the node:http
+    // server instrumentation.
+    const abortController = new AbortController();
+    let onListen: ((_: unknown) => void) | undefined;
+    const listening = new Promise(resolve => (onListen = resolve));
+    // Captured so we can tell "spans were disabled" apart from "the client
+    // was never instrumented at all" -- header injection survives spans: false.
+    let sentryTraceHeader: string | null = null;
+    const target = Deno.serve(
+      { port: 0, signal: abortController.signal, onListen, hostname: '127.0.0.1' },
+      (request: Request) => {
+        sentryTraceHeader = request.headers.get('sentry-trace');
+        return new Response('pong');
+      },
+    );
+    await listening;
+
+    await startSpan({ name: 'parent', op: 'test' }, async () => {
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request({ host: '127.0.0.1', port: target.addr.port, path: '/ping', method: 'GET' }, res => {
+          res.on('data', () => {});
+          res.on('end', () => resolve());
+          res.on('error', reject);
+        });
+        req.on('error', reject);
+        req.end();
+      });
+    });
+
+    abortController.abort();
+    await target.finished;
+
+    // The parent span proves tracing itself is live, so an absent
+    // http.client span is the option working rather than tracing being off.
+    assert(sentryTraceHeader, 'expected an injected sentry-trace header, so the client was instrumented');
+    const parent = transactions.find(t => t.transaction === 'parent');
+    assert(parent, `expected the 'parent' transaction, got: ${transactions.map(t => t.transaction).join(', ')}`);
+    const childOps = parent!.spans?.map(s => s.op) ?? [];
+    assertEquals(
+      childOps.includes('http.client'),
+      false,
+      `expected no http.client span, got ops: ${childOps.join(', ')}`,
+    );
+  },
+});
+
+Deno.test({
+  name: 'denoHttpIntegration: node:http incoming request creates no http.server transaction when spans: false',
+  async fn() {
+    const transactions: TransactionEvent[] = [];
+    initWithSpansDisabled(transactions);
+
+    // Captured inside the handler so we can tell "spans were disabled" apart
+    // from "the request was never instrumented at all".
+    let isolatedTransactionName: string | undefined;
+    const server = http.createServer((_req, res) => {
+      isolatedTransactionName = getIsolationScope().getScopeData().transactionName;
+      res.end('ok');
+    });
+    const port: number = await new Promise(resolve => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve((server.address() as { port: number }).port);
+      });
+    });
+
+    const response = await fetch(`http://127.0.0.1:${port}/users/42`);
+    assertEquals(await response.text(), 'ok');
+    await new Promise<void>(resolve => server.close(() => resolve()));
+
+    // Request isolation still runs with spans off, so this proves the
+    // instrumentation saw the request.
+    assertEquals(isolatedTransactionName, 'GET /users/42');
+    const ops = transactions.map(t => t.contexts?.trace?.op);
+    assertEquals(ops.includes('http.server'), false, `expected no http.server transaction, got ops: ${ops.join(', ')}`);
+  },
+});

--- a/packages/deno/test/deno-http.test.ts
+++ b/packages/deno/test/deno-http.test.ts
@@ -112,7 +112,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: 'denoHttpIntegration: node:http incoming request records a release-health session',
+  name: 'denoHttpIntegration: node:http incoming request records a release-health session by default',
   async fn() {
     resetGlobals();
     const envelopes: Envelope[] = [];

--- a/packages/deno/test/deno-http.test.ts
+++ b/packages/deno/test/deno-http.test.ts
@@ -1,13 +1,14 @@
 // <reference lib="deno.ns" />
 
 import * as http from 'node:http';
-import type { TransactionEvent } from '@sentry/core';
-import { getMainCarrier } from '@sentry/core';
+import type { Envelope, SessionAggregates, TransactionEvent } from '@sentry/core';
+import { forEachEnvelopeItem, getMainCarrier } from '@sentry/core';
 import { assert } from 'https://deno.land/std@0.212.0/assert/assert.ts';
 import { assertEquals } from 'https://deno.land/std@0.212.0/assert/assert_equals.ts';
 import { assertExists } from 'https://deno.land/std@0.212.0/assert/assert_exists.ts';
 import type { DenoClient } from '../build/esm/index.js';
 import { init, startSpan } from '../build/esm/index.js';
+import { makeTestTransport } from './transport.ts';
 
 function resetGlobals(): void {
   getMainCarrier().__SENTRY__ = undefined;
@@ -107,6 +108,52 @@ Deno.test({
     assertEquals(txn.transaction, 'QUERY /users/42');
     assertEquals(txn.contexts?.trace?.data?.['http.method'], 'QUERY');
     assertEquals(txn.contexts?.trace?.data?.['http.response.status_code'], 200);
+  },
+});
+
+Deno.test({
+  name: 'denoHttpIntegration: node:http incoming request records a release-health session',
+  async fn() {
+    resetGlobals();
+    const envelopes: Envelope[] = [];
+    const client = init({
+      dsn: 'https://username@domain/123',
+      release: '1.0.0',
+      transport: makeTestTransport(envelope => {
+        envelopes.push(envelope);
+      }),
+    });
+
+    const server = http.createServer((_req, res) => {
+      res.end('ok');
+    });
+    const port: number = await new Promise(resolve => {
+      server.listen(0, '127.0.0.1', () => {
+        resolve((server.address() as { port: number }).port);
+      });
+    });
+
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    assertEquals(await response.text(), 'ok');
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    await client.flush(2_000);
+
+    let sessionAggregates: SessionAggregates | undefined;
+    for (const envelope of envelopes) {
+      forEachEnvelopeItem(envelope, item => {
+        const [headers, body] = item;
+        if (headers.type === 'sessions') {
+          sessionAggregates = body as SessionAggregates;
+        }
+      });
+    }
+
+    assertExists(sessionAggregates);
+    assertEquals(sessionAggregates.attrs?.release, '1.0.0');
+    assertEquals(sessionAggregates.aggregates.length, 1);
+    assertEquals(sessionAggregates.aggregates[0]?.exited, 1);
+    assertEquals(sessionAggregates.aggregates[0]?.errored, 0);
+    assertEquals(sessionAggregates.aggregates[0]?.crashed, 0);
   },
 });
 


### PR DESCRIPTION
Deno's `node:http` server integration disabled release-health sessions even<br>though the shared HTTP instrumentation enables them by default. Keeping the<br>shared default aligns Deno with the other server runtimes and restores session<br>aggregates for incoming requests when a release is configured.

## Root cause

The Deno integration passed `sessions: false` when it subscribed to shared HTTP<br>server instrumentation. There is no Deno-specific duplicate instrumentation<br>that requires that override.

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [X] Link an issue if there is one related to your pull request.

Fixes getsentry/sentry-javascript#22888