### PR TITLE
feat(nuxt)!: Remove unstable_sentryBundlerPluginOptions

### DIFF
--- a/packages/nuxt/src/common/types.ts
+++ b/packages/nuxt/src/common/types.ts
@@ -1,7 +1,5 @@
 import type { BuildTimeOptionsBase } from '@sentry/core';
 import type { init as initNode } from '@sentry/node';
-import type { SentryRollupPluginOptions } from '@sentry/bundler-plugins/rollup';
-import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
 import type { init as initVue } from '@sentry/vue';
 
 // Omitting Vue 'app' as the Nuxt SDK will add the app instance in the client plugin (users do not have to provide this)
@@ -91,12 +89,4 @@ export type SentryNuxtModuleOptions = BuildTimeOptionsBase & {
    * @default ['default', 'handler', 'server']
    */
   experimental_entrypointWrappedFunctions?: string[];
-
-  /**
-   * Options to be passed directly to the Sentry Rollup Plugin (`@sentry/bundler-plugins/rollup`) and Sentry Vite Plugin (`@sentry/bundler-plugins/vite`) that ship with the Sentry Nuxt SDK.
-   * You can use this option to override any options the SDK passes to the Vite (for Nuxt) and Rollup (for Nitro) plugin.
-   *
-   * Please note that this option is unstable and may change in a breaking way in any release.
-   */
-  unstable_sentryBundlerPluginOptions?: SentryRollupPluginOptions & SentryVitePluginOptions;
 };

--- a/packages/nuxt/src/vite/sourceMaps.ts
+++ b/packages/nuxt/src/vite/sourceMaps.ts
@@ -1,6 +1,7 @@
 import type { Nuxt } from '@nuxt/schema';
 import { sentryRollupPlugin, type SentryRollupPluginOptions } from '@sentry/bundler-plugins/rollup';
 import { sentryVitePlugin, type SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
+import { warnOnRemovedBuildOptions } from '@sentry/core';
 import type { NitroConfig } from 'nitropack';
 import type { Plugin } from 'vite';
 import type { SentryNuxtModuleOptions } from '../common/types';
@@ -22,6 +23,10 @@ export function setupSourceMaps(
   nuxt: Nuxt,
   addVitePlugin: (plugin: Plugin[], options?: { dev?: boolean; build?: boolean }) => void,
 ): void {
+  // Warn here rather than in `getPluginOptions`, which runs once per bundler (Vite and Nitro's
+  // Rollup) and would emit the same warning twice.
+  warnOnRemovedBuildOptions(moduleOptions, ['unstable_sentryBundlerPluginOptions']);
+
   const isDebug = moduleOptions.debug;
 
   const sourceMapsEnabled = moduleOptions.sourcemaps?.disable !== true;
@@ -139,14 +144,13 @@ export function getPluginOptions(
       name: moduleOptions.release?.name,
       // Support all release options from BuildTimeOptionsBase
       ...moduleOptions.release,
-      ...moduleOptions?.unstable_sentryBundlerPluginOptions?.release,
     },
+    moduleMetadata: moduleOptions.moduleMetadata,
     _metaOptions: {
       telemetry: {
         metaFramework: 'nuxt',
       },
     },
-    ...moduleOptions?.unstable_sentryBundlerPluginOptions,
 
     sourcemaps: {
       disable: moduleOptions.sourcemaps?.disable,
@@ -157,7 +161,7 @@ export function getPluginOptions(
       ignore: sourcemapsOptions.ignore ?? undefined,
       filesToDeleteAfterUpload,
       rewriteSources: sourcemapsOptions.rewriteSources ?? normalizePath,
-      ...moduleOptions?.unstable_sentryBundlerPluginOptions?.sourcemaps,
+      resolveSourceMap: sourcemapsOptions.resolveSourceMap,
     },
   };
 }

--- a/packages/nuxt/test/vite/buildOptions.test-d.ts
+++ b/packages/nuxt/test/vite/buildOptions.test-d.ts
@@ -20,7 +20,10 @@ describe('Sentry Nuxt build-time options type', () => {
         assets: ['./dist/**/*'],
         ignore: ['./dist/*.map'],
         filesToDeleteAfterUpload: ['./dist/*.map'],
+        rewriteSources: (source: string) => source,
+        resolveSourceMap: (artifactPath: string) => `${artifactPath}.map`,
       },
+      moduleMetadata: { team: 'sdk' },
       release: {
         name: 'test-release-1.0.0',
         create: true,
@@ -58,19 +61,20 @@ describe('Sentry Nuxt build-time options type', () => {
       autoInjectServerSentry: 'experimental_dynamic-import',
       configDir: '~/custom-config',
       experimental_entrypointWrappedFunctions: ['default', 'handler', 'server', 'customExport'],
-      unstable_sentryBundlerPluginOptions: {
-        // Rollup plugin options
-        bundleSizeOptimizations: {
-          excludeDebugStatements: true,
-        },
-        // Vite plugin options
-        sourcemaps: {
-          assets: './dist/**/*',
-        },
-      },
     };
 
     expectTypeOf(completeOptions).toEqualTypeOf<SentryNuxtModuleOptions>();
+  });
+
+  it('rejects the removed `unstable_sentryBundlerPluginOptions`', () => {
+    const options: SentryNuxtModuleOptions = {
+      // @ts-expect-error - removed in v11, use the top-level build options instead
+      unstable_sentryBundlerPluginOptions: {
+        sourcemaps: { assets: './dist/**/*' },
+      },
+    };
+
+    expectTypeOf(options).toEqualTypeOf<SentryNuxtModuleOptions>();
   });
 
   it('allows partial configuration', () => {

--- a/packages/nuxt/test/vite/sourceMaps-nuxtHooks.test.ts
+++ b/packages/nuxt/test/vite/sourceMaps-nuxtHooks.test.ts
@@ -76,6 +76,39 @@ describe('setupSourceMaps hooks', () => {
     mockSentryRollupPlugin.mockClear();
   });
 
+  describe('removed `unstable_sentryBundlerPluginOptions`', () => {
+    // `getPluginOptions` runs once per bundler (Vite and Nitro's Rollup), so warning there emitted
+    // the same message twice. This pins it to exactly one.
+    it('warns exactly once, even though both bundler plugins are set up', async () => {
+      const { setupSourceMaps } = await import('../../src/vite/sourceMaps');
+      const mockNuxt = createMockNuxt({});
+      const { mockAddVitePlugin } = createMockAddVitePlugin();
+
+      setupSourceMaps(
+        // @ts-expect-error - removed in v11, but JS configs get no type checking
+        { unstable_sentryBundlerPluginOptions: { org: 'override-org' } },
+        mockNuxt as unknown as Nuxt,
+        mockAddVitePlugin,
+      );
+      await mockNuxt.triggerHook('nitro:config', { rollupConfig: {} });
+
+      const removalWarnings = consoleWarnSpy.mock.calls.filter(([message]) =>
+        String(message).includes('unstable_sentryBundlerPluginOptions'),
+      );
+      expect(removalWarnings).toHaveLength(1);
+    });
+
+    it('does not warn for a config without removed options', async () => {
+      const { setupSourceMaps } = await import('../../src/vite/sourceMaps');
+      const mockNuxt = createMockNuxt({});
+      const { mockAddVitePlugin } = createMockAddVitePlugin();
+
+      setupSourceMaps({ org: 'my-org' }, mockNuxt as unknown as Nuxt, mockAddVitePlugin);
+
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining('unstable_'));
+    });
+  });
+
   describe('vite plugin registration', () => {
     it('calls `addVitePlugin` when setupSourceMaps is called', async () => {
       const { setupSourceMaps } = await import('../../src/vite/sourceMaps');

--- a/packages/nuxt/test/vite/sourceMaps.test.ts
+++ b/packages/nuxt/test/vite/sourceMaps.test.ts
@@ -194,33 +194,17 @@ describe('getPluginOptions', () => {
     });
   });
 
-  it('merges with unstable_sentryBundlerPluginOptions correctly', () => {
-    const options: SentryNuxtModuleOptions = {
-      org: 'base-org',
-      bundleSizeOptimizations: {
-        excludeDebugStatements: false,
-      },
-      unstable_sentryBundlerPluginOptions: {
-        org: 'override-org',
-        release: { name: 'override-release' },
-        sourcemaps: { assets: ['override/**/*'] },
-        bundleSizeOptimizations: {
-          excludeDebugStatements: true,
-        },
-      },
-    };
+  it('passes moduleMetadata and sourcemaps.resolveSourceMap through to the plugin', () => {
+    const resolveSourceMap = (artifactPath: string): string => `${artifactPath}.map`;
 
-    const result = getPluginOptions(options);
+    const result = getPluginOptions({
+      moduleMetadata: { team: 'sdk' },
+      sourcemaps: { resolveSourceMap },
+    });
 
     expect(result).toMatchObject({
-      org: 'override-org',
-      release: { name: 'override-release' },
-      sourcemaps: expect.objectContaining({
-        assets: ['override/**/*'],
-      }),
-      bundleSizeOptimizations: {
-        excludeDebugStatements: true,
-      },
+      moduleMetadata: { team: 'sdk' },
+      sourcemaps: expect.objectContaining({ resolveSourceMap }),
     });
   });
 


### PR DESCRIPTION
Removes `unstable_sentryBundlerPluginOptions` from the Nuxt module options.

Everything it exposed is reachable as a top-level build option. Adds a build-time warning for plain JS configs, where TypeScript cannot catch the removed key.

closes getsentry/sentry-javascript#23340