### PR TITLE
ref(nextjs): Add deprecation notices to nested reactComponentAnnotation options

### DIFF
--- a/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
+++ b/packages/nextjs/src/config/turbopack/constructTurbopackConfig.ts
@@ -99,7 +99,8 @@ export function constructTurbopackConfig({
   // Add component annotation loader for react component name annotation in Turbopack builds.
   // This is only added when annotation is enabled AND the Next.js version supports the
   // `condition` field in Turbopack rules (Next.js 16+).
-  const reactComponentAnnotation = {
+  // Typed as the unified option so reads below resolve to the non-deprecated declarations.
+  const reactComponentAnnotation: NonNullable<SentryBuildOptions['reactComponentAnnotation']> = {
     ...userSentryOptions?.reactComponentAnnotation,
     // eslint-disable-next-line typescript/no-deprecated
     ...userSentryOptions?._experimental?.turbopackReactComponentAnnotation,

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -166,11 +166,15 @@ export type SentryBuildWebpackOptions = {
   reactComponentAnnotation?: {
     /**
      * Whether the component name annotate plugin should be enabled or not.
+     *
+     * @deprecated Use the top-level `reactComponentAnnotation` option instead, which works for both webpack and Turbopack builds.
      */
     enabled?: boolean;
 
     /**
      * A list of strings representing the names of components to ignore. The plugin will not apply `data-sentry` annotations on the DOM element for these components.
+     *
+     * @deprecated Use the top-level `reactComponentAnnotation` option instead, which works for both webpack and Turbopack builds.
      */
     ignoredComponents?: string[];
   }; // TODO(v12): remove this option
@@ -683,7 +687,18 @@ export type SentryBuildOptions = {
      * @deprecated Use the top-level `reactComponentAnnotation` option instead, which works for both webpack and Turbopack builds.
      */
     turbopackReactComponentAnnotation?: {
+      /**
+       * Whether the component name annotate plugin should be enabled or not.
+       *
+       * @deprecated Use the top-level `reactComponentAnnotation` option instead, which works for both webpack and Turbopack builds.
+       */
       enabled?: boolean;
+
+      /**
+       * A list of strings representing the names of components to ignore. The plugin will not apply `data-sentry` annotations on the DOM element for these components.
+       *
+       * @deprecated Use the top-level `reactComponentAnnotation` option instead, which works for both webpack and Turbopack builds.
+       */
       ignoredComponents?: string[];
     }; // TODO(v12): remove this option
   }>;


### PR DESCRIPTION
Follow-up to #23268. Adds `@deprecated` to the individual properties inside
`webpack.reactComponentAnnotation` and `_experimental.turbopackReactComponentAnnotation`, so hovering
`enabled` or `ignoredComponents` surfaces the notice too, not just the parent option.