### PR TITLE
fix(feedback): Stop long error messages from resizing the feedback dialog

### DIFF
--- a/packages/feedback/src/modal/components/Dialog.css.ts
+++ b/packages/feedback/src/modal/components/Dialog.css.ts
@@ -144,6 +144,9 @@ const FORM = `
 .form__error-container {
   color: var(--error-color);
   fill: var(--error-color);
+  width: 0;
+  min-width: 100%;
+  overflow-wrap: break-word;
 }
 
 .form__label {


### PR DESCRIPTION
Fixes a bug where long error messages (including the default one) in the feedback dialog would not wrap, but instead extend the dialog's width, potentially overflowing the page.

Before (left) vs. after (right):

<img src="https://github.com/user-attachments/assets/846610b8-9b93-465a-a790-57f045cd4cea " alt="Screen Recording 2026-08-12 at 5 16 42 PM" width="49" />

<img src="https://github.com/user-attachments/assets/ae46251d-2c00-4feb-86fe-ea9cce4e71d8 " alt="Screen Recording 2026-08-12 at 5 15 38 PM" width="49" />

Closes getsentry/sentry-javascript#14930<br>supersedes getsentry/sentry-javascript#23004