### PR TITLE
fix(server-utils): Record LangGraph span I/O for non-MessagesAnnotation state

### DIFF
--- a/packages/server-utils/src/ai/langgraph/index.ts
+++ b/packages/server-utils/src/ai/langgraph/index.ts
@@ -155,23 +155,31 @@ export function instrumentCompiledGraphInvoke(
               span.setAttribute(GEN_AI_TOOL_DEFINITIONS, JSON.stringify(tools));
             }
 
-            // Parse input messages
+            // Parse input state. MessagesAnnotation graphs expose a `messages` array. A custom state
+            // annotation exposes arbitrary keys instead, so the whole state is recorded as a fallback
+            // rather than dropped silently.
             const recordInputs = options.recordInputs;
             const recordOutputs = options.recordOutputs;
-            const inputMessages =
-              args.length > 0 ? ((args[0] as { messages?: LangChainMessage[] } | null)?.messages ?? []) : [];
+            const inputState = args.length > 0 ? args[0] : undefined;
+            const inputMessages = (inputState as { messages?: LangChainMessage[] } | null)?.messages ?? [];
 
-            if (inputMessages && recordInputs) {
-              const normalizedMessages = normalizeLangChainMessages(inputMessages);
-              const { systemInstructions, filteredMessages } = extractSystemInstructions(normalizedMessages);
+            if (recordInputs) {
+              if (inputMessages.length > 0) {
+                const normalizedMessages = normalizeLangChainMessages(inputMessages);
+                const { systemInstructions, filteredMessages } = extractSystemInstructions(normalizedMessages);
 
-              if (systemInstructions) {
-                span.setAttribute(GEN_AI_SYSTEM_INSTRUCTIONS, systemInstructions);
+                if (systemInstructions) {
+                  span.setAttribute(GEN_AI_SYSTEM_INSTRUCTIONS, systemInstructions);
+                }
+
+                span.setAttributes({
+                  [GEN_AI_INPUT_MESSAGES]: stringify(filteredMessages),
+                });
+              } else if (inputState && typeof inputState === 'object') {
+                span.setAttributes({
+                  [GEN_AI_INPUT_MESSAGES]: stringify([{ role: 'user', content: stringify(inputState) }]),
+                });
               }
-
-              span.setAttributes({
-                [GEN_AI_INPUT_MESSAGES]: stringify(filteredMessages),
-              });
             }
 
             // Call original invoke

--- a/packages/server-utils/src/ai/langgraph/index.ts
+++ b/packages/server-utils/src/ai/langgraph/index.ts
@@ -155,16 +155,18 @@ export function instrumentCompiledGraphInvoke(
               span.setAttribute(GEN_AI_TOOL_DEFINITIONS, JSON.stringify(tools));
             }
 
-            // Parse input state. MessagesAnnotation graphs expose a `messages` array. A custom state
-            // annotation exposes arbitrary keys instead, so the whole state is recorded as a fallback
-            // rather than dropped silently.
+            // Parse input state. MessagesAnnotation graphs expose a `messages` array (possibly empty);
+            // a custom state annotation exposes arbitrary keys instead. Route on whether `messages` is
+            // an array, mirroring the output side in setResponseAttributes, so an empty chat history is
+            // recorded as an empty chat array rather than misread as custom state and wrapped.
             const recordInputs = options.recordInputs;
             const recordOutputs = options.recordOutputs;
             const inputState = args.length > 0 ? args[0] : undefined;
-            const inputMessages = (inputState as { messages?: LangChainMessage[] } | null)?.messages ?? [];
+            const stateMessages = (inputState as { messages?: LangChainMessage[] } | null)?.messages;
+            const inputMessages = Array.isArray(stateMessages) ? stateMessages : null;
 
             if (recordInputs) {
-              if (inputMessages.length > 0) {
+              if (inputMessages) {
                 const normalizedMessages = normalizeLangChainMessages(inputMessages);
                 const { systemInstructions, filteredMessages } = extractSystemInstructions(normalizedMessages);
 
@@ -186,7 +188,7 @@ export function instrumentCompiledGraphInvoke(
             const result = await Reflect.apply(target, thisArg, args);
 
             if (recordOutputs) {
-              setResponseAttributes(span, inputMessages ?? null, result);
+              setResponseAttributes(span, inputMessages, result);
             }
 
             return result;

--- a/packages/server-utils/src/ai/langgraph/utils.ts
+++ b/packages/server-utils/src/ai/langgraph/utils.ts
@@ -5,6 +5,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   startSpan,
+  stringify,
 } from '@sentry/core';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
@@ -285,6 +286,11 @@ export function setResponseAttributes(span: Span, inputMessages: LangChainMessag
   const outputMessages = resultObj?.messages;
 
   if (!outputMessages || !Array.isArray(outputMessages)) {
+    // A custom state annotation has no `messages` array. Record the whole output state as a
+    // fallback so it is not dropped silently.
+    if (result && typeof result === 'object') {
+      span.setAttribute(GEN_AI_RESPONSE_TEXT, stringify([{ role: 'assistant', content: stringify(result) }]));
+    }
     return;
   }
 

--- a/packages/server-utils/test/ai/lib/tracing/langgraph.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langgraph.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { GEN_AI_INPUT_MESSAGES, GEN_AI_RESPONSE_TEXT } from '@sentry/conventions/attributes';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getMainCarrier, setCurrentClient, spanToJSON } from '@sentry/core';
+import type { Span } from '@sentry/core';
 import {
   instrumentCreateReactAgent,
   instrumentStateGraph,
   instrumentStateGraphCompile,
 } from '../../../../src/ai/langgraph';
+import { getDefaultTestClientOptions, TestClient } from '../../../mocks/client';
 
 describe('langgraph double-patch guard', () => {
   it('instrumentStateGraphCompile returns the same wrapper when applied twice', () => {
@@ -30,5 +34,108 @@ describe('instrumentStateGraph', () => {
 
     expect(result).toBe(stateGraph);
     expect(stateGraph.compile).not.toBe(originalCompile);
+  });
+});
+
+describe('invoke_agent input/output recording', () => {
+  beforeEach(() => {
+    getMainCarrier().__SENTRY__ = undefined;
+  });
+
+  afterEach(() => {
+    getMainCarrier().__SENTRY__ = undefined;
+  });
+
+  function setupClient(): Span[] {
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://public@dsn.ingest.sentry.io/1337',
+        tracesSampleRate: 1,
+      }),
+    );
+    setCurrentClient(client);
+    client.init();
+
+    const endedSpans: Span[] = [];
+    client.on('spanEnd', span => endedSpans.push(span));
+    return endedSpans;
+  }
+
+  // Regression test for a graph built on a custom state annotation (no `messages` key). The
+  // instrumentation used to read `args[0].messages` only, so the whole state was dropped.
+  it('records the full state for a graph that does not use MessagesAnnotation', async () => {
+    const endedSpans = setupClient();
+
+    const compiled = {
+      invoke: async (input: Record<string, unknown>) => ({ ...input, expanded: 'expanded idea', validated: true }),
+    };
+    const stateGraph = { compile: () => compiled };
+
+    instrumentStateGraph(stateGraph, { recordInputs: true, recordOutputs: true });
+    const graph = stateGraph.compile();
+    const result = await graph.invoke({ idea: 'test idea' });
+
+    expect(result).toEqual({ idea: 'test idea', expanded: 'expanded idea', validated: true });
+    expect(endedSpans).toHaveLength(1);
+
+    const data = spanToJSON(endedSpans[0]!).data;
+
+    const inputMessages = data[GEN_AI_INPUT_MESSAGES] as string | undefined;
+    expect(inputMessages).toBeDefined();
+    const parsedInput = JSON.parse(inputMessages!) as Array<{ role: string; content: string }>;
+    expect(parsedInput).toHaveLength(1);
+    expect(parsedInput[0]!.role).toBe('user');
+    expect(JSON.parse(parsedInput[0]!.content)).toEqual({ idea: 'test idea' });
+
+    const responseText = data[GEN_AI_RESPONSE_TEXT] as string | undefined;
+    expect(responseText).toBeDefined();
+    const parsedOutput = JSON.parse(responseText!) as Array<{ role: string; content: string }>;
+    expect(parsedOutput[0]!.role).toBe('assistant');
+    expect(JSON.parse(parsedOutput[0]!.content)).toEqual({
+      idea: 'test idea',
+      expanded: 'expanded idea',
+      validated: true,
+    });
+  });
+
+  it('still records chat messages for a MessagesAnnotation graph', async () => {
+    const endedSpans = setupClient();
+
+    const compiled = {
+      invoke: async (input: { messages: Array<{ role: string; content: string }> }) => ({
+        messages: [...input.messages, { role: 'assistant', content: 'The weather is sunny' }],
+      }),
+    };
+    const stateGraph = { compile: () => compiled };
+
+    instrumentStateGraph(stateGraph, { recordInputs: true, recordOutputs: true });
+    const graph = stateGraph.compile();
+    await graph.invoke({ messages: [{ role: 'user', content: 'What is the weather today?' }] });
+
+    const data = spanToJSON(endedSpans[0]!).data;
+
+    const inputMessages = data[GEN_AI_INPUT_MESSAGES] as string | undefined;
+    expect(inputMessages).toBeDefined();
+    expect(JSON.parse(inputMessages!)).toEqual([{ role: 'user', content: 'What is the weather today?' }]);
+
+    const responseText = data[GEN_AI_RESPONSE_TEXT] as string | undefined;
+    expect(responseText).toBeDefined();
+    expect(responseText).toContain('The weather is sunny');
+  });
+
+  it('does not record input messages when invoked with null input', async () => {
+    const endedSpans = setupClient();
+
+    const compiled = {
+      invoke: async (_input?: unknown) => ({ messages: [{ role: 'assistant', content: 'resumed' }] }),
+    };
+    const stateGraph = { compile: () => compiled };
+
+    instrumentStateGraph(stateGraph, { recordInputs: true, recordOutputs: true });
+    const graph = stateGraph.compile();
+    await expect(graph.invoke(null)).resolves.toBeDefined();
+
+    const data = spanToJSON(endedSpans[0]!).data;
+    expect(data[GEN_AI_INPUT_MESSAGES]).toBeUndefined();
   });
 });

--- a/packages/server-utils/test/ai/lib/tracing/langgraph.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langgraph.test.ts
@@ -123,6 +123,31 @@ describe('invoke_agent input/output recording', () => {
     expect(responseText).toContain('The weather is sunny');
   });
 
+  it('records an empty messages array on the chat path rather than wrapping it as custom state', async () => {
+    const endedSpans = setupClient();
+
+    const compiled = {
+      invoke: async (_input: { messages: Array<{ role: string; content: string }> }) => ({
+        messages: [{ role: 'assistant', content: 'Hello' }],
+      }),
+    };
+    const stateGraph = { compile: () => compiled };
+
+    instrumentStateGraph(stateGraph, { recordInputs: true, recordOutputs: true });
+    const graph = stateGraph.compile();
+    await graph.invoke({ messages: [] });
+
+    const data = spanToJSON(endedSpans[0]!).data;
+
+    const inputMessages = data[GEN_AI_INPUT_MESSAGES] as string | undefined;
+    expect(inputMessages).toBeDefined();
+    expect(JSON.parse(inputMessages!)).toEqual([]);
+
+    const responseText = data[GEN_AI_RESPONSE_TEXT] as string | undefined;
+    expect(responseText).toBeDefined();
+    expect(responseText).toContain('Hello');
+  });
+
   it('does not record input messages when invoked with null input', async () => {
     const endedSpans = setupClient();
 


### PR DESCRIPTION
`instrumentLangGraph` recorded span input and output only when the graph state uses `MessagesAnnotation`. The input read did `args[0].messages ?? []` and the output helper returned early when `result.messages` was not an array, so a graph on a custom state annotation produced an empty `gen_ai.input.messages` and no `gen_ai.response.text`. No error, just an empty `invoke_agent` span in the AI Agents view.

This keeps the `MessagesAnnotation` path unchanged. When there is no `messages` array, it serializes the whole input and output state and records it, wrapped as a single `{ role, content }` message so the attribute stays a valid chat array (the convention `extractLLMRequestAttributes` already uses in this package). A null input (the resume case) records nothing rather than a misleading empty array. Serialization uses core's circular-safe `stringify` so an unusual state object cannot throw inside the span callback.

Fixes getsentry/sentry-javascript#19628

AI assistance (Claude, Anthropic) was used in developing this change. The design, review and verification were done by the author. Verified locally: the `@sentry/server-utils` vitest suite (335 to 339 passing), the new tests failing before and passing after the fix, `oxlint --type-aware`, `oxfmt --check`, `tsc` on the changed files, plus a real Google Gemini LangGraph run showing the span input and output empty before and populated after.