### PR TITLE
feat(core)!: Remove Unstable*PluginOptions build option types

### DIFF
--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -895,23 +895,63 @@ The legacy per-transaction profiling sampling options were removed. Configure se
 The following long-deprecated top-level options in `withSentryConfig` / the `sentry` config were removed. Most of them
 moved under the `webpack` option in v10; use the replacement listed below instead:
 
-| Removed option                          | Replacement                                                    |
-| --------------------------------------- | -------------------------------------------------------------- |
-| `autoInstrumentServerFunctions`         | `webpack.autoInstrumentServerFunctions`                        |
-| `autoInstrumentMiddleware`              | `webpack.autoInstrumentMiddleware`                             |
-| `autoInstrumentAppDirectory`            | `webpack.autoInstrumentAppDirectory`                           |
-| `automaticVercelMonitors`               | `webpack.automaticVercelMonitors`                              |
-| `excludeServerRoutes`                   | `webpack.excludeServerRoutes`                                  |
-| `reactComponentAnnotation`              | `webpack.reactComponentAnnotation`                             |
-| `unstable_sentryWebpackPluginOptions`   | `webpack.unstable_sentryWebpackPluginOptions`                  |
-| `disableSentryWebpackConfig`            | `webpack.disableSentryConfig`                                  |
-| `disableLogger`                         | `webpack.treeshake.removeDebugLogging`                         |
-| `disableManifestInjection`              | `routeManifestInjection: false`                                |
-| `_experimental.turbopackApplicationKey` | `applicationKey` (works for both webpack and Turbopack builds) |
+| Removed option                          | Replacement                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------- |
+| `autoInstrumentServerFunctions`         | `webpack.autoInstrumentServerFunctions`                                 |
+| `autoInstrumentMiddleware`              | `webpack.autoInstrumentMiddleware`                                      |
+| `autoInstrumentAppDirectory`            | `webpack.autoInstrumentAppDirectory`                                    |
+| `automaticVercelMonitors`               | `webpack.automaticVercelMonitors`                                       |
+| `excludeServerRoutes`                   | `webpack.excludeServerRoutes`                                           |
+| `reactComponentAnnotation`              | `webpack.reactComponentAnnotation`                                      |
+| `unstable_sentryWebpackPluginOptions`   | Removed entirely, see [below](#removed-unstable-bundler-plugin-options) |
+| `disableSentryWebpackConfig`            | `webpack.disableSentryConfig`                                           |
+| `disableLogger`                         | `webpack.treeshake.removeDebugLogging`                                  |
+| `disableManifestInjection`              | `routeManifestInjection: false`                                         |
+| `_experimental.turbopackApplicationKey` | `applicationKey` (works for both webpack and Turbopack builds)          |
 
 ### Meta-framework build options
 
 The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin options were removed from `@sentry/astro`, `@sentry/nuxt`, `@sentry/sveltekit`, and `@sentry/react-router`. Use the top-level equivalents (e.g. `sourcemaps`, `release`, `authToken`, `org`, `project`, `telemetry`) instead.
+
+### Removed `unstable_` bundler plugin options
+
+The `unstable_sentry*PluginOptions` escape hatch was removed from every SDK. It existed because the Sentry
+bundler plugins shipped on a separate release cadence from the SDK; they now live in the SDK monorepo and
+move in lockstep, so every supported plugin option is reachable as a first-class build option.
+
+| SDK                    | Removed option                                                                      |
+| ---------------------- | ----------------------------------------------------------------------------------- |
+| `@sentry/astro`        | `unstable_sentryVitePluginOptions` (top-level and inside `sourceMapsUploadOptions`) |
+| `@sentry/nextjs`       | `unstable_sentryWebpackPluginOptions` (top-level and inside `webpack`)              |
+| `@sentry/nuxt`         | `unstable_sentryBundlerPluginOptions`                                               |
+| `@sentry/react-router` | `unstable_sentryVitePluginOptions`                                                  |
+| `@sentry/solidstart`   | `unstable_sentryVitePluginOptions`                                                  |
+| `@sentry/sveltekit`    | `unstable_sentryVitePluginOptions`                                                  |
+
+Set the option you need directly on the Sentry build options instead. Most real-world usage of this escape
+hatch was to set `applicationKey`, which has a top-level equivalent in every SDK:
+
+```js
+// before
+unstable_sentryWebpackPluginOptions: {
+  applicationKey: 'my-app',
+},
+
+// after
+applicationKey: 'my-app',
+```
+
+Passing a removed option logs a build-time warning naming it, because meta-framework build configs are
+often plain JavaScript (for example `next.config.js`) where TypeScript cannot catch it.
+
+`moduleMetadata` and `sourcemaps.resolveSourceMap` were promoted to first-class build options as part of
+this change — they were previously only reachable through the escape hatch. `reactComponentAnnotation`
+remains available on the React-based SDKs (`@sentry/nextjs`, `@sentry/react-router`,
+`@sentry/tanstackstart-react`).
+
+The following bundler plugin options have no first-class equivalent and are no longer reachable:
+`release.uploadLegacySourcemaps`, `_experiments`, and the whole-plugin `disable` flag (use
+`sourcemaps.disable` instead).
 
 ### `@sentry/nuxt`
 

--- a/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
+++ b/packages/core/src/build-time-plugins/buildTimeOptionsBase.ts
@@ -1,24 +1,19 @@
 /**
  * Sentry-internal base interface for build-time options used in Sentry's meta-framework SDKs (e.g., Next.js, Nuxt, SvelteKit).
  *
- * SDKs should extend this interface to add framework-specific configurations. To include bundler-specific
- * options, combine this type with one of the `Unstable[Bundler]PluginOptions` types, such as
- * `UnstableVitePluginOptions` or `UnstableWebpackPluginOptions`.
+ * SDKs should extend this interface to add framework-specific configurations.
  *
  * If an option from this base interface doesn't apply to an SDK, use the `Omit` utility type to exclude it.
  *
  * @example
  * ```typescript
- * import type { BuildTimeOptionsBase, UnstableVitePluginOptions } from '@sentry/core';
- * import type { SentryVitePluginOptions } from '@sentry/bundler-plugins/vite';
+ * import type { BuildTimeOptionsBase } from '@sentry/core';
  *
  * // Example of how a framework SDK would define its build-time options
- * type MyFrameworkBuildOptions =
- *   BuildTimeOptionsBase &
- *   UnstableVitePluginOptions<SentryVitePluginOptions> & {
- *     // Framework-specific options can be added here
- *     myFrameworkSpecificOption?: boolean;
- *   };
+ * type MyFrameworkBuildOptions = BuildTimeOptionsBase & {
+ *   // Framework-specific options can be added here
+ *   myFrameworkSpecificOption?: boolean;
+ * };
  * ```
  *
  * @internal Only meant for Sentry-internal SDK usage.
@@ -209,78 +204,6 @@ export interface ReactComponentAnnotationOptions {
    */
   ignoredComponents?: string[];
 }
