### PR TITLE
feat(astro)!: Remove unstable_sentryVitePluginOptions

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -1,4 +1,5 @@
 import { sentryVitePlugin } from '@sentry/bundler-plugins/vite';
+import { warnOnRemovedBuildOptions } from '@sentry/core';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 import type { AstroConfig, AstroIntegration, AstroIntegrationLogger } from 'astro';
 import * as fs from 'fs';
@@ -38,7 +39,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           buildTimeInstrumentation,
           bundleSizeOptimizations,
           applicationKey,
-          unstable_sentryVitePluginOptions,
+          moduleMetadata,
           debug,
           org,
           project,
@@ -50,20 +51,20 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           errorHandler,
         } = options;
 
+        warnOnRemovedBuildOptions(options, ['unstable_sentryVitePluginOptions'], message => logger.warn(message));
+        // The nested spelling is not covered by the check above.
+        // eslint-disable-next-line typescript/no-deprecated
+        warnOnRemovedBuildOptions(options.sourceMapsUploadOptions, ['unstable_sentryVitePluginOptions'], message =>
+          logger.warn(message),
+        );
+
         const sdkEnabled = {
           client: typeof enabled === 'boolean' ? enabled : (enabled?.client ?? true),
           server: typeof enabled === 'boolean' ? enabled : (enabled?.server ?? true),
         };
 
         const sourceMapsNeeded = sdkEnabled.client || sdkEnabled.server;
-        // eslint-disable-next-line typescript/no-deprecated
-        const { unstable_sentryVitePluginOptions: deprecatedVitePluginOptions, ...uploadOptions } =
-          sourceMapsUploadOptions || {};
-
-        const unstableMerged_sentryVitePluginOptions = {
-          ...deprecatedVitePluginOptions,
-          ...unstable_sentryVitePluginOptions,
-        };
+        const uploadOptions = sourceMapsUploadOptions || {};
 
         const shouldUploadSourcemaps =
           (sourceMapsNeeded &&
@@ -103,6 +104,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
               plugins: [
                 sentryVitePlugin({
                   applicationKey,
+                  moduleMetadata,
                   // Priority: top-level options > deprecated options > env vars
                   // eslint-disable-next-line typescript/no-deprecated
                   org: org ?? uploadOptions.org ?? env.SENTRY_ORG,
@@ -121,12 +123,8 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                       metaFramework: 'astro',
                     },
                   },
-                  ...unstableMerged_sentryVitePluginOptions,
                   debug: debug ?? false,
-                  release: {
-                    ...unstableMerged_sentryVitePluginOptions?.release,
-                    ...release,
-                  },
+                  release,
                   sourcemaps: {
                     ...sourcemaps,
                     // eslint-disable-next-line typescript/no-deprecated
@@ -136,11 +134,9 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                       // eslint-disable-next-line typescript/no-deprecated
                       uploadOptions?.filesToDeleteAfterUpload ??
                       updatedFilesToDeleteAfterUpload,
-                    ...unstableMerged_sentryVitePluginOptions?.sourcemaps,
                   },
                   bundleSizeOptimizations: {
                     ...bundleSizeOptimizations,
-                    ...unstableMerged_sentryVitePluginOptions?.bundleSizeOptimizations,
                   },
                 }),
               ],

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -1,5 +1,4 @@
-import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
-import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
+import type { BuildTimeOptionsBase } from '@sentry/core';
 import type { RouteData } from 'astro';
 
 type SdkInitPaths = {
@@ -97,22 +96,6 @@ type SourceMapsOptions = {
    * @deprecated Use `sourcemaps.filesToDeleteAfterUpload` instead
    */
   filesToDeleteAfterUpload?: string | Array<string>;
-
-  /**
-   * Options to further customize the Sentry Vite Plugin (@sentry/bundler-plugins/vite) behavior directly.
-   * Options specified in this object take precedence over all other options.
-   *
-   * @see https://www.npmjs.com/package/@sentry/vite-plugin/v/2.14.2#options which lists all available options.
-   *
-   * Warning: Options within this object are subject to change at any time.
-   * We DO NOT guarantee semantic versioning for these options, meaning breaking
-   * changes can occur at any time within a major SDK version.
-   *
-   * Furthermore, some options are untested with Astro specifically. Use with caution.
-   *
-   * @deprecated Use top-level `unstable_sentryVitePluginOptions` instead
-   */
-  unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
 };
 
 type InstrumentationOptions = {
@@ -164,7 +147,6 @@ type SdkEnabledOptions = {
  * If you specify a dedicated init file, the SDK options passed to `sentryAstro` will be ignored for init.
  */
 export type SentryOptions = BuildTimeOptionsBase &
-  UnstableVitePluginOptions<SentryVitePluginOptions> &
   SdkInitPaths &
   InstrumentationOptions &
   SdkEnabledOptions & {

--- a/packages/astro/test/buildOptions.test-d.ts
+++ b/packages/astro/test/buildOptions.test-d.ts
@@ -52,16 +52,6 @@ describe('Sentry Astro build-time options type', () => {
         excludeReplayWorker: true,
       },
 
-      // --- UnstableVitePluginOptions ---
-      unstable_sentryVitePluginOptions: {
-        sourcemaps: {
-          assets: './dist/**/*',
-        },
-        bundleSizeOptimizations: {
-          excludeDebugStatements: true,
-        },
-      },
-
       // --- SentryOptions specific options ---
       enabled: true,
       clientInitPath: './src/sentry.client.config.ts',
@@ -84,15 +74,6 @@ describe('Sentry Astro build-time options type', () => {
       autoInstrumentation: {
         requestHandler: true,
       },
-      unstable_sentryVitePluginOptions: {
-        sourcemaps: {
-          assets: './dist/**/*',
-        },
-        bundleSizeOptimizations: {
-          excludeDebugStatements: true,
-        },
-      },
-
       // Deprecated sourceMapsUploadOptions
       sourceMapsUploadOptions: {
         enabled: true,
@@ -102,11 +83,6 @@ describe('Sentry Astro build-time options type', () => {
         telemetry: false,
         assets: './build/**/*',
         filesToDeleteAfterUpload: ['./build/*.map'],
-        unstable_sentryVitePluginOptions: {
-          sourcemaps: {
-            ignore: ['./build/*.spec.js'],
-          },
-        },
       },
     };
 
@@ -159,24 +135,14 @@ describe('Sentry Astro build-time options type', () => {
     expectTypeOf(baseOptions).toEqualTypeOf<SentryOptions>();
   });
 
-  it('supports UnstableVitePluginOptions at top level', () => {
-    const viteOptions: SentryOptions = {
+  it('rejects the removed `unstable_sentryVitePluginOptions`', () => {
+    const options: SentryOptions = {
+      // @ts-expect-error - removed in v11, use the top-level build options instead
       unstable_sentryVitePluginOptions: {
-        org: 'override-org',
-        project: 'override-project',
-        sourcemaps: {
-          assets: './custom-dist/**/*',
-          ignore: ['./custom-dist/ignore/**/*'],
-        },
-        bundleSizeOptimizations: {
-          excludeDebugStatements: true,
-          excludeTracing: false,
-        },
-        debug: true,
-        silent: false,
+        sourcemaps: { assets: './dist/**/*' },
       },
     };
 
-    expectTypeOf(viteOptions).toEqualTypeOf<SentryOptions>();
+    expectTypeOf(options).toEqualTypeOf<SentryOptions>();
   });
 });

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -259,57 +259,41 @@ describe('sentryAstro integration', () => {
     );
   });
 
-  it('prefers user-specified unstable vite plugin options and merges them with default values', async () => {
+  // No `@ts-expect-error` here on purpose: `SentryOptions` intersects `Record<string, unknown>`, so
+  // TypeScript accepts any key and this runtime warning is the only signal an Astro user ever gets.
+  it('warns for the removed option nested inside `sourceMapsUploadOptions`', async () => {
     const integration = sentryAstro({
-      bundleSizeOptimizations: {
-        excludeReplayShadowDom: true,
-      },
-      sourceMapsUploadOptions: {
-        enabled: true,
-        org: 'my-org',
-        project: 'my-project',
-        assets: ['dist/server/**/*, dist/client/**/*'],
-        unstable_sentryVitePluginOptions: {
-          org: 'my-other-org',
-          project: 'my-other-project',
-          applicationKey: 'my-application-key',
-          sourcemaps: {
-            assets: ['foo/*.js'],
-            ignore: ['bar/*.js'],
-          },
-          bundleSizeOptimizations: {
-            excludeReplayIframe: true,
-          },
-        },
-      },
+      // @ts-expect-error - removed in v11
+      sourceMapsUploadOptions: { unstable_sentryVitePluginOptions: { org: 'my-other-org' } },
     });
     // @ts-expect-error - the hook exists, and we only need to pass what we actually use
-    await integration.hooks['astro:config:setup']({
-      ...baseConfigHookObject,
-      updateConfig,
-      injectScript,
-      // @ts-expect-error - only passing in partial config
-      config: {
-        outDir: new URL('file://path/to/project/build'),
-      },
-    });
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
 
-    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
-    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        org: 'my-other-org',
-        project: 'my-other-project',
-        applicationKey: 'my-application-key',
-        sourcemaps: {
-          assets: ['foo/*.js'],
-          ignore: ['bar/*.js'],
-          filesToDeleteAfterUpload: ['./dist/**/client/**/*.map', './dist/**/server/**/*.map'],
-        },
-        bundleSizeOptimizations: {
-          excludeReplayShadowDom: true,
-          excludeReplayIframe: true,
-        },
-      }),
+    expect(baseConfigHookObject.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('unstable_sentryVitePluginOptions'),
+    );
+  });
+
+  it('forwards moduleMetadata to the vite plugin', async () => {
+    const integration = sentryAstro({ moduleMetadata: { team: 'sdk' } });
+    // @ts-expect-error - the hook exists, and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(expect.objectContaining({ moduleMetadata: { team: 'sdk' } }));
+  });
+
+  // TypeScript rejects the key (see `buildOptions.test-d.ts`); this covers JS configs, which get no
+  // type checking.
+  it('warns via the Astro logger when the removed `unstable_sentryVitePluginOptions` is still set', async () => {
+    const integration = sentryAstro({
+      // @ts-expect-error - removed in v11
+      unstable_sentryVitePluginOptions: { org: 'my-other-org' },
+    });
+    // @ts-expect-error - the hook exists, and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
+
+    expect(baseConfigHookObject.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('unstable_sentryVitePluginOptions'),
     );
   });
 


### PR DESCRIPTION
Removes `unstable_sentryVitePluginOptions` from the Astro integration options — both the top-level option and the deprecated copy inside `sourceMapsUploadOptions`.

Everything it exposed is reachable as a top-level build option. Adds a build-time warning, routed through Astro's integration logger.

The warning matters more here than elsewhere: `SentryOptions` intersects `Record<string, unknown>`, so TypeScript accepts any key and would otherwise leave the removal entirely silent. The key is also excluded from the generic "additional options" warning, which would wrongly tell users to move it into their `sentry.client.config` file.

Fixes getsentry/sentry-javascript#23342