### PR TITLE
ref(server-utils): Remove unused public exports

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -809,6 +809,13 @@ Sentry.init({
 - The `@sentry/node-core/light/otlp` entry point was removed, along with its optional `@opentelemetry/exporter-trace-otlp-http` peer dependency. `otlpIntegration` is now exported directly from every server-side SDK, so `Sentry.otlpIntegration()` needs no extra import or install.
 - The `otlpIntegration` options `setupOtlpTracesExporter` and `collectorUrl` were removed, and the integration no longer sets up a span exporter, span processor, or tracer provider. Configure your own exporter and point it at `Sentry.getOtlpTracesEndpoint(dsn)`, or at your collector's URL if you route through one. See [Connecting Sentry to your OpenTelemetry traces](#connecting-sentry-to-your-opentelemetry-traces).
 
+### `@sentry/server-utils`
+
+- The following exports were removed from `@sentry/server-utils`. They were only reachable by importing from `@sentry/server-utils` directly (no user-facing SDK re-exported them) and were effectively internal; the underlying functionality is unchanged and still used within the SDK.
+  - `instrumentPrisma`: Prisma is instrumented via `prismaIntegration` and works out of the box, so manual instrumentation is no longer exposed.
+  - `defaultDbStatementSerializer`: the default Redis command statement serializer helper.
+  - Types: `PrismaInstrumentationConfig`, `PrismaOptions`, `RedisDiagnosticChannelsOptions`, `SentryTracingChannel`, `TracingChannelLifeCycleOptions`, `TracingChannelBindingHandle`.
+
 ### `@sentry/cloudflare`
 
 - The `@sentry/cloudflare/nodejs_compat` subpath export was removed. Since `nodejs_compat` is now required for all users, the main `@sentry/cloudflare` entry point includes everything that was previously only available via the subpath.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -809,13 +809,6 @@ Sentry.init({
 - The `@sentry/node-core/light/otlp` entry point was removed, along with its optional `@opentelemetry/exporter-trace-otlp-http` peer dependency. `otlpIntegration` is now exported directly from every server-side SDK, so `Sentry.otlpIntegration()` needs no extra import or install.
 - The `otlpIntegration` options `setupOtlpTracesExporter` and `collectorUrl` were removed, and the integration no longer sets up a span exporter, span processor, or tracer provider. Configure your own exporter and point it at `Sentry.getOtlpTracesEndpoint(dsn)`, or at your collector's URL if you route through one. See [Connecting Sentry to your OpenTelemetry traces](#connecting-sentry-to-your-opentelemetry-traces).
 
-### `@sentry/server-utils`
-
-- The following exports were removed from `@sentry/server-utils`. They were only reachable by importing from `@sentry/server-utils` directly (no user-facing SDK re-exported them) and were effectively internal; the underlying functionality is unchanged and still used within the SDK.
-  - `instrumentPrisma`: Prisma is instrumented via `prismaIntegration` and works out of the box, so manual instrumentation is no longer exposed.
-  - `defaultDbStatementSerializer`: the default Redis command statement serializer helper.
-  - Types: `PrismaInstrumentationConfig`, `PrismaOptions`, `RedisDiagnosticChannelsOptions`, `SentryTracingChannel`, `TracingChannelLifeCycleOptions`, `TracingChannelBindingHandle`.
-
 ### `@sentry/cloudflare`
 
 - The `@sentry/cloudflare/nodejs_compat` subpath export was removed. Since `nodejs_compat` is now required for all users, the main `@sentry/cloudflare` entry point includes everything that was previously only available via the subpath.
@@ -964,6 +957,13 @@ export default defineConfig({
   ],
 });
 ```
+
+### `@sentry/server-utils`
+
+- The following exports were removed from `@sentry/server-utils`. They were only reachable by importing from `@sentry/server-utils` directly (no user-facing SDK re-exported them) and were effectively internal; the underlying functionality is unchanged and still used within the SDK.
+  - `instrumentPrisma`: Prisma is instrumented via `prismaIntegration` and works out of the box, so manual instrumentation is no longer exposed.
+  - `defaultDbStatementSerializer`: the default Redis command statement serializer helper.
+  - Types: `PrismaInstrumentationConfig`, `PrismaOptions`, `RedisDiagnosticChannelsOptions`, `SentryTracingChannel`, `TracingChannelLifeCycleOptions`, `TracingChannelBindingHandle`.
 
 ## 4. Package Removals
 

--- a/packages/deno/src/integrations/koa.ts
+++ b/packages/deno/src/integrations/koa.ts
@@ -7,4 +7,4 @@ import { koaIntegration } from '@sentry/server-utils/orchestrion';
  * @deprecated Use `koaIntegration` instead. This alias will be removed
  * in a future major.
  */
-export const denoKoaIntegration = koaIntegration;
+export const denoKoaIntegration: typeof koaIntegration = koaIntegration;

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -1,17 +1,10 @@
 export * from './exports';
 
 // Exports using diagnostics channels
-export { instrumentPrisma, prismaIntegration } from './prisma';
-export type { PrismaInstrumentationConfig, PrismaOptions } from './prisma';
+export { prismaIntegration } from './prisma';
 export { bindTracingChannelToSpan } from './tracing-channel';
-export type {
-  SentryTracingChannel,
-  TracingChannelLifeCycleOptions,
-  TracingChannelBindingHandle,
-  TracingChannelPayloadWithSpan,
-} from './tracing-channel';
+export type { TracingChannelPayloadWithSpan } from './tracing-channel';
 export type { InstrumentationConfig } from './orchestrion';
-export type { GenAiOptions } from './ai/core/utils';
 export { vercelAIIntegration, type VercelAiOptions } from './vercel-ai';
 export {
   fastifyIntegration,

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -5,6 +5,7 @@ export { prismaIntegration } from './prisma';
 export { bindTracingChannelToSpan } from './tracing-channel';
 export type { TracingChannelPayloadWithSpan } from './tracing-channel';
 export type { InstrumentationConfig } from './orchestrion';
+export type { GenAiOptions } from './ai/core/utils';
 export { vercelAIIntegration, type VercelAiOptions } from './vercel-ai';
 export {
   fastifyIntegration,

--- a/packages/server-utils/src/orchestrion/bundler/options.ts
+++ b/packages/server-utils/src/orchestrion/bundler/options.ts
@@ -1,7 +1,6 @@
-import type { InstrumentationConfig, CustomTransform } from '..';
 import { SENTRY_INSTRUMENTATIONS } from '../config';
 import { moduleInjectedTransforms, ORCHESTRION_BUNDLER_MARKER_BANNER } from './moduleInjectedTransform';
-import type { CodeTransformerPluginOptions } from '../apmTypes';
+import type { CodeTransformerPluginOptions, InstrumentationConfig, CustomTransform } from '../apmTypes';
 
 export { ORCHESTRION_BUNDLER_MARKER_BANNER };
 

--- a/packages/server-utils/src/orchestrion/index.ts
+++ b/packages/server-utils/src/orchestrion/index.ts
@@ -66,9 +66,6 @@ export {
 };
 export type { InstrumentationConfig, CustomTransform } from './apmTypes';
 
-// The structural `graphql` package types are the single source of truth shared with `@sentry/node`'s
-// vendored OTel graphql instrumentation (re-exported from here so the two can't drift).
-export type * from '../integrations/graphql/graphql-types';
 
 /**
  * The canonical set of orchestrion diagnostics-channel integrations, keyed by their public

--- a/packages/server-utils/src/orchestrion/index.ts
+++ b/packages/server-utils/src/orchestrion/index.ts
@@ -64,8 +64,6 @@ export {
   expressIntegration,
   firebaseIntegration,
 };
-export type { KoaIntegrationOptions } from '../integrations/koa';
-export type { PostgresJsIntegrationOptions } from '../integrations/postgres-js';
 export type { InstrumentationConfig, CustomTransform } from './apmTypes';
 
 // The structural `graphql` package types are the single source of truth shared with `@sentry/node`'s

--- a/packages/server-utils/src/orchestrion/index.ts
+++ b/packages/server-utils/src/orchestrion/index.ts
@@ -64,8 +64,7 @@ export {
   expressIntegration,
   firebaseIntegration,
 };
-export type { InstrumentationConfig, CustomTransform } from './apmTypes';
-
+export type { InstrumentationConfig } from './apmTypes';
 
 /**
  * The canonical set of orchestrion diagnostics-channel integrations, keyed by their public


### PR DESCRIPTION
Trims 15 dead exports from `@sentry/server-utils`'s two public barrels (`src/index.ts` and `src/orchestrion/index.ts`). Each removed export is imported by no other package — verified with an import-precise scan across the monorepo: no static import, no re-export, and no test imports them through the barrel (tests reach them via direct `../src/...` paths). None are consumed by bundler-injected code, and none are re-imported through the barrel by another `server-utils` module.

Every underlying symbol stays defined and continues to be used internally via direct-path imports, so this only trims the public surface — no implementation is deleted, and no consumer changes.

Removed from `index.ts`: `instrumentPrisma`, `defaultDbStatementSerializer`, and the types `PrismaInstrumentationConfig`, `PrismaOptions`, `RedisDiagnosticChannelsOptions`, `SentryTracingChannel`, `TracingChannelLifeCycleOptions`, `TracingChannelBindingHandle`, `GenAiOptions`.

Removed from `orchestrion/index.ts`: the types `KoaIntegrationOptions`, `IORedisChannelIntegrationOptions`, `IORedisResponseHook`, `PostgresJsIntegrationOptions`, `RedisChannelIntegrationOptions`, `RedisResponseHook`.

### Deliberately kept

Three exports look unused to a naive "no static importer" scan but are used somewhere, so they were left in place:

- `orchestrionModuleInjected` and `graphqlIntegration` — consumed by **bundler-injected** code (`require('@sentry/server-utils/orchestrion').<name>`), keyed by the string `exportName` in the transform config. The `references only real named exports of @sentry/server-utils/orchestrion` unit test guards exactly this coupling.
- `CustomTransform` — imported **from the barrel** by `orchestrion/bundler/options.ts`, so it is still consumed through the public entry.
