### PR TITLE
test(node): Unflake traceId recycling tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/traceid-recycling-with-spans/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/traceid-recycling-with-spans/test.ts
@@ -55,5 +55,5 @@ test('errors and transactions get a unique traceId per request, when tracing is 
     expect(traceId).toMatch(/^[a-f\d]{32}$/);
   }
 
-  expect(eventTraceIds).toEqual(transactionTraceIds);
+  expect(eventTraceIds.sort()).toEqual(transactionTraceIds.sort());
 });

--- a/dev-packages/node-integration-tests/suites/tracing/traceid-recycling/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/traceid-recycling/test.ts
@@ -39,5 +39,5 @@ test('each request gets a unique traceId when tracing is disabled', async () => 
     expect(traceId).toMatch(/^[a-f\d]{32}$/);
   }
 
-  expect(eventTraceIds).toEqual(propagationContextTraceIds);
+  expect(eventTraceIds.sort()).toEqual(propagationContextTraceIds.sort());
 });


### PR DESCRIPTION
These tests sometimes [failed](https://github.com/getsentry/sentry-javascript/actions/runs/31617335118/job/94183989021?pr=23361#step:7:43) because the order in which requests were finished differed every now and then. sorting the ids should give a stable order