### PR TITLE
test(node-integration-tests): Pin langchain to unbreak ESM initChatModel test

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/v1/test.ts
@@ -317,7 +317,10 @@ conditionalTest({ min: 20 })('LangChain integration (v1)', () => {
     },
     {
       additionalDependencies: {
-        langchain: '^1.0.0',
+        // Pinned: langchain 1.5.7 imports DEFAULT_LANGSMITH_GATEWAY from @langchain/core/utils/gateway,
+        // which no published @langchain/core exports yet, breaking ESM named-export validation.
+        // Restore ^1.0.0 once a @langchain/core release exports it.
+        langchain: '1.5.6',
         '@langchain/core': '^1.0.0',
         '@langchain/openai': '^1.0.0',
       },


### PR DESCRIPTION
## What

Pins `langchain` to 1.5.6 in the LangChain v1 initChatModel integration test. The other test blocks keep `^1.0.0` since their scenarios never import the `langchain` meta-package.

## Why

The upstream `langchain` 1.5.7 release imports `DEFAULT_LANGSMITH_GATEWAY` from `@langchain/core/utils/gateway`, but no published `@langchain/core` (latest 1.2.6) exports it. ESM validates named exports at link time, so the `[esm]` variant of the test crashes on develop. The pin can be reverted once a `@langchain/core` release ships the export.