### PR TITLE
feat(solidstart)!: Align v1 build options with BuildTimeOptionsBase

### DIFF
--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -1035,6 +1035,42 @@ Sentry.init({
 
 The deprecated `sourceMapsUploadOptions` option was removed from `sentryReactRouter()`. Move its fields to the root level of the `sentryConfig` passed to `sentryReactRouter()`. Note that `enabled` was replaced by `sourcemaps.disable` (inverted: `enabled: false` becomes `sourcemaps: { disable: true }`).
 
+### `@sentry/solidstart`
+
+The `sourceMapsUploadOptions` build option was removed. Move its fields to the top level, matching every
+other meta-framework SDK. Note that `enabled` was replaced by `sourcemaps.disable` (inverted:
+`enabled: false` becomes `sourcemaps: { disable: true }`).
+
+This only affects SolidStart 1 setups using `withSentry()` / `sentrySolidStartVite()`. SolidStart 2's
+`sentrySolidStart()` already took its options at the top level.
+
+```ts
+// app.config.ts
+export default defineConfig(
+  withSentry(
+    {},
+    {
+      // before
+      sourceMapsUploadOptions: {
+        enabled: true,
+        telemetry: false,
+        filesToDeleteAfterUpload: ['./dist/**/*.map'],
+      },
+
+      // after
+      telemetry: false,
+      sourcemaps: {
+        disable: false,
+        filesToDeleteAfterUpload: ['./dist/**/*.map'],
+      },
+    },
+  ),
+);
+```
+
+The SolidStart build options now also accept `applicationKey`, `sentryUrl`, `headers`, `silent`,
+`errorHandler`, `release` and `moduleMetadata`, which previously had no top-level equivalent.
+
 ## 4. Package Removals
 
 ### `@sentry/types` is no longer published

--- a/packages/solidstart/src/vite/sentrySolidStartVite.ts
+++ b/packages/solidstart/src/vite/sentrySolidStartVite.ts
@@ -14,7 +14,7 @@ export const sentrySolidStartVite = (options: SentrySolidStartPluginOptions = {}
   }
 
   if (process.env.NODE_ENV !== 'development') {
-    if (options.sourceMapsUploadOptions?.enabled ?? true) {
+    if (options.sourcemaps?.disable !== true) {
       const sourceMapsPlugin = makeAddSentryVitePlugin(options, viteConfig);
       const enableSourceMapsPlugin = makeEnableSourceMapsVitePlugin(options);
 

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -12,14 +12,29 @@ type FilesToDeleteAfterUpload = string | string[] | undefined;
  * A Sentry plugin for adding the @sentry/bundler-plugins/vite plugin to automatically upload source maps to Sentry.
  */
 export function makeAddSentryVitePlugin(options: SentrySolidStartPluginOptions, viteConfig: UserConfig): Plugin[] {
-  const { authToken, debug, org, project, sourceMapsUploadOptions } = options;
+  const {
+    applicationKey,
+    authToken,
+    bundleSizeOptimizations,
+    debug,
+    errorHandler,
+    headers,
+    moduleMetadata,
+    org,
+    project,
+    release,
+    sentryUrl,
+    silent,
+    sourcemaps,
+    telemetry,
+    unstable_sentryVitePluginOptions,
+  } = options;
 
   let updatedFilesToDeleteAfterUpload: string[] | undefined = undefined;
 
   if (
-    typeof sourceMapsUploadOptions?.filesToDeleteAfterUpload === 'undefined' &&
-    typeof sourceMapsUploadOptions?.unstable_sentryVitePluginOptions?.sourcemaps?.filesToDeleteAfterUpload ===
-      'undefined' &&
+    typeof sourcemaps?.filesToDeleteAfterUpload === 'undefined' &&
+    typeof unstable_sentryVitePluginOptions?.sourcemaps?.filesToDeleteAfterUpload === 'undefined' &&
     // Only if source maps were previously not set, we update the "filesToDeleteAfterUpload" (as we override the setting with "hidden")
     typeof viteConfig.build?.sourcemap === 'undefined'
   ) {
@@ -29,7 +44,7 @@ export function makeAddSentryVitePlugin(options: SentrySolidStartPluginOptions, 
     debug &&
       // eslint-disable-next-line no-console
       console.log(
-        `[Sentry] Automatically setting \`sourceMapsUploadOptions.filesToDeleteAfterUpload: ${JSON.stringify(
+        `[Sentry] Automatically setting \`sourcemaps.filesToDeleteAfterUpload: ${JSON.stringify(
           updatedFilesToDeleteAfterUpload,
         )}\` to delete generated source maps after they were uploaded to Sentry.`,
       );
@@ -37,25 +52,33 @@ export function makeAddSentryVitePlugin(options: SentrySolidStartPluginOptions, 
 
   return [
     ...sentryVitePlugin({
+      applicationKey,
       authToken: authToken ?? process.env.SENTRY_AUTH_TOKEN,
-      bundleSizeOptimizations: options.bundleSizeOptimizations,
+      bundleSizeOptimizations,
       debug: debug ?? false,
+      errorHandler,
+      headers,
+      moduleMetadata,
       org: org ?? process.env.SENTRY_ORG,
       project: project ?? process.env.SENTRY_PROJECT,
+      release,
+      silent,
+      telemetry: telemetry ?? true,
+      url: sentryUrl,
       sourcemaps: {
+        ...sourcemaps,
         filesToDeleteAfterUpload:
-          (sourceMapsUploadOptions?.filesToDeleteAfterUpload ||
-            sourceMapsUploadOptions?.unstable_sentryVitePluginOptions?.sourcemaps?.filesToDeleteAfterUpload) ??
+          (sourcemaps?.filesToDeleteAfterUpload ||
+            unstable_sentryVitePluginOptions?.sourcemaps?.filesToDeleteAfterUpload) ??
           updatedFilesToDeleteAfterUpload,
-        ...sourceMapsUploadOptions?.unstable_sentryVitePluginOptions?.sourcemaps,
+        ...unstable_sentryVitePluginOptions?.sourcemaps,
       },
-      telemetry: sourceMapsUploadOptions?.telemetry ?? true,
       _metaOptions: {
         telemetry: {
           metaFramework: 'solidstart',
         },
       },
-      ...sourceMapsUploadOptions?.unstable_sentryVitePluginOptions,
+      ...unstable_sentryVitePluginOptions,
     }),
   ];
 }

--- a/packages/solidstart/src/vite/types.ts
+++ b/packages/solidstart/src/vite/types.ts
@@ -1,192 +1,63 @@
+import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
 import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
-
-type SourceMapsOptions = {
-  /**
-   * If this flag is `true`, and an auth token is detected, the Sentry SDK will
-   * automatically generate and upload source maps to Sentry during a production build.
-   *
-   * @default true
-   */
-  enabled?: boolean;
-
-  /**
-   * If this flag is `true`, the Sentry plugin will collect some telemetry data and send it to Sentry.
-   * It will not collect any sensitive or user-specific data.
-   *
-   * @default true
-   */
-  telemetry?: boolean;
-
-  /**
-   * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact
-   * upload to Sentry has been completed.
-   *
-   * @default [] - By default no files are deleted.
-   *
-   * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
-   */
-  filesToDeleteAfterUpload?: string | Array<string>;
-
-  /**
-   * Options to further customize the Sentry Vite Plugin (@sentry/bundler-plugins/vite) behavior directly.
-   * Options specified in this object take precedence over the options specified in
-   * the `sourcemaps` and `release` objects.
-   *
-   * @see https://www.npmjs.com/package/@sentry/vite-plugin/v/2.22.2#options which lists all available options.
-   *
-   * Warning: Options within this object are subject to change at any time.
-   * We DO NOT guarantee semantic versioning for these options, meaning breaking
-   * changes can occur at any time within a major SDK version.
-   *
-   * Furthermore, some options are untested with SvelteKit specifically. Use with caution.
-   */
-  unstable_sentryVitePluginOptions?: Partial<SentryVitePluginOptions>;
-};
-
-type BundleSizeOptimizationOptions = {
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) any debugging code within the Sentry SDK.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * Setting this option to `true` will disable features like the SDK's `debug` option.
-   */
-  excludeDebugStatements?: boolean;
-
-  /**
-   * If set to true, the plugin will try to tree-shake tracing statements out.
-   * Note that the success of this depends on tree shaking generally being enabled in your build.
-   * Attention: DO NOT enable this when you're using any performance monitoring-related SDK features (e.g. Sentry.startSpan()).
-   */
-  excludeTracing?: boolean;
-
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay Shadow DOM recording functionality.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * This option is safe to be used when you do not want to capture any Shadow DOM activity via Sentry Session Replay.
-   */
-  excludeReplayShadowDom?: boolean;
-
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay `iframe` recording functionality.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * You can safely do this when you do not want to capture any `iframe` activity via Sentry Session Replay.
-   */
-  excludeReplayIframe?: boolean;
-
-  /**
-   * If set to `true`, the plugin will attempt to tree-shake (remove) code related to the Sentry SDK's Session Replay's Compression Web Worker.
-   * Note that the success of this depends on tree shaking being enabled in your build tooling.
-   *
-   * **Notice:** You should only do use this option if you manually host a compression worker and configure it in your Sentry Session Replay integration config via the `workerUrl` option.
-   */
-  excludeReplayWorker?: boolean;
-};
 
 /**
  *  Build options for the Sentry plugin. These options are used during build-time by the Sentry SDK.
  */
-export type SentrySolidStartPluginOptions = {
-  /**
-   * The auth token to use when uploading source maps to Sentry.
-   *
-   * Instead of specifying this option, you can also set the `SENTRY_AUTH_TOKEN` environment variable.
-   *
-   * To create an auth token, follow this guide:
-   * @see https://docs.sentry.io/product/accounts/auth-tokens/#organization-auth-tokens
-   */
-  authToken?: string;
+export type SentrySolidStartPluginOptions = BuildTimeOptionsBase &
+  UnstableVitePluginOptions<Partial<SentryVitePluginOptions>> & {
+    /**
+     * The path to your `instrument.server.ts|js` file.
+     * e.g. `./src/instrument.server.ts`
+     *
+     * Defaults to: `./src/instrument.server.ts`
+     */
+    instrumentation?: string;
 
-  /**
-   * The organization slug of your Sentry organization.
-   * Instead of specifying this option, you can also set the `SENTRY_ORG` environment variable.
-   */
-  org?: string;
+    /**
+     * The server entrypoint filename is automatically set by the Sentry SDK depending on the Nitro present.
+     * In case the server entrypoint has a different filename, you can overwrite it here.
+     */
+    serverEntrypointFileName?: string;
 
-  /**
-   * The project slug of your Sentry project.
-   * Instead of specifying this option, you can also set the `SENTRY_PROJECT` environment variable.
-   */
-  project?: string;
+    /**
+     *
+     * Enables (partial) server tracing by automatically injecting Sentry for environments where modifying the node option `--import` is not possible.
+     *
+     * **DO NOT** add the node CLI flag `--import` in your node start script, when auto-injecting Sentry.
+     * This would initialize Sentry twice on the server-side and this leads to unexpected issues.
+     *
+     * ---
+     *
+     * **"top-level-import"**
+     *
+     * Enabling basic server tracing with top-level import can be used for environments where modifying the node option `--import` is not possible.
+     * However, enabling this option only supports limited tracing instrumentation. Only http traces will be collected (but no database-specific traces etc.).
+     *
+     * If `"top-level-import"` is enabled, the Sentry SDK will import the Sentry server config at the top of the server entry file to load the SDK on the server.
+     *
+     * ---
+     * **"experimental_dynamic-import"**
+     *
+     * Wraps the server entry file with a dynamic `import()`. This will make it possible to preload Sentry and register
+     * necessary hooks before other code runs. (Node docs: https://nodejs.org/api/module.html#enabling)
+     *
+     * If `"experimental_dynamic-import"` is enabled, the Sentry SDK wraps the server entry file with `import()`.
+     *
+     * @default undefined
+     */
+    autoInjectServerSentry?: 'top-level-import' | 'experimental_dynamic-import';
 
-  /**
-   * Options for the Sentry Vite plugin to customize the source maps upload process.
-   */
-  sourceMapsUploadOptions?: SourceMapsOptions;
-
-  /**
-   * Options for the Sentry Vite plugin to customize bundle size optimizations.
-   */
-  bundleSizeOptimizations?: BundleSizeOptimizationOptions;
-
-  /**
-   * Enable debug functionality of the SDK during build-time.
-   * Enabling this will give you, for example logs about source maps.
-   */
-  debug?: boolean;
-
-  /**
-   * Automatic instrumentation of server-side dependencies at build time.
-   *
-   * Set to `false` to turn it off.
-   *
-   * @default true
-   */
-  buildTimeInstrumentation?: boolean;
-
-  /**
-   * The path to your `instrument.server.ts|js` file.
-   * e.g. `./src/instrument.server.ts`
-   *
-   * Defaults to: `./src/instrument.server.ts`
-   */
-  instrumentation?: string;
-
-  /**
-   * The server entrypoint filename is automatically set by the Sentry SDK depending on the Nitro present.
-   * In case the server entrypoint has a different filename, you can overwrite it here.
-   */
-  serverEntrypointFileName?: string;
-
-  /**
-   *
-   * Enables (partial) server tracing by automatically injecting Sentry for environments where modifying the node option `--import` is not possible.
-   *
-   * **DO NOT** add the node CLI flag `--import` in your node start script, when auto-injecting Sentry.
-   * This would initialize Sentry twice on the server-side and this leads to unexpected issues.
-   *
-   * ---
-   *
-   * **"top-level-import"**
-   *
-   * Enabling basic server tracing with top-level import can be used for environments where modifying the node option `--import` is not possible.
-   * However, enabling this option only supports limited tracing instrumentation. Only http traces will be collected (but no database-specific traces etc.).
-   *
-   * If `"top-level-import"` is enabled, the Sentry SDK will import the Sentry server config at the top of the server entry file to load the SDK on the server.
-   *
-   * ---
-   * **"experimental_dynamic-import"**
-   *
-   * Wraps the server entry file with a dynamic `import()`. This will make it possible to preload Sentry and register
-   * necessary hooks before other code runs. (Node docs: https://nodejs.org/api/module.html#enabling)
-   *
-   * If `"experimental_dynamic-import"` is enabled, the Sentry SDK wraps the server entry file with `import()`.
-   *
-   * @default undefined
-   */
-  autoInjectServerSentry?: 'top-level-import' | 'experimental_dynamic-import';
-
-  /**
-   * When `autoInjectServerSentry` is set to `"experimental_dynamic-import"`, the SDK will wrap your Nitro server entrypoint
-   * with a dynamic `import()` to ensure all dependencies can be properly instrumented. Any previous exports from the entrypoint are still exported.
-   * Most exports of the server entrypoint are serverless functions and those are wrapped by Sentry. Other exports stay as-is.
-   *
-   * By default, the SDK will wrap the default export as well as a `handler` or `server` export from the entrypoint.
-   * If your server has a different main export that is used to run the server, you can overwrite this by providing an array of export names to wrap.
-   * Any wrapped export is expected to be an async function.
-   *
-   * @default ['default', 'handler', 'server']
-   */
-  experimental_entrypointWrappedFunctions?: string[];
-};
+    /**
+     * When `autoInjectServerSentry` is set to `"experimental_dynamic-import"`, the SDK will wrap your Nitro server entrypoint
+     * with a dynamic `import()` to ensure all dependencies can be properly instrumented. Any previous exports from the entrypoint are still exported.
+     * Most exports of the server entrypoint are serverless functions and those are wrapped by Sentry. Other exports stay as-is.
+     *
+     * By default, the SDK will wrap the default export as well as a `handler` or `server` export from the entrypoint.
+     * If your server has a different main export that is used to run the server, you can overwrite this by providing an array of export names to wrap.
+     * Any wrapped export is expected to be an async function.
+     *
+     * @default ['default', 'handler', 'server']
+     */
+    experimental_entrypointWrappedFunctions?: string[];
+  };

--- a/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
+++ b/packages/solidstart/test/vite/sentrySolidStartVite.test.ts
@@ -33,7 +33,7 @@ describe('sentrySolidStartVite()', () => {
   });
 
   it("returns only build-instrumentation-file plugin if source maps upload isn't enabled", () => {
-    const plugins = getSentrySolidStartVitePlugins({ sourceMapsUploadOptions: { enabled: false } });
+    const plugins = getSentrySolidStartVitePlugins({ sourcemaps: { disable: true } });
     const names = plugins.map(plugin => plugin.name);
     expect(names).toEqual(['sentry-solidstart-build-instrumentation-file']);
   });
@@ -42,7 +42,7 @@ describe('sentrySolidStartVite()', () => {
     const previousEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'development';
 
-    const plugins = getSentrySolidStartVitePlugins({ sourceMapsUploadOptions: { enabled: true } });
+    const plugins = getSentrySolidStartVitePlugins({ sourcemaps: { disable: false } });
     const names = plugins.map(plugin => plugin.name);
     expect(names).toEqual(['sentry-solidstart-build-instrumentation-file']);
 

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -80,7 +80,10 @@ describe('makeAddSentryVitePlugin()', () => {
       {
         org: 'my-org',
         authToken: 'my-token',
-        sourceMapsUploadOptions: {
+        applicationKey: 'my-app-key',
+        sentryUrl: 'https://my.sentry.io',
+        moduleMetadata: { team: 'sdk' },
+        sourcemaps: {
           filesToDeleteAfterUpload: ['baz/*.js'],
         },
         bundleSizeOptimizations: {
@@ -94,6 +97,10 @@ describe('makeAddSentryVitePlugin()', () => {
       expect.objectContaining({
         org: 'my-org',
         authToken: 'my-token',
+        applicationKey: 'my-app-key',
+        // `sentryUrl` is resolved to the plugin's `url` option
+        url: 'https://my.sentry.io',
+        moduleMetadata: { team: 'sdk' },
         sourcemaps: {
           filesToDeleteAfterUpload: ['baz/*.js'],
         },
@@ -175,15 +182,13 @@ describe('makeAddSentryVitePlugin()', () => {
         bundleSizeOptimizations: {
           excludeTracing: true,
         },
-        sourceMapsUploadOptions: {
-          unstable_sentryVitePluginOptions: {
-            org: 'unstable-org',
-            sourcemaps: {
-              assets: ['unstable/*.js'],
-            },
-            bundleSizeOptimizations: {
-              excludeTracing: false,
-            },
+        unstable_sentryVitePluginOptions: {
+          org: 'unstable-org',
+          sourcemaps: {
+            assets: ['unstable/*.js'],
+          },
+          bundleSizeOptimizations: {
+            excludeTracing: false,
           },
         },
       },


### PR DESCRIPTION
SolidStart has two entry points. `sentrySolidStart()` (v2) already uses `BuildTimeOptionsBase`; `sentrySolidStartVite()` / `withSentry()` (v1) used a hand-rolled type with no `applicationKey`, making `unstable_sentryVitePluginOptions` the only way to reach it. Both majors stay supported in v11, so v1 converges onto the shared type rather than being dropped.

`sourceMapsUploadOptions` moves to the top level, and `enabled: false` becomes `sourcemaps: { disable: true }` (inverted). v1 gains `applicationKey`, `sentryUrl`, `headers`, `silent`, `errorHandler`, `release` and `moduleMetadata`.

The `unstable_` hatch stays functional here and only changes location — its removal is a separate PR, so this one is reviewable as a pure type migration.

Breaking change for SolidStart v1 users; migration guide entry included.

Fixes getsentry/sentry-javascript#23341