### PR TITLE
ref(server-utils)!: Replace deprecated `ai.*` and `gen_ai.prompt` attributes

### DIFF
--- a/dev-packages/e2e-tests/test-applications/deno/tests/ai.test.ts
+++ b/dev-packages/e2e-tests/test-applications/deno/tests/ai.test.ts
@@ -44,7 +44,7 @@ test('should create AI pipeline spans with Vercel AI SDK', async ({ baseURL }) =
     if (typeof span.description === 'string' && span.description.startsWith('ai.')) {
       return true;
     }
-    if (span.data?.['ai.operationId'] != null || span.data?.['ai.pipeline.name'] != null) {
+    if (span.data?.['ai.operationId'] != null || span.data?.['gen_ai.pipeline.name'] != null) {
       return true;
     }
     return false;

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -536,6 +536,8 @@ Affected SDKs: All SDKs.
 - The `gen_ai.tool.output` span attribute was renamed to `gen_ai.tool.call.result` across all AI integrations.
 - The Vercel AI token attributes `gen_ai.usage.input_tokens.cached`, `gen_ai.usage.input_tokens.cache_write`, and `gen_ai.usage.output_tokens.reasoning` were renamed to `gen_ai.usage.cache_read.input_tokens`, `gen_ai.usage.cache_creation.input_tokens`, and `gen_ai.usage.reasoning.output_tokens`.
 - The deprecated `gen_ai.tool.type` span attribute is no longer set on tool spans.
+- The `ai.pipeline.name` and `ai.streaming` span attributes on Vercel AI spans were renamed to `gen_ai.pipeline.name` and `gen_ai.response.streaming`.
+- The `gen_ai.prompt` span attribute is no longer set by the Anthropic integration. The legacy Completions API's `prompt` is now reported as a user message on `gen_ai.input.messages`, like every other request shape.
 - Span attributes now use the shared `@sentry/conventions` package under the hood.
 
 If you reference these attributes in custom instrumentation, `beforeSendSpan`, dashboards, or alerts, update them to the new names.

--- a/packages/server-utils/src/ai/anthropic-ai/index.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/index.ts
@@ -9,7 +9,6 @@ import {
 import type { Span, SpanAttributeValue } from '@sentry/core';
 import {
   GEN_AI_OPERATION_NAME,
-  GEN_AI_PROMPT,
   GEN_AI_PROVIDER_NAME,
   GEN_AI_REQUEST_FREQUENCY_PENALTY,
   GEN_AI_REQUEST_MAX_TOKENS,
@@ -82,10 +81,6 @@ export function extractRequestAttributes(args: unknown[], operationName: string)
 export function addPrivateRequestAttributes(span: Span, params: Record<string, unknown>): void {
   const messages = messagesFromParams(params);
   setMessagesAttribute(span, messages);
-
-  if ('prompt' in params) {
-    span.setAttributes({ [GEN_AI_PROMPT]: JSON.stringify(params.prompt) });
-  }
 }
 
 /**

--- a/packages/server-utils/src/ai/anthropic-ai/utils.ts
+++ b/packages/server-utils/src/ai/anthropic-ai/utils.ts
@@ -68,7 +68,7 @@ export function handleResponseError(span: Span, response: AnthropicAiResponse): 
  * Include the system prompt in the messages list, if available
  */
 export function messagesFromParams(params: Record<string, unknown>): unknown[] {
-  const { system, messages, input } = params;
+  const { system, messages, input, prompt } = params;
 
   const systemMessages = typeof system === 'string' ? [{ role: 'system', content: params.system }] : [];
 
@@ -76,7 +76,11 @@ export function messagesFromParams(params: Record<string, unknown>): unknown[] {
 
   const messagesParamMessages = Array.isArray(messages) ? messages : messages != null ? [messages] : [];
 
-  const userMessages = inputParamMessages ?? messagesParamMessages;
+  // The legacy Completions API takes a single raw `prompt` string instead of a message list. Model
+  // it as one user message so it lands on `gen_ai.input.messages` like every other request shape.
+  const promptMessages = prompt != null ? [{ role: 'user', content: stringify(prompt, String) }] : [];
+
+  const userMessages = inputParamMessages ?? (messagesParamMessages.length ? messagesParamMessages : promptMessages);
 
   return [...systemMessages, ...userMessages];
 }

--- a/packages/server-utils/src/ai/vercel-ai/index.ts
+++ b/packages/server-utils/src/ai/vercel-ai/index.ts
@@ -15,10 +15,12 @@ import {
   GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
   GEN_AI_OUTPUT_MESSAGES,
+  GEN_AI_PIPELINE_NAME,
   GEN_AI_PROVIDER_NAME,
   GEN_AI_REQUEST_MODEL,
   GEN_AI_RESPONSE_FINISH_REASONS,
   GEN_AI_RESPONSE_MODEL,
+  GEN_AI_RESPONSE_STREAMING,
   GEN_AI_TOOL_CALL_ARGUMENTS,
   GEN_AI_TOOL_CALL_RESULT,
   GEN_AI_TOOL_DEFINITIONS,
@@ -421,7 +423,7 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
   span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, 'auto.vercelai.otel');
 
   const nameWthoutAi = name.replace('ai.', '');
-  span.setAttribute('ai.pipeline.name', nameWthoutAi);
+  span.setAttribute(GEN_AI_PIPELINE_NAME, nameWthoutAi);
   span.updateName(nameWthoutAi);
 
   const functionId = attributes[AI_TELEMETRY_FUNCTION_ID_ATTRIBUTE];
@@ -434,7 +436,7 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
   if (attributes[AI_MODEL_ID_ATTRIBUTE] && !attributes[GEN_AI_RESPONSE_MODEL]) {
     span.setAttribute(GEN_AI_RESPONSE_MODEL, attributes[AI_MODEL_ID_ATTRIBUTE]);
   }
-  span.setAttribute('ai.streaming', name.includes('stream'));
+  span.setAttribute(GEN_AI_RESPONSE_STREAMING, name.includes('stream'));
 
   // Set the op based on the operation name registry
   const operationName = SPAN_TO_OPERATION_NAME.get(name);


### PR DESCRIPTION
* `ai.pipeline.name` -> `gen_ai.pipeline.name`
* `ai.streaming` -> `gen_ai.response.streaming`
* `gen_ai.prompt` -> `gen_ai.input.messages`

`gen_ai.response.text` and `gen_ai.response.tool_calls` are left for now since we need to figure out if and into what shape we need to normalize responses und tool calls across AI providers.

part of getsentry/sentry-javascript#18895