### PR TITLE
fix(sveltekit): Detect native tracing in flattened SvelteKit 3 config

### DIFF
--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Plugin } from 'vite';
 import { WRAPPED_MODULE_SUFFIX } from '../common/utils';
-import type { BackwardsForwardsCompatibleSvelteConfig } from './svelteConfig';
+import type { BackwardsForwardsCompatibleKitConfig, BackwardsForwardsCompatibleSvelteConfig } from './svelteConfig';
 
 const AcornParser = acorn.Parser.extend(tsPlugin());
 
@@ -132,9 +132,18 @@ function isNativeServerTracingEnabled(plugins: readonly Plugin[] | undefined): b
   }
 
   for (const plugin of plugins) {
-    const options = (plugin?.api as { options?: BackwardsForwardsCompatibleSvelteConfig } | undefined)?.options;
-    // SvelteKit 3 (>= next.8) promoted `tracing` out of `experimental`; older versions nest it there.
-    if (options?.kit?.tracing?.server || options?.kit?.experimental?.tracing?.server) {
+    const options = (
+      plugin?.api as
+        | { options?: BackwardsForwardsCompatibleSvelteConfig & BackwardsForwardsCompatibleKitConfig }
+        | undefined
+    )?.options;
+
+    // SvelteKit 3 flattened the plugin config: what used to live under `kit` now sits
+    // at the top level of the exposed options.
+    const kitConfig = options?.kit ?? options;
+
+    // SvelteKit 3 promoted `tracing` out of `experimental`; older versions nest it there.
+    if (kitConfig?.tracing?.server || kitConfig?.experimental?.tracing?.server) {
       return true;
     }
   }

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -18,9 +18,10 @@ export type SvelteKitTracingConfig = {
  * The location of SvelteKit's native tracing config differs by version:
  * - SvelteKit 2.31+ and early Kit 3 prereleases nest it under `kit.experimental.tracing`
  * - SvelteKit 3 (>= 3.0.0-next.8) promoted it to `kit.tracing`
- * We type (and read) both so detection works across the supported peer range.
+ * - SvelteKit 3 (>= 3.0.0-next.21) dropped the `kit` nesting entirely, leaving `tracing`
+ * We type (and read) all of them so detection works across the supported peer range.
  */
-type BackwardsForwardsCompatibleKitConfig = Config['kit'] &
+export type BackwardsForwardsCompatibleKitConfig = Config['kit'] &
   Pick<SvelteKitTracingConfig, 'tracing'> & { experimental?: SvelteKitTracingConfig };
 
 export interface BackwardsForwardsCompatibleSvelteConfig extends Config {

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -225,30 +225,31 @@ describe('makeAutoInstrumentationPlugin()', () => {
     // `onlyInstrumentClient` option computed from it is `false`); the config is exposed on the
     // SvelteKit Vite plugin's `api.options` instead.
     // The tracing config location differs by SvelteKit version:
+    // - SvelteKit 3 (>= 3.0.0-next.21): `tracing.server` (the `kit` nesting was flattened away)
     // - SvelteKit 3 (>= 3.0.0-next.8): `kit.tracing.server`
     // - SvelteKit 2.31+ and early Kit 3 prereleases: `kit.experimental.tracing.server`
     function configWithKitTracing(
       ssr: boolean,
       serverTracing: boolean,
-      location: 'tracing' | 'experimental' = 'tracing',
+      location: 'tracing' | 'experimental' | 'flat' = 'tracing',
     ): unknown {
-      const kit =
-        location === 'tracing'
-          ? { tracing: { server: serverTracing } }
-          : { experimental: { tracing: { server: serverTracing } } };
+      const tracing = { tracing: { server: serverTracing } };
+      const options =
+        location === 'flat' ? tracing : { kit: location === 'tracing' ? tracing : { experimental: tracing } };
+
       return {
         build: { ssr },
         plugins: [
           { name: 'some-other-plugin' },
           {
             name: 'vite-plugin-sveltekit-setup',
-            api: { options: { kit } },
+            api: { options },
           },
         ],
       };
     }
 
-    describe.each(['tracing', 'experimental'] as const)('with the config under `kit.%s`', location => {
+    describe.each(['tracing', 'experimental', 'flat'] as const)('with the config in the `%s` location', location => {
       it.each(['path/to/+page.server.ts', 'path/to/+layout.server.js', 'path/to/+page.ts', 'path/to/+layout.mjs'])(
         "doesn't wrap %s in the SSR build when native tracing is enabled, even if `onlyInstrumentClient` is `false`",
         async (path: string) => {


### PR DESCRIPTION
SvelteKit 3 (>= next.21) flattened the config exposed on the `sveltekit()` Vite plugin's `api.options`, so our `api.options.kit.tracing.server` check stopped detecting native server tracing and the SDK wrapped `load` functions in the SSR build twice.

Detection now falls back to the top level when `kit` is absent, covering the flat, `kit.tracing` and `kit.experimental.tracing` shapes.