### PR TITLE
feat(solidstart)!: Remove unstable_sentryVitePluginOptions

### DIFF
--- a/packages/solidstart/src/vite/sentrySolidStart.ts
+++ b/packages/solidstart/src/vite/sentrySolidStart.ts
@@ -1,5 +1,4 @@
-import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
-import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
+import { type BuildTimeOptionsBase, warnOnRemovedBuildOptions } from '@sentry/core';
 import { setupSentryNitroModule } from '@sentry/nitro';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 import type { Plugin, UserConfig } from 'vite';
@@ -8,7 +7,7 @@ import { makeAddSentryVitePluginSolidStart2, makeEnableSourceMapsVitePlugin } fr
 /**
  * Build-time options for the Sentry SolidStart SDK on SolidStart 2.
  */
-export type SentrySolidStartOptions = BuildTimeOptionsBase & UnstableVitePluginOptions<SentryVitePluginOptions>;
+export type SentrySolidStartOptions = BuildTimeOptionsBase;
 
 /**
  * Vite plugins for the Sentry SolidStart SDK. Requires SolidStart 2.
@@ -39,6 +38,8 @@ export type SentrySolidStartOptions = BuildTimeOptionsBase & UnstableVitePluginO
  * @returns An array of Vite plugins
  */
 export function sentrySolidStart(options: SentrySolidStartOptions = {}): Plugin[] {
+  warnOnRemovedBuildOptions(options, ['unstable_sentryVitePluginOptions']);
+
   const plugins: Plugin[] = [makeSentryNitroPlugin(options)];
 
   // Only the Nitro plugin is dev-safe; its module handles `dev` itself.

--- a/packages/solidstart/src/vite/sentrySolidStartVite.ts
+++ b/packages/solidstart/src/vite/sentrySolidStartVite.ts
@@ -1,3 +1,4 @@
+import { warnOnRemovedBuildOptions } from '@sentry/core';
 import type { Plugin, UserConfig } from 'vite';
 import { makeBuildInstrumentationFilePlugin } from './buildInstrumentationFile';
 import { makeAddSentryVitePlugin, makeEnableSourceMapsVitePlugin } from './sourceMaps';
@@ -7,6 +8,8 @@ import type { SentrySolidStartPluginOptions } from './types';
  * Various Sentry vite plugins to be used for SolidStart.
  */
 export const sentrySolidStartVite = (options: SentrySolidStartPluginOptions = {}, viteConfig: UserConfig): Plugin[] => {
+  warnOnRemovedBuildOptions(options, ['unstable_sentryVitePluginOptions']);
+
   const sentryPlugins: Plugin[] = [];
 
   if (options.autoInjectServerSentry !== 'experimental_dynamic-import') {

--- a/packages/solidstart/src/vite/sourceMaps.ts
+++ b/packages/solidstart/src/vite/sourceMaps.ts
@@ -27,14 +27,12 @@ export function makeAddSentryVitePlugin(options: SentrySolidStartPluginOptions, 
     silent,
     sourcemaps,
     telemetry,
-    unstable_sentryVitePluginOptions,
   } = options;
 
   let updatedFilesToDeleteAfterUpload: string[] | undefined = undefined;
 
   if (
     typeof sourcemaps?.filesToDeleteAfterUpload === 'undefined' &&
-    typeof unstable_sentryVitePluginOptions?.sourcemaps?.filesToDeleteAfterUpload === 'undefined' &&
     // Only if source maps were previously not set, we update the "filesToDeleteAfterUpload" (as we override the setting with "hidden")
     typeof viteConfig.build?.sourcemap === 'undefined'
   ) {
@@ -67,18 +65,13 @@ export function makeAddSentryVitePlugin(options: SentrySolidStartPluginOptions, 
       url: sentryUrl,
       sourcemaps: {
         ...sourcemaps,
-        filesToDeleteAfterUpload:
-          (sourcemaps?.filesToDeleteAfterUpload ||
-            unstable_sentryVitePluginOptions?.sourcemaps?.filesToDeleteAfterUpload) ??
-          updatedFilesToDeleteAfterUpload,
-        ...unstable_sentryVitePluginOptions?.sourcemaps,
+        filesToDeleteAfterUpload: sourcemaps?.filesToDeleteAfterUpload ?? updatedFilesToDeleteAfterUpload,
       },
       _metaOptions: {
         telemetry: {
           metaFramework: 'solidstart',
         },
       },
-      ...unstable_sentryVitePluginOptions,
     }),
   ];
 }
@@ -102,13 +95,11 @@ export function makeAddSentryVitePluginSolidStart2(options: SentrySolidStartOpti
     sentryUrl,
     sourcemaps,
     telemetry,
-    unstable_sentryVitePluginOptions,
     ...passthroughOptions
   } = options;
 
   // Deferred because the default depends on whether the user set `build.sourcemap` themselves,
-  // which is only known once Vite resolves its config. `PromiseLike` because the unstable spelling
-  // may itself be a promise.
+  // which is only known once Vite resolves its config.
   let resolveFilesToDeleteAfterUpload:
     | ((value: FilesToDeleteAfterUpload | PromiseLike<FilesToDeleteAfterUpload>) => void)
     | undefined;
@@ -121,10 +112,7 @@ export function makeAddSentryVitePluginSolidStart2(options: SentrySolidStartOpti
     apply: 'build',
     enforce: 'post',
     config(config) {
-      // The promise always wins over the passed-in value, so the unstable spelling has to be read
-      // here too or it is silently replaced by the default below.
-      const userFilesToDelete =
-        sourcemaps?.filesToDeleteAfterUpload ?? unstable_sentryVitePluginOptions?.sourcemaps?.filesToDeleteAfterUpload;
+      const userFilesToDelete = sourcemaps?.filesToDeleteAfterUpload;
 
       // Only clean up source maps we turned on ourselves.
       if (typeof userFilesToDelete === 'undefined' && typeof config.build?.sourcemap === 'undefined') {
@@ -149,18 +137,12 @@ export function makeAddSentryVitePluginSolidStart2(options: SentrySolidStartOpti
     project: project ?? process.env.SENTRY_PROJECT,
     telemetry: telemetry ?? true,
     url: sentryUrl,
-    // Spread here so it overrides the plain options above, but not the objects merged below —
-    // spreading replaces whole keys rather than deep-merging.
-    ...unstable_sentryVitePluginOptions,
     sourcemaps: {
       ...sourcemaps,
-      ...unstable_sentryVitePluginOptions?.sourcemaps,
       filesToDeleteAfterUpload: filesToDeleteAfterUploadPromise,
     },
     _metaOptions: {
-      ...unstable_sentryVitePluginOptions?._metaOptions,
       telemetry: {
-        ...unstable_sentryVitePluginOptions?._metaOptions?.telemetry,
         metaFramework: 'solidstart',
       },
     },

--- a/packages/solidstart/src/vite/types.ts
+++ b/packages/solidstart/src/vite/types.ts
@@ -1,63 +1,61 @@
-import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
-import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
+import type { BuildTimeOptionsBase } from '@sentry/core';
 
 /**
  *  Build options for the Sentry plugin. These options are used during build-time by the Sentry SDK.
  */
-export type SentrySolidStartPluginOptions = BuildTimeOptionsBase &
-  UnstableVitePluginOptions<Partial<SentryVitePluginOptions>> & {
-    /**
-     * The path to your `instrument.server.ts|js` file.
-     * e.g. `./src/instrument.server.ts`
-     *
-     * Defaults to: `./src/instrument.server.ts`
-     */
-    instrumentation?: string;
+export type SentrySolidStartPluginOptions = BuildTimeOptionsBase & {
+  /**
+   * The path to your `instrument.server.ts|js` file.
+   * e.g. `./src/instrument.server.ts`
+   *
+   * Defaults to: `./src/instrument.server.ts`
+   */
+  instrumentation?: string;
 
-    /**
-     * The server entrypoint filename is automatically set by the Sentry SDK depending on the Nitro present.
-     * In case the server entrypoint has a different filename, you can overwrite it here.
-     */
-    serverEntrypointFileName?: string;
+  /**
+   * The server entrypoint filename is automatically set by the Sentry SDK depending on the Nitro present.
+   * In case the server entrypoint has a different filename, you can overwrite it here.
+   */
+  serverEntrypointFileName?: string;
 
-    /**
-     *
-     * Enables (partial) server tracing by automatically injecting Sentry for environments where modifying the node option `--import` is not possible.
-     *
-     * **DO NOT** add the node CLI flag `--import` in your node start script, when auto-injecting Sentry.
-     * This would initialize Sentry twice on the server-side and this leads to unexpected issues.
-     *
-     * ---
-     *
-     * **"top-level-import"**
-     *
-     * Enabling basic server tracing with top-level import can be used for environments where modifying the node option `--import` is not possible.
-     * However, enabling this option only supports limited tracing instrumentation. Only http traces will be collected (but no database-specific traces etc.).
-     *
-     * If `"top-level-import"` is enabled, the Sentry SDK will import the Sentry server config at the top of the server entry file to load the SDK on the server.
-     *
-     * ---
-     * **"experimental_dynamic-import"**
-     *
-     * Wraps the server entry file with a dynamic `import()`. This will make it possible to preload Sentry and register
-     * necessary hooks before other code runs. (Node docs: https://nodejs.org/api/module.html#enabling)
-     *
-     * If `"experimental_dynamic-import"` is enabled, the Sentry SDK wraps the server entry file with `import()`.
-     *
-     * @default undefined
-     */
-    autoInjectServerSentry?: 'top-level-import' | 'experimental_dynamic-import';
+  /**
+   *
+   * Enables (partial) server tracing by automatically injecting Sentry for environments where modifying the node option `--import` is not possible.
+   *
+   * **DO NOT** add the node CLI flag `--import` in your node start script, when auto-injecting Sentry.
+   * This would initialize Sentry twice on the server-side and this leads to unexpected issues.
+   *
+   * ---
+   *
+   * **"top-level-import"**
+   *
+   * Enabling basic server tracing with top-level import can be used for environments where modifying the node option `--import` is not possible.
+   * However, enabling this option only supports limited tracing instrumentation. Only http traces will be collected (but no database-specific traces etc.).
+   *
+   * If `"top-level-import"` is enabled, the Sentry SDK will import the Sentry server config at the top of the server entry file to load the SDK on the server.
+   *
+   * ---
+   * **"experimental_dynamic-import"**
+   *
+   * Wraps the server entry file with a dynamic `import()`. This will make it possible to preload Sentry and register
+   * necessary hooks before other code runs. (Node docs: https://nodejs.org/api/module.html#enabling)
+   *
+   * If `"experimental_dynamic-import"` is enabled, the Sentry SDK wraps the server entry file with `import()`.
+   *
+   * @default undefined
+   */
+  autoInjectServerSentry?: 'top-level-import' | 'experimental_dynamic-import';
 
-    /**
-     * When `autoInjectServerSentry` is set to `"experimental_dynamic-import"`, the SDK will wrap your Nitro server entrypoint
-     * with a dynamic `import()` to ensure all dependencies can be properly instrumented. Any previous exports from the entrypoint are still exported.
-     * Most exports of the server entrypoint are serverless functions and those are wrapped by Sentry. Other exports stay as-is.
-     *
-     * By default, the SDK will wrap the default export as well as a `handler` or `server` export from the entrypoint.
-     * If your server has a different main export that is used to run the server, you can overwrite this by providing an array of export names to wrap.
-     * Any wrapped export is expected to be an async function.
-     *
-     * @default ['default', 'handler', 'server']
-     */
-    experimental_entrypointWrappedFunctions?: string[];
-  };
+  /**
+   * When `autoInjectServerSentry` is set to `"experimental_dynamic-import"`, the SDK will wrap your Nitro server entrypoint
+   * with a dynamic `import()` to ensure all dependencies can be properly instrumented. Any previous exports from the entrypoint are still exported.
+   * Most exports of the server entrypoint are serverless functions and those are wrapped by Sentry. Other exports stay as-is.
+   *
+   * By default, the SDK will wrap the default export as well as a `handler` or `server` export from the entrypoint.
+   * If your server has a different main export that is used to run the server, you can overwrite this by providing an array of export names to wrap.
+   * Any wrapped export is expected to be an async function.
+   *
+   * @default ['default', 'handler', 'server']
+   */
+  experimental_entrypointWrappedFunctions?: string[];
+};

--- a/packages/solidstart/test/vite/sourceMaps.test.ts
+++ b/packages/solidstart/test/vite/sourceMaps.test.ts
@@ -1,6 +1,7 @@
 import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
 import type { Plugin, UserConfig } from 'vite';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { sentrySolidStart } from '../../src/vite/sentrySolidStart';
 import {
   getUpdatedSourceMapSettings,
   makeAddSentryVitePlugin,
@@ -173,41 +174,6 @@ describe('makeAddSentryVitePlugin()', () => {
       }),
     );
   });
-
-  it('should override options with unstable_sentryVitePluginOptions', () => {
-    makeAddSentryVitePlugin(
-      {
-        org: 'my-org',
-        authToken: 'my-token',
-        bundleSizeOptimizations: {
-          excludeTracing: true,
-        },
-        unstable_sentryVitePluginOptions: {
-          org: 'unstable-org',
-          sourcemaps: {
-            assets: ['unstable/*.js'],
-          },
-          bundleSizeOptimizations: {
-            excludeTracing: false,
-          },
-        },
-      },
-      {},
-    );
-
-    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        org: 'unstable-org',
-        authToken: 'my-token',
-        bundleSizeOptimizations: {
-          excludeTracing: false,
-        },
-        sourcemaps: {
-          assets: ['unstable/*.js'],
-        },
-      }),
-    );
-  });
 });
 
 describe('makeAddSentryVitePluginSolidStart2()', () => {
@@ -245,28 +211,21 @@ describe('makeAddSentryVitePluginSolidStart2()', () => {
     );
   });
 
-  it('lets `unstable_sentryVitePluginOptions` override what the SDK sets', () => {
-    makeAddSentryVitePluginSolidStart2({
-      org: 'my-org',
-      unstable_sentryVitePluginOptions: {
-        org: 'unstable-org',
-        sourcemaps: { assets: ['unstable/*.js'] },
-      },
-    });
+  it('always tags telemetry as solidstart', () => {
+    makeAddSentryVitePluginSolidStart2({ org: 'my-org' });
 
     expect(sentryVitePluginSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        org: 'unstable-org',
-        sourcemaps: expect.objectContaining({ assets: ['unstable/*.js'] }),
+        _metaOptions: { telemetry: { metaFramework: 'solidstart' } },
       }),
     );
   });
 
-  // The deferred promise always wins, so ignoring the unstable value here would silently swap in
-  // the SDK's default and delete a different set of files.
-  it('respects `filesToDeleteAfterUpload` set through unstable options', async () => {
+  // `filesToDeleteAfterUpload` is resolved through a deferred promise, because the default depends
+  // on whether the user set `build.sourcemap` themselves - only known once Vite resolves its config.
+  it('resolves `filesToDeleteAfterUpload` to the user-specified value', async () => {
     const plugins = makeAddSentryVitePluginSolidStart2({
-      unstable_sentryVitePluginOptions: { sourcemaps: { filesToDeleteAfterUpload: ['custom/**/*.map'] } },
+      sourcemaps: { filesToDeleteAfterUpload: ['custom/**/*.map'] },
     });
 
     runConfigHook(plugins[0]!);
@@ -274,27 +233,32 @@ describe('makeAddSentryVitePluginSolidStart2()', () => {
     await expect(lastPluginOptions?.sourcemaps?.filesToDeleteAfterUpload).resolves.toEqual(['custom/**/*.map']);
   });
 
-  it('prefers the stable `filesToDeleteAfterUpload` when both are set', async () => {
-    const plugins = makeAddSentryVitePluginSolidStart2({
-      sourcemaps: { filesToDeleteAfterUpload: ['stable/**/*.map'] },
-      unstable_sentryVitePluginOptions: { sourcemaps: { filesToDeleteAfterUpload: ['unstable/**/*.map'] } },
-    });
+  // Only clean up source maps the SDK turned on itself.
+  it('defaults `filesToDeleteAfterUpload` only when the user left `build.sourcemap` unset', async () => {
+    const plugins = makeAddSentryVitePluginSolidStart2({ org: 'my-org' });
 
     runConfigHook(plugins[0]!);
 
-    await expect(lastPluginOptions?.sourcemaps?.filesToDeleteAfterUpload).resolves.toEqual(['stable/**/*.map']);
+    await expect(lastPluginOptions?.sourcemaps?.filesToDeleteAfterUpload).resolves.toEqual(['./**/*.map']);
   });
 
-  it('always tags telemetry as solidstart, even when unstable options set _metaOptions', () => {
-    makeAddSentryVitePluginSolidStart2({
-      unstable_sentryVitePluginOptions: { _metaOptions: { telemetry: { metaFramework: 'not-solidstart' } } },
-    });
+  it('leaves `filesToDeleteAfterUpload` unset when the user configured `build.sourcemap`', async () => {
+    const plugins = makeAddSentryVitePluginSolidStart2({ org: 'my-org' });
 
-    expect(sentryVitePluginSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        _metaOptions: { telemetry: { metaFramework: 'solidstart' } },
-      }),
-    );
+    runConfigHook(plugins[0]!, { build: { sourcemap: true } });
+
+    await expect(lastPluginOptions?.sourcemaps?.filesToDeleteAfterUpload).resolves.toBeUndefined();
+  });
+
+  it('warns when the removed `unstable_sentryVitePluginOptions` is still set', () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    // @ts-expect-error - removed in v11, but JS configs get no type checking
+    sentrySolidStart({ unstable_sentryVitePluginOptions: { org: 'other-org' } });
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('unstable_sentryVitePluginOptions'));
+
+    consoleWarnSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Removes `unstable_sentryVitePluginOptions` from both SolidStart entry points — `sentrySolidStartVite()` / `withSentry()` (v1) and `sentrySolidStart()` (v2). They share `sourceMaps.ts`, so splitting this per-major would leave the file half-migrated.

Everything the hatch exposed is reachable as a top-level build option after the preceding v1 alignment PR. Adds a build-time warning on both entry points.

Fixes getsentry/sentry-javascript#23346