### PR TITLE
feat(core)!: Remove `enableMetrics` option

### DIFF
--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -485,6 +485,22 @@ Sentry.init({
 });
 ```
 
+### The `enableMetrics` option was removed
+
+Affected SDKs: All SDKs.
+
+The `enableMetrics` option was removed. Metrics now follow an opt-in-by-usage model: metrics are captured whenever you use a metric API (`Sentry.metrics.*`). There is no longer an option to disable metric capture once you use a metric API. The `beforeSendMetric` callback is unaffected and remains available as a top-level option.
+
+```js
+// before
+Sentry.init({
+  enableMetrics: true,
+});
+
+// after: no option needed, metrics are captured when you use a metric API
+Sentry.init({});
+```
+
 ### Browser sessions use `unhandled` instead of `crashed`
 
 Affected SDKs: All SDKs running in the browser.

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -669,7 +669,7 @@ Affected SDKs: `@sentry/cloudflare`.
 - The `createSpanEnvelope` function and the `SpanEnvelope` / `SpanItem` types were removed. They existed only to send standalone (v1) spans as their own segment envelope, which the SDK no longer does. Standalone spans are gone; spans are sent either on their transaction or, with span streaming, as streamed spans (`StreamedSpanEnvelope`).
 - The `disableInstrumentationWarnings` option and the `MissingInstrumentationContext` type were removed. Now that instrumentation is channel-based, the SDK can no longer detect the "you imported a framework before `Sentry.init()`" case, so the warning it gated and the context it attached no longer exist.
 - The deprecated `sendDefaultPii` option was removed. Use [`dataCollection`](#senddefaultpii-is-replaced-by-datacollection) instead.
-- The `_experiments.enableMetrics` and `_experiments.beforeSendMetric` options were removed, use the top-level `enableMetrics` and `beforeSendMetric` options instead.
+- The `_experiments.enableMetrics` and top-level `enableMetrics` options were removed. Metrics are now captured whenever you use a metric API (`Sentry.metrics.*`), so you can simply omit the option. The `_experiments.beforeSendMetric` callback moved to the top-level `beforeSendMetric` option.
 
 ```js
 // before
@@ -684,7 +684,6 @@ Sentry.init({
 
 // after
 Sentry.init({
-  enableMetrics: true,
   beforeSendMetric: metric => {
     return metric;
   },

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -485,22 +485,6 @@ Sentry.init({
 });
 ```
 
-### The `enableMetrics` option was removed
-
-Affected SDKs: All SDKs.
-
-The `enableMetrics` option was removed. Metrics now follow an opt-in-by-usage model: metrics are captured whenever you use a metric API (`Sentry.metrics.*`). There is no longer an option to disable metric capture once you use a metric API. The `beforeSendMetric` callback is unaffected and remains available as a top-level option.
-
-```js
-// before
-Sentry.init({
-  enableMetrics: true,
-});
-
-// after: no option needed, metrics are captured when you use a metric API
-Sentry.init({});
-```
-
 ### Browser sessions use `unhandled` instead of `crashed`
 
 Affected SDKs: All SDKs running in the browser.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -295,18 +295,14 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       setupWeightBasedFlushing(this, 'afterCaptureLog', 'flushLogs', estimateLogSizeInBytes, _INTERNAL_flushLogsBuffer);
     }
 
-    const enableMetrics = this._options.enableMetrics ?? true;
-
     // Setup metric flushing with weight and timeout tracking
-    if (enableMetrics) {
-      setupWeightBasedFlushing(
-        this,
-        'afterCaptureMetric',
-        'flushMetrics',
-        estimateMetricSizeInBytes,
-        _INTERNAL_flushMetricsBuffer,
-      );
-    }
+    setupWeightBasedFlushing(
+      this,
+      'afterCaptureMetric',
+      'flushMetrics',
+      estimateMetricSizeInBytes,
+      _INTERNAL_flushMetricsBuffer,
+    );
   }
 
   /**

--- a/packages/core/src/metrics/internal.ts
+++ b/packages/core/src/metrics/internal.ts
@@ -173,13 +173,7 @@ export function _INTERNAL_captureMetric(beforeMetric: Metric, options?: Internal
     return;
   }
 
-  const { enableMetrics, beforeSendMetric } = client.getOptions();
-  const metricsEnabled = enableMetrics ?? true;
-
-  if (!metricsEnabled) {
-    DEBUG_BUILD && debug.warn('metrics option not enabled, metric will not be captured.');
-    return;
-  }
+  const { beforeSendMetric } = client.getOptions();
 
   // Enrich metric with contextual attributes
   const { user, attributes: scopeAttributes } = getCombinedScopeData(getIsolationScope(), currentScope);

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -531,13 +531,6 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   beforeSendLog?: (log: Log) => Log | null;
 
   /**
-   * If metrics support should be enabled.
-   *
-   * @default true
-   */
-  enableMetrics?: boolean;
-
-  /**
    * Interval in ms for the idle flush timer used by logs and metrics.
    * Set to 0 to disable timer-based flushing entirely — useful for
    * serverless runtimes that forbid background timers (e.g. Cloudflare Workers).

--- a/packages/core/test/lib/metrics/internal.test.ts
+++ b/packages/core/test/lib/metrics/internal.test.ts
@@ -41,21 +41,6 @@ describe('_INTERNAL_captureMetric', () => {
     );
   });
 
-  it('does not capture metrics when enableMetrics is not enabled', () => {
-    const logWarnSpy = vi.spyOn(loggerModule.debug, 'warn').mockImplementation(() => undefined);
-    const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableMetrics: false });
-    const client = new TestClient(options);
-    const scope = new Scope();
-    scope.setClient(client);
-
-    _INTERNAL_captureMetric({ type: 'counter', name: 'test.metric', value: 1 }, { scope });
-
-    expect(logWarnSpy).toHaveBeenCalledWith('metrics option not enabled, metric will not be captured.');
-    expect(_INTERNAL_getMetricBuffer(client)).toBeUndefined();
-
-    logWarnSpy.mockRestore();
-  });
-
   it('includes trace context when available', () => {
     const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
     const client = new TestClient(options);

--- a/packages/core/test/lib/metrics/public-api.test.ts
+++ b/packages/core/test/lib/metrics/public-api.test.ts
@@ -112,17 +112,6 @@ describe('Metrics Public API', () => {
         }),
       );
     });
-
-    it('does not capture counter when enableMetrics is not enabled', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableMetrics: false });
-      const client = new TestClient(options);
-      const scope = new Scope();
-      scope.setClient(client);
-
-      count('api.requests', 1, { scope });
-
-      expect(_INTERNAL_getMetricBuffer(client)).toBeUndefined();
-    });
   });
 
   describe('gauge', () => {
@@ -206,17 +195,6 @@ describe('Metrics Public API', () => {
         }),
       );
     });
-
-    it('does not capture gauge when enableMetrics is not enabled', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableMetrics: false });
-      const client = new TestClient(options);
-      const scope = new Scope();
-      scope.setClient(client);
-
-      gauge('memory.usage', 1024, { scope });
-
-      expect(_INTERNAL_getMetricBuffer(client)).toBeUndefined();
-    });
   });
 
   describe('distribution', () => {
@@ -299,17 +277,6 @@ describe('Metrics Public API', () => {
           },
         }),
       );
-    });
-
-    it('does not capture distribution when enableMetrics is not enabled', () => {
-      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, enableMetrics: false });
-      const client = new TestClient(options);
-      const scope = new Scope();
-      scope.setClient(client);
-
-      distribution('task.duration', 500, { scope });
-
-      expect(_INTERNAL_getMetricBuffer(client)).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
Removes the `enableMetrics` option for v11. Metrics are now captured whenever a metric API (`Sentry.metrics.*`) is used, with no way to disable them. `beforeSendMetric` is unaffected and stays available.

Fixes getsentry/sentry-javascript#23309

Similar to [https://github.com/getsentry/sentry-javascript/pull/23319](<https://github.com/getsentry/sentry-javascript/pull/23319>)