### PR TITLE
ref(server-utils): Rename `anthropicIntegration` to `anthropicAIIntegration`

### DIFF
--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -118,7 +118,7 @@ export type { DenoHttpIntegrationOptions } from './integrations/http';
 // adds to the defaults, so users who customize `defaultIntegrations` can re-add it.
 export {
   amqplibIntegration,
-  anthropicIntegration,
+  anthropicAIIntegration,
   awsIntegration,
   dataloaderIntegration,
   redisIntegration,

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -13,7 +13,7 @@ import {
 } from '@sentry/core';
 import {
   amqplibIntegration,
-  anthropicIntegration,
+  anthropicAIIntegration,
   awsIntegration,
   expressIntegration,
   firebaseIntegration,
@@ -74,7 +74,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
     // The orchestrion channels may be injected after (or while) the SDK loads.
     // If they never load, these are no-ops.
     amqplibIntegration(),
-    anthropicIntegration(),
+    anthropicAIIntegration(),
     awsIntegration(),
     expressIntegration(),
     firebaseIntegration(),

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -5,7 +5,7 @@ export { expressErrorHandler, setupExpressErrorHandler } from './integrations/tr
 export { fastifyIntegration, setupFastifyErrorHandler } from './integrations/tracing/fastify';
 export {
   amqplibIntegration,
-  anthropicIntegration as anthropicAIIntegration,
+  anthropicAIIntegration,
   dataloaderIntegration,
   expressIntegration,
   firebaseIntegration,

--- a/packages/node/src/integrations/tracing/index.ts
+++ b/packages/node/src/integrations/tracing/index.ts
@@ -2,7 +2,7 @@ import type { Integration } from '@sentry/core';
 import { prismaIntegration } from '@sentry/server-utils';
 import {
   amqplibIntegration,
-  anthropicIntegration,
+  anthropicAIIntegration,
   expressIntegration,
   firebaseIntegration,
   genericPoolIntegration,
@@ -52,7 +52,7 @@ export function getAutoPerformanceIntegrations(): Integration[] {
     langGraphIntegration(),
     vercelAIIntegration(),
     openAIIntegration(),
-    anthropicIntegration(),
+    anthropicAIIntegration(),
     googleGenAIIntegration(),
     postgresJsIntegration(),
     firebaseIntegration(),

--- a/packages/server-utils/src/integrations/anthropic.ts
+++ b/packages/server-utils/src/integrations/anthropic.ts
@@ -39,7 +39,7 @@ interface AnthropicChannelContext {
   result?: unknown;
 }
 
-const _anthropicIntegration = ((options: AnthropicAiOptions = {}) => {
+const _anthropicAIIntegration = ((options: AnthropicAiOptions = {}) => {
   return {
     name: INTEGRATION_NAME,
     setup(client) {
@@ -161,4 +161,4 @@ function wrapStreamResult(
  * diagnostics_channels injected into the SDK's chat (`messages`/`completions`/beta `messages`) and
  * `messages.stream()` methods, so it requires the orchestrion runtime hook or bundler plugin.
  */
-export const anthropicIntegration = defineIntegration(_anthropicIntegration);
+export const anthropicAIIntegration = defineIntegration(_anthropicAIIntegration);

--- a/packages/server-utils/src/orchestrion/config/channel-integration-definitions.ts
+++ b/packages/server-utils/src/orchestrion/config/channel-integration-definitions.ts
@@ -29,7 +29,7 @@ export const CHANNEL_INTEGRATION_DEFINITIONS = [
   { exportName: 'genericPoolIntegration', modules: ['generic-pool'] },
   { exportName: 'lruMemoizerIntegration', modules: ['lru-memoizer'] },
   { exportName: 'openAIIntegration', modules: ['openai'] },
-  { exportName: 'anthropicIntegration', modules: ['@anthropic-ai/sdk'] },
+  { exportName: 'anthropicAIIntegration', modules: ['@anthropic-ai/sdk'] },
   { exportName: 'googleGenAIIntegration', modules: ['@google/genai'] },
   { exportName: 'vercelAIIntegration', modules: ['ai'] },
   { exportName: 'amqplibIntegration', modules: ['amqplib'] },

--- a/packages/server-utils/src/orchestrion/index.ts
+++ b/packages/server-utils/src/orchestrion/index.ts
@@ -1,5 +1,5 @@
 import { amqplibIntegration } from '../integrations/amqplib';
-import { anthropicIntegration } from '../integrations/anthropic';
+import { anthropicAIIntegration } from '../integrations/anthropic';
 import { awsIntegration } from '../integrations/aws-sdk';
 import { dataloaderIntegration } from '../integrations/dataloader';
 import { genericPoolIntegration } from '../integrations/generic-pool';
@@ -38,7 +38,7 @@ export { nestjsChannels } from './config/nestjs';
 export { remixChannels } from './config/remix';
 export {
   amqplibIntegration,
-  anthropicIntegration,
+  anthropicAIIntegration,
   awsIntegration,
   dataloaderIntegration,
   genericPoolIntegration,
@@ -98,7 +98,7 @@ export const channelIntegrations = {
   mongooseIntegration,
   lruMemoizerIntegration,
   openAIIntegration,
-  anthropicIntegration,
+  anthropicAIIntegration,
   googleGenAIIntegration,
   langChainIntegration,
   langGraphIntegration,


### PR DESCRIPTION
Renames the orchestrion channel-integration factory `anthropicIntegration` to `anthropicAIIntegration` in `@sentry/server-utils`, and updates every consumer (`@sentry/node`, `@sentry/deno`) accordingly.

_Reasoning_: `anthropicAIIntegration` is the public, OTel-parity casing that `@sentry/node` already exposed by aliasing the server-utils export (`anthropicIntegration as anthropicAIIntegration`). Making the canonical export match that casing lets node drop the alias and keeps the factory name consistent across SDKs. `@sentry/deno` previously re-exported the lowercase name, so its public export changes to `anthropicAIIntegration` to match.

Split out of a larger `@sentry/server-utils` cleanup branch as an isolated, mechanical rename.
