### PR TITLE
ref(server-utils): Rename `vercelAiIntegration` to `vercelAIIntegration`

### DIFF
--- a/packages/cloudflare/src/integrations/tracing/vercelai.ts
+++ b/packages/cloudflare/src/integrations/tracing/vercelai.ts
@@ -10,10 +10,14 @@
 
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration, extendIntegration } from '@sentry/core';
-import { addVercelAiProcessors, vercelAiIntegration, type VercelAiOptions } from '@sentry/server-utils';
+import {
+  addVercelAiProcessors,
+  vercelAIIntegration as channelVercelAIIntegration,
+  type VercelAiOptions,
+} from '@sentry/server-utils';
 
 const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
-  const inner = vercelAiIntegration(options);
+  const inner = channelVercelAIIntegration(options);
 
   return extendIntegration(inner, {
     options,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -142,7 +142,6 @@ export {
   postgresIntegration,
   postgresJsIntegration,
   tediousIntegration,
-  vercelAiIntegration,
 } from '@sentry/server-utils/orchestrion';
 export { otlpIntegration, getOtlpTracesEndpoint } from '@sentry/server-utils/no-diagnostic-channels';
 // Deprecated aliases kept for back-compat. Each forwards to the shared

--- a/packages/deno/src/integrations/tracing/vercelai.ts
+++ b/packages/deno/src/integrations/tracing/vercelai.ts
@@ -6,7 +6,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration, extendIntegration } from '@sentry/core';
 import {
   addVercelAiProcessors,
-  vercelAiIntegration as serverUtilsVercelAiIntegration,
+  vercelAIIntegration as serverUtilsVercelAiIntegration,
   type VercelAiOptions,
 } from '@sentry/server-utils';
 

--- a/packages/deno/src/sdk.ts
+++ b/packages/deno/src/sdk.ts
@@ -34,7 +34,7 @@ import {
   postgresIntegration,
   postgresJsIntegration,
   tediousIntegration,
-  vercelAiIntegration,
+  vercelAIIntegration,
   redisIntegration,
 } from '@sentry/server-utils/orchestrion';
 import { DenoClient } from './client';
@@ -66,7 +66,7 @@ export function getDefaultIntegrations(_options: Options): Integration[] {
     denoHttpIntegration(),
     redisIntegration(),
     graphqlDiagnosticsIntegration(),
-    vercelAiIntegration(),
+    vercelAIIntegration(),
     // orchestrion-based instrumentations. We add a deliberate list here rather
     // than every channel integration: each one needs a Deno test proving it
     // records spans.

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -28,7 +28,7 @@ export {
   postgresJsIntegration,
   redisIntegration,
   tediousIntegration,
-  vercelAiIntegration as vercelAIIntegration,
+  vercelAIIntegration,
 } from '@sentry/server-utils/orchestrion';
 export {
   otlpIntegration,

--- a/packages/node/src/integrations/tracing/index.ts
+++ b/packages/node/src/integrations/tracing/index.ts
@@ -23,7 +23,7 @@ import {
   postgresJsIntegration,
   redisIntegration,
   tediousIntegration,
-  vercelAiIntegration,
+  vercelAIIntegration,
 } from '@sentry/server-utils/orchestrion';
 import { fastifyIntegration } from './fastify';
 
@@ -50,7 +50,7 @@ export function getAutoPerformanceIntegrations(): Integration[] {
     // LangChain must come first to disable AI provider integrations before they instrument
     langChainIntegration(),
     langGraphIntegration(),
-    vercelAiIntegration(),
+    vercelAIIntegration(),
     openAIIntegration(),
     anthropicIntegration(),
     googleGenAIIntegration(),

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -15,7 +15,7 @@ export type {
 } from './tracing-channel';
 export type { InstrumentationConfig } from './orchestrion';
 export type { GenAiOptions } from './ai/core/utils';
-export { vercelAiIntegration, type VercelAiOptions } from './vercel-ai';
+export { vercelAIIntegration, type VercelAiOptions } from './vercel-ai';
 export {
   fastifyIntegration,
   // oxlint-disable-next-line typescript/no-deprecated

--- a/packages/server-utils/src/integrations/vercel-ai.ts
+++ b/packages/server-utils/src/integrations/vercel-ai.ts
@@ -1,12 +1,12 @@
 import type { Client, IntegrationFn } from '@sentry/core';
 import { defineIntegration, extendIntegration } from '@sentry/core';
-import { vercelAiIntegration as baseVercelAiIntegration } from '../vercel-ai';
+import { vercelAIIntegration as baseVercelAIIntegration } from '../vercel-ai';
 import * as dc from 'node:diagnostics_channel';
 import { vercelAiModuleNames } from '../orchestrion/config/vercel-ai';
 import { invokeOrchestrionInstrumentation } from '../orchestrion/instrumentation';
 import { subscribeVercelAiOrchestrionChannels } from '../vercel-ai/vercel-ai-orchestrion-subscriber';
 
-type VercelAiOptions = Parameters<typeof baseVercelAiIntegration>[0];
+type VercelAiOptions = Parameters<typeof baseVercelAIIntegration>[0];
 
 // In channel-based (orchestrion) mode we emit our own `gen_ai.*` spans from the
 // diagnostics channels. The `ai` SDK would otherwise emit its own native
@@ -16,8 +16,8 @@ type VercelAiOptions = Parameters<typeof baseVercelAiIntegration>[0];
 // `experimental_telemetry.isEnabled` to `false`, so `ai` falls back to its
 // internal no-op tracer and never creates the native spans in the first place.
 // See `subscribeVercelAiOrchestrionChannels`.
-const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {
-  const parentIntegration = baseVercelAiIntegration(options);
+const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
+  const parentIntegration = baseVercelAIIntegration(options);
 
   // The native `ai:telemetry` half is the base integration's own `setupOnce`; the
   // orchestrion half registers lazily via `setup`, only once `ai` is injected.
@@ -38,4 +38,4 @@ function instrumentVercelAiOrchestrion(options: VercelAiOptions): void {
  * - v7 via native `ai:telemetry` tracing channel
  * - v4, v5 & v6 via orchestrion `orchestrion:ai:*` channels
  */
-export const vercelAiIntegration = defineIntegration(_vercelAiIntegration);
+export const vercelAIIntegration = defineIntegration(_vercelAIIntegration);

--- a/packages/server-utils/src/orchestrion/config/channel-integration-definitions.ts
+++ b/packages/server-utils/src/orchestrion/config/channel-integration-definitions.ts
@@ -31,7 +31,7 @@ export const CHANNEL_INTEGRATION_DEFINITIONS = [
   { exportName: 'openAIIntegration', modules: ['openai'] },
   { exportName: 'anthropicIntegration', modules: ['@anthropic-ai/sdk'] },
   { exportName: 'googleGenAIIntegration', modules: ['@google/genai'] },
-  { exportName: 'vercelAiIntegration', modules: ['ai'] },
+  { exportName: 'vercelAIIntegration', modules: ['ai'] },
   { exportName: 'amqplibIntegration', modules: ['amqplib'] },
   { exportName: 'hapiIntegration', modules: ['@hapi/hapi'] },
   { exportName: 'expressIntegration', modules: ['express', 'router'] },

--- a/packages/server-utils/src/orchestrion/index.ts
+++ b/packages/server-utils/src/orchestrion/index.ts
@@ -21,7 +21,7 @@ import { openAIIntegration } from '../integrations/openai';
 import { postgresIntegration } from '../integrations/postgres';
 import { postgresJsIntegration } from '../integrations/postgres-js';
 import { tediousIntegration } from '../integrations/tedious';
-import { vercelAiIntegration } from '../integrations/vercel-ai';
+import { vercelAIIntegration } from '../integrations/vercel-ai';
 import { expressIntegration } from '../integrations/express';
 import { firebaseIntegration } from '../integrations/firebase';
 
@@ -61,7 +61,7 @@ export {
   postgresIntegration,
   postgresJsIntegration,
   tediousIntegration,
-  vercelAiIntegration,
+  vercelAIIntegration,
   expressIntegration,
   firebaseIntegration,
 };
@@ -103,7 +103,7 @@ export const channelIntegrations = {
   googleGenAIIntegration,
   langChainIntegration,
   langGraphIntegration,
-  vercelAiIntegration,
+  vercelAIIntegration,
   amqplibIntegration,
   hapiIntegration,
   koaIntegration,

--- a/packages/server-utils/src/vercel-ai/index.ts
+++ b/packages/server-utils/src/vercel-ai/index.ts
@@ -6,7 +6,7 @@ import * as dc from 'node:diagnostics_channel';
 /** Options for the Vercel AI integration. */
 export type VercelAiOptions = GenAiOptions;
 
-const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {
+const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
   return {
     name: 'VercelAI' as const,
     setupOnce() {
@@ -27,4 +27,4 @@ const _vercelAiIntegration = ((options: VercelAiOptions = {}) => {
 /**
  * Auto-instrument the `ai` SDK's native telemetry tracing channel (ai >= 7).
  */
-export const vercelAiIntegration = defineIntegration(_vercelAiIntegration);
+export const vercelAIIntegration = defineIntegration(_vercelAIIntegration);


### PR DESCRIPTION
Renames the orchestrion channel-integration factory `vercelAiIntegration` to `vercelAIIntegration` in `@sentry/server-utils`, and updates every consumer (`@sentry/node`, `@sentry/deno`, `@sentry/cloudflare`) accordingly.

_Reasoning_: `vercelAIIntegration` is the public, OTel-parity casing that `@sentry/node` already exposed by aliasing the server-utils export (`vercelAiIntegration as vercelAIIntegration`). Making the canonical export match that casing lets node drop the alias and keeps the factory name consistent across SDKs.

Notes on the edge SDKs: `@sentry/cloudflare` and `@sentry/deno` wrap the server-utils factory in their own `vercelAIIntegration`, so they import it under a local alias (`channelVercelAIIntegration` / `serverUtilsVercelAiIntegration`) to avoid a name clash. `@sentry/deno` already re-exports its own `vercelAIIntegration` from its Deno-specific integration, so the (now duplicate) server-utils re-export is dropped from its barrel. The `VercelAiOptions` type keeps its existing casing.

Split out of a larger `@sentry/server-utils` cleanup branch as an isolated, mechanical rename.