-
-/**
- * Utility type for adding Vite plugin options to build-time configuration.
- * Use this type to extend your build-time options with Vite-specific plugin configurations.
- *
- * @template PluginOptionsType - The type of Vite plugin options to include
- *
- * @example
- * ```typescript
- * type SomeSDKsBuildOptions = BuildTimeOptionsBase & UnstableVitePluginOptions<SentryVitePluginOptions>;
- * ```
- *
- * @internal Only meant for Sentry-internal SDK usage.
- * @hidden
- */
-export type UnstableVitePluginOptions<PluginOptionsType> = {
-  /**
-   * Options to be passed directly to the Sentry Vite Plugin (`@sentry/bundler-plugins/vite`) that ships with the Sentry SDK.
-   * You can use this option to override any options the SDK passes to the Vite plugin.
-   *
-   * Please note that this option is unstable and may change in a breaking way in any release.
-   */
-  unstable_sentryVitePluginOptions?: PluginOptionsType;
-};
-
-/**
- * Utility type for adding Webpack plugin options to build-time configuration.
- * Use this type to extend your build-time options with Webpack-specific plugin configurations.
- *
- * @template PluginOptionsType - The type of Webpack plugin options to include
- *
- * @example
- * ```typescript
- * type SomeSDKsBuildOptions = BuildTimeOptionsBase & UnstableWebpackPluginOptions<SentryWebpackPluginOptions>;
- * ```
- *
- * @internal Only meant for Sentry-internal SDK usage.
- * @hidden
- */
-export type UnstableWebpackPluginOptions<PluginOptionsType> = {
-  /**
-   * Options to be passed directly to the Sentry Webpack Plugin (`@sentry/bundler-plugins/webpack`) that ships with the Sentry SDK.
-   * You can use this option to override any options the SDK passes to the Webpack plugin.
-   *
-   * Please note that this option is unstable and may change in a breaking way in any release.
-   */
-  unstable_sentryWebpackPluginOptions?: PluginOptionsType;
-};
-
-/**
- * Utility type for adding Rollup plugin options to build-time configuration.
- * Use this type to extend your build-time options with Rollup-specific plugin configurations.
- *
- * @template PluginOptionsType - The type of Rollup plugin options to include
- *
- * @example
- * ```typescript
- * type SomeSDKsBuildOptions = BuildTimeOptionsBase & UnstableRollupPluginOptions<SentryRollupPluginOptions>;
- * ```
- *
- * @internal Only meant for Sentry-internal SDK usage.
- * @hidden
- */
-export type UnstableRollupPluginOptions<PluginOptionsType> = {
-  /**
-   * Options to be passed directly to the Sentry Rollup Plugin (`@sentry/bundler-plugins/rollup`) that ships with the Sentry SDK.
-   * You can use this option to override any options the SDK passes to the Rollup plugin.
-   *
-   * Please note that this option is unstable and may change in a breaking way in any release.
-   */
-  unstable_sentryRollupPluginOptions?: PluginOptionsType;
-};
 
 interface SourceMapsOptions {
   /**

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -522,9 +522,6 @@ export type {
   ModuleMetadataCallbackArgs,
   ReactComponentAnnotationOptions,
   ResolveSourceMapHook,
-  UnstableVitePluginOptions,
-  UnstableRollupPluginOptions,
-  UnstableWebpackPluginOptions,
 } from './build-time-plugins/buildTimeOptionsBase';
 export type { RandomSafeContextRunner as _INTERNAL_RandomSafeContextRunner } from './utils/randomSafeContext';
 export {


### PR DESCRIPTION
Removes `UnstableVitePluginOptions`, `UnstableWebpackPluginOptions` and `UnstableRollupPluginOptions` from `@sentry/core`, now that no SDK references them. Lands last in the stack.

Adds the v11 migration guide entry with the per-SDK mapping table.

Fixes #23347