### PR TITLE
feat(react-router)!: Remove unstable_sentryVitePluginOptions

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/vite.config.ts
@@ -2,25 +2,21 @@ import { reactRouter } from '@react-router/dev/vite';
 import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
 import { defineConfig } from 'vite';
 
-// Deliberately routes `sourcemaps` through `unstable_sentryVitePluginOptions`. That shape
-// used to drop the SDK's `sourcemaps.disable: true`, which re-enabled debug ID injection in
-// the Vite plugin on top of the injection done by `sentryOnBuildEnd` - two debug IDs per
-// chunk, only one of which has an uploaded artifact bundle.
-// See https://github.com/getsentry/sentry-javascript/issues/22929
+// Guards against debug IDs being injected twice - once by the Vite plugin and once by
+// `sentryOnBuildEnd` - which leaves two IDs per chunk, only one of which has an uploaded
+// artifact bundle. See https://github.com/getsentry/sentry-javascript/issues/22929
 export const sentryConfig: SentryReactRouterBuildOptions = {
   authToken: 'fake-auth-token',
   org: 'test-org',
   project: 'test-project',
+  sentryUrl: 'http://localhost:3032',
   release: {
     name: 'test-release',
   },
-  unstable_sentryVitePluginOptions: {
-    url: 'http://localhost:3032',
-    sourcemaps: {
-      // The maps have to survive until `sentryOnBuildEnd` uploads them, so this asserts
-      // the option is not forwarded to the Vite plugin (which deletes in a `finally`).
-      filesToDeleteAfterUpload: ['./build/client/assets/**/*.map'],
-    },
+  sourcemaps: {
+    // The maps have to survive until `sentryOnBuildEnd` uploads them, so this asserts the option is
+    // not forwarded to the Vite plugin (which deletes in a `finally` block regardless of `disable`).
+    filesToDeleteAfterUpload: ['./build/client/assets/**/*.map'],
   },
   debug: true,
 };

--- a/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
+++ b/packages/react-router/src/vite/buildEnd/handleOnBuildEnd.ts
@@ -17,15 +17,6 @@ function getSentryConfig(viteConfig: unknown): SentryReactRouterBuildOptions {
 }
 
 /**
- * This hook is the only place that injects debug IDs and uploads source maps for React
- * Router, so `disable` has to be honoured wherever the user set it. Reading it from the
- * top-level config only would silently ignore `unstable_sentryVitePluginOptions`.
- */
-function resolveSourceMapsDisable(sentryConfig: SentryReactRouterBuildOptions): boolean | 'disable-upload' | undefined {
-  return sentryConfig.sourcemaps?.disable ?? sentryConfig.unstable_sentryVitePluginOptions?.sourcemaps?.disable;
-}
-
-/**
  * A build end hook that handles Sentry release creation and source map uploads.
  * It creates a new Sentry release if configured, uploads source maps to Sentry,
  * and optionally deletes the source map files after upload.
@@ -33,42 +24,36 @@ function resolveSourceMapsDisable(sentryConfig: SentryReactRouterBuildOptions): 
 export const sentryOnBuildEnd: BuildEndHook = async ({ reactRouterConfig, viteConfig }) => {
   const sentryConfig = getSentryConfig(viteConfig);
 
-  const unstableSentryVitePluginOptions = sentryConfig.unstable_sentryVitePluginOptions;
-
   const {
     authToken,
+    headers,
     org,
     project,
     release,
+    sentryUrl,
     sourcemaps = { disable: false },
     debug = false,
   }: Omit<SentryReactRouterBuildOptions, 'sourcemaps'> &
     // Pick 'sourcemaps' from Vite plugin options as the types allow more (e.g. Promise values for `deleteFilesAfterUpload`)
     Pick<SentryVitePluginOptions, 'sourcemaps'> = {
-    ...unstableSentryVitePluginOptions,
     ...sentryConfig,
     sourcemaps: {
-      ...unstableSentryVitePluginOptions?.sourcemaps,
       ...sentryConfig.sourcemaps,
-      disable: resolveSourceMapsDisable(sentryConfig),
+      disable: sentryConfig.sourcemaps?.disable,
     },
     release: {
-      ...unstableSentryVitePluginOptions?.release,
       ...sentryConfig.release,
     },
-    project: unstableSentryVitePluginOptions?.project
-      ? Array.isArray(unstableSentryVitePluginOptions?.project)
-        ? unstableSentryVitePluginOptions?.project[0]
-        : unstableSentryVitePluginOptions?.project
-      : sentryConfig.project,
   };
 
+  // `url` and `headers` previously only reached the CLI through `unstable_sentryVitePluginOptions`,
+  // so self-hosted setups had no supported way to point this upload at their instance.
   const cliInstance = new SentryCli(null, {
     authToken,
+    headers,
     org,
-    ...sentryConfig.unstable_sentryVitePluginOptions,
-    // same handling as in bundler plugins: https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/05084f214c763a05137d863ff5a05ef38254f68d/packages/bundler-plugin-core/src/build-plugin-manager.ts#L102-L103
-    project: Array.isArray(project) ? project[0] : project,
+    project,
+    url: sentryUrl,
   });
 
   // check if release should be created

--- a/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
+++ b/packages/react-router/src/vite/makeCustomSentryVitePlugins.ts
@@ -1,4 +1,5 @@
 import { sentryVitePlugin } from '@sentry/bundler-plugins/vite';
+import { warnOnRemovedBuildOptions } from '@sentry/core';
 import { type Plugin } from 'vite';
 import type { SentryReactRouterBuildOptions } from './types';
 
@@ -6,71 +7,55 @@ import type { SentryReactRouterBuildOptions } from './types';
  * Create a custom subset of sentry's vite plugins
  */
 export async function makeCustomSentryVitePlugins(options: SentryReactRouterBuildOptions): Promise<Plugin[]> {
+  warnOnRemovedBuildOptions(options, ['unstable_sentryVitePluginOptions']);
+
   const {
     debug,
-    unstable_sentryVitePluginOptions,
     bundleSizeOptimizations,
     applicationKey,
     authToken,
+    errorHandler,
+    headers,
+    moduleMetadata,
     org,
     project,
+    sentryUrl,
+    silent,
     telemetry,
     reactComponentAnnotation,
     release,
   } = options;
-
-  const unstableSourcemapsDisable = unstable_sentryVitePluginOptions?.sourcemaps?.disable;
-
-  // Anything other than `true` would have the Vite plugin inject debug IDs on top of the
-  // ones `sentryOnBuildEnd` injects, which breaks source map resolution. The value still
-  // applies to the buildEnd hook - only the Vite plugin ignores it.
-  if (unstableSourcemapsDisable !== undefined && unstableSourcemapsDisable !== true) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[Sentry] \`unstable_sentryVitePluginOptions.sourcemaps.disable: ${JSON.stringify(
-        unstableSourcemapsDisable,
-      )}\` does not apply to the Vite plugin. Debug ID injection and source map upload are handled by the \`sentryOnBuildEnd\` hook for React Router, so letting the Vite plugin do it as well would inject a second debug ID per chunk. The option still applies to \`sentryOnBuildEnd\`.`,
-    );
-  }
 
   const sentryVitePlugins = sentryVitePlugin({
     applicationKey,
     authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
     bundleSizeOptimizations,
     debug: debug ?? false,
+    errorHandler,
+    headers,
+    moduleMetadata,
     org: org ?? process.env.SENTRY_ORG,
     project: project ?? process.env.SENTRY_PROJECT,
+    reactComponentAnnotation,
+    release,
+    silent,
     telemetry: telemetry ?? true,
-    // Spread here so it can override the plain options above, but not the objects
-    // merged below - object spread replaces whole keys rather than deep-merging.
-    ...unstable_sentryVitePluginOptions,
+    // The plugin creates, finalizes and sets commits on the release in `writeBundle` regardless of
+    // `sourcemaps.disable`, so self-hosted setups need the URL here too - not just on the
+    // `sentryOnBuildEnd` CLI instance.
+    url: sentryUrl,
     _metaOptions: {
-      ...unstable_sentryVitePluginOptions?._metaOptions,
       telemetry: {
-        ...unstable_sentryVitePluginOptions?._metaOptions?.telemetry,
         metaFramework: 'react-router',
       },
     },
-    reactComponentAnnotation: {
-      // Only assign when set, as an explicit `undefined` would erase the unstable value
-      ...(reactComponentAnnotation?.enabled !== undefined && { enabled: reactComponentAnnotation.enabled }),
-      ...(reactComponentAnnotation?.ignoredComponents !== undefined && {
-        ignoredComponents: reactComponentAnnotation.ignoredComponents,
-      }),
-      ...unstable_sentryVitePluginOptions?.reactComponentAnnotation,
-    },
-    release: {
-      ...unstable_sentryVitePluginOptions?.release,
-      ...release,
-    },
     sourcemaps: {
-      ...unstable_sentryVitePluginOptions?.sourcemaps,
-      // Injection and upload are handled in the buildEnd hook, so the Vite plugin must
-      // never do it too. This is deliberately not overridable - see the warning above.
+      // Debug ID injection and upload are handled by the `sentryOnBuildEnd` hook, so the Vite plugin
+      // must never do it as well - that would inject a second debug ID per chunk and break source
+      // map resolution.
       disable: true,
-      // The plugin deletes these in a `finally` block that runs regardless of `disable`,
-      // which would remove the maps before `sentryOnBuildEnd` gets to upload them.
-      // Deletion is handled there instead, from the same option.
+      // The plugin deletes these in a `finally` block that runs regardless of `disable`, which would
+      // remove the maps before `sentryOnBuildEnd` gets to upload them. Deletion happens there instead.
       filesToDeleteAfterUpload: undefined,
     },
   }) as Plugin[];

--- a/packages/react-router/src/vite/types.ts
+++ b/packages/react-router/src/vite/types.ts
@@ -1,24 +1,25 @@
-import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
-import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
+import type { BuildTimeOptionsBase, ReactComponentAnnotationOptions } from '@sentry/core';
 
-export type SentryReactRouterBuildOptions = BuildTimeOptionsBase &
-  UnstableVitePluginOptions<Partial<SentryVitePluginOptions>> & {
-    /**
-     * Options related to react component name annotations.
-     * Disabled by default, unless a value is set for this option.
-     * When enabled, your app's DOM will automatically be annotated during build-time with their respective component names.
-     * This will unlock the capability to search for Replays in Sentry by component name, as well as see component names in breadcrumbs and performance monitoring.
-     * Please note that this feature is not currently supported by the esbuild bundler plugins, and will only annotate React components
-     */
-    reactComponentAnnotation?: {
-      /**
-       * Whether the component name annotate plugin should be enabled or not.
-       */
-      enabled?: boolean;
+/**
+ * `resolveSourceMap` is a bundler-plugin hook, applied during the plugin's own debug ID upload.
+ * React Router keeps the Vite plugin's source map handling disabled and uploads through `SentryCli`
+ * in `sentryOnBuildEnd` instead, so there is nowhere to apply the hook - it is omitted rather than
+ * accepted and silently ignored.
+ */
+type SourceMapsOptions = Omit<NonNullable<BuildTimeOptionsBase['sourcemaps']>, 'resolveSourceMap'>;
 
-      /**
-       * A list of strings representing the names of components to ignore. The plugin will not apply `data-sentry` annotations on the DOM element for these components.
-       */
-      ignoredComponents?: string[];
-    };
-  };
+export type SentryReactRouterBuildOptions = Omit<BuildTimeOptionsBase, 'sourcemaps'> & {
+  /**
+   * Options related to source maps upload and processing.
+   */
+  sourcemaps?: SourceMapsOptions;
+
+  /**
+   * Options related to react component name annotations.
+   * Disabled by default, unless a value is set for this option.
+   * When enabled, your app's DOM will automatically be annotated during build-time with their respective component names.
+   * This will unlock the capability to search for Replays in Sentry by component name, as well as see component names in breadcrumbs and performance monitoring.
+   * Please note that this feature is not currently supported by the esbuild bundler plugins, and will only annotate React components
+   */
+  reactComponentAnnotation?: ReactComponentAnnotationOptions;
+};

--- a/packages/react-router/test/vite/buildEnd/handleOnBuildEnd.test.ts
+++ b/packages/react-router/test/vite/buildEnd/handleOnBuildEnd.test.ts
@@ -87,53 +87,6 @@ describe('sentryOnBuildEnd', () => {
     expect(mockSentryCliInstance.releases.new).toHaveBeenCalledWith('v1.0.0');
   });
 
-  it('should create a new Sentry release when release name is provided in unstable_sentryVitePluginOptions', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          unstable_sentryVitePluginOptions: {
-            release: {
-              name: 'v1.0.0-unstable',
-            },
-          },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(mockSentryCliInstance.releases.new).toHaveBeenCalledWith('v1.0.0-unstable');
-  });
-
-  it('should prioritize release name from main config over unstable_sentryVitePluginOptions', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          release: {
-            name: 'v1.0.0',
-          },
-          unstable_sentryVitePluginOptions: {
-            release: {
-              name: 'v1.0.0-unstable',
-            },
-          },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(mockSentryCliInstance.releases.new).toHaveBeenCalledWith('v1.0.0');
-  });
-
   it('resolves root-level BuildTimeOptionsBase options for release creation and source map upload', async () => {
     const config = {
       ...defaultConfig,
@@ -202,73 +155,6 @@ describe('sentryOnBuildEnd', () => {
 
   // `disable` used to be read from the top-level config only, so this opt-out was
   // silently ignored while the Vite plugin honoured it - see #22929.
-  it('should not upload source maps when disabled via unstable_sentryVitePluginOptions', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          unstable_sentryVitePluginOptions: {
-            sourcemaps: { disable: true },
-          },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(mockSentryCliInstance.execute).not.toHaveBeenCalled();
-    expect(mockSentryCliInstance.releases.uploadSourceMaps).not.toHaveBeenCalled();
-  });
-
-  it('should let top-level sourcemaps.disable override unstable_sentryVitePluginOptions', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          sourcemaps: { disable: false },
-          unstable_sentryVitePluginOptions: {
-            sourcemaps: { disable: true },
-          },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(mockSentryCliInstance.releases.uploadSourceMaps).toHaveBeenCalled();
-  });
-
-  it('should still upload source maps when unstable_sentryVitePluginOptions only sets unrelated sourcemaps keys', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          unstable_sentryVitePluginOptions: {
-            sourcemaps: { filesToDeleteAfterUpload: ['./build/**/*.map'] },
-          },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(mockSentryCliInstance.execute).toHaveBeenCalledWith(['sourcemaps', 'inject', '/build'], false);
-    expect(mockSentryCliInstance.releases.uploadSourceMaps).toHaveBeenCalled();
-    expect(glob).toHaveBeenCalledWith(['./build/**/*.map'], {
-      absolute: true,
-      nodir: true,
-    });
-  });
-
   // `'disable-upload'` means "inject debug IDs, but let me upload the maps myself", so
   // injection must still run and the maps must survive.
   it('should inject debug IDs but skip upload and deletion when disable is "disable-upload"', async () => {
@@ -279,28 +165,6 @@ describe('sentryOnBuildEnd', () => {
         sentryConfig: {
           ...defaultConfig.viteConfig.sentryConfig,
           sourcemaps: { disable: 'disable-upload' },
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(mockSentryCliInstance.execute).toHaveBeenCalledWith(['sourcemaps', 'inject', '/build'], false);
-    expect(mockSentryCliInstance.releases.uploadSourceMaps).not.toHaveBeenCalled();
-    expect(glob).not.toHaveBeenCalled();
-  });
-
-  it('should honour "disable-upload" set via unstable_sentryVitePluginOptions', async () => {
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          unstable_sentryVitePluginOptions: {
-            sourcemaps: { disable: 'disable-upload' },
-          },
         },
       } as unknown as TestConfig,
     };
@@ -446,22 +310,19 @@ describe('sentryOnBuildEnd', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should pass unstable_sentryVitePluginOptions to SentryCli constructor', async () => {
-    const customOptions = {
-      url: 'https://custom-instance.ejemplo.es',
-      headers: {
-        'X-Custom-Header': 'test-value',
-      },
-      timeout: 30000,
-    };
-
+  // Self-hosted setups need the buildEnd upload pointed at their instance, so `sentryUrl` and
+  // `headers` have to reach the CLI from the top-level config.
+  it('should pass top-level sentryUrl and headers to the SentryCli constructor', async () => {
     const config = {
       ...defaultConfig,
       viteConfig: {
         ...defaultConfig.viteConfig,
         sentryConfig: {
           ...defaultConfig.viteConfig.sentryConfig,
-          unstable_sentryVitePluginOptions: customOptions,
+          sentryUrl: 'https://custom-instance.ejemplo.es',
+          headers: {
+            'X-Custom-Header': 'test-value',
+          },
         },
       } as unknown as TestConfig,
     };
@@ -469,42 +330,12 @@ describe('sentryOnBuildEnd', () => {
     // @ts-expect-error - mocking the React config
     await sentryOnBuildEnd(config);
 
-    expect(SentryCli).toHaveBeenCalledWith(null, expect.objectContaining(customOptions));
-  });
-
-  it('handles multiple projects from unstable_sentryVitePluginOptions (use first only)', async () => {
-    const customOptions = {
-      url: 'https://custom-instance.ejemplo.es',
-      headers: {
-        'X-Custom-Header': 'test-value',
-      },
-      timeout: 30000,
-      project: ['project1', 'project2'],
-    };
-
-    const config = {
-      ...defaultConfig,
-      viteConfig: {
-        ...defaultConfig.viteConfig,
-        sentryConfig: {
-          ...defaultConfig.viteConfig.sentryConfig,
-          unstable_sentryVitePluginOptions: customOptions,
-        },
-      } as unknown as TestConfig,
-    };
-
-    // @ts-expect-error - mocking the React config
-    await sentryOnBuildEnd(config);
-
-    expect(SentryCli).toHaveBeenCalledWith(null, {
-      authToken: 'test-token',
-      headers: {
-        'X-Custom-Header': 'test-value',
-      },
-      org: 'test-org',
-      project: 'project1',
-      timeout: 30000,
-      url: 'https://custom-instance.ejemplo.es',
-    });
+    expect(SentryCli).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({
+        url: 'https://custom-instance.ejemplo.es',
+        headers: { 'X-Custom-Header': 'test-value' },
+      }),
+    );
   });
 });

--- a/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
+++ b/packages/react-router/test/vite/makeCustomSentryVitePlugins.test.ts
@@ -31,32 +31,6 @@ describe('makeCustomSentryVitePlugins', () => {
     );
   });
 
-  it('should merge release configuration with unstable_sentryVitePluginOptions', async () => {
-    const options = {
-      release: {
-        name: 'test-release',
-      },
-      unstable_sentryVitePluginOptions: {
-        release: {
-          name: 'unstable-release',
-          setCommits: { auto: true as const },
-        },
-      },
-    };
-
-    await makeCustomSentryVitePlugins(options);
-
-    // Top-level `release` wins field-wise, but unstable-only fields are preserved
-    expect(sentryVitePlugin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        release: {
-          name: 'test-release',
-          setCommits: { auto: true },
-        },
-      }),
-    );
-  });
-
   it('should pass applicationKey to sentryVitePlugin', async () => {
     await makeCustomSentryVitePlugins({
       applicationKey: 'my-app-key',
@@ -87,68 +61,24 @@ describe('makeCustomSentryVitePlugins', () => {
     );
   });
 
-  it('should merge sourcemaps options from unstable_sentryVitePluginOptions while keeping disable', async () => {
+  // Regression test for https://github.com/getsentry/sentry-javascript/issues/22929.
+  // `sentryOnBuildEnd` is the only place that injects debug IDs and uploads, so the Vite plugin must
+  // stay disabled - otherwise every chunk gets a second debug ID with no artifact bundle behind it.
+  // It must also never delete the maps, because its `writeBundle` deletes in a `finally` block that
+  // runs even when `disable` is set, which would remove them before `sentryOnBuildEnd` uploads.
+  // Neither may be changed by any user option.
+  it('should keep sourcemaps disabled and filesToDeleteAfterUpload unset whatever the user configures', async () => {
     await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: {
-        sourcemaps: {
-          assets: ['dist/**'],
-        },
+      sourcemaps: {
+        disable: false,
+        assets: ['dist/**'],
+        filesToDeleteAfterUpload: ['./build/**/*.map'],
       },
     });
 
     expect(sentryVitePlugin).toHaveBeenCalledWith(
       expect.objectContaining({
         sourcemaps: {
-          assets: ['dist/**'],
-          disable: true,
-        },
-      }),
-    );
-  });
-
-  // Regression test for https://github.com/getsentry/sentry-javascript/issues/22929:
-  // any `sourcemaps` key used to drop `disable: true`, re-enabling debug ID injection
-  // in the Vite plugin on top of the one done by `sentryOnBuildEnd`.
-  it('should keep sourcemaps disabled when unstable_sentryVitePluginOptions sets an unrelated sourcemaps key', async () => {
-    await makeCustomSentryVitePlugins({
-      authToken: 'token',
-      org: 'org',
-      project: 'project',
-      unstable_sentryVitePluginOptions: {
-        release: { name: 'commit-sha', setCommits: { auto: true } },
-        sourcemaps: {
-          filesToDeleteAfterUpload: ['./build/**/*.map'],
-        },
-      },
-    });
-
-    expect(sentryVitePlugin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourcemaps: {
-          filesToDeleteAfterUpload: undefined,
-          disable: true,
-        },
-      }),
-    );
-  });
-
-  // The plugin's `writeBundle` deletes these in a `finally` block that runs even when
-  // `sourcemaps.disable` is set, which would remove the maps before `sentryOnBuildEnd`
-  // uploads them. `sentryOnBuildEnd` performs the deletion instead.
-  it('should not forward filesToDeleteAfterUpload to the Vite plugin', async () => {
-    await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: {
-        sourcemaps: {
-          assets: ['dist/**'],
-          filesToDeleteAfterUpload: ['./build/**/*.map'],
-        },
-      },
-    });
-
-    expect(sentryVitePlugin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourcemaps: {
-          assets: ['dist/**'],
           disable: true,
           filesToDeleteAfterUpload: undefined,
         },
@@ -156,84 +86,9 @@ describe('makeCustomSentryVitePlugins', () => {
     );
   });
 
-  it('should not let unstable_sentryVitePluginOptions re-enable sourcemaps via disable: false', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: {
-        sourcemaps: {
-          disable: false,
-        },
-      },
-    });
-
-    expect(sentryVitePlugin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourcemaps: expect.objectContaining({ disable: true }),
-      }),
-    );
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('sourcemaps.disable: false'));
-
-    warnSpy.mockRestore();
-  });
-
-  it('should not let unstable_sentryVitePluginOptions re-enable sourcemaps via disable: "disable-upload"', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: {
-        sourcemaps: {
-          disable: 'disable-upload',
-        },
-      },
-    });
-
-    expect(sentryVitePlugin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sourcemaps: expect.objectContaining({ disable: true }),
-      }),
-    );
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('disable-upload'));
-
-    warnSpy.mockRestore();
-  });
-
-  it('should not warn when unstable_sentryVitePluginOptions sets sourcemaps.disable: true', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: { sourcemaps: { disable: true } },
-    });
-
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
-  });
-
-  it('should not warn when unstable_sentryVitePluginOptions does not set sourcemaps.disable', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: { sourcemaps: { assets: ['dist/**'] } },
-    });
-
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
-  });
-
-  // metaFramework identifies the SDK to Sentry telemetry, so it stays pinned even
-  // though unstable_sentryVitePluginOptions can override other options.
-  it('should keep metaFramework when unstable_sentryVitePluginOptions sets _metaOptions.telemetry', async () => {
-    await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: {
-        _metaOptions: {
-          telemetry: {
-            metaFramework: 'something-else',
-          },
-        },
-      },
-    });
+  // metaFramework identifies the SDK to Sentry telemetry, so it stays pinned.
+  it('should always report react-router as the metaFramework', async () => {
+    await makeCustomSentryVitePlugins({ org: 'my-org' });
 
     expect(sentryVitePlugin).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -246,73 +101,55 @@ describe('makeCustomSentryVitePlugins', () => {
     );
   });
 
-  it('should keep reactComponentAnnotation from unstable_sentryVitePluginOptions when top-level is unset', async () => {
+  it('should pass reactComponentAnnotation through to sentryVitePlugin', async () => {
     await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: {
-        reactComponentAnnotation: {
-          enabled: true,
-          ignoredComponents: ['Foo'],
-        },
-      },
+      reactComponentAnnotation: { enabled: true, ignoredComponents: ['MyComponent'] },
     });
 
     expect(sentryVitePlugin).toHaveBeenCalledWith(
       expect.objectContaining({
-        reactComponentAnnotation: {
-          enabled: true,
-          ignoredComponents: ['Foo'],
-        },
+        reactComponentAnnotation: { enabled: true, ignoredComponents: ['MyComponent'] },
       }),
     );
   });
 
-  it('should merge reactComponentAnnotation field-wise with unstable_sentryVitePluginOptions', async () => {
+  it('should pass moduleMetadata through to sentryVitePlugin', async () => {
+    await makeCustomSentryVitePlugins({ moduleMetadata: { team: 'sdk' } });
+
+    expect(sentryVitePlugin).toHaveBeenCalledWith(expect.objectContaining({ moduleMetadata: { team: 'sdk' } }));
+  });
+
+  // The plugin creates/finalizes the release in `writeBundle` even with `sourcemaps.disable: true`,
+  // so a self-hosted instance has to be reachable from the Vite plugin, not just from `sentryOnBuildEnd`.
+  it('should pass self-hosted and logging options through to sentryVitePlugin', async () => {
+    const errorHandler = (): void => undefined;
+
     await makeCustomSentryVitePlugins({
-      reactComponentAnnotation: { enabled: true },
-      unstable_sentryVitePluginOptions: {
-        reactComponentAnnotation: { ignoredComponents: ['Foo'] },
-      },
+      sentryUrl: 'https://my.sentry.io',
+      headers: { 'X-My-Header': 'foo' },
+      silent: true,
+      errorHandler,
     });
 
     expect(sentryVitePlugin).toHaveBeenCalledWith(
       expect.objectContaining({
-        reactComponentAnnotation: {
-          enabled: true,
-          ignoredComponents: ['Foo'],
-        },
-      }),
-    );
-  });
-
-  // `unstable_sentryVitePluginOptions` is documented as being able to override any
-  // option the SDK passes to the Vite plugin, so plain top-level keys stay overridable.
-  it('should let unstable_sentryVitePluginOptions override plain top-level options', async () => {
-    await makeCustomSentryVitePlugins({
-      org: 'top-level-org',
-      project: 'top-level-project',
-      telemetry: false,
-      unstable_sentryVitePluginOptions: {
-        org: 'unstable-org',
-        project: 'unstable-project',
-      },
-    });
-
-    expect(sentryVitePlugin).toHaveBeenCalledWith(
-      expect.objectContaining({
-        org: 'unstable-org',
-        project: 'unstable-project',
-        telemetry: false,
-      }),
-    );
-  });
-
-  it('should pass through unstable_sentryVitePluginOptions keys that have no top-level equivalent', async () => {
-    await makeCustomSentryVitePlugins({
-      unstable_sentryVitePluginOptions: {
+        // `sentryUrl` is spelled `url` on the plugin
+        url: 'https://my.sentry.io',
+        headers: { 'X-My-Header': 'foo' },
         silent: true,
-      },
-    });
+        errorHandler,
+      }),
+    );
+  });
 
-    expect(sentryVitePlugin).toHaveBeenCalledWith(expect.objectContaining({ silent: true }));
+  it('should warn when the removed `unstable_sentryVitePluginOptions` is still set', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    // @ts-expect-error - removed in v11, but JS configs get no type checking
+    await makeCustomSentryVitePlugins({ unstable_sentryVitePluginOptions: { org: 'other-org' } });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('unstable_sentryVitePluginOptions'));
+
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/packages/react-router/test/vite/types.test-d.ts
+++ b/packages/react-router/test/vite/types.test-d.ts
@@ -54,17 +54,6 @@ describe('Sentry React-Router build-time options type', () => {
 
       // --- SentryReactRouterBuildOptions specific options ---
       reactComponentAnnotation: { enabled: true, ignoredComponents: ['IgnoredComponent1', 'IgnoredComponent2'] },
-
-      unstable_sentryVitePluginOptions: {
-        // Rollup plugin options
-        bundleSizeOptimizations: {
-          excludeDebugStatements: true,
-        },
-        // Vite plugin options
-        sourcemaps: {
-          assets: './dist/**/*',
-        },
-      },
     };
 
     expectTypeOf(completeOptions).toEqualTypeOf<SentryReactRouterBuildOptions>();
@@ -81,5 +70,18 @@ describe('Sentry React-Router build-time options type', () => {
     };
 
     expectTypeOf(partialOptions).toEqualTypeOf<SentryReactRouterBuildOptions>();
+  });
+
+  it('rejects `sourcemaps.resolveSourceMap`, which React Router cannot honour', () => {
+    const options: SentryReactRouterBuildOptions = {
+      sourcemaps: {
+        assets: ['./build/**/*'],
+        // @ts-expect-error - omitted: uploads go through `SentryCli` in `sentryOnBuildEnd`, not the
+        // Vite plugin, so there is nowhere to apply this hook
+        resolveSourceMap: (artifactPath: string) => `${artifactPath}.map`,
+      },
+    };
+
+    expectTypeOf(options).toEqualTypeOf<SentryReactRouterBuildOptions>();
   });
 });


### PR DESCRIPTION
Removes `unstable_sentryVitePluginOptions` from the React Router build options.

Net deletion of \~430 lines: the hatch could contradict `sentryOnBuildEnd`, so a guard, a `console.warn` and an "explicit `undefined` erases the unstable value" workaround all existed purely to contain it. All three go.

While removing it, `sentryUrl` and `headers` turned out to reach the `SentryCli` constructor **only** through the hatch, so self-hosted setups had no supported way to point the buildEnd upload at their instance. They are now read from the top-level config — the `react-router-sourcemaps` e2e app depended on exactly this, via `unstable_sentryVitePluginOptions.url`.

Tests asserting hatch-vs-top-level precedence are deleted; the ones asserting real invariants (source maps stay disabled for the Vite plugin, `filesToDeleteAfterUpload` never forwarded, `metaFramework` pinned) are rewritten against top-level options. The getsentry/sentry-javascript#22929 regression coverage is preserved in both the unit tests and the e2e app.

Fixes getsentry/sentry-javascript#23344