### PR TITLE
feat(core): Support MCP 2026-07-28 observability

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/tests/index.test.ts
@@ -1,14 +1,25 @@
 import { expect, test } from '@playwright/test';
 import { waitForRequest } from '@sentry-internal/test-utils';
 
+const APP_NAME = 'cloudflare-mcp-agent';
+
+function getTransaction(eventData: Awaited<ReturnType<typeof waitForRequest>>) {
+  const event = eventData.envelope[1][0][1];
+  return typeof event !== 'string' && 'type' in event && event.type === 'transaction' ? event : undefined;
+}
+
+function requireTransaction(eventData: Awaited<ReturnType<typeof waitForRequest>>) {
+  const event = getTransaction(eventData);
+  if (!event) {
+    throw new Error('Expected a transaction event');
+  }
+  return event;
+}
+
 test('sends spans for MCP tool calls via MCPAgent (DurableObject)', async ({ baseURL }) => {
-  const mcpToolWaiter = waitForRequest('cloudflare-mcp-agent', event => {
-    const transaction = event.envelope[1][0][1];
-    return (
-      typeof transaction !== 'string' &&
-      'transaction' in transaction &&
-      transaction.transaction === 'tools/call my-tool'
-    );
+  const mcpToolWaiter = waitForRequest(APP_NAME, eventData => {
+    const event = getTransaction(eventData);
+    return event?.transaction === 'tools/call my-tool' && event.contexts?.trace?.op === 'mcp.server';
   });
 
   // Step 1: Initialize the MCP session
@@ -75,23 +86,28 @@ test('sends spans for MCP tool calls via MCPAgent (DurableObject)', async ({ bas
   expect(response.status).toBe(200);
 
   const mcpData = await mcpToolWaiter;
-  const mcpEvent = mcpData.envelope[1][0][1];
+  const mcpEvent = requireTransaction(mcpData);
+  const trace = mcpEvent.contexts?.trace;
 
-  expect(mcpEvent.contexts?.trace?.trace_id).toBe(mcpData.envelope[0].trace.trace_id);
-  expect(mcpEvent.contexts?.trace).toEqual({
-    trace_id: expect.any(String),
-    parent_span_id: expect.any(String),
-    span_id: expect.any(String),
-    op: 'mcp.server',
-    origin: 'auto.function.mcp_server',
-    status: 'ok',
-    data: expect.objectContaining({
-      'sentry.origin': 'auto.function.mcp_server',
-      'sentry.op': 'mcp.server',
-      'mcp.method.name': 'tools/call',
-      'mcp.tool.name': 'my-tool',
-      'mcp.tool.extra': 'from-mcpagent',
-      'mcp.tool.input': '{"message":"hello from MCPAgent test"}',
-    }),
-  });
+  expect(trace?.trace_id).toBe(mcpData.envelope[0].trace.trace_id);
+  expect(trace?.parent_span_id).toEqual(expect.any(String));
+  expect(trace?.op).toBe('mcp.server');
+  expect(trace?.origin).toBe('auto.function.mcp_server');
+  expect(trace?.status).toBe('ok');
+  expect(trace?.data?.['sentry.origin']).toBe('auto.function.mcp_server');
+  expect(trace?.data?.['sentry.op']).toBe('mcp.server');
+  expect(trace?.data?.['sentry.kind']).toBe('server');
+  expect(trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+  expect(trace?.data?.['mcp.method.name']).toBe('tools/call');
+  expect(trace?.data?.['jsonrpc.request.id']).toBe('1');
+  expect(trace?.data?.['mcp.request.id']).toBe('1');
+  expect(trace?.data?.['gen_ai.operation.name']).toBe('execute_tool');
+  expect(trace?.data?.['gen_ai.tool.name']).toBe('my-tool');
+  expect(trace?.data?.['mcp.tool.name']).toBe('my-tool');
+  expect(trace?.data?.['gen_ai.tool.call.arguments']).toBe('{"message":"hello from MCPAgent test"}');
+  expect(trace?.data?.['gen_ai.tool.call.result']).toBe(
+    '{"content":[{"type":"text","text":"Tool my-tool: hello from MCPAgent test"}]}',
+  );
+  expect(trace?.data?.['mcp.tool.extra']).toBe('from-mcpagent');
+  expect(trace?.data?.['mcp.tool.input']).toBe('{"message":"hello from MCPAgent test"}');
 });

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/src/index.ts
@@ -16,12 +16,10 @@ import { createMcpHandler } from 'agents/mcp/server';
 import { z } from 'zod';
 
 function createServer() {
-  const server = Sentry.wrapMcpServerWithSentry(
-    new McpServer({
-      name: 'cloudflare-mcp',
-      version: '2.0.0',
-    }),
-  );
+  const server = new McpServer({
+    name: 'cloudflare-mcp',
+    version: '2.0.0',
+  });
 
   server.registerTool(
     'my-tool',
@@ -57,7 +55,7 @@ function createServer() {
   return server;
 }
 
-const mcpHandler = createMcpHandler(createServer, {
+const mcpHandler = createMcpHandler(Sentry.wrapMcpServerFactoryWithSentry(createServer), {
   route: '/mcp',
 });
 

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/tests/index.test.ts
@@ -5,7 +5,7 @@ const APP_NAME = 'cloudflare-mcp';
 
 function getTransaction(eventData: Awaited<ReturnType<typeof waitForRequest>>) {
   const event = eventData.envelope[1][0][1];
-  return typeof event !== 'string' && 'transaction' in event ? event : undefined;
+  return typeof event !== 'string' && 'type' in event && event.type === 'transaction' ? event : undefined;
 }
 
 function requireTransaction(eventData: Awaited<ReturnType<typeof waitForRequest>>) {
@@ -16,19 +16,29 @@ function requireTransaction(eventData: Awaited<ReturnType<typeof waitForRequest>
   return event;
 }
 
+function getMcpSpan(transaction: ReturnType<typeof requireTransaction>, description: string) {
+  const span = transaction.spans?.find(
+    candidate => candidate.op === 'mcp.server' && candidate.description === description,
+  );
+  expect(span).toBeDefined();
+  return span!;
+}
+
 test.describe.configure({ mode: 'serial' });
 
 test('sends spans for MCP 2026-07-28 tool calls', async ({ baseURL }) => {
   const url = `${baseURL}/mcp?protocol=modern`;
   const requestWaiter = waitForRequest(APP_NAME, eventData => {
     const event = getTransaction(eventData);
-    return event?.transaction === 'POST /mcp' && event.contexts?.trace?.data?.['url.full'] === url;
-  });
-  const mcpWaiter = waitForRequest(APP_NAME, eventData => {
-    const event = getTransaction(eventData);
     return (
-      event?.transaction === 'tools/call my-tool' &&
-      event.contexts?.trace?.data?.['mcp.protocol.version'] === '2026-07-28'
+      event?.transaction === 'POST /mcp' &&
+      event.contexts?.trace?.data?.['url.full'] === url &&
+      event.spans?.some(
+        span =>
+          span.op === 'mcp.server' &&
+          span.description === 'tools/call my-tool' &&
+          span.data?.['mcp.protocol.version'] === '2026-07-28',
+      ) === true
     );
   });
 
@@ -73,11 +83,9 @@ test('sends spans for MCP 2026-07-28 tool calls', async ({ baseURL }) => {
   });
 
   const requestData = await requestWaiter;
-  const mcpData = await mcpWaiter;
   const requestEvent = requireTransaction(requestData);
-  const mcpEvent = requireTransaction(mcpData);
   const requestTrace = requestEvent.contexts?.trace;
-  const mcpTrace = mcpEvent.contexts?.trace;
+  const mcpSpan = getMcpSpan(requestEvent, 'tools/call my-tool');
 
   expect(requestTrace?.op).toBe('http.server');
   expect(requestTrace?.origin).toBe('auto.http.cloudflare');
@@ -97,35 +105,46 @@ test('sends spans for MCP 2026-07-28 tool calls', async ({ baseURL }) => {
   expect(requestTrace?.data?.['network.protocol.name']).toBe('HTTP/1.1');
   expect(requestTrace?.data?.['http.response.status_code']).toBe(200);
   expect(requestTrace?.data?.['mcp.server.extra']).toBe(' /|\ ^._.^ /|\ ');
-  expect(mcpTrace?.trace_id).toBe(requestTrace?.trace_id);
-  expect(mcpTrace?.trace_id).toBe((mcpData.envelope[0].trace as { trace_id: string }).trace_id);
-  expect(mcpTrace?.parent_span_id).toBe(requestTrace?.span_id);
-  expect(requestData.envelope[0].event_id).not.toBe(mcpData.envelope[0].event_id);
-  expect(mcpTrace?.op).toBe('mcp.server');
-  expect(mcpTrace?.origin).toBe('auto.function.mcp_server');
-  expect(mcpTrace?.status).toBe('ok');
-  expect(mcpTrace?.data?.['mcp.transport']).toBe('PerRequestHTTPServerTransport');
-  expect(mcpTrace?.data?.['network.transport']).toBe('tcp');
-  expect(mcpTrace?.data?.['mcp.protocol.version']).toBe('2026-07-28');
-  expect(mcpTrace?.data?.['mcp.client.name']).toBe('cloudflare-modern-client');
-  expect(mcpTrace?.data?.['mcp.client.version']).toBe('2.0.0');
-  expect(mcpTrace?.data?.['mcp.server.name']).toBe('cloudflare-mcp');
-  expect(mcpTrace?.data?.['mcp.server.version']).toBe('2.0.0');
-  expect(mcpTrace?.data?.['mcp.method.name']).toBe('tools/call');
-  expect(mcpTrace?.data?.['mcp.request.id']).toBe('modern-tool-call');
-  expect(mcpTrace?.data?.['mcp.tool.name']).toBe('my-tool');
-  expect(mcpTrace?.data?.['mcp.request.argument.message']).toBe('"ʕっ•ᴥ•ʔっ"');
-  expect(mcpTrace?.data?.['mcp.tool.result.content_count']).toBe(1);
-  expect(mcpTrace?.data?.['mcp.tool.result.content']).toBe('Tool my-tool: ʕっ•ᴥ•ʔっ');
+  expect(mcpSpan.trace_id).toBe(requestTrace?.trace_id);
+  expect(mcpSpan.parent_span_id).toBe(requestTrace?.span_id);
+  expect(mcpSpan.op).toBe('mcp.server');
+  expect(mcpSpan.origin).toBe('auto.function.mcp_server');
+  expect(mcpSpan.status).toBe('ok');
+  expect(mcpSpan.data?.['mcp.transport']).toBe('PerRequestHTTPServerTransport');
+  expect(mcpSpan.data?.['network.transport']).toBe('tcp');
+  expect(mcpSpan.data?.['mcp.protocol.version']).toBe('2026-07-28');
+  expect(mcpSpan.data?.['mcp.client.name']).toBe('cloudflare-modern-client');
+  expect(mcpSpan.data?.['mcp.client.version']).toBe('2.0.0');
+  expect(mcpSpan.data?.['mcp.server.name']).toBe('cloudflare-mcp');
+  expect(mcpSpan.data?.['mcp.server.version']).toBe('2.0.0');
+  expect(mcpSpan.data?.['mcp.method.name']).toBe('tools/call');
+  expect(mcpSpan.data?.['jsonrpc.request.id']).toBe('modern-tool-call');
+  expect(mcpSpan.data?.['mcp.request.id']).toBe('modern-tool-call');
+  expect(mcpSpan.data?.['gen_ai.operation.name']).toBe('execute_tool');
+  expect(mcpSpan.data?.['gen_ai.tool.call.arguments']).toBe('{"message":"ʕっ•ᴥ•ʔっ"}');
+  expect(mcpSpan.data?.['gen_ai.tool.call.result']).toBe(
+    '{"content":[{"type":"text","text":"Tool my-tool: ʕっ•ᴥ•ʔっ"}]}',
+  );
+  expect(mcpSpan.data?.['gen_ai.tool.name']).toBe('my-tool');
+  expect(mcpSpan.data?.['mcp.tool.name']).toBe('my-tool');
+  expect(mcpSpan.data?.['mcp.request.argument.message']).toBe('"ʕっ•ᴥ•ʔっ"');
+  expect(mcpSpan.data?.['mcp.tool.result.content_count']).toBe(1);
+  expect(mcpSpan.data?.['mcp.tool.result.content']).toBe('Tool my-tool: ʕっ•ᴥ•ʔっ');
 });
 
 test('keeps sending spans for legacy-compatible MCP tool calls', async ({ baseURL }) => {
   const url = `${baseURL}/mcp?protocol=legacy`;
-  const mcpWaiter = waitForRequest(APP_NAME, eventData => {
+  const requestWaiter = waitForRequest(APP_NAME, eventData => {
     const event = getTransaction(eventData);
     return (
-      event?.transaction === 'tools/call my-tool' &&
-      event.contexts?.trace?.data?.['mcp.request.argument.message'] === '"legacy protocol request"'
+      event?.transaction === 'POST /mcp' &&
+      event.contexts?.trace?.data?.['url.full'] === url &&
+      event.spans?.some(
+        span =>
+          span.op === 'mcp.server' &&
+          span.description === 'tools/call my-tool' &&
+          span.data?.['mcp.request.argument.message'] === '"legacy protocol request"',
+      ) === true
     );
   });
 
@@ -150,15 +169,24 @@ test('keeps sending spans for legacy-compatible MCP tool calls', async ({ baseUR
 
   expect(response.status).toBe(200);
 
-  const mcpEvent = requireTransaction(await mcpWaiter);
-  const trace = mcpEvent.contexts?.trace;
+  const requestEvent = requireTransaction(await requestWaiter);
+  const requestTrace = requestEvent.contexts?.trace;
+  const mcpSpan = getMcpSpan(requestEvent, 'tools/call my-tool');
 
-  expect(trace?.op).toBe('mcp.server');
-  expect(trace?.status).toBe('ok');
-  expect(trace?.data?.['mcp.transport']).toBe('WebStandardStreamableHTTPServerTransport');
-  expect(trace?.data?.['mcp.method.name']).toBe('tools/call');
-  expect(trace?.data?.['mcp.request.id']).toBe('legacy-tool-call');
-  expect(trace?.data?.['mcp.tool.name']).toBe('my-tool');
-  expect(trace?.data?.['mcp.protocol.version']).toBeUndefined();
-  expect(trace?.data?.['mcp.tool.result.content']).toBe('Tool my-tool: legacy protocol request');
+  expect(requestTrace?.op).toBe('http.server');
+  expect(mcpSpan.trace_id).toBe(requestTrace?.trace_id);
+  expect(mcpSpan.parent_span_id).toBe(requestTrace?.span_id);
+  expect(mcpSpan.status).toBe('ok');
+  expect(mcpSpan.data?.['mcp.transport']).toBe('WebStandardStreamableHTTPServerTransport');
+  expect(mcpSpan.data?.['mcp.method.name']).toBe('tools/call');
+  expect(mcpSpan.data?.['jsonrpc.request.id']).toBe('legacy-tool-call');
+  expect(mcpSpan.data?.['mcp.request.id']).toBe('legacy-tool-call');
+  expect(mcpSpan.data?.['gen_ai.tool.call.arguments']).toBe('{"message":"legacy protocol request"}');
+  expect(mcpSpan.data?.['gen_ai.tool.call.result']).toBe(
+    '{"content":[{"type":"text","text":"Tool my-tool: legacy protocol request"}]}',
+  );
+  expect(mcpSpan.data?.['gen_ai.tool.name']).toBe('my-tool');
+  expect(mcpSpan.data?.['mcp.tool.name']).toBe('my-tool');
+  expect(mcpSpan.data?.['mcp.protocol.version']).toBeUndefined();
+  expect(mcpSpan.data?.['mcp.tool.result.content']).toBe('Tool my-tool: legacy protocol request');
 });

--- a/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/package.json
@@ -30,8 +30,5 @@
   "type": "module",
   "volta": {
     "extends": "../../package.json"
-  },
-  "sentryTest": {
-    "optional": true
   }
 }

--- a/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/src/mcp.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/src/mcp.ts
@@ -1,11 +1,41 @@
 import { randomUUID } from 'node:crypto';
 import express from 'express';
-import { McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
-import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { createMcpHandler, McpServer, ResourceTemplate } from '@modelcontextprotocol/server';
+import { NodeStreamableHTTPServerTransport, toNodeHandler } from '@modelcontextprotocol/node';
 import { z } from 'zod';
-import { wrapMcpServerWithSentry } from '@sentry/node';
+import { wrapMcpServerFactoryWithSentry, wrapMcpServerWithSentry } from '@sentry/node';
 
 const mcpRouter = express.Router();
+
+const modernHandler = createMcpHandler(
+  wrapMcpServerFactoryWithSentry(() => {
+    const modernServer = new McpServer({
+      name: 'Echo-2026',
+      version: '2.0.0',
+    });
+
+    modernServer.registerTool(
+      'echo-modern',
+      {
+        description: 'Echo tool served through the per-request 2026-07-28 protocol',
+        inputSchema: z.object({ message: z.string() }),
+        outputSchema: z.object({ echoed: z.string() }),
+      },
+      async ({ message }) => ({
+        content: [{ type: 'text', text: `Modern tool echo: ${message}` }],
+        structuredContent: { echoed: message },
+      }),
+    );
+
+    return modernServer;
+  }),
+  { legacy: 'reject' },
+);
+const modernNodeHandler = toNodeHandler(modernHandler);
+
+mcpRouter.all('/mcp-modern', async (req, res) => {
+  await modernNodeHandler(req, res, req.body);
+});
 
 const server = wrapMcpServerWithSentry(
   new McpServer({

--- a/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/tests/mcp.test.ts
@@ -3,7 +3,71 @@ import { waitForTransaction } from '@sentry-internal/test-utils';
 import { Client } from '@modelcontextprotocol/client';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 
-test('records transactions for stable MCP SDK v2 handlers using the register API', async ({ baseURL }) => {
+const APP_NAME = 'node-express-mcp-v2';
+
+function waitForMcpTransaction(spanDescription: string) {
+  return waitForTransaction(APP_NAME, transactionEvent => {
+    return transactionEvent.spans?.some(span => span.op === 'mcp.server' && span.description === spanDescription);
+  });
+}
+
+function getMcpSpan(transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>, spanDescription: string) {
+  const span = transactionEvent.spans?.find(
+    candidate => candidate.op === 'mcp.server' && candidate.description === spanDescription,
+  );
+  expect(span).toBeDefined();
+  return span!;
+}
+
+function expectMcpSpanToBeHttpDescendant(
+  transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>,
+  mcpSpan: ReturnType<typeof getMcpSpan>,
+) {
+  expect(transactionEvent.contexts?.trace?.op).toBe('http.server');
+  expect(mcpSpan.trace_id).toBe(transactionEvent.contexts?.trace?.trace_id);
+
+  const rootSpanId = transactionEvent.contexts?.trace?.span_id;
+  const spansById = new Map(transactionEvent.spans?.map(span => [span.span_id, span]));
+  let parentSpanId = mcpSpan.parent_span_id;
+
+  while (parentSpanId && parentSpanId !== rootSpanId) {
+    const parentSpan = spansById.get(parentSpanId);
+    expect(parentSpan).toBeDefined();
+    parentSpanId = parentSpan?.parent_span_id;
+  }
+
+  expect(parentSpanId).toBe(rootSpanId);
+}
+
+const MODERN_PROTOCOL_VERSION = '2026-07-28';
+const MODERN_CLIENT_METADATA = {
+  'io.modelcontextprotocol/protocolVersion': MODERN_PROTOCOL_VERSION,
+  'io.modelcontextprotocol/clientInfo': {
+    name: 'test-client-2026',
+    version: '1.0.0',
+  },
+  'io.modelcontextprotocol/clientCapabilities': {},
+};
+
+async function sendModernRequest(
+  baseURL: string,
+  message: { id: string; method: string; params: Record<string, unknown> },
+  name?: string,
+) {
+  return fetch(`${baseURL}/mcp-modern`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'MCP-Protocol-Version': MODERN_PROTOCOL_VERSION,
+      'Mcp-Method': message.method,
+      ...(name ? { 'Mcp-Name': name } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', ...message }),
+  });
+}
+
+test('records child spans for stable MCP SDK v2 handlers using the register API', async ({ baseURL }) => {
   const transport = new StreamableHTTPClientTransport(new URL(`${baseURL}/mcp`));
 
   const client = new Client({
@@ -11,26 +75,22 @@ test('records transactions for stable MCP SDK v2 handlers using the register API
     version: '1.0.0',
   });
 
-  const initializeTransactionPromise = waitForTransaction('node-express-mcp-v2', transactionEvent => {
-    return transactionEvent.transaction === 'initialize';
-  });
+  const initializeTransactionPromise = waitForMcpTransaction('initialize');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
     const initializeTransaction = await initializeTransactionPromise;
-    expect(initializeTransaction).toBeDefined();
-    expect(initializeTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('initialize');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.client.name']).toEqual('test-client-v2');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.server.name']).toEqual('Echo-V2');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
+    const initializeSpan = getMcpSpan(initializeTransaction, 'initialize');
+    expectMcpSpanToBeHttpDescendant(initializeTransaction, initializeSpan);
+    expect(initializeSpan.data?.['mcp.method.name']).toEqual('initialize');
+    expect(initializeSpan.data?.['mcp.client.name']).toEqual('test-client-v2');
+    expect(initializeSpan.data?.['mcp.server.name']).toEqual('Echo-V2');
+    expect(initializeSpan.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
   });
 
   await test.step('registerTool handler', async () => {
-    const toolTransactionPromise = waitForTransaction('node-express-mcp-v2', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call echo';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -49,18 +109,17 @@ test('records transactions for stable MCP SDK v2 handlers using the register API
     });
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.name']).toEqual('echo');
-    // Proves span was completed with results (span correlation worked end-to-end)
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.result.content_count']).toEqual(1);
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo');
+    expectMcpSpanToBeHttpDescendant(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toEqual('tools/call');
+    expect(toolSpan.data?.['gen_ai.operation.name']).toEqual('execute_tool');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toEqual('echo');
+    expect(toolSpan.data?.['mcp.tool.name']).toEqual('echo');
+    expect(toolSpan.data?.['mcp.tool.result.content_count']).toEqual(1);
   });
 
   await test.step('registerResource handler', async () => {
-    const resourceTransactionPromise = waitForTransaction('node-express-mcp-v2', transactionEvent => {
-      return transactionEvent.transaction === 'resources/read echo://foobar';
-    });
+    const resourceTransactionPromise = waitForMcpTransaction('resources/read');
 
     const resourceResult = await client.readResource({
       uri: 'echo://foobar',
@@ -71,15 +130,13 @@ test('records transactions for stable MCP SDK v2 handlers using the register API
     });
 
     const resourceTransaction = await resourceTransactionPromise;
-    expect(resourceTransaction).toBeDefined();
-    expect(resourceTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(resourceTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('resources/read');
+    const resourceSpan = getMcpSpan(resourceTransaction, 'resources/read');
+    expectMcpSpanToBeHttpDescendant(resourceTransaction, resourceSpan);
+    expect(resourceSpan.data?.['mcp.method.name']).toEqual('resources/read');
   });
 
   await test.step('registerPrompt handler', async () => {
-    const promptTransactionPromise = waitForTransaction('node-express-mcp-v2', transactionEvent => {
-      return transactionEvent.transaction === 'prompts/get echo';
-    });
+    const promptTransactionPromise = waitForMcpTransaction('prompts/get echo');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -101,15 +158,13 @@ test('records transactions for stable MCP SDK v2 handlers using the register API
     });
 
     const promptTransaction = await promptTransactionPromise;
-    expect(promptTransaction).toBeDefined();
-    expect(promptTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(promptTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('prompts/get');
+    const promptSpan = getMcpSpan(promptTransaction, 'prompts/get echo');
+    expectMcpSpanToBeHttpDescendant(promptTransaction, promptSpan);
+    expect(promptSpan.data?.['mcp.method.name']).toEqual('prompts/get');
   });
 
   await test.step('error tool sets span status to internal_error', async () => {
-    const toolTransactionPromise = waitForTransaction('node-express-mcp-v2', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call always-error';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call always-error');
 
     try {
       await client.callTool({ name: 'always-error', arguments: {} });
@@ -118,10 +173,83 @@ test('records transactions for stable MCP SDK v2 handlers using the register API
     }
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.status).toEqual('internal_error');
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call always-error');
+    expectMcpSpanToBeHttpDescendant(toolTransaction, toolSpan);
+    expect(toolSpan.status).toEqual('internal_error');
   });
 
   await client.close();
+});
+
+test('records stateless MCP 2026-07-28 requests with canonical attributes', async ({ baseURL }) => {
+  const discoverTransactionPromise = waitForMcpTransaction('server/discover');
+  const discoverResponse = await sendModernRequest(baseURL!, {
+    id: 'modern-discover',
+    method: 'server/discover',
+    params: { _meta: MODERN_CLIENT_METADATA },
+  });
+  expect(discoverResponse.status).toBe(200);
+  await expect(discoverResponse.json()).resolves.toMatchObject({
+    jsonrpc: '2.0',
+    id: 'modern-discover',
+    result: {
+      resultType: 'complete',
+      supportedVersions: [MODERN_PROTOCOL_VERSION],
+    },
+  });
+
+  const discoverTransaction = await discoverTransactionPromise;
+  const discoverSpan = getMcpSpan(discoverTransaction, 'server/discover');
+  expectMcpSpanToBeHttpDescendant(discoverTransaction, discoverSpan);
+  expect(discoverSpan.data).toMatchObject({
+    'mcp.client.name': 'test-client-2026',
+    'mcp.method.name': 'server/discover',
+    'mcp.protocol.version': '2026-07-28',
+    'mcp.result.type': 'complete',
+    'mcp.server.name': 'Echo-2026',
+    'sentry.kind': 'server',
+  });
+  expect(discoverSpan.data?.['mcp.session.id']).toBeUndefined();
+
+  const toolTransactionPromise = waitForMcpTransaction('tools/call echo-modern');
+  const toolResponse = await sendModernRequest(
+    baseURL!,
+    {
+      id: 'modern-tool-call',
+      method: 'tools/call',
+      params: {
+        _meta: MODERN_CLIENT_METADATA,
+        name: 'echo-modern',
+        arguments: { message: 'modern payload' },
+      },
+    },
+    'echo-modern',
+  );
+  expect(toolResponse.status).toBe(200);
+  await expect(toolResponse.json()).resolves.toMatchObject({
+    jsonrpc: '2.0',
+    id: 'modern-tool-call',
+    result: {
+      resultType: 'complete',
+      content: [{ type: 'text', text: 'Modern tool echo: modern payload' }],
+      structuredContent: { echoed: 'modern payload' },
+    },
+  });
+
+  const toolTransaction = await toolTransactionPromise;
+  const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo-modern');
+  expectMcpSpanToBeHttpDescendant(toolTransaction, toolSpan);
+  expect(toolSpan.data).toMatchObject({
+    'gen_ai.operation.name': 'execute_tool',
+    'gen_ai.tool.call.arguments': '{"message":"modern payload"}',
+    'gen_ai.tool.call.result': '{"echoed":"modern payload"}',
+    'gen_ai.tool.name': 'echo-modern',
+    'mcp.method.name': 'tools/call',
+    'mcp.protocol.version': '2026-07-28',
+    'mcp.result.type': 'complete',
+    'mcp.tool.name': 'echo-modern',
+    'sentry.kind': 'server',
+  });
+  expect(toolSpan.data?.['jsonrpc.request.id']).toBeDefined();
+  expect(toolSpan.data?.['mcp.session.id']).toBeUndefined();
 });

--- a/dev-packages/e2e-tests/test-applications/node-express-streaming/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-streaming/tests/mcp.test.ts
@@ -4,39 +4,66 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
-// TODO: MCP handler spans (tools/call, resources/read, etc.) are not emitted as streamed spans
-// with SSE transport — only the POST /messages HTTP server span arrives in the envelope.
-// Re-enable once the MCP instrumentation supports span streaming over SSE.
-test.skip('Should record streamed spans for mcp handlers', async ({ baseURL }) => {
-  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
+const APP_NAME = 'node-express-streaming';
+const LEGACY_SSE_TRACE_ID = '0123456789abcdef0123456789abcdef';
+const LEGACY_SSE_TRACE_HEADER = `${LEGACY_SSE_TRACE_ID}-0123456789abcdef-1`;
+const STREAMABLE_TRACE_ID = 'fedcba9876543210fedcba9876543210';
+const STREAMABLE_TRACE_HEADER = `${STREAMABLE_TRACE_ID}-fedcba9876543210-1`;
 
+function waitForMcpSpan(spanName: string, serverName: string) {
+  return waitForStreamedSpan(APP_NAME, span => {
+    return (
+      span.name === spanName &&
+      getSpanOp(span) === 'mcp.server' &&
+      !span.is_segment &&
+      span.attributes['mcp.server.name']?.value === serverName
+    );
+  });
+}
+
+function waitForHttpSpan(spanName: string) {
+  return waitForStreamedSpan(APP_NAME, span => {
+    return span.name === spanName && getSpanOp(span) === 'http.server' && span.is_segment;
+  });
+}
+
+function expectMcpSpanToBeHttpChild(
+  httpSpan: Awaited<ReturnType<typeof waitForStreamedSpan>>,
+  mcpSpan: Awaited<ReturnType<typeof waitForStreamedSpan>>,
+) {
+  expect(httpSpan.is_segment).toBe(true);
+  expect(mcpSpan.is_segment).toBe(false);
+  expect(mcpSpan.trace_id).toBe(httpSpan.trace_id);
+  expect(mcpSpan.parent_span_id).toBeTruthy();
+  expect(mcpSpan.parent_span_id).not.toBe(mcpSpan.span_id);
+}
+
+test('records streamed MCP child spans for legacy SSE handlers', async ({ baseURL }) => {
+  test.setTimeout(60_000);
+  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`), {
+    requestInit: { headers: { 'sentry-trace': LEGACY_SSE_TRACE_HEADER } },
+  });
   const client = new Client({
     name: 'test-client',
     version: '1.0.0',
   });
-
-  const initializeSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-    return span.name === 'initialize' && getSpanOp(span) === 'mcp.server' && span.is_segment;
-  });
+  const initializeHttpSpanPromise = waitForHttpSpan('POST /messages');
+  const initializeSpanPromise = waitForMcpSpan('initialize', 'Echo');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
-    const initializeSpan = await initializeSpanPromise;
-    expect(initializeSpan).toBeDefined();
-    expect(getSpanOp(initializeSpan)).toBe('mcp.server');
+    const [initializeHttpSpan, initializeSpan] = await Promise.all([initializeHttpSpanPromise, initializeSpanPromise]);
+    expectMcpSpanToBeHttpChild(initializeHttpSpan, initializeSpan);
+    expect(initializeSpan.trace_id).toBe(LEGACY_SSE_TRACE_ID);
     expect(initializeSpan.attributes['mcp.method.name']?.value).toBe('initialize');
     expect(initializeSpan.attributes['mcp.client.name']?.value).toBe('test-client');
     expect(initializeSpan.attributes['mcp.server.name']?.value).toBe('Echo');
   });
 
   await test.step('tool handler', async () => {
-    const postSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'POST /messages' && getSpanOp(span) === 'http.server' && span.is_segment;
-    });
-    const toolSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'tools/call echo' && getSpanOp(span) === 'mcp.server' && span.is_segment;
-    });
+    const httpSpanPromise = waitForHttpSpan('POST /messages');
+    const toolSpanPromise = waitForMcpSpan('tools/call echo', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -54,23 +81,23 @@ test.skip('Should record streamed spans for mcp handlers', async ({ baseURL }) =
       ],
     });
 
-    const postSpan = await postSpanPromise;
-    expect(postSpan).toBeDefined();
-    expect(getSpanOp(postSpan)).toBe('http.server');
-
-    const toolSpan = await toolSpanPromise;
-    expect(toolSpan).toBeDefined();
-    expect(getSpanOp(toolSpan)).toBe('mcp.server');
+    const [httpSpan, toolSpan] = await Promise.all([httpSpanPromise, toolSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, toolSpan);
     expect(toolSpan.attributes['mcp.method.name']?.value).toBe('tools/call');
+    expect(toolSpan.attributes['gen_ai.operation.name']?.value).toBe('execute_tool');
+    expect(toolSpan.attributes['gen_ai.tool.call.arguments']?.value).toBe('{"message":"foobar"}');
+    expect(toolSpan.attributes['gen_ai.tool.call.result']?.value).toBe(
+      '{"content":[{"type":"text","text":"Tool echo: foobar"}]}',
+    );
+    expect(toolSpan.attributes['gen_ai.tool.name']?.value).toBe('echo');
+    expect(toolSpan.attributes['mcp.tool.name']?.value).toBe('echo');
+    expect(toolSpan.attributes['jsonrpc.request.id']?.value).toBeDefined();
+    expect(toolSpan.attributes['mcp.request.id']?.value).toBe(toolSpan.attributes['jsonrpc.request.id']?.value);
   });
 
   await test.step('registerTool handler', async () => {
-    const postSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'POST /messages' && getSpanOp(span) === 'http.server' && span.is_segment;
-    });
-    const toolSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'tools/call echo-register' && getSpanOp(span) === 'mcp.server' && span.is_segment;
-    });
+    const httpSpanPromise = waitForHttpSpan('POST /messages');
+    const toolSpanPromise = waitForMcpSpan('tools/call echo-register', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo-register',
@@ -88,24 +115,16 @@ test.skip('Should record streamed spans for mcp handlers', async ({ baseURL }) =
       ],
     });
 
-    const postSpan = await postSpanPromise;
-    expect(postSpan).toBeDefined();
-    expect(getSpanOp(postSpan)).toBe('http.server');
-
-    const toolSpan = await toolSpanPromise;
-    expect(toolSpan).toBeDefined();
-    expect(getSpanOp(toolSpan)).toBe('mcp.server');
+    const [httpSpan, toolSpan] = await Promise.all([httpSpanPromise, toolSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, toolSpan);
     expect(toolSpan.attributes['mcp.method.name']?.value).toBe('tools/call');
+    expect(toolSpan.attributes['gen_ai.tool.name']?.value).toBe('echo-register');
     expect(toolSpan.attributes['mcp.tool.name']?.value).toBe('echo-register');
   });
 
   await test.step('resource handler', async () => {
-    const postSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'POST /messages' && getSpanOp(span) === 'http.server' && span.is_segment;
-    });
-    const resourceSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'resources/read echo://foobar' && getSpanOp(span) === 'mcp.server' && span.is_segment;
-    });
+    const httpSpanPromise = waitForHttpSpan('POST /messages');
+    const resourceSpanPromise = waitForMcpSpan('resources/read', 'Echo');
 
     const resourceResult = await client.readResource({
       uri: 'echo://foobar',
@@ -115,23 +134,15 @@ test.skip('Should record streamed spans for mcp handlers', async ({ baseURL }) =
       contents: [{ text: 'Resource echo: foobar', uri: 'echo://foobar' }],
     });
 
-    const postSpan = await postSpanPromise;
-    expect(postSpan).toBeDefined();
-    expect(getSpanOp(postSpan)).toBe('http.server');
-
-    const resourceSpan = await resourceSpanPromise;
-    expect(resourceSpan).toBeDefined();
-    expect(getSpanOp(resourceSpan)).toBe('mcp.server');
+    const [httpSpan, resourceSpan] = await Promise.all([httpSpanPromise, resourceSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, resourceSpan);
+    expect(resourceSpan.name).toBe('resources/read');
     expect(resourceSpan.attributes['mcp.method.name']?.value).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const postSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'POST /messages' && getSpanOp(span) === 'http.server' && span.is_segment;
-    });
-    const promptSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'prompts/get echo' && getSpanOp(span) === 'mcp.server' && span.is_segment;
-    });
+    const httpSpanPromise = waitForHttpSpan('POST /messages');
+    const promptSpanPromise = waitForMcpSpan('prompts/get echo', 'Echo');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -152,70 +163,62 @@ test.skip('Should record streamed spans for mcp handlers', async ({ baseURL }) =
       ],
     });
 
-    const postSpan = await postSpanPromise;
-    expect(postSpan).toBeDefined();
-    expect(getSpanOp(postSpan)).toBe('http.server');
-
-    const promptSpan = await promptSpanPromise;
-    expect(promptSpan).toBeDefined();
-    expect(getSpanOp(promptSpan)).toBe('mcp.server');
+    const [httpSpan, promptSpan] = await Promise.all([httpSpanPromise, promptSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, promptSpan);
     expect(promptSpan.attributes['mcp.method.name']?.value).toBe('prompts/get');
+    expect(promptSpan.attributes['gen_ai.prompt.name']?.value).toBe('echo');
+    expect(promptSpan.attributes['gen_ai.prompt.variable.message']?.value).toBe('foobar');
+    expect(promptSpan.attributes['mcp.prompt.name']?.value).toBe('echo');
+    expect(promptSpan.attributes['mcp.request.argument.message']?.value).toBe('"foobar"');
   });
 
   await test.step('error tool sets span status to error', async () => {
-    const toolSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return span.name === 'tools/call always-error' && getSpanOp(span) === 'mcp.server' && span.is_segment;
-    });
+    const httpSpanPromise = waitForHttpSpan('POST /messages');
+    const toolSpanPromise = waitForMcpSpan('tools/call always-error', 'Echo');
 
-    try {
-      await client.callTool({ name: 'always-error', arguments: {} });
-    } catch {
-      // Expected: MCP SDK throws when the tool returns a JSON-RPC error
-    }
+    await expect(client.callTool({ name: 'always-error', arguments: {} })).resolves.toMatchObject({ isError: true });
 
-    const toolSpan = await toolSpanPromise;
-    expect(toolSpan).toBeDefined();
-    expect(getSpanOp(toolSpan)).toBe('mcp.server');
+    const [httpSpan, toolSpan] = await Promise.all([httpSpanPromise, toolSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, toolSpan);
     expect(toolSpan.status).toBe('error');
   });
+
+  await client.close();
 });
 
-test('Should record streamed spans for streamable HTTP transport (wrapper transport pattern)', async ({ baseURL }) => {
-  const transport = new StreamableHTTPClientTransport(new URL(`${baseURL}/mcp`));
-
+/**
+ * StreamableHTTPServerTransport wraps WebStandardStreamableHTTPServerTransport via getters and setters,
+ * so onmessage and send can observe different `this` values. This verifies that response completion
+ * remains correlated with the original request while the MCP spans retain their HTTP parent.
+ *
+ * @see https://github.com/getsentry/sentry-mcp/issues/767
+ */
+test('records streamed MCP child spans for streamable HTTP handlers', async ({ baseURL }) => {
+  const transport = new StreamableHTTPClientTransport(new URL(`${baseURL}/mcp`), {
+    requestInit: { headers: { 'sentry-trace': STREAMABLE_TRACE_HEADER } },
+  });
   const client = new Client({
     name: 'test-client-streamable',
     version: '1.0.0',
   });
-
-  const initializeSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-    return (
-      span.name === 'initialize' &&
-      getSpanOp(span) === 'mcp.server' &&
-      span.attributes['mcp.server.name']?.value === 'Echo-Streamable'
-    );
-  });
+  const initializeHttpSpanPromise = waitForHttpSpan('POST /mcp');
+  const initializeSpanPromise = waitForMcpSpan('initialize', 'Echo-Streamable');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
-    const initializeSpan = await initializeSpanPromise;
-    expect(initializeSpan).toBeDefined();
-    expect(getSpanOp(initializeSpan)).toBe('mcp.server');
+    const [initializeHttpSpan, initializeSpan] = await Promise.all([initializeHttpSpanPromise, initializeSpanPromise]);
+    expectMcpSpanToBeHttpChild(initializeHttpSpan, initializeSpan);
+    expect(initializeSpan.trace_id).toBe(STREAMABLE_TRACE_ID);
     expect(initializeSpan.attributes['mcp.method.name']?.value).toBe('initialize');
     expect(initializeSpan.attributes['mcp.client.name']?.value).toBe('test-client-streamable');
     expect(initializeSpan.attributes['mcp.server.name']?.value).toBe('Echo-Streamable');
     expect(String(initializeSpan.attributes['mcp.transport']?.value)).toMatch(/StreamableHTTPServerTransport/);
   });
 
-  await test.step('tool handler (tests wrapper transport correlation)', async () => {
-    const toolSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return (
-        span.name === 'tools/call echo' &&
-        getSpanOp(span) === 'mcp.server' &&
-        String(span.attributes['mcp.transport']?.value).includes('StreamableHTTPServerTransport')
-      );
-    });
+  await test.step('tool handler preserves wrapper transport correlation', async () => {
+    const httpSpanPromise = waitForHttpSpan('POST /mcp');
+    const toolSpanPromise = waitForMcpSpan('tools/call echo', 'Echo-Streamable');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -233,22 +236,18 @@ test('Should record streamed spans for streamable HTTP transport (wrapper transp
       ],
     });
 
-    const toolSpan = await toolSpanPromise;
-    expect(toolSpan).toBeDefined();
-    expect(getSpanOp(toolSpan)).toBe('mcp.server');
+    const [httpSpan, toolSpan] = await Promise.all([httpSpanPromise, toolSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, toolSpan);
     expect(toolSpan.attributes['mcp.method.name']?.value).toBe('tools/call');
+    expect(toolSpan.attributes['gen_ai.operation.name']?.value).toBe('execute_tool');
+    expect(toolSpan.attributes['gen_ai.tool.name']?.value).toBe('echo');
     expect(toolSpan.attributes['mcp.tool.name']?.value).toBe('echo');
     expect(toolSpan.attributes['mcp.tool.result.content_count']?.value).toBe(1);
   });
 
   await test.step('resource handler', async () => {
-    const resourceSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return (
-        span.name === 'resources/read echo://streamable-test' &&
-        getSpanOp(span) === 'mcp.server' &&
-        String(span.attributes['mcp.transport']?.value).includes('StreamableHTTPServerTransport')
-      );
-    });
+    const httpSpanPromise = waitForHttpSpan('POST /mcp');
+    const resourceSpanPromise = waitForMcpSpan('resources/read', 'Echo-Streamable');
 
     const resourceResult = await client.readResource({
       uri: 'echo://streamable-test',
@@ -258,20 +257,15 @@ test('Should record streamed spans for streamable HTTP transport (wrapper transp
       contents: [{ text: 'Resource echo: streamable-test', uri: 'echo://streamable-test' }],
     });
 
-    const resourceSpan = await resourceSpanPromise;
-    expect(resourceSpan).toBeDefined();
-    expect(getSpanOp(resourceSpan)).toBe('mcp.server');
+    const [httpSpan, resourceSpan] = await Promise.all([httpSpanPromise, resourceSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, resourceSpan);
+    expect(resourceSpan.name).toBe('resources/read');
     expect(resourceSpan.attributes['mcp.method.name']?.value).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const promptSpanPromise = waitForStreamedSpan('node-express-streaming', span => {
-      return (
-        span.name === 'prompts/get echo' &&
-        getSpanOp(span) === 'mcp.server' &&
-        String(span.attributes['mcp.transport']?.value).includes('StreamableHTTPServerTransport')
-      );
-    });
+    const httpSpanPromise = waitForHttpSpan('POST /mcp');
+    const promptSpanPromise = waitForMcpSpan('prompts/get echo', 'Echo-Streamable');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -292,10 +286,11 @@ test('Should record streamed spans for streamable HTTP transport (wrapper transp
       ],
     });
 
-    const promptSpan = await promptSpanPromise;
-    expect(promptSpan).toBeDefined();
-    expect(getSpanOp(promptSpan)).toBe('mcp.server');
+    const [httpSpan, promptSpan] = await Promise.all([httpSpanPromise, promptSpanPromise]);
+    expectMcpSpanToBeHttpChild(httpSpan, promptSpan);
     expect(promptSpan.attributes['mcp.method.name']?.value).toBe('prompts/get');
+    expect(promptSpan.attributes['gen_ai.prompt.name']?.value).toBe('echo');
+    expect(promptSpan.attributes['mcp.prompt.name']?.value).toBe('echo');
   });
 
   await client.close();

--- a/dev-packages/e2e-tests/test-applications/node-express-v5/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/tests/mcp.test.ts
@@ -4,36 +4,70 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
-test('Should record transactions for mcp handlers', async ({ baseURL }) => {
-  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
+const APP_NAME = 'node-express-v5';
 
+function waitForMcpTransaction(spanDescription: string, serverName: string) {
+  return waitForTransaction(APP_NAME, transactionEvent => {
+    return (
+      transactionEvent.spans?.some(
+        span =>
+          span.op === 'mcp.server' &&
+          span.description === spanDescription &&
+          span.data?.['mcp.server.name'] === serverName,
+      ) === true
+    );
+  });
+}
+
+function getMcpSpan(transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>, spanDescription: string) {
+  const span = transactionEvent.spans?.find(
+    candidate => candidate.op === 'mcp.server' && candidate.description === spanDescription,
+  );
+  expect(span).toBeDefined();
+  return span!;
+}
+
+function expectMcpSpanToBeHttpChild(
+  transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>,
+  mcpSpan: ReturnType<typeof getMcpSpan>,
+) {
+  expect(transactionEvent.contexts?.trace?.op).toBe('http.server');
+  expect(mcpSpan.trace_id).toBe(transactionEvent.contexts?.trace?.trace_id);
+
+  const rootSpanId = transactionEvent.contexts?.trace?.span_id;
+  const spansById = new Map(transactionEvent.spans?.map(span => [span.span_id, span]));
+  let parentSpanId = mcpSpan.parent_span_id;
+
+  while (parentSpanId && parentSpanId !== rootSpanId) {
+    const parentSpan = spansById.get(parentSpanId);
+    expect(parentSpan).toBeDefined();
+    parentSpanId = parentSpan?.parent_span_id;
+  }
+
+  expect(parentSpanId).toBe(rootSpanId);
+}
+
+test('records MCP handler spans inside legacy SSE HTTP transactions', async ({ baseURL }) => {
+  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
   const client = new Client({
     name: 'test-client',
     version: '1.0.0',
   });
-
-  const initializeTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-    return transactionEvent.transaction === 'initialize';
-  });
+  const initializeTransactionPromise = waitForMcpTransaction('initialize', 'Echo');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
     const initializeTransaction = await initializeTransactionPromise;
-    expect(initializeTransaction).toBeDefined();
-    expect(initializeTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('initialize');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.client.name']).toEqual('test-client');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.server.name']).toEqual('Echo');
+    const initializeSpan = getMcpSpan(initializeTransaction, 'initialize');
+    expectMcpSpanToBeHttpChild(initializeTransaction, initializeSpan);
+    expect(initializeSpan.data?.['mcp.method.name']).toBe('initialize');
+    expect(initializeSpan.data?.['mcp.client.name']).toBe('test-client');
+    expect(initializeSpan.data?.['mcp.server.name']).toBe('Echo');
   });
 
   await test.step('tool handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const toolTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call echo';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -51,22 +85,19 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.operation.name']).toBe('execute_tool');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['jsonrpc.request.id']).toBeDefined();
+    expect(toolSpan.data?.['mcp.request.id']).toBe(toolSpan.data?.['jsonrpc.request.id']);
   });
 
   await test.step('registerTool handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const toolTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call echo-register';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo-register', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo-register',
@@ -84,21 +115,16 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.name']).toEqual('echo-register');
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo-register');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo-register');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo-register');
   });
 
   await test.step('resource handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const resourceTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'resources/read echo://foobar';
-    });
+    const resourceTransactionPromise = waitForMcpTransaction('resources/read', 'Echo');
 
     const resourceResult = await client.readResource({
       uri: 'echo://foobar',
@@ -108,22 +134,15 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       contents: [{ text: 'Resource echo: foobar', uri: 'echo://foobar' }],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-
     const resourceTransaction = await resourceTransactionPromise;
-    expect(resourceTransaction).toBeDefined();
-
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const resourceSpan = getMcpSpan(resourceTransaction, 'resources/read');
+    expectMcpSpanToBeHttpChild(resourceTransaction, resourceSpan);
+    expect(resourceSpan.description).toBe('resources/read');
+    expect(resourceSpan.data?.['mcp.method.name']).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const promptTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'prompts/get echo';
-    });
+    const promptTransactionPromise = waitForMcpTransaction('prompts/get echo', 'Echo');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -144,79 +163,57 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-
     const promptTransaction = await promptTransactionPromise;
-    expect(promptTransaction).toBeDefined();
-
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const promptSpan = getMcpSpan(promptTransaction, 'prompts/get echo');
+    expectMcpSpanToBeHttpChild(promptTransaction, promptSpan);
+    expect(promptSpan.data?.['mcp.method.name']).toBe('prompts/get');
+    expect(promptSpan.data?.['gen_ai.prompt.name']).toBe('echo');
+    expect(promptSpan.data?.['mcp.prompt.name']).toBe('echo');
   });
 
   await test.step('error tool sets span status to internal_error', async () => {
-    const toolTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call always-error';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call always-error', 'Echo');
 
-    try {
-      await client.callTool({ name: 'always-error', arguments: {} });
-    } catch {
-      // Expected: MCP SDK throws when the tool returns a JSON-RPC error
-    }
+    await expect(client.callTool({ name: 'always-error', arguments: {} })).resolves.toMatchObject({ isError: true });
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.status).toEqual('internal_error');
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call always-error');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.status).toBe('internal_error');
   });
+
+  await client.close();
 });
 
 /**
- * Tests for StreamableHTTPServerTransport (wrapper transport pattern)
- *
- * StreamableHTTPServerTransport wraps WebStandardStreamableHTTPServerTransport via getters/setters.
- * This causes different `this` values in onmessage vs send, which was breaking span correlation.
- *
- * The fix uses sessionId as the correlation key instead of transport object reference.
- * This test verifies that spans are correctly recorded when using the wrapper transport.
+ * StreamableHTTPServerTransport wraps WebStandardStreamableHTTPServerTransport via getters and setters,
+ * so onmessage and send can observe different `this` values. This verifies that response completion
+ * remains correlated with the original request while the MCP spans retain their HTTP parent.
  *
  * @see https://github.com/getsentry/sentry-mcp/issues/767
  */
-test('Should record transactions for streamable HTTP transport (wrapper transport pattern)', async ({ baseURL }) => {
+test('records MCP handler spans inside streamable HTTP transactions', async ({ baseURL }) => {
   const transport = new StreamableHTTPClientTransport(new URL(`${baseURL}/mcp`));
-
   const client = new Client({
     name: 'test-client-streamable',
     version: '1.0.0',
   });
-
-  const initializeTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-    return (
-      transactionEvent.transaction === 'initialize' &&
-      transactionEvent.contexts?.trace?.data?.['mcp.server.name'] === 'Echo-Streamable'
-    );
-  });
+  const initializeTransactionPromise = waitForMcpTransaction('initialize', 'Echo-Streamable');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
     const initializeTransaction = await initializeTransactionPromise;
-    expect(initializeTransaction).toBeDefined();
-    expect(initializeTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('initialize');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.client.name']).toEqual('test-client-streamable');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.server.name']).toEqual('Echo-Streamable');
-    // Verify it's using a StreamableHTTP transport (may be wrapper or inner depending on environment)
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
+    const initializeSpan = getMcpSpan(initializeTransaction, 'initialize');
+    expectMcpSpanToBeHttpChild(initializeTransaction, initializeSpan);
+    expect(initializeSpan.data?.['mcp.method.name']).toBe('initialize');
+    expect(initializeSpan.data?.['mcp.client.name']).toBe('test-client-streamable');
+    expect(initializeSpan.data?.['mcp.server.name']).toBe('Echo-Streamable');
+    expect(initializeSpan.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
   });
 
-  await test.step('tool handler (tests wrapper transport correlation)', async () => {
-    // This is the critical test - without the sessionId fix, the span would not be completed
-    // because onmessage and send see different transport instances (wrapper vs inner)
-    const toolTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return transactionEvent.transaction === 'tools/call echo' && transport?.includes('StreamableHTTPServerTransport');
-    });
+  await test.step('tool handler preserves wrapper transport correlation', async () => {
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo', 'Echo-Streamable');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -235,22 +232,16 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.name']).toEqual('echo');
-    // This attribute proves the span was completed with results (sessionId correlation worked)
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.result.content_count']).toEqual(1);
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.result.content_count']).toBe(1);
   });
 
   await test.step('resource handler', async () => {
-    const resourceTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return (
-        transactionEvent.transaction === 'resources/read echo://streamable-test' &&
-        transport?.includes('StreamableHTTPServerTransport')
-      );
-    });
+    const resourceTransactionPromise = waitForMcpTransaction('resources/read', 'Echo-Streamable');
 
     const resourceResult = await client.readResource({
       uri: 'echo://streamable-test',
@@ -261,18 +252,14 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const resourceTransaction = await resourceTransactionPromise;
-    expect(resourceTransaction).toBeDefined();
-    expect(resourceTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(resourceTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('resources/read');
+    const resourceSpan = getMcpSpan(resourceTransaction, 'resources/read');
+    expectMcpSpanToBeHttpChild(resourceTransaction, resourceSpan);
+    expect(resourceSpan.description).toBe('resources/read');
+    expect(resourceSpan.data?.['mcp.method.name']).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const promptTransactionPromise = waitForTransaction('node-express-v5', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return (
-        transactionEvent.transaction === 'prompts/get echo' && transport?.includes('StreamableHTTPServerTransport')
-      );
-    });
+    const promptTransactionPromise = waitForMcpTransaction('prompts/get echo', 'Echo-Streamable');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -294,11 +281,10 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const promptTransaction = await promptTransactionPromise;
-    expect(promptTransaction).toBeDefined();
-    expect(promptTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(promptTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('prompts/get');
+    const promptSpan = getMcpSpan(promptTransaction, 'prompts/get echo');
+    expectMcpSpanToBeHttpChild(promptTransaction, promptSpan);
+    expect(promptSpan.data?.['mcp.method.name']).toBe('prompts/get');
   });
 
-  // Clean up - close the client connection
   await client.close();
 });

--- a/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express/tests/mcp.test.ts
@@ -4,36 +4,70 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
-test('Should record transactions for mcp handlers', async ({ baseURL }) => {
-  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
+const APP_NAME = 'node-express';
 
+function waitForMcpTransaction(spanDescription: string, serverName: string) {
+  return waitForTransaction(APP_NAME, transactionEvent => {
+    return (
+      transactionEvent.spans?.some(
+        span =>
+          span.op === 'mcp.server' &&
+          span.description === spanDescription &&
+          span.data?.['mcp.server.name'] === serverName,
+      ) === true
+    );
+  });
+}
+
+function getMcpSpan(transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>, spanDescription: string) {
+  const span = transactionEvent.spans?.find(
+    candidate => candidate.op === 'mcp.server' && candidate.description === spanDescription,
+  );
+  expect(span).toBeDefined();
+  return span!;
+}
+
+function expectMcpSpanToBeHttpChild(
+  transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>,
+  mcpSpan: ReturnType<typeof getMcpSpan>,
+) {
+  expect(transactionEvent.contexts?.trace?.op).toBe('http.server');
+  expect(mcpSpan.trace_id).toBe(transactionEvent.contexts?.trace?.trace_id);
+
+  const rootSpanId = transactionEvent.contexts?.trace?.span_id;
+  const spansById = new Map(transactionEvent.spans?.map(span => [span.span_id, span]));
+  let parentSpanId = mcpSpan.parent_span_id;
+
+  while (parentSpanId && parentSpanId !== rootSpanId) {
+    const parentSpan = spansById.get(parentSpanId);
+    expect(parentSpan).toBeDefined();
+    parentSpanId = parentSpan?.parent_span_id;
+  }
+
+  expect(parentSpanId).toBe(rootSpanId);
+}
+
+test('records MCP handler spans inside legacy SSE HTTP transactions', async ({ baseURL }) => {
+  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
   const client = new Client({
     name: 'test-client',
     version: '1.0.0',
   });
-
-  const initializeTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-    return transactionEvent.transaction === 'initialize';
-  });
+  const initializeTransactionPromise = waitForMcpTransaction('initialize', 'Echo');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
     const initializeTransaction = await initializeTransactionPromise;
-    expect(initializeTransaction).toBeDefined();
-    expect(initializeTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('initialize');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.client.name']).toEqual('test-client');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.server.name']).toEqual('Echo');
+    const initializeSpan = getMcpSpan(initializeTransaction, 'initialize');
+    expectMcpSpanToBeHttpChild(initializeTransaction, initializeSpan);
+    expect(initializeSpan.data?.['mcp.method.name']).toBe('initialize');
+    expect(initializeSpan.data?.['mcp.client.name']).toBe('test-client');
+    expect(initializeSpan.data?.['mcp.server.name']).toBe('Echo');
   });
 
   await test.step('tool handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const toolTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call echo';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -51,24 +85,19 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-    expect(postTransaction.contexts?.trace?.op).toEqual('http.server');
-
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.operation.name']).toBe('execute_tool');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['jsonrpc.request.id']).toBeDefined();
+    expect(toolSpan.data?.['mcp.request.id']).toBe(toolSpan.data?.['jsonrpc.request.id']);
   });
 
   await test.step('registerTool handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const toolTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call echo-register';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo-register', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo-register',
@@ -86,24 +115,16 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-    expect(postTransaction.contexts?.trace?.op).toEqual('http.server');
-
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.name']).toEqual('echo-register');
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo-register');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo-register');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo-register');
   });
 
   await test.step('resource handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const resourceTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'resources/read echo://foobar';
-    });
+    const resourceTransactionPromise = waitForMcpTransaction('resources/read', 'Echo');
 
     const resourceResult = await client.readResource({
       uri: 'echo://foobar',
@@ -113,24 +134,15 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       contents: [{ text: 'Resource echo: foobar', uri: 'echo://foobar' }],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-    expect(postTransaction.contexts?.trace?.op).toEqual('http.server');
-
     const resourceTransaction = await resourceTransactionPromise;
-    expect(resourceTransaction).toBeDefined();
-    expect(resourceTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(resourceTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('resources/read');
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const resourceSpan = getMcpSpan(resourceTransaction, 'resources/read');
+    expectMcpSpanToBeHttpChild(resourceTransaction, resourceSpan);
+    expect(resourceSpan.description).toBe('resources/read');
+    expect(resourceSpan.data?.['mcp.method.name']).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const postTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const promptTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'prompts/get echo';
-    });
+    const promptTransactionPromise = waitForMcpTransaction('prompts/get echo', 'Echo');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -151,81 +163,57 @@ test('Should record transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-    expect(postTransaction.contexts?.trace?.op).toEqual('http.server');
-
     const promptTransaction = await promptTransactionPromise;
-    expect(promptTransaction).toBeDefined();
-    expect(promptTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(promptTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('prompts/get');
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const promptSpan = getMcpSpan(promptTransaction, 'prompts/get echo');
+    expectMcpSpanToBeHttpChild(promptTransaction, promptSpan);
+    expect(promptSpan.data?.['mcp.method.name']).toBe('prompts/get');
+    expect(promptSpan.data?.['gen_ai.prompt.name']).toBe('echo');
+    expect(promptSpan.data?.['mcp.prompt.name']).toBe('echo');
   });
 
   await test.step('error tool sets span status to internal_error', async () => {
-    const toolTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call always-error';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call always-error', 'Echo');
 
-    try {
-      await client.callTool({ name: 'always-error', arguments: {} });
-    } catch {
-      // Expected: MCP SDK throws when the tool returns a JSON-RPC error
-    }
+    await expect(client.callTool({ name: 'always-error', arguments: {} })).resolves.toMatchObject({ isError: true });
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.status).toEqual('internal_error');
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call always-error');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.status).toBe('internal_error');
   });
+
+  await client.close();
 });
 
 /**
- * Tests for StreamableHTTPServerTransport (wrapper transport pattern)
- *
- * StreamableHTTPServerTransport wraps WebStandardStreamableHTTPServerTransport via getters/setters.
- * This causes different `this` values in onmessage vs send, which was breaking span correlation.
- *
- * The fix uses sessionId as the correlation key instead of transport object reference.
- * This test verifies that spans are correctly recorded when using the wrapper transport.
+ * StreamableHTTPServerTransport wraps WebStandardStreamableHTTPServerTransport via getters and setters,
+ * so onmessage and send can observe different `this` values. This verifies that response completion
+ * remains correlated with the original request while the MCP spans retain their HTTP parent.
  *
  * @see https://github.com/getsentry/sentry-mcp/issues/767
  */
-test('Should record transactions for streamable HTTP transport (wrapper transport pattern)', async ({ baseURL }) => {
+test('records MCP handler spans inside streamable HTTP transactions', async ({ baseURL }) => {
   const transport = new StreamableHTTPClientTransport(new URL(`${baseURL}/mcp`));
-
   const client = new Client({
     name: 'test-client-streamable',
     version: '1.0.0',
   });
-
-  const initializeTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-    return (
-      transactionEvent.transaction === 'initialize' &&
-      transactionEvent.contexts?.trace?.data?.['mcp.server.name'] === 'Echo-Streamable'
-    );
-  });
+  const initializeTransactionPromise = waitForMcpTransaction('initialize', 'Echo-Streamable');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
     const initializeTransaction = await initializeTransactionPromise;
-    expect(initializeTransaction).toBeDefined();
-    expect(initializeTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('initialize');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.client.name']).toEqual('test-client-streamable');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.server.name']).toEqual('Echo-Streamable');
-    // Verify it's using a StreamableHTTP transport (may be wrapper or inner depending on environment)
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
+    const initializeSpan = getMcpSpan(initializeTransaction, 'initialize');
+    expectMcpSpanToBeHttpChild(initializeTransaction, initializeSpan);
+    expect(initializeSpan.data?.['mcp.method.name']).toBe('initialize');
+    expect(initializeSpan.data?.['mcp.client.name']).toBe('test-client-streamable');
+    expect(initializeSpan.data?.['mcp.server.name']).toBe('Echo-Streamable');
+    expect(initializeSpan.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
   });
 
-  await test.step('tool handler (tests wrapper transport correlation)', async () => {
-    // This is the critical test - without the sessionId fix, the span would not be completed
-    // because onmessage and send see different transport instances (wrapper vs inner)
-    const toolTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return transactionEvent.transaction === 'tools/call echo' && transport?.includes('StreamableHTTPServerTransport');
-    });
+  await test.step('tool handler preserves wrapper transport correlation', async () => {
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo', 'Echo-Streamable');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -244,22 +232,16 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.name']).toEqual('echo');
-    // This attribute proves the span was completed with results (sessionId correlation worked)
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.result.content_count']).toEqual(1);
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.result.content_count']).toBe(1);
   });
 
   await test.step('resource handler', async () => {
-    const resourceTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return (
-        transactionEvent.transaction === 'resources/read echo://streamable-test' &&
-        transport?.includes('StreamableHTTPServerTransport')
-      );
-    });
+    const resourceTransactionPromise = waitForMcpTransaction('resources/read', 'Echo-Streamable');
 
     const resourceResult = await client.readResource({
       uri: 'echo://streamable-test',
@@ -270,18 +252,14 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const resourceTransaction = await resourceTransactionPromise;
-    expect(resourceTransaction).toBeDefined();
-    expect(resourceTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(resourceTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('resources/read');
+    const resourceSpan = getMcpSpan(resourceTransaction, 'resources/read');
+    expectMcpSpanToBeHttpChild(resourceTransaction, resourceSpan);
+    expect(resourceSpan.description).toBe('resources/read');
+    expect(resourceSpan.data?.['mcp.method.name']).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const promptTransactionPromise = waitForTransaction('node-express', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return (
-        transactionEvent.transaction === 'prompts/get echo' && transport?.includes('StreamableHTTPServerTransport')
-      );
-    });
+    const promptTransactionPromise = waitForMcpTransaction('prompts/get echo', 'Echo-Streamable');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -303,11 +281,10 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const promptTransaction = await promptTransactionPromise;
-    expect(promptTransaction).toBeDefined();
-    expect(promptTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(promptTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('prompts/get');
+    const promptSpan = getMcpSpan(promptTransaction, 'prompts/get echo');
+    expectMcpSpanToBeHttpChild(promptTransaction, promptSpan);
+    expect(promptSpan.data?.['mcp.method.name']).toBe('prompts/get');
   });
 
-  // Clean up - close the client connection
   await client.close();
 });

--- a/dev-packages/e2e-tests/test-applications/tsx-express/tests/mcp.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/tests/mcp.test.ts
@@ -4,36 +4,70 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
-test('Records transactions for mcp handlers', async ({ baseURL }) => {
-  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
+const APP_NAME = 'tsx-express';
 
+function waitForMcpTransaction(spanDescription: string, serverName: string) {
+  return waitForTransaction(APP_NAME, transactionEvent => {
+    return (
+      transactionEvent.spans?.some(
+        span =>
+          span.op === 'mcp.server' &&
+          span.description === spanDescription &&
+          span.data?.['mcp.server.name'] === serverName,
+      ) === true
+    );
+  });
+}
+
+function getMcpSpan(transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>, spanDescription: string) {
+  const span = transactionEvent.spans?.find(
+    candidate => candidate.op === 'mcp.server' && candidate.description === spanDescription,
+  );
+  expect(span).toBeDefined();
+  return span!;
+}
+
+function expectMcpSpanToBeHttpChild(
+  transactionEvent: Awaited<ReturnType<typeof waitForTransaction>>,
+  mcpSpan: ReturnType<typeof getMcpSpan>,
+) {
+  expect(transactionEvent.contexts?.trace?.op).toBe('http.server');
+  expect(mcpSpan.trace_id).toBe(transactionEvent.contexts?.trace?.trace_id);
+
+  const rootSpanId = transactionEvent.contexts?.trace?.span_id;
+  const spansById = new Map(transactionEvent.spans?.map(span => [span.span_id, span]));
+  let parentSpanId = mcpSpan.parent_span_id;
+
+  while (parentSpanId && parentSpanId !== rootSpanId) {
+    const parentSpan = spansById.get(parentSpanId);
+    expect(parentSpan).toBeDefined();
+    parentSpanId = parentSpan?.parent_span_id;
+  }
+
+  expect(parentSpanId).toBe(rootSpanId);
+}
+
+test('records MCP handler spans inside legacy SSE HTTP transactions', async ({ baseURL }) => {
+  const transport = new SSEClientTransport(new URL(`${baseURL}/sse`));
   const client = new Client({
     name: 'test-client',
     version: '1.0.0',
   });
-
-  const initializeTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-    return transactionEvent.transaction === 'initialize';
-  });
+  const initializeTransactionPromise = waitForMcpTransaction('initialize', 'Echo');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
     const initializeTransaction = await initializeTransactionPromise;
-    expect(initializeTransaction).toBeDefined();
-    expect(initializeTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('initialize');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.client.name']).toEqual('test-client');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.server.name']).toEqual('Echo');
+    const initializeSpan = getMcpSpan(initializeTransaction, 'initialize');
+    expectMcpSpanToBeHttpChild(initializeTransaction, initializeSpan);
+    expect(initializeSpan.data?.['mcp.method.name']).toBe('initialize');
+    expect(initializeSpan.data?.['mcp.client.name']).toBe('test-client');
+    expect(initializeSpan.data?.['mcp.server.name']).toBe('Echo');
   });
 
   await test.step('tool handler', async () => {
-    const postTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const toolTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call echo';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -51,25 +85,19 @@ test('Records transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-    expect(postTransaction.contexts?.trace?.op).toEqual('http.server');
-
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.operation.name']).toBe('execute_tool');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['jsonrpc.request.id']).toBeDefined();
+    expect(toolSpan.data?.['mcp.request.id']).toBe(toolSpan.data?.['jsonrpc.request.id']);
   });
 
   await test.step('registerTool handler', async () => {
-    const postTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const toolTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call echo-register';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo-register', 'Echo');
 
     const toolResult = await client.callTool({
       name: 'echo-register',
@@ -87,23 +115,16 @@ test('Records transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.name']).toEqual('echo-register');
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo-register');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo-register');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo-register');
   });
 
   await test.step('resource handler', async () => {
-    const postTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const resourceTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'resources/read echo://foobar';
-    });
+    const resourceTransactionPromise = waitForMcpTransaction('resources/read', 'Echo');
 
     const resourceResult = await client.readResource({
       uri: 'echo://foobar',
@@ -113,22 +134,15 @@ test('Records transactions for mcp handlers', async ({ baseURL }) => {
       contents: [{ text: 'Resource echo: foobar', uri: 'echo://foobar' }],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-
     const resourceTransaction = await resourceTransactionPromise;
-    expect(resourceTransaction).toBeDefined();
-
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const resourceSpan = getMcpSpan(resourceTransaction, 'resources/read');
+    expectMcpSpanToBeHttpChild(resourceTransaction, resourceSpan);
+    expect(resourceSpan.description).toBe('resources/read');
+    expect(resourceSpan.data?.['mcp.method.name']).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const postTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'POST /messages';
-    });
-    const promptTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'prompts/get echo';
-    });
+    const promptTransactionPromise = waitForMcpTransaction('prompts/get echo', 'Echo');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -149,79 +163,57 @@ test('Records transactions for mcp handlers', async ({ baseURL }) => {
       ],
     });
 
-    const postTransaction = await postTransactionPromise;
-    expect(postTransaction).toBeDefined();
-
     const promptTransaction = await promptTransactionPromise;
-    expect(promptTransaction).toBeDefined();
-
-    // TODO: When https://github.com/modelcontextprotocol/typescript-sdk/pull/358 is released check for trace id equality between the post transaction and the handler transaction
+    const promptSpan = getMcpSpan(promptTransaction, 'prompts/get echo');
+    expectMcpSpanToBeHttpChild(promptTransaction, promptSpan);
+    expect(promptSpan.data?.['mcp.method.name']).toBe('prompts/get');
+    expect(promptSpan.data?.['gen_ai.prompt.name']).toBe('echo');
+    expect(promptSpan.data?.['mcp.prompt.name']).toBe('echo');
   });
 
   await test.step('error tool sets span status to internal_error', async () => {
-    const toolTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      return transactionEvent.transaction === 'tools/call always-error';
-    });
+    const toolTransactionPromise = waitForMcpTransaction('tools/call always-error', 'Echo');
 
-    try {
-      await client.callTool({ name: 'always-error', arguments: {} });
-    } catch {
-      // Expected: MCP SDK throws when the tool returns a JSON-RPC error
-    }
+    await expect(client.callTool({ name: 'always-error', arguments: {} })).resolves.toMatchObject({ isError: true });
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.status).toEqual('internal_error');
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call always-error');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.status).toBe('internal_error');
   });
+
+  await client.close();
 });
 
 /**
- * Tests for StreamableHTTPServerTransport (wrapper transport pattern)
- *
- * StreamableHTTPServerTransport wraps WebStandardStreamableHTTPServerTransport via getters/setters.
- * This causes different `this` values in onmessage vs send, which was breaking span correlation.
- *
- * The fix uses sessionId as the correlation key instead of transport object reference.
- * This test verifies that spans are correctly recorded when using the wrapper transport.
+ * StreamableHTTPServerTransport wraps WebStandardStreamableHTTPServerTransport via getters and setters,
+ * so onmessage and send can observe different `this` values. This verifies that response completion
+ * remains correlated with the original request while the MCP spans retain their HTTP parent.
  *
  * @see https://github.com/getsentry/sentry-mcp/issues/767
  */
-test('Should record transactions for streamable HTTP transport (wrapper transport pattern)', async ({ baseURL }) => {
+test('records MCP handler spans inside streamable HTTP transactions', async ({ baseURL }) => {
   const transport = new StreamableHTTPClientTransport(new URL(`${baseURL}/mcp`));
-
   const client = new Client({
     name: 'test-client-streamable',
     version: '1.0.0',
   });
-
-  const initializeTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-    return (
-      transactionEvent.transaction === 'initialize' &&
-      transactionEvent.contexts?.trace?.data?.['mcp.server.name'] === 'Echo-Streamable'
-    );
-  });
+  const initializeTransactionPromise = waitForMcpTransaction('initialize', 'Echo-Streamable');
 
   await client.connect(transport);
 
   await test.step('initialize handshake', async () => {
     const initializeTransaction = await initializeTransactionPromise;
-    expect(initializeTransaction).toBeDefined();
-    expect(initializeTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('initialize');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.client.name']).toEqual('test-client-streamable');
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.server.name']).toEqual('Echo-Streamable');
-    // Verify it's using a StreamableHTTP transport (may be wrapper or inner depending on environment)
-    expect(initializeTransaction.contexts?.trace?.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
+    const initializeSpan = getMcpSpan(initializeTransaction, 'initialize');
+    expectMcpSpanToBeHttpChild(initializeTransaction, initializeSpan);
+    expect(initializeSpan.data?.['mcp.method.name']).toBe('initialize');
+    expect(initializeSpan.data?.['mcp.client.name']).toBe('test-client-streamable');
+    expect(initializeSpan.data?.['mcp.server.name']).toBe('Echo-Streamable');
+    expect(initializeSpan.data?.['mcp.transport']).toMatch(/StreamableHTTPServerTransport/);
   });
 
-  await test.step('tool handler (tests wrapper transport correlation)', async () => {
-    // This is the critical test - without the sessionId fix, the span would not be completed
-    // because onmessage and send see different transport instances (wrapper vs inner)
-    const toolTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return transactionEvent.transaction === 'tools/call echo' && transport?.includes('StreamableHTTPServerTransport');
-    });
+  await test.step('tool handler preserves wrapper transport correlation', async () => {
+    const toolTransactionPromise = waitForMcpTransaction('tools/call echo', 'Echo-Streamable');
 
     const toolResult = await client.callTool({
       name: 'echo',
@@ -240,22 +232,16 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const toolTransaction = await toolTransactionPromise;
-    expect(toolTransaction).toBeDefined();
-    expect(toolTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('tools/call');
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.name']).toEqual('echo');
-    // This attribute proves the span was completed with results (sessionId correlation worked)
-    expect(toolTransaction.contexts?.trace?.data?.['mcp.tool.result.content_count']).toEqual(1);
+    const toolSpan = getMcpSpan(toolTransaction, 'tools/call echo');
+    expectMcpSpanToBeHttpChild(toolTransaction, toolSpan);
+    expect(toolSpan.data?.['mcp.method.name']).toBe('tools/call');
+    expect(toolSpan.data?.['gen_ai.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.name']).toBe('echo');
+    expect(toolSpan.data?.['mcp.tool.result.content_count']).toBe(1);
   });
 
   await test.step('resource handler', async () => {
-    const resourceTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return (
-        transactionEvent.transaction === 'resources/read echo://streamable-test' &&
-        transport?.includes('StreamableHTTPServerTransport')
-      );
-    });
+    const resourceTransactionPromise = waitForMcpTransaction('resources/read', 'Echo-Streamable');
 
     const resourceResult = await client.readResource({
       uri: 'echo://streamable-test',
@@ -266,18 +252,14 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const resourceTransaction = await resourceTransactionPromise;
-    expect(resourceTransaction).toBeDefined();
-    expect(resourceTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(resourceTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('resources/read');
+    const resourceSpan = getMcpSpan(resourceTransaction, 'resources/read');
+    expectMcpSpanToBeHttpChild(resourceTransaction, resourceSpan);
+    expect(resourceSpan.description).toBe('resources/read');
+    expect(resourceSpan.data?.['mcp.method.name']).toBe('resources/read');
   });
 
   await test.step('prompt handler', async () => {
-    const promptTransactionPromise = waitForTransaction('tsx-express', transactionEvent => {
-      const transport = transactionEvent.contexts?.trace?.data?.['mcp.transport'] as string | undefined;
-      return (
-        transactionEvent.transaction === 'prompts/get echo' && transport?.includes('StreamableHTTPServerTransport')
-      );
-    });
+    const promptTransactionPromise = waitForMcpTransaction('prompts/get echo', 'Echo-Streamable');
 
     const promptResult = await client.getPrompt({
       name: 'echo',
@@ -299,11 +281,10 @@ test('Should record transactions for streamable HTTP transport (wrapper transpor
     });
 
     const promptTransaction = await promptTransactionPromise;
-    expect(promptTransaction).toBeDefined();
-    expect(promptTransaction.contexts?.trace?.op).toEqual('mcp.server');
-    expect(promptTransaction.contexts?.trace?.data?.['mcp.method.name']).toEqual('prompts/get');
+    const promptSpan = getMcpSpan(promptTransaction, 'prompts/get echo');
+    expectMcpSpanToBeHttpChild(promptTransaction, promptSpan);
+    expect(promptSpan.data?.['mcp.method.name']).toBe('prompts/get');
   });
 
-  // Clean up - close the client connection
   await client.close();
 });

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -161,6 +161,7 @@ export {
   logger,
   consoleLoggingIntegration,
   createConsolaReporter,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   NODE_VERSION,
   featureFlagsIntegration,

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -147,6 +147,7 @@ export {
   logger,
   consoleLoggingIntegration,
   createConsolaReporter,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   NODE_VERSION,
   featureFlagsIntegration,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -166,6 +166,7 @@ export {
   createConsolaReporter,
   createSentryWinstonTransport,
   pinoIntegration,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   featureFlagsIntegration,
   launchDarklyIntegration,

--- a/packages/cloudflare/src/client.ts
+++ b/packages/cloudflare/src/client.ts
@@ -1,6 +1,7 @@
 import type { ClientOptions, Options, ServerRuntimeClientOptions } from '@sentry/core';
 import {
   _INTERNAL_clearAiProviderSkips,
+  _INTERNAL_setDeferSegmentSpanCapture,
   applySdkMetadata,
   debug,
   ServerRuntimeClient,
@@ -46,6 +47,10 @@ export class CloudflareClient extends ServerRuntimeClient {
 
     super(clientOptions);
     this._flushLock = flushLock;
+
+    // A request can return before async instrumentation closes its child spans. Defer static
+    // transaction snapshots so those late children are not dropped.
+    _INTERNAL_setDeferSegmentSpanCapture(this);
 
     // Track span lifecycle to know when to flush
     this._unsubscribeSpanStart = this.on('spanStart', span => {

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -97,6 +97,7 @@ export {
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   consoleLoggingIntegration,
   createConsolaReporter,

--- a/packages/cloudflare/test/client.test.ts
+++ b/packages/cloudflare/test/client.test.ts
@@ -1,5 +1,7 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Event } from '@sentry/core';
+import { startInactiveSpan, withActiveSpan, withScope } from '@sentry/core';
 import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CloudflareClient, type CloudflareClientOptions } from '../src/client';
 import { makeFlushLock } from '../src/flush';
 
@@ -221,6 +223,68 @@ describe('CloudflareClient', () => {
   });
 
   describe('span lifecycle tracking', () => {
+    it('includes a child that ends after its static segment', async () => {
+      const transactions: Event[] = [];
+      const client = new CloudflareClient({
+        ...MOCK_CLIENT_OPTIONS,
+        tracesSampleRate: 1,
+        traceLifecycle: 'static',
+        beforeSendTransaction: event => {
+          transactions.push(event);
+          return null;
+        },
+      });
+      client.init();
+
+      withScope(scope => {
+        scope.setClient(client);
+        const root = startInactiveSpan({ name: 'GET /mcp' });
+        const child = withActiveSpan(root, () => startInactiveSpan({ name: 'tools/call weather' }));
+
+        root.end();
+        child.end();
+      });
+      await client.flush();
+
+      expect(transactions).toHaveLength(1);
+      expect(transactions[0]!.spans).toHaveLength(1);
+      expect(transactions[0]!.spans?.[0]?.description).toBe('tools/call weather');
+    });
+
+    it('captures a child that ends after its static segment was sent as an orphan transaction', () => {
+      const transactions: Event[] = [];
+      const client = new CloudflareClient({
+        ...MOCK_CLIENT_OPTIONS,
+        tracesSampleRate: 1,
+        traceLifecycle: 'static',
+        beforeSendTransaction: event => {
+          transactions.push(event);
+          return null;
+        },
+      });
+      client.init();
+
+      let child: ReturnType<typeof startInactiveSpan>;
+      withScope(scope => {
+        scope.setClient(client);
+        const root = startInactiveSpan({ name: 'GET /mcp' });
+        child = withActiveSpan(root, () => startInactiveSpan({ name: 'tools/call weather' }));
+        root.end();
+      });
+      client.emit('flush');
+
+      expect(transactions).toHaveLength(1);
+      expect(transactions[0]!.transaction).toBe('GET /mcp');
+      expect(transactions[0]!.spans).toHaveLength(0);
+
+      child!.end();
+      client.emit('flush');
+
+      expect(transactions).toHaveLength(2);
+      expect(transactions[1]!.transaction).toBe('tools/call weather');
+      expect(transactions[1]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+    });
+
     it('tracks pending spans when spanStart is emitted', () => {
       const client = new CloudflareClient(MOCK_CLIENT_OPTIONS);
 

--- a/packages/cloudflare/test/instrumentations/worker/instrumentEmail.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentEmail.test.ts
@@ -255,7 +255,9 @@ describe('instrumentEmail', () => {
       );
 
       const emailMessage = createMockEmailMessage();
-      await wrappedHandler.email?.(emailMessage, MOCK_ENV, createMockExecutionContext());
+      const context = createMockExecutionContext();
+      await wrappedHandler.email?.(emailMessage, MOCK_ENV, context);
+      await Promise.all(vi.mocked(context.waitUntil).mock.calls.map(([promise]) => promise));
 
       expect(sentryEvent.transaction).toEqual(`Handle Email ${emailMessage.to}`);
       expect(sentryEvent.spans).toHaveLength(0);

--- a/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
@@ -268,7 +268,9 @@ describe('instrumentQueue', () => {
       );
 
       const batch = createMockQueueBatch();
-      await wrappedHandler.queue?.(batch, MOCK_ENV, createMockExecutionContext());
+      const context = createMockExecutionContext();
+      await wrappedHandler.queue?.(batch, MOCK_ENV, context);
+      await Promise.all(vi.mocked(context.waitUntil).mock.calls.map(([promise]) => promise));
 
       expect(sentryEvent.transaction).toEqual(`process ${batch.queue}`);
       expect(sentryEvent.spans).toHaveLength(0);

--- a/packages/cloudflare/test/instrumentations/worker/instrumentScheduled.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentScheduled.test.ts
@@ -249,7 +249,9 @@ describe('instrumentScheduled', () => {
         handler,
       );
 
-      await wrappedHandler.scheduled?.(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+      const context = createMockExecutionContext();
+      await wrappedHandler.scheduled?.(createMockScheduledController(), MOCK_ENV, context);
+      await Promise.all(vi.mocked(context.waitUntil).mock.calls.map(([promise]) => promise));
 
       expect(sentryEvent.transaction).toEqual('Scheduled Cron 0 0 0 * * *');
       expect(sentryEvent.spans).toHaveLength(0);

--- a/packages/core/src/integrations/mcp-server/attributeExtraction.ts
+++ b/packages/core/src/integrations/mcp-server/attributeExtraction.ts
@@ -2,24 +2,45 @@
  * Core attribute extraction and building functions for MCP server instrumentation
  */
 
-import { isURLObjectRelative, parseStringToURLObject } from '../../utils/url';
 import {
+  GEN_AI_OPERATION_NAME_ATTRIBUTE,
+  LEGACY_MCP_REQUEST_ID_ATTRIBUTE,
+  MCP_CANCELLED_REASON_ATTRIBUTE,
+  MCP_CANCELLED_REQUEST_ID_ATTRIBUTE,
+  MCP_INPUT_RESPONSE_COUNT_ATTRIBUTE,
   MCP_LOGGING_DATA_TYPE_ATTRIBUTE,
   MCP_LOGGING_LEVEL_ATTRIBUTE,
   MCP_LOGGING_LOGGER_ATTRIBUTE,
   MCP_LOGGING_MESSAGE_ATTRIBUTE,
+  MCP_LOGGING_REQUESTED_LEVEL_ATTRIBUTE,
+  MCP_COMPLETION_REFERENCE_TYPE_ATTRIBUTE,
+  MCP_PAGINATION_CURSOR_PRESENT_ATTRIBUTE,
   MCP_REQUEST_ID_ATTRIBUTE,
+  MCP_REQUEST_STATE_PRESENT_ATTRIBUTE,
   MCP_RESOURCE_URI_ATTRIBUTE,
+  MCP_PROGRESS_CURRENT_ATTRIBUTE,
+  MCP_PROGRESS_MESSAGE_ATTRIBUTE,
+  MCP_PROGRESS_PERCENTAGE_ATTRIBUTE,
+  MCP_PROGRESS_TOTAL_ATTRIBUTE,
+  MCP_SUBSCRIPTION_ID_ATTRIBUTE,
 } from './attributes';
 import { extractTargetInfo, getRequestArguments } from './methodConfig';
-import type { JsonRpcNotification, JsonRpcRequest, McpSpanType } from './types';
+import { getBoundedMcpString, serializeMcpValue } from './serialization';
+import type { JsonRpcNotification, JsonRpcRequest, McpAttributes, McpSpanType } from './types';
+
+const MCP_LOG_LEVELS = new Set(['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']);
+const PAGINATED_METHODS = new Set(['tools/list', 'resources/list', 'resources/templates/list', 'prompts/list']);
+
+function getMcpToken(value: unknown): string | undefined {
+  return typeof value === 'string' || typeof value === 'number' ? getBoundedMcpString(String(value)) : undefined;
+}
 
 /**
  * Formats logging data for span attributes
  * @internal
  */
 function formatLoggingData(data: unknown): string {
-  return typeof data === 'string' ? data : JSON.stringify(data);
+  return serializeMcpValue(data) ?? '[unserializable]';
 }
 
 /**
@@ -33,25 +54,28 @@ export function getNotificationAttributes(
   method: string,
   params: Record<string, unknown>,
   recordInputs?: boolean,
-): Record<string, string | number> {
-  const attributes: Record<string, string | number> = {};
+): McpAttributes {
+  const attributes: McpAttributes = {};
 
   switch (method) {
     case 'notifications/cancelled':
-      if (params?.requestId) {
-        attributes['mcp.cancelled.request_id'] = String(params.requestId);
+      {
+        const requestId = getMcpToken(params.requestId);
+        if (requestId !== undefined) {
+          attributes[MCP_CANCELLED_REQUEST_ID_ATTRIBUTE] = requestId;
+        }
       }
-      if (params?.reason) {
-        attributes['mcp.cancelled.reason'] = String(params.reason);
+      if (recordInputs && typeof params.reason === 'string') {
+        attributes[MCP_CANCELLED_REASON_ATTRIBUTE] = getBoundedMcpString(params.reason);
       }
       break;
 
     case 'notifications/message':
-      if (params?.level) {
-        attributes[MCP_LOGGING_LEVEL_ATTRIBUTE] = String(params.level);
+      if (typeof params.level === 'string' && MCP_LOG_LEVELS.has(params.level)) {
+        attributes[MCP_LOGGING_LEVEL_ATTRIBUTE] = params.level;
       }
-      if (params?.logger) {
-        attributes[MCP_LOGGING_LOGGER_ATTRIBUTE] = String(params.logger);
+      if (typeof params.logger === 'string') {
+        attributes[MCP_LOGGING_LOGGER_ATTRIBUTE] = getBoundedMcpString(params.logger);
       }
       if (params?.data !== undefined) {
         attributes[MCP_LOGGING_DATA_TYPE_ATTRIBUTE] = typeof params.data;
@@ -62,30 +86,23 @@ export function getNotificationAttributes(
       break;
 
     case 'notifications/progress':
-      if (params?.progressToken) {
-        attributes['mcp.progress.token'] = String(params.progressToken);
+      if (typeof params.progress === 'number' && Number.isFinite(params.progress)) {
+        attributes[MCP_PROGRESS_CURRENT_ATTRIBUTE] = params.progress;
       }
-      if (typeof params?.progress === 'number') {
-        attributes['mcp.progress.current'] = params.progress;
-      }
-      if (typeof params?.total === 'number') {
-        attributes['mcp.progress.total'] = params.total;
-        if (typeof params?.progress === 'number') {
-          attributes['mcp.progress.percentage'] = (params.progress / params.total) * 100;
+      if (typeof params.total === 'number' && Number.isFinite(params.total)) {
+        attributes[MCP_PROGRESS_TOTAL_ATTRIBUTE] = params.total;
+        if (typeof params.progress === 'number' && Number.isFinite(params.progress) && params.total !== 0) {
+          attributes[MCP_PROGRESS_PERCENTAGE_ATTRIBUTE] = (params.progress / params.total) * 100;
         }
       }
-      if (params?.message) {
-        attributes['mcp.progress.message'] = String(params.message);
+      if (recordInputs && typeof params.message === 'string') {
+        attributes[MCP_PROGRESS_MESSAGE_ATTRIBUTE] = getBoundedMcpString(params.message, 10_000);
       }
       break;
 
     case 'notifications/resources/updated':
-      if (params?.uri) {
-        attributes[MCP_RESOURCE_URI_ATTRIBUTE] = String(params.uri);
-        const urlObject = parseStringToURLObject(String(params.uri));
-        if (urlObject && !isURLObjectRelative(urlObject)) {
-          attributes['mcp.resource.protocol'] = urlObject.protocol.replace(':', '');
-        }
+      if (typeof params.uri === 'string') {
+        attributes[MCP_RESOURCE_URI_ATTRIBUTE] = getBoundedMcpString(params.uri);
       }
       break;
 
@@ -95,7 +112,23 @@ export function getNotificationAttributes(
       break;
   }
 
+  if (isNotificationSubscriptionId(params._meta)) {
+    attributes[MCP_SUBSCRIPTION_ID_ATTRIBUTE] = getBoundedMcpString(
+      String(params._meta['io.modelcontextprotocol/subscriptionId']),
+    );
+  }
+
   return attributes;
+}
+
+function isNotificationSubscriptionId(
+  meta: unknown,
+): meta is Record<'io.modelcontextprotocol/subscriptionId', string | number> {
+  if (!meta || typeof meta !== 'object') {
+    return false;
+  }
+  const subscriptionId = (meta as Record<string, unknown>)['io.modelcontextprotocol/subscriptionId'];
+  return typeof subscriptionId === 'string' || typeof subscriptionId === 'number';
 }
 
 /**
@@ -111,14 +144,42 @@ export function buildTypeSpecificAttributes(
   message: JsonRpcRequest | JsonRpcNotification,
   params?: Record<string, unknown>,
   recordInputs?: boolean,
-): Record<string, string | number> {
+): McpAttributes {
   if (type === 'request') {
     const request = message as JsonRpcRequest;
     const targetInfo = extractTargetInfo(request.method, params || {});
 
+    const inputResponses = params?.inputResponses;
+    const meta = params?._meta;
+    const requestedLogLevel =
+      meta && typeof meta === 'object' && !Array.isArray(meta)
+        ? (meta as Record<string, unknown>)['io.modelcontextprotocol/logLevel']
+        : undefined;
+    const completionReference =
+      request.method === 'completion/complete' && params?.ref && typeof params.ref === 'object'
+        ? (params.ref as Record<string, unknown>).type
+        : undefined;
+
     return {
-      ...(request.id !== undefined && { [MCP_REQUEST_ID_ATTRIBUTE]: String(request.id) }),
+      ...(request.id !== undefined && {
+        [MCP_REQUEST_ID_ATTRIBUTE]: getBoundedMcpString(String(request.id)),
+        [LEGACY_MCP_REQUEST_ID_ATTRIBUTE]: getBoundedMcpString(String(request.id)),
+      }),
       ...targetInfo.attributes,
+      ...(request.method === 'tools/call' && { [GEN_AI_OPERATION_NAME_ATTRIBUTE]: 'execute_tool' }),
+      ...(inputResponses && typeof inputResponses === 'object' && !Array.isArray(inputResponses)
+        ? { [MCP_INPUT_RESPONSE_COUNT_ATTRIBUTE]: Object.keys(inputResponses).length }
+        : {}),
+      ...(typeof params?.requestState === 'string' && { [MCP_REQUEST_STATE_PRESENT_ATTRIBUTE]: true }),
+      ...(typeof requestedLogLevel === 'string' && MCP_LOG_LEVELS.has(requestedLogLevel)
+        ? { [MCP_LOGGING_REQUESTED_LEVEL_ATTRIBUTE]: requestedLogLevel }
+        : {}),
+      ...(PAGINATED_METHODS.has(request.method) && typeof params?.cursor === 'string'
+        ? { [MCP_PAGINATION_CURSOR_PRESENT_ATTRIBUTE]: true }
+        : {}),
+      ...(completionReference === 'ref/prompt' || completionReference === 'ref/resource'
+        ? { [MCP_COMPLETION_REFERENCE_TYPE_ATTRIBUTE]: completionReference }
+        : {}),
       ...(recordInputs ? getRequestArguments(request.method, params || {}) : {}),
     };
   }

--- a/packages/core/src/integrations/mcp-server/attributes.ts
+++ b/packages/core/src/integrations/mcp-server/attributes.ts
@@ -1,166 +1,133 @@
-/**
- * Essential MCP attribute constants for Sentry instrumentation
- *
- * Based on OpenTelemetry MCP semantic conventions
- * @see https://github.com/open-telemetry/semantic-conventions/blob/3097fb0af5b9492b0e3f55dc5f6c21a3dc2be8df/docs/gen-ai/mcp.md
- */
+import {
+  CLIENT_ADDRESS,
+  CLIENT_PORT,
+  ERROR_TYPE,
+  GEN_AI_OPERATION_NAME,
+  GEN_AI_PROMPT_NAME,
+  GEN_AI_TOOL_CALL_ARGUMENTS,
+  GEN_AI_TOOL_CALL_RESULT,
+  GEN_AI_TOOL_NAME,
+  JSONRPC_REQUEST_ID,
+  MCP_CANCELLED_REASON,
+  MCP_CANCELLED_REQUEST_ID,
+  MCP_CLIENT_NAME,
+  MCP_CLIENT_TITLE,
+  MCP_CLIENT_VERSION,
+  MCP_LOGGING_DATA_TYPE,
+  MCP_LOGGING_LEVEL,
+  MCP_LOGGING_LOGGER,
+  MCP_LOGGING_MESSAGE,
+  MCP_METHOD_NAME,
+  MCP_PROGRESS_CURRENT,
+  MCP_PROGRESS_MESSAGE,
+  MCP_PROGRESS_PERCENTAGE,
+  MCP_PROGRESS_TOTAL,
+  MCP_PROMPT_NAME,
+  MCP_PROMPT_RESULT_DESCRIPTION,
+  MCP_PROMPT_RESULT_MESSAGE_COUNT,
+  MCP_PROTOCOL_VERSION,
+  MCP_REQUEST_ARGUMENT_KEY_BASE,
+  MCP_REQUEST_ID,
+  MCP_RESOURCE_URI,
+  MCP_SERVER_NAME,
+  MCP_SERVER_TITLE,
+  MCP_SERVER_VERSION,
+  MCP_SESSION_ID,
+  MCP_TOOL_NAME,
+  MCP_TOOL_RESULT_CONTENT,
+  MCP_TOOL_RESULT_CONTENT_COUNT,
+  MCP_TOOL_RESULT_IS_ERROR,
+  MCP_TRANSPORT,
+  NETWORK_PROTOCOL_NAME,
+  NETWORK_TRANSPORT,
+  RPC_RESPONSE_STATUS_CODE,
+  SENTRY_KIND,
+} from '@sentry/conventions/attributes';
 
-// =============================================================================
-// CORE MCP ATTRIBUTES
-// =============================================================================
+/** OpenTelemetry MCP and JSON-RPC attributes available through `@sentry/conventions`. */
+export const MCP_METHOD_NAME_ATTRIBUTE = MCP_METHOD_NAME;
+export const MCP_REQUEST_ID_ATTRIBUTE = JSONRPC_REQUEST_ID;
+export const MCP_SESSION_ID_ATTRIBUTE = MCP_SESSION_ID;
+export const MCP_RESOURCE_URI_ATTRIBUTE = MCP_RESOURCE_URI;
+export const MCP_PROTOCOL_VERSION_ATTRIBUTE = MCP_PROTOCOL_VERSION;
+export const MCP_CLIENT_NAME_ATTRIBUTE = MCP_CLIENT_NAME;
+export const MCP_CLIENT_TITLE_ATTRIBUTE = MCP_CLIENT_TITLE;
+export const MCP_CLIENT_VERSION_ATTRIBUTE = MCP_CLIENT_VERSION;
+export const MCP_SERVER_NAME_ATTRIBUTE = MCP_SERVER_NAME;
+export const MCP_SERVER_TITLE_ATTRIBUTE = MCP_SERVER_TITLE;
+export const MCP_SERVER_VERSION_ATTRIBUTE = MCP_SERVER_VERSION;
+export const MCP_TOOL_NAME_ATTRIBUTE = GEN_AI_TOOL_NAME;
+export const MCP_PROMPT_NAME_ATTRIBUTE = GEN_AI_PROMPT_NAME;
+export const MCP_TOOL_ARGUMENTS_ATTRIBUTE = GEN_AI_TOOL_CALL_ARGUMENTS;
+export const MCP_TOOL_RESULT_ATTRIBUTE = GEN_AI_TOOL_CALL_RESULT;
+export const GEN_AI_OPERATION_NAME_ATTRIBUTE = GEN_AI_OPERATION_NAME;
+export const ERROR_TYPE_ATTRIBUTE = ERROR_TYPE;
+export const RPC_RESPONSE_STATUS_CODE_ATTRIBUTE = RPC_RESPONSE_STATUS_CODE;
+export const NETWORK_TRANSPORT_ATTRIBUTE = NETWORK_TRANSPORT;
+export const NETWORK_PROTOCOL_NAME_ATTRIBUTE = NETWORK_PROTOCOL_NAME;
+export const CLIENT_ADDRESS_ATTRIBUTE = CLIENT_ADDRESS;
+export const CLIENT_PORT_ATTRIBUTE = CLIENT_PORT;
+export const SENTRY_KIND_ATTRIBUTE = SENTRY_KIND;
 
-/** The name of the request or notification method */
-export const MCP_METHOD_NAME_ATTRIBUTE = 'mcp.method.name';
+/** Historical Sentry MCP attributes retained during the canonical-name migration. */
+// oxlint-disable-next-line typescript/no-deprecated -- Required for backward-compatible telemetry.
+export const LEGACY_MCP_REQUEST_ID_ATTRIBUTE = MCP_REQUEST_ID;
+// oxlint-disable-next-line typescript/no-deprecated -- Required for backward-compatible telemetry.
+export const LEGACY_MCP_TOOL_NAME_ATTRIBUTE = MCP_TOOL_NAME;
+// oxlint-disable-next-line typescript/no-deprecated -- Required for backward-compatible telemetry.
+export const LEGACY_MCP_PROMPT_NAME_ATTRIBUTE = MCP_PROMPT_NAME;
+// oxlint-disable-next-line typescript/no-deprecated -- Required for backward-compatible telemetry.
+export const MCP_TRANSPORT_ATTRIBUTE = MCP_TRANSPORT;
+export const MCP_REQUEST_ARGUMENT = MCP_REQUEST_ARGUMENT_KEY_BASE;
+// oxlint-disable-next-line typescript/no-deprecated -- Required for backward-compatible telemetry.
+export const MCP_TOOL_RESULT_IS_ERROR_ATTRIBUTE = MCP_TOOL_RESULT_IS_ERROR;
+export const MCP_TOOL_RESULT_CONTENT_COUNT_ATTRIBUTE = MCP_TOOL_RESULT_CONTENT_COUNT;
+// oxlint-disable-next-line typescript/no-deprecated -- Required for backward-compatible telemetry.
+export const MCP_TOOL_RESULT_CONTENT_ATTRIBUTE = MCP_TOOL_RESULT_CONTENT;
 
-/** JSON-RPC request identifier for the request. Unique within the MCP session. */
-export const MCP_REQUEST_ID_ATTRIBUTE = 'mcp.request.id';
+/** Sentry MCP extensions which do not yet have accepted OpenTelemetry attributes. */
+export const MCP_RESULT_TYPE_ATTRIBUTE = 'mcp.result.type';
+export const MCP_CACHE_TTL_ATTRIBUTE = 'mcp.cache.ttl_ms';
+export const MCP_CACHE_SCOPE_ATTRIBUTE = 'mcp.cache.scope';
+export const MCP_RESULT_COUNT_ATTRIBUTE = 'mcp.result.count';
+export const MCP_RESULT_TOTAL_COUNT_ATTRIBUTE = 'mcp.result.total_count';
+export const MCP_RESULT_HAS_MORE_ATTRIBUTE = 'mcp.result.has_more';
+export const MCP_PAGINATION_CURSOR_PRESENT_ATTRIBUTE = 'mcp.pagination.cursor.present';
+export const MCP_PAGINATION_NEXT_CURSOR_PRESENT_ATTRIBUTE = 'mcp.pagination.next_cursor.present';
+export const MCP_COMPLETION_REFERENCE_TYPE_ATTRIBUTE = 'mcp.completion.reference.type';
+export const MCP_RESOURCE_RESULT_MIME_TYPES_ATTRIBUTE = 'mcp.resource.result.mime_types';
+export const MCP_INPUT_REQUEST_COUNT_ATTRIBUTE = 'mcp.input_request.count';
+export const MCP_INPUT_REQUEST_METHODS_ATTRIBUTE = 'mcp.input_request.methods';
+export const MCP_INPUT_RESPONSE_COUNT_ATTRIBUTE = 'mcp.input_response.count';
+export const MCP_REQUEST_STATE_PRESENT_ATTRIBUTE = 'mcp.request_state.present';
+export const MCP_REQUEST_OUTCOME_ATTRIBUTE = 'mcp.request.outcome';
+export const MCP_DISCOVERY_PROTOCOL_VERSIONS_ATTRIBUTE = 'mcp.discovery.protocol_versions';
+export const MCP_DISCOVERY_EXTENSION_IDS_ATTRIBUTE = 'mcp.discovery.extension_ids';
+export const MCP_SERVER_CAPABILITIES_ATTRIBUTE = 'mcp.server.capabilities';
+export const MCP_CLIENT_CAPABILITIES_ATTRIBUTE = 'mcp.client.capabilities';
+export const MCP_CLIENT_EXTENSION_IDS_ATTRIBUTE = 'mcp.client.extension_ids';
+export const MCP_SUBSCRIPTION_ID_ATTRIBUTE = 'mcp.subscription.id';
+export const MCP_LOGGING_REQUESTED_LEVEL_ATTRIBUTE = 'mcp.logging.requested_level';
+export const MCP_PROMPT_VARIABLE_ATTRIBUTE_PREFIX = 'gen_ai.prompt.variable';
 
-/** Identifies the MCP session */
-export const MCP_SESSION_ID_ATTRIBUTE = 'mcp.session.id';
-
-/** Transport method used for MCP communication */
-export const MCP_TRANSPORT_ATTRIBUTE = 'mcp.transport';
-
-// =============================================================================
-// CLIENT ATTRIBUTES
-// =============================================================================
-
-/** Name of the MCP client application */
-export const MCP_CLIENT_NAME_ATTRIBUTE = 'mcp.client.name';
-
-/** Display title of the MCP client application */
-export const MCP_CLIENT_TITLE_ATTRIBUTE = 'mcp.client.title';
-
-/** Version of the MCP client application */
-export const MCP_CLIENT_VERSION_ATTRIBUTE = 'mcp.client.version';
-
-// =============================================================================
-// SERVER ATTRIBUTES
-// =============================================================================
-
-/** Name of the MCP server application */
-export const MCP_SERVER_NAME_ATTRIBUTE = 'mcp.server.name';
-
-/** Display title of the MCP server application */
-export const MCP_SERVER_TITLE_ATTRIBUTE = 'mcp.server.title';
-
-/** Version of the MCP server application */
-export const MCP_SERVER_VERSION_ATTRIBUTE = 'mcp.server.version';
-
-/** MCP protocol version used in the session */
-export const MCP_PROTOCOL_VERSION_ATTRIBUTE = 'mcp.protocol.version';
-
-// =============================================================================
-// METHOD-SPECIFIC ATTRIBUTES
-// =============================================================================
-
-/** Name of the tool being called */
-export const MCP_TOOL_NAME_ATTRIBUTE = 'mcp.tool.name';
-
-/** The resource URI being accessed */
-export const MCP_RESOURCE_URI_ATTRIBUTE = 'mcp.resource.uri';
-
-/** Name of the prompt template */
-export const MCP_PROMPT_NAME_ATTRIBUTE = 'mcp.prompt.name';
-
-// =============================================================================
-// TOOL RESULT ATTRIBUTES
-// =============================================================================
-
-/** Whether a tool execution resulted in an error */
-export const MCP_TOOL_RESULT_IS_ERROR_ATTRIBUTE = 'mcp.tool.result.is_error';
-
-/** Number of content items in the tool result */
-export const MCP_TOOL_RESULT_CONTENT_COUNT_ATTRIBUTE = 'mcp.tool.result.content_count';
-
-/** Serialized content of the tool result */
-export const MCP_TOOL_RESULT_CONTENT_ATTRIBUTE = 'mcp.tool.result.content';
-
-/** Prefix for tool result attributes that contain sensitive content */
+export const MCP_CANCELLED_REQUEST_ID_ATTRIBUTE = MCP_CANCELLED_REQUEST_ID;
+export const MCP_CANCELLED_REASON_ATTRIBUTE = MCP_CANCELLED_REASON;
+export const MCP_PROGRESS_CURRENT_ATTRIBUTE = MCP_PROGRESS_CURRENT;
+export const MCP_PROGRESS_TOTAL_ATTRIBUTE = MCP_PROGRESS_TOTAL;
+export const MCP_PROGRESS_PERCENTAGE_ATTRIBUTE = MCP_PROGRESS_PERCENTAGE;
+export const MCP_PROGRESS_MESSAGE_ATTRIBUTE = MCP_PROGRESS_MESSAGE;
+export const MCP_LOGGING_LEVEL_ATTRIBUTE = MCP_LOGGING_LEVEL;
+export const MCP_LOGGING_LOGGER_ATTRIBUTE = MCP_LOGGING_LOGGER;
+export const MCP_LOGGING_DATA_TYPE_ATTRIBUTE = MCP_LOGGING_DATA_TYPE;
+export const MCP_LOGGING_MESSAGE_ATTRIBUTE = MCP_LOGGING_MESSAGE;
+export const MCP_PROMPT_RESULT_DESCRIPTION_ATTRIBUTE = MCP_PROMPT_RESULT_DESCRIPTION;
+export const MCP_PROMPT_RESULT_MESSAGE_COUNT_ATTRIBUTE = MCP_PROMPT_RESULT_MESSAGE_COUNT;
 export const MCP_TOOL_RESULT_PREFIX = 'mcp.tool.result';
-
-// =============================================================================
-// PROMPT RESULT ATTRIBUTES
-// =============================================================================
-
-/** Description of the prompt result */
-export const MCP_PROMPT_RESULT_DESCRIPTION_ATTRIBUTE = 'mcp.prompt.result.description';
-
-/** Number of messages in the prompt result */
-export const MCP_PROMPT_RESULT_MESSAGE_COUNT_ATTRIBUTE = 'mcp.prompt.result.message_count';
-
-/** Role of the message in the prompt result (for single message results) */
-export const MCP_PROMPT_RESULT_MESSAGE_ROLE_ATTRIBUTE = 'mcp.prompt.result.message_role';
-
-/** Content of the message in the prompt result (for single message results) */
-export const MCP_PROMPT_RESULT_MESSAGE_CONTENT_ATTRIBUTE = 'mcp.prompt.result.message_content';
-
-/** Prefix for prompt result attributes that contain sensitive content */
 export const MCP_PROMPT_RESULT_PREFIX = 'mcp.prompt.result';
 
-// =============================================================================
-// REQUEST ARGUMENT ATTRIBUTES
-// =============================================================================
-
-/** Prefix for MCP request argument prefix for each argument */
-export const MCP_REQUEST_ARGUMENT = 'mcp.request.argument';
-
-// =============================================================================
-// LOGGING ATTRIBUTES
-// =============================================================================
-
-/** Log level for MCP logging operations */
-export const MCP_LOGGING_LEVEL_ATTRIBUTE = 'mcp.logging.level';
-
-/** Logger name for MCP logging operations */
-export const MCP_LOGGING_LOGGER_ATTRIBUTE = 'mcp.logging.logger';
-
-/** Data type of the logged message */
-export const MCP_LOGGING_DATA_TYPE_ATTRIBUTE = 'mcp.logging.data_type';
-
-/** Log message content */
-export const MCP_LOGGING_MESSAGE_ATTRIBUTE = 'mcp.logging.message';
-
-// =============================================================================
-// NETWORK ATTRIBUTES (OpenTelemetry Standard)
-// =============================================================================
-
-/** OSI transport layer protocol */
-export const NETWORK_TRANSPORT_ATTRIBUTE = 'network.transport';
-
-/** The version of JSON RPC protocol used */
-export const NETWORK_PROTOCOL_VERSION_ATTRIBUTE = 'network.protocol.version';
-
-/** Client address - domain name if available without reverse DNS lookup; otherwise, IP address or Unix domain socket name */
-export const CLIENT_ADDRESS_ATTRIBUTE = 'client.address';
-
-/** Client port number */
-export const CLIENT_PORT_ATTRIBUTE = 'client.port';
-
-// =============================================================================
-// SENTRY-SPECIFIC MCP ATTRIBUTE VALUES
-// =============================================================================
-
-/** Sentry operation value for MCP server spans */
+/** Sentry operation value for MCP server spans. */
 export const MCP_SERVER_OP_VALUE = 'mcp.server';
-
-/**
- * Sentry operation value for client-to-server notifications
- * Following OpenTelemetry MCP semantic conventions
- */
 export const MCP_NOTIFICATION_CLIENT_TO_SERVER_OP_VALUE = 'mcp.notification.client_to_server';
-
-/**
- * Sentry operation value for server-to-client notifications
- * Following OpenTelemetry MCP semantic conventions
- */
 export const MCP_NOTIFICATION_SERVER_TO_CLIENT_OP_VALUE = 'mcp.notification.server_to_client';
-
-/** Sentry origin value for MCP function spans */
 export const MCP_FUNCTION_ORIGIN_VALUE = 'auto.function.mcp_server';
-
-/** Sentry origin value for MCP notification spans */
 export const MCP_NOTIFICATION_ORIGIN_VALUE = 'auto.mcp.notification';
-
-/** Sentry source value for MCP route spans */
-export const MCP_ROUTE_SOURCE_VALUE = 'route';

--- a/packages/core/src/integrations/mcp-server/correlation.ts
+++ b/packages/core/src/integrations/mcp-server/correlation.ts
@@ -3,64 +3,95 @@
  *
  * Handles mapping requestId to span data for correlation with handler execution.
  *
- * Uses sessionId as the primary key for stateful transports. This handles the wrapper
- * transport pattern (e.g., NodeStreamableHTTPServerTransport wrapping WebStandardStreamableHTTPServerTransport)
- * where onmessage and send may receive different `this` values but share the same sessionId.
- *
- * Falls back to WeakMap by transport instance for stateless transports (no sessionId).
+ * Correlation is scoped to the transport captured by the instrumentation wrapper. A session id
+ * is peer-controlled and is not a unique transport identity.
  */
 
+import { getClient } from '../../currentScopes';
 import { SPAN_STATUS_ERROR } from '../../tracing';
 import type { Span } from '../../types/span';
-import { MCP_PROTOCOL_VERSION_ATTRIBUTE } from './attributes';
-import { extractPromptResultAttributes, extractToolResultAttributes } from './resultExtraction';
-import {
-  buildServerAttributesFromInfo,
-  extractSessionDataFromInitializeResponse,
-  extractSessionDataFromResponse,
-} from './sessionExtraction';
-import { updateSessionDataForTransport } from './sessionManagement';
-import type { MCPTransport, RequestId, RequestSpanMapValue, ResolvedMcpOptions } from './types';
+import { ERROR_TYPE_ATTRIBUTE, MCP_REQUEST_OUTCOME_ATTRIBUTE } from './attributes';
+import type { MCPTransport, RequestId, RequestSpanMapValue, SessionData } from './types';
 
-/**
- * Session-scoped correlation for stateful transports (with sessionId)
- * @internal Using sessionId as key handles wrapper transport patterns where
- * different transport objects share the same logical session
- */
-const sessionToSpanMap = new Map<string, Map<RequestId, RequestSpanMapValue>>();
+type TransportSpanStore = WeakMap<MCPTransport, Map<RequestId, RequestSpanMapValue>>;
 
-/**
- * Transport-scoped correlation fallback for stateless transports (no sessionId)
- * @internal WeakMap allows automatic cleanup when transport is garbage collected
- */
-const statelessSpanMap = new WeakMap<MCPTransport, Map<RequestId, RequestSpanMapValue>>();
+const incomingRequestSpans: TransportSpanStore = new WeakMap();
+const outgoingRequestSpans: TransportSpanStore = new WeakMap();
+const responseSendSpans: TransportSpanStore = new WeakMap();
+const responseProcessingSpans: TransportSpanStore = new WeakMap();
 
-/**
- * Gets or creates the span map for a transport, using sessionId when available
- * @internal
- * @param transport - MCP transport instance
- * @returns Span map for the transport/session
- */
-function getOrCreateSpanMap(transport: MCPTransport): Map<RequestId, RequestSpanMapValue> {
-  const sessionId = transport.sessionId;
+/** Gets the span map for a transport identity. */
+function getSpanMap(
+  store: TransportSpanStore,
+  transport: MCPTransport,
+): Map<RequestId, RequestSpanMapValue> | undefined {
+  return store.get(transport);
+}
 
-  if (sessionId) {
-    // Stateful transport - use sessionId as key (handles wrapper pattern)
-    let spanMap = sessionToSpanMap.get(sessionId);
-    if (!spanMap) {
-      spanMap = new Map();
-      sessionToSpanMap.set(sessionId, spanMap);
-    }
-    return spanMap;
-  }
-
-  // Stateless fallback - use transport instance as key
-  let spanMap = statelessSpanMap.get(transport);
+function getOrCreateSpanMap(store: TransportSpanStore, transport: MCPTransport): Map<RequestId, RequestSpanMapValue> {
+  let spanMap = store.get(transport);
   if (!spanMap) {
     spanMap = new Map();
-    statelessSpanMap.set(transport, spanMap);
+    store.set(transport, spanMap);
   }
   return spanMap;
+}
+
+function takeSpan(
+  store: TransportSpanStore,
+  transport: MCPTransport,
+  requestId: RequestId,
+): RequestSpanMapValue | undefined {
+  const spanMap = getSpanMap(store, transport);
+  const spanData = spanMap?.get(requestId);
+  if (!spanMap || !spanData) {
+    return undefined;
+  }
+
+  spanMap.delete(requestId);
+  return spanData;
+}
+
+export function deleteSpanForResponseSend(transport: MCPTransport, spanData: RequestSpanMapValue): void {
+  const spanMap = getSpanMap(responseSendSpans, transport);
+  if (spanMap?.get(spanData.requestId) === spanData) {
+    spanMap.delete(spanData.requestId);
+  }
+}
+
+export function deleteSpanForOutgoingRequest(transport: MCPTransport, spanData: RequestSpanMapValue): void {
+  const stores = [outgoingRequestSpans, responseProcessingSpans];
+  for (const store of stores) {
+    const spanMap = getSpanMap(store, transport);
+    if (spanMap?.get(spanData.requestId) === spanData) {
+      spanMap.delete(spanData.requestId);
+    }
+  }
+}
+
+export function finishSpan(spanData: RequestSpanMapValue, callback: (span: Span) => void): boolean {
+  if (spanData.finished) {
+    return false;
+  }
+
+  spanData.finished = true;
+  callback(spanData.span);
+  return true;
+}
+
+function shouldIncludeUserInfo(): boolean {
+  return Boolean(getClient()?.getDataCollectionOptions().userInfo);
+}
+
+function finishDuplicateSpan(spanData: RequestSpanMapValue): void {
+  finishSpan(spanData, span => {
+    span.setAttributes({
+      [ERROR_TYPE_ATTRIBUTE]: 'duplicate_request_id',
+      [MCP_REQUEST_OUTCOME_ATTRIBUTE]: 'request_id_reused',
+    });
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: 'duplicate_request_id' });
+    span.end();
+  });
 }
 
 /**
@@ -70,101 +101,140 @@ function getOrCreateSpanMap(transport: MCPTransport): Map<RequestId, RequestSpan
  * @param span - Active span to correlate
  * @param method - MCP method name
  */
-export function storeSpanForRequest(transport: MCPTransport, requestId: RequestId, span: Span, method: string): void {
-  const spanMap = getOrCreateSpanMap(transport);
+export function storeSpanForRequest(
+  transport: MCPTransport,
+  requestId: RequestId,
+  span: Span,
+  method: string,
+  sessionData?: SessionData,
+  traceContext?: { baggage?: string; tracestate?: string },
+): void {
+  const spanMap = getOrCreateSpanMap(incomingRequestSpans, transport);
+  const previousSpan = spanMap.get(requestId) ?? takeSpan(responseSendSpans, transport, requestId);
+  if (previousSpan) {
+    finishDuplicateSpan(previousSpan);
+  }
   spanMap.set(requestId, {
+    requestId,
     span,
     method,
+    protocolVersion: sessionData?.protocolVersion,
+    sessionData,
+    baggage: traceContext?.baggage,
+    tracestate: traceContext?.tracestate,
     // oxlint-disable-next-line sdk/no-unsafe-random-apis
     startTime: Date.now(),
+    includeUserInfo: shouldIncludeUserInfo(),
   });
 }
 
-/**
- * Completes span with results and cleans up correlation
- * @param transport - MCP transport instance
- * @param requestId - Request identifier
- * @param result - Execution result for attribute extraction
- * @param options - Resolved MCP options
- * @param hasError - Whether the JSON-RPC response contained an error
- */
-export function completeSpanWithResults(
-  transport: MCPTransport,
-  requestId: RequestId,
-  result: unknown,
-  options: ResolvedMcpOptions,
-  hasError = false,
-): void {
-  const spanMap = getOrCreateSpanMap(transport);
-  const spanData = spanMap.get(requestId);
-  if (spanData) {
-    const { span, method } = spanData;
-    const responseSessionData =
-      method === 'initialize'
-        ? extractSessionDataFromInitializeResponse(result)
-        : extractSessionDataFromResponse(result);
-    if (responseSessionData.protocolVersion || responseSessionData.serverInfo) {
-      updateSessionDataForTransport(transport, responseSessionData);
-    }
-    const responseAttributes: Record<string, string | number> = {
-      ...buildServerAttributesFromInfo(responseSessionData.serverInfo),
-    };
-    if (responseSessionData.protocolVersion) {
-      responseAttributes[MCP_PROTOCOL_VERSION_ATTRIBUTE] = responseSessionData.protocolVersion;
-    }
-    if (Object.keys(responseAttributes).length > 0) {
-      span.setAttributes(responseAttributes);
-    }
-
-    if (hasError) {
-      span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-    } else if (method === 'tools/call') {
-      const toolAttributes = extractToolResultAttributes(result, options.recordOutputs);
-      span.setAttributes(toolAttributes);
-    } else if (method === 'prompts/get') {
-      const promptAttributes = extractPromptResultAttributes(result, options.recordOutputs);
-      span.setAttributes(promptAttributes);
-    }
-
-    span.end();
-    spanMap.delete(requestId);
-  }
+/** Returns request correlation without consuming it. */
+export function getSpanForRequest(transport: MCPTransport, requestId: RequestId): RequestSpanMapValue | undefined {
+  return getSpanMap(incomingRequestSpans, transport)?.get(requestId);
 }
 
-/**
- * Cleans up pending spans for a specific transport (when that transport closes)
- * @param transport - MCP transport instance
- */
-export function cleanupPendingSpansForTransport(transport: MCPTransport): void {
-  const sessionId = transport.sessionId;
+/** Removes and returns an incoming request correlation. */
+export function takeSpanForRequest(transport: MCPTransport, requestId: RequestId): RequestSpanMapValue | undefined {
+  return takeSpan(incomingRequestSpans, transport, requestId);
+}
 
-  // Try sessionId-based cleanup first (for stateful transports)
-  if (sessionId) {
-    const spanMap = sessionToSpanMap.get(sessionId);
+/** Moves an incoming request to the in-flight response-send store. */
+export function takeSpanForResponseSend(
+  transport: MCPTransport,
+  requestId: RequestId,
+): RequestSpanMapValue | undefined {
+  const spanData = takeSpan(incomingRequestSpans, transport, requestId);
+  if (spanData) {
+    getOrCreateSpanMap(responseSendSpans, transport).set(requestId, spanData);
+  }
+  return spanData;
+}
+
+/** Stores a client span for a server-to-client request. */
+export function storeSpanForOutgoingRequest(
+  transport: MCPTransport,
+  requestId: RequestId,
+  span: Span,
+  method: string,
+  sessionData?: SessionData,
+  traceContext?: { baggage?: string; tracestate?: string },
+): RequestSpanMapValue {
+  const spanMap = getOrCreateSpanMap(outgoingRequestSpans, transport);
+  const previousSpan = spanMap.get(requestId) ?? takeSpan(responseProcessingSpans, transport, requestId);
+  if (previousSpan) {
+    finishDuplicateSpan(previousSpan);
+  }
+  const spanData: RequestSpanMapValue = {
+    requestId,
+    span,
+    method,
+    protocolVersion: sessionData?.protocolVersion,
+    sessionData,
+    baggage: traceContext?.baggage,
+    tracestate: traceContext?.tracestate,
+    // oxlint-disable-next-line sdk/no-unsafe-random-apis
+    startTime: Date.now(),
+    includeUserInfo: shouldIncludeUserInfo(),
+  };
+  spanMap.set(requestId, spanData);
+  return spanData;
+}
+
+/** Returns outgoing request correlation without consuming it. */
+export function getSpanForOutgoingRequest(
+  transport: MCPTransport,
+  requestId: RequestId,
+): RequestSpanMapValue | undefined {
+  const spanMap = getSpanMap(outgoingRequestSpans, transport);
+  return (
+    spanMap?.get(requestId) ?? (typeof requestId === 'string' ? spanMap?.get(toNumericRequestId(requestId)) : undefined)
+  );
+}
+
+function toNumericRequestId(requestId: string): number {
+  const numericRequestId = Number(requestId);
+  return Number.isFinite(numericRequestId) ? numericRequestId : Number.NaN;
+}
+
+export function takeSpanForCancelledRequest(
+  transport: MCPTransport,
+  requestId: RequestId,
+): RequestSpanMapValue | undefined {
+  return takeSpan(incomingRequestSpans, transport, requestId) ?? takeSpan(responseSendSpans, transport, requestId);
+}
+
+export function takeSpanForOutgoingRequest(
+  transport: MCPTransport,
+  requestId: RequestId,
+): RequestSpanMapValue | undefined {
+  const exactSpanData = takeSpan(outgoingRequestSpans, transport, requestId);
+  return (
+    exactSpanData ??
+    (typeof requestId === 'string'
+      ? takeSpan(outgoingRequestSpans, transport, toNumericRequestId(requestId))
+      : undefined)
+  );
+}
+
+export function takeSpanForOutgoingResponse(
+  transport: MCPTransport,
+  requestId: RequestId,
+): RequestSpanMapValue | undefined {
+  const spanData = takeSpanForOutgoingRequest(transport, requestId);
+  if (spanData) {
+    getOrCreateSpanMap(responseProcessingSpans, transport).set(spanData.requestId, spanData);
+  }
+  return spanData;
+}
+
+export function takePendingSpansForTransport(transport: MCPTransport): RequestSpanMapValue[] {
+  const pendingSpans: RequestSpanMapValue[] = [];
+  for (const store of [incomingRequestSpans, outgoingRequestSpans, responseSendSpans, responseProcessingSpans]) {
+    const spanMap = store.get(transport);
     if (spanMap) {
-      for (const [, spanData] of spanMap) {
-        spanData.span.setStatus({
-          code: SPAN_STATUS_ERROR,
-          message: 'cancelled',
-        });
-        spanData.span.end();
-      }
-      sessionToSpanMap.delete(sessionId);
+      pendingSpans.push(...spanMap.values());
+      spanMap.clear();
     }
-    return;
   }
-
-  // Fallback to transport-based cleanup (for stateless transports)
-  const spanMap = statelessSpanMap.get(transport);
-  if (spanMap) {
-    for (const [, spanData] of spanMap) {
-      spanData.span.setStatus({
-        code: SPAN_STATUS_ERROR,
-        message: 'cancelled',
-      });
-      spanData.span.end();
-    }
-    spanMap.clear();
-    // Note: WeakMap entries are automatically cleaned up when transport is GC'd
-  }
+  return pendingSpans;
 }

--- a/packages/core/src/integrations/mcp-server/errorCapture.ts
+++ b/packages/core/src/integrations/mcp-server/errorCapture.ts
@@ -15,11 +15,11 @@ import type { McpErrorType } from './types';
  * Captures an error without affecting MCP server operation.
  *
  * The active span already contains all MCP context (method, tool, arguments, etc.)
- * @param error - Error to capture
+ * @param error - Thrown value to capture
  * @param errorType - Classification of error type for filtering
  * @param extraData - Additional context data to include
  */
-export function captureError(error: Error, errorType?: McpErrorType, extraData?: Record<string, unknown>): void {
+export function captureError(error: unknown, errorType?: McpErrorType, extraData?: Record<string, unknown>): void {
   try {
     const client = getClient();
     if (!client) {

--- a/packages/core/src/integrations/mcp-server/handlerErrorCapture.ts
+++ b/packages/core/src/integrations/mcp-server/handlerErrorCapture.ts
@@ -1,0 +1,262 @@
+import { isObjectLike } from '../../utils/is';
+import { captureError } from './errorCapture';
+import { isMcpServerError } from './outcome';
+import { getBoundedMcpString } from './serialization';
+import type { MCPHandler, MCPServerInstance } from './types';
+
+const MCP_PROTOCOL_VERSION_META_KEY = 'io.modelcontextprotocol/protocolVersion';
+const LEGACY_URL_ELICITATION_REQUIRED_ERROR_CODE = -32042;
+
+export type HandlerKind = 'tool' | 'resource' | 'prompt' | 'protocol';
+
+export type HandlerState = {
+  handlerKind: HandlerKind;
+  handlerName: string;
+};
+
+type WrappedHandlerInfo = {
+  originalHandler: MCPHandler;
+  state: HandlerState;
+};
+
+type WrappedHandler = {
+  handler: MCPHandler;
+  state: HandlerState;
+};
+
+const wrappedHandlers = new WeakMap<MCPHandler, WrappedHandlerInfo>();
+const handlersBeingRegistered = new WeakMap<MCPHandler, number>();
+
+export function createWrappedHandler(originalHandler: MCPHandler, state: HandlerState): WrappedHandler {
+  const existingInfo = wrappedHandlers.get(originalHandler);
+
+  if (existingInfo && (existingInfo.state === state || handlersBeingRegistered.has(originalHandler))) {
+    return { handler: originalHandler, state: existingInfo.state };
+  }
+
+  const unwrappedHandler = existingInfo?.originalHandler || originalHandler;
+  const wrappedHandler = function (this: unknown, ...handlerArgs: unknown[]): unknown {
+    return callErrorCapturingHandler.call(this, unwrappedHandler, state, handlerArgs);
+  };
+
+  wrappedHandlers.set(wrappedHandler, { originalHandler: unwrappedHandler, state });
+
+  return { handler: wrappedHandler, state };
+}
+
+export function callWithHandlerRegistration<T>(handler: MCPHandler, register: () => T): T {
+  handlersBeingRegistered.set(handler, (handlersBeingRegistered.get(handler) || 0) + 1);
+
+  try {
+    return register();
+  } finally {
+    const remainingRegistrations = (handlersBeingRegistered.get(handler) || 1) - 1;
+    if (remainingRegistrations === 0) {
+      handlersBeingRegistered.delete(handler);
+    } else {
+      handlersBeingRegistered.set(handler, remainingRegistrations);
+    }
+  }
+}
+
+function callErrorCapturingHandler(
+  this: MCPServerInstance,
+  originalHandler: MCPHandler,
+  state: HandlerState,
+  handlerArgs: unknown[],
+): unknown {
+  try {
+    const result = originalHandler.apply(this, handlerArgs);
+
+    if (isThenable(result)) {
+      return Promise.resolve(result).catch(error => {
+        captureHandlerErrorUnlessCancelled(error, state, handlerArgs);
+        throw error;
+      });
+    }
+
+    return result;
+  } catch (error) {
+    captureHandlerErrorUnlessCancelled(error, state, handlerArgs);
+    throw error;
+  }
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  if (!isObjectLike(value) && typeof value !== 'function') {
+    return false;
+  }
+
+  return typeof (value as { then?: unknown }).then === 'function';
+}
+
+function captureHandlerErrorUnlessCancelled(error: unknown, state: HandlerState, handlerArgs: unknown[]): void {
+  if (isCancellationError(error, handlerArgs) || isExpectedProtocolError(error, handlerArgs)) {
+    return;
+  }
+
+  captureHandlerError(error, state, handlerArgs);
+}
+
+function isExpectedProtocolError(error: unknown, handlerArgs: unknown[]): boolean {
+  const code = getProperty(error, 'code');
+  if (typeof code !== 'number') {
+    return false;
+  }
+
+  if (code === LEGACY_URL_ELICITATION_REQUIRED_ERROR_CODE) {
+    return true;
+  }
+
+  return !isMcpServerError(
+    { code, message: getStringProperty(error, 'message') || '' },
+    getProtocolVersionFromHandlerArgs(handlerArgs),
+  );
+}
+
+function getProtocolVersionFromHandlerArgs(handlerArgs: unknown[]): string | undefined {
+  const request = handlerArgs[0];
+  const params = getProperty(request, 'params');
+  const requestMeta = getProperty(params, '_meta');
+  const requestVersion = getStringProperty(requestMeta, MCP_PROTOCOL_VERSION_META_KEY);
+  if (requestVersion) {
+    return requestVersion;
+  }
+
+  const handlerContext = handlerArgs[handlerArgs.length - 1];
+  const mcpRequest = getProperty(handlerContext, 'mcpReq');
+  const envelope = getProperty(mcpRequest, 'envelope');
+  const envelopeVersion = getStringProperty(envelope, MCP_PROTOCOL_VERSION_META_KEY);
+  if (envelopeVersion) {
+    return envelopeVersion;
+  }
+
+  const classification = getProperty(handlerArgs[1], 'classification');
+  return getStringProperty(classification, 'revision');
+}
+
+function isCancellationError(error: unknown, handlerArgs: unknown[]): boolean {
+  const signal = getHandlerAbortSignal(handlerArgs);
+  if (!signal || getProperty(signal, 'aborted') !== true) {
+    return false;
+  }
+
+  const signalReason = getProperty(signal, 'reason');
+  if (signalReason !== undefined && error === signalReason) {
+    return true;
+  }
+
+  const errorName = getStringProperty(error, 'name');
+  const errorCode = getStringProperty(error, 'code');
+  return (
+    errorName === 'AbortError' ||
+    errorName === 'CanceledError' ||
+    errorName === 'CancelledError' ||
+    errorCode === 'ABORT_ERR' ||
+    errorCode === 'ERR_CANCELED' ||
+    errorCode === 'ERR_CANCELLED'
+  );
+}
+
+function getHandlerAbortSignal(handlerArgs: unknown[]): object | undefined {
+  const handlerContext = handlerArgs[handlerArgs.length - 1];
+  if (!isObjectLike(handlerContext)) {
+    return undefined;
+  }
+
+  const mcpRequest = getProperty(handlerContext, 'mcpReq');
+  const modernSignal = isObjectLike(mcpRequest) ? getProperty(mcpRequest, 'signal') : undefined;
+  if (isObjectLike(modernSignal)) {
+    return modernSignal;
+  }
+
+  const legacySignal = getProperty(handlerContext, 'signal');
+  return isObjectLike(legacySignal) ? legacySignal : undefined;
+}
+
+function captureHandlerError(error: unknown, state: HandlerState, handlerArgs: unknown[]): void {
+  try {
+    const normalizedError = normalizeHandlerError(error);
+    const handlerName = getBoundedMcpString(resolveHandlerName(state, handlerArgs));
+
+    if (state.handlerKind === 'tool') {
+      const errorName = getStringProperty(normalizedError, 'name') || '';
+      const errorMessage = getStringProperty(normalizedError, 'message') || '';
+      const errorData = { tool_name: handlerName };
+
+      if (
+        errorName === 'ProtocolValidationError' ||
+        errorMessage.includes('validation') ||
+        errorMessage.includes('protocol')
+      ) {
+        captureError(normalizedError, 'validation', errorData);
+      } else if (
+        errorName === 'ServerTimeoutError' ||
+        errorMessage.includes('timed out') ||
+        errorMessage.includes('timeout')
+      ) {
+        captureError(normalizedError, 'timeout', errorData);
+      } else {
+        captureError(normalizedError, 'tool_execution', errorData);
+      }
+    } else if (state.handlerKind === 'resource') {
+      captureError(normalizedError, 'resource_execution', { resource_name: handlerName });
+    } else if (state.handlerKind === 'prompt') {
+      captureError(normalizedError, 'prompt_execution', { prompt_name: handlerName });
+    } else {
+      captureError(normalizedError, 'protocol', { method_name: handlerName });
+    }
+  } catch {
+    // noop
+  }
+}
+
+function resolveHandlerName(state: HandlerState, handlerArgs: unknown[]): string {
+  if (state.handlerKind !== 'protocol' || state.handlerName !== 'unknown') {
+    return state.handlerName;
+  }
+
+  return getStringProperty(handlerArgs[0], 'method') || state.handlerName;
+}
+
+function normalizeHandlerError(error: unknown): Error {
+  try {
+    if (error instanceof Error) {
+      return error;
+    }
+  } catch {
+    return new Error('Non-Error exception thrown by MCP handler');
+  }
+
+  if (typeof error === 'string') {
+    return new Error(getBoundedMcpString(error));
+  }
+  if (error === null) {
+    return new Error('null');
+  }
+  if (error === undefined) {
+    return new Error('undefined');
+  }
+  if (typeof error === 'number' || typeof error === 'boolean' || typeof error === 'bigint') {
+    return new Error(`${error}`);
+  }
+
+  return new Error('Non-Error exception thrown by MCP handler');
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+  const property = getProperty(value, key);
+  return typeof property === 'string' ? property : undefined;
+}
+
+function getProperty(value: unknown, key: string): unknown {
+  if (!isObjectLike(value)) {
+    return undefined;
+  }
+
+  try {
+    return value[key];
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/integrations/mcp-server/handlers.ts
+++ b/packages/core/src/integrations/mcp-server/handlers.ts
@@ -1,244 +1,42 @@
-/**
- * Handler method wrapping for MCP server instrumentation
- *
- * Provides automatic error capture and span correlation for tool, resource,
- * and prompt handlers.
- */
+/** Handler wrapping for MCP server instrumentation. */
 
-import { DEBUG_BUILD } from '../../debug-build';
-import { debug } from '../../utils/debug-logger';
-import { isObjectLike } from '../../utils/is';
-import { fill } from '../../utils/object';
-import { captureError } from './errorCapture';
-import type { MCPHandler, MCPServerInstance } from './types';
+import {
+  wrapExistingHandlers as wrapExistingRegistrationHandlers,
+  wrapRegistrationMethod,
+} from './registrationHandlers';
+import { wrapRequestHandlers } from './requestHandlers';
+import type { MCPServerInstance } from './types';
 
-/**
- * Generic function to wrap MCP server method handlers
- * @internal
- * @param serverInstance - MCP server instance
- * @param methodName - Method name to wrap (tool, resource, prompt)
- */
-function wrapMethodHandler(serverInstance: MCPServerInstance, methodName: keyof MCPServerInstance): void {
-  fill(serverInstance, methodName, originalMethod => {
-    return function (this: MCPServerInstance, name: string, ...args: unknown[]) {
-      const handler = args[args.length - 1];
-
-      if (typeof handler !== 'function') {
-        return (originalMethod as (...args: unknown[]) => unknown).call(this, name, ...args);
-      }
-
-      const wrappedHandler = createWrappedHandler(handler as MCPHandler, methodName, name);
-      return (originalMethod as (...args: unknown[]) => unknown).call(this, name, ...args.slice(0, -1), wrappedHandler);
-    };
-  });
-}
-
-/**
- * Creates a wrapped handler with span correlation and error capture
- * @internal
- * @param originalHandler - Original handler function
- * @param methodName - MCP method name
- * @param handlerName - Handler identifier
- * @returns Wrapped handler function
- */
-function createWrappedHandler(originalHandler: MCPHandler, methodName: keyof MCPServerInstance, handlerName: string) {
-  return function (this: unknown, ...handlerArgs: unknown[]): unknown {
-    try {
-      return createErrorCapturingHandler.call(this, originalHandler, methodName, handlerName, handlerArgs);
-    } catch (error) {
-      DEBUG_BUILD && debug.warn('MCP handler wrapping failed:', error);
-      return originalHandler.apply(this, handlerArgs);
-    }
-  };
-}
-
-/**
- * Creates an error-capturing wrapper for handler execution
- * @internal
- * @param originalHandler - Original handler function
- * @param methodName - MCP method name
- * @param handlerName - Handler identifier
- * @param handlerArgs - Handler arguments
- * @param extraHandlerData - Additional handler context
- * @returns Handler execution result
- */
-function createErrorCapturingHandler(
-  this: MCPServerInstance,
-  originalHandler: MCPHandler,
-  methodName: keyof MCPServerInstance,
-  handlerName: string,
-  handlerArgs: unknown[],
-): unknown {
-  try {
-    const result = originalHandler.apply(this, handlerArgs);
-
-    if (isObjectLike(result) && typeof (result as { then?: unknown }).then === 'function') {
-      return Promise.resolve(result).catch(error => {
-        captureHandlerError(error, methodName, handlerName);
-        throw error;
-      });
-    }
-
-    return result;
-  } catch (error) {
-    captureHandlerError(error as Error, methodName, handlerName);
-    throw error;
-  }
-}
-
-/**
- * Captures handler execution errors based on handler type
- * @internal
- * @param error - Error to capture
- * @param methodName - MCP method name
- * @param handlerName - Handler identifier
- */
-function captureHandlerError(error: Error, methodName: keyof MCPServerInstance, handlerName: string): void {
-  try {
-    const extraData: Record<string, unknown> = {};
-
-    if (methodName === 'tool' || methodName === 'registerTool') {
-      extraData.tool_name = handlerName;
-
-      if (
-        error.name === 'ProtocolValidationError' ||
-        error.message.includes('validation') ||
-        error.message.includes('protocol')
-      ) {
-        captureError(error, 'validation', extraData);
-      } else if (
-        error.name === 'ServerTimeoutError' ||
-        error.message.includes('timed out') ||
-        error.message.includes('timeout')
-      ) {
-        captureError(error, 'timeout', extraData);
-      } else {
-        captureError(error, 'tool_execution', extraData);
-      }
-    } else if (methodName === 'resource' || methodName === 'registerResource') {
-      extraData.resource_uri = handlerName;
-      captureError(error, 'resource_execution', extraData);
-    } else if (methodName === 'prompt' || methodName === 'registerPrompt') {
-      extraData.prompt_name = handlerName;
-      captureError(error, 'prompt_execution', extraData);
-    }
-  } catch {
-    // noop
-  }
-}
-
-/**
- * Wraps tool handlers to associate them with request spans.
- * Instruments both `tool` (legacy API) and `registerTool` (new API) if present.
- * @param serverInstance - MCP server instance
- */
+/** Wraps tool registrations from both the legacy and current MCP SDK APIs. */
 export function wrapToolHandlers(serverInstance: MCPServerInstance): void {
   // eslint-disable-next-line typescript/no-deprecated
-  if (typeof serverInstance.tool === 'function') wrapMethodHandler(serverInstance, 'tool');
-  if (typeof serverInstance.registerTool === 'function') wrapMethodHandler(serverInstance, 'registerTool');
+  if (typeof serverInstance.tool === 'function') wrapRegistrationMethod(serverInstance, 'tool');
+  if (typeof serverInstance.registerTool === 'function') wrapRegistrationMethod(serverInstance, 'registerTool');
 }
 
-/**
- * Wraps resource handlers to associate them with request spans.
- * Instruments both `resource` (legacy API) and `registerResource` (new API) if present.
- * @param serverInstance - MCP server instance
- */
+/** Wraps resource registrations from both the legacy and current MCP SDK APIs. */
 export function wrapResourceHandlers(serverInstance: MCPServerInstance): void {
   // eslint-disable-next-line typescript/no-deprecated
-  if (typeof serverInstance.resource === 'function') wrapMethodHandler(serverInstance, 'resource');
-  if (typeof serverInstance.registerResource === 'function') wrapMethodHandler(serverInstance, 'registerResource');
+  if (typeof serverInstance.resource === 'function') wrapRegistrationMethod(serverInstance, 'resource');
+  if (typeof serverInstance.registerResource === 'function') wrapRegistrationMethod(serverInstance, 'registerResource');
 }
 
-/**
- * Wraps prompt handlers to associate them with request spans.
- * Instruments both `prompt` (legacy API) and `registerPrompt` (new API) if present.
- * @param serverInstance - MCP server instance
- */
+/** Wraps prompt registrations from both the legacy and current MCP SDK APIs. */
 export function wrapPromptHandlers(serverInstance: MCPServerInstance): void {
   // eslint-disable-next-line typescript/no-deprecated
-  if (typeof serverInstance.prompt === 'function') wrapMethodHandler(serverInstance, 'prompt');
-  if (typeof serverInstance.registerPrompt === 'function') wrapMethodHandler(serverInstance, 'registerPrompt');
+  if (typeof serverInstance.prompt === 'function') wrapRegistrationMethod(serverInstance, 'prompt');
+  if (typeof serverInstance.registerPrompt === 'function') wrapRegistrationMethod(serverInstance, 'registerPrompt');
 }
 
-/**
- * Wraps all MCP handler types for span correlation.
- * Supports both the legacy API (`tool`, `resource`, `prompt`) and the newer API
- * (`registerTool`, `registerResource`, `registerPrompt`), instrumenting whichever methods are present.
- * @param serverInstance - MCP server instance
- */
+/** Wraps high-level registration callbacks and the low-level request API. */
 export function wrapAllMCPHandlers(serverInstance: MCPServerInstance): void {
   wrapToolHandlers(serverInstance);
   wrapResourceHandlers(serverInstance);
   wrapPromptHandlers(serverInstance);
+  wrapRequestHandlers(serverInstance);
 }
 
-/**
- * Retroactively wraps handlers on tools, resources, and prompts that were registered
- * before `wrapMcpServerWithSentry` was called.
- *
- * The MCP SDK stores registered entries in private maps and invokes them via the entry's
- * own property at call time — `executor` for tools, `readCallback` for resources, and
- * `handler` for prompts. Replacing those properties
- * in-place is therefore equivalent to having wrapped the original registration call.
- *
- * NOTE: This intentionally accesses private MCP SDK internals (`_registeredTools` etc.).
- * The properties and their shapes are verified against @modelcontextprotocol/sdk source:
- * https://github.com/modelcontextprotocol/typescript-sdk/blob/2c0c481cb9dbfd15c8613f765c940a5f5bace94d/packages/server/src/server/mcp.ts#L304
- * When upgrading the MCP SDK, re-verify that these internal maps and their callable
- * properties still exist and are invoked directly (not captured by closure at registration).
- * All access is defensive — if a property is absent or not a function we skip silently.
- * @internal
- */
+/** Wraps high-level handlers which were registered before Sentry instrumentation. */
 export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
-  const server = serverInstance as unknown as Record<string, unknown>;
-
-  // Tools: MCP SDK calls registeredTool.executor (generated from handler at registration time)
-  const registeredTools = server['_registeredTools'];
-  if (isObjectLike(registeredTools)) {
-    for (const [name, tool] of Object.entries(registeredTools as Record<string, Record<string, unknown>>)) {
-      if (typeof tool['executor'] === 'function') {
-        tool['executor'] = createWrappedHandler(tool['executor'] as MCPHandler, 'registerTool', name);
-      }
-    }
-  }
-
-  // Resources: MCP SDK calls registeredResource.readCallback
-  const registeredResources = server['_registeredResources'];
-  if (isObjectLike(registeredResources)) {
-    for (const [name, resource] of Object.entries(registeredResources as Record<string, Record<string, unknown>>)) {
-      if (typeof resource['readCallback'] === 'function') {
-        resource['readCallback'] = createWrappedHandler(
-          resource['readCallback'] as MCPHandler,
-          'registerResource',
-          name,
-        );
-      }
-    }
-  }
-
-  // Resource templates: MCP SDK calls registeredResourceTemplate.readCallback
-  const registeredResourceTemplates = server['_registeredResourceTemplates'];
-  if (isObjectLike(registeredResourceTemplates)) {
-    for (const [name, template] of Object.entries(
-      registeredResourceTemplates as Record<string, Record<string, unknown>>,
-    )) {
-      if (typeof template['readCallback'] === 'function') {
-        template['readCallback'] = createWrappedHandler(
-          template['readCallback'] as MCPHandler,
-          'registerResource',
-          name,
-        );
-      }
-    }
-  }
-
-  // Prompts: MCP SDK calls registeredPrompt.handler
-  const registeredPrompts = server['_registeredPrompts'];
-  if (isObjectLike(registeredPrompts)) {
-    for (const [name, prompt] of Object.entries(registeredPrompts as Record<string, Record<string, unknown>>)) {
-      if (typeof prompt['handler'] === 'function') {
-        prompt['handler'] = createWrappedHandler(prompt['handler'] as MCPHandler, 'registerPrompt', name);
-      }
-    }
-  }
+  wrapExistingRegistrationHandlers(serverInstance);
 }

--- a/packages/core/src/integrations/mcp-server/index.ts
+++ b/packages/core/src/integrations/mcp-server/index.ts
@@ -1,5 +1,7 @@
 import { getClient } from '../../currentScopes';
+import { isThenable } from '../../utils/is';
 import { fill } from '../../utils/object';
+import { captureError } from './errorCapture';
 import { wrapAllMCPHandlers, wrapExistingHandlers } from './handlers';
 import { wrapTransportError, wrapTransportOnClose, wrapTransportOnMessage, wrapTransportSend } from './transport';
 import type { MCPServerInstance, McpServerWrapperOptions, MCPTransport, ResolvedMcpOptions } from './types';
@@ -37,7 +39,7 @@ const wrappedMcpServerInstances = new WeakSet();
  * server.registerTool('my-tool', schema, handler);
  *
  * // Explicitly control input/output capture
- * const server = Sentry.wrapMcpServerWithSentry(
+ * const serverWithCustomCapture = Sentry.wrapMcpServerWithSentry(
  *   new McpServer({ name: "my-server", version: "1.0.0" }),
  *   { recordInputs: true, recordOutputs: false }
  * );
@@ -91,4 +93,58 @@ export function wrapMcpServerWithSentry<S extends object>(mcpServerInstance: S, 
 
   wrappedMcpServerInstances.add(mcpServerInstance);
   return mcpServerInstance;
+}
+
+/**
+ * Wraps every MCP server produced by a factory with Sentry instrumentation.
+ *
+ * This helper is intended for MCP SDK serving entries which construct a fresh
+ * server per request or connection, such as `createMcpHandler` and `serveStdio`.
+ * It supports synchronous and asynchronous factories while preserving the
+ * factory's arguments, `this` value, return type, and thrown or rejected errors.
+ * Factory failures are captured as protocol Issues before being rethrown unchanged.
+ *
+ * @example
+ * ```typescript
+ * import * as Sentry from '@sentry/node';
+ * import { createMcpHandler, McpServer } from '@modelcontextprotocol/server';
+ *
+ * const handler = createMcpHandler(
+ *   Sentry.wrapMcpServerFactoryWithSentry(ctx => {
+ *     const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+ *     server.registerTool('my-tool', schema, handler);
+ *     return server;
+ *   }),
+ * );
+ * ```
+ *
+ * @param factory - Factory which creates an MCP server instance
+ * @param options - Optional configuration applied to every created server
+ * @returns A factory with the same call signature and result type
+ */
+export function wrapMcpServerFactoryWithSentry<Factory extends (...args: never[]) => object | PromiseLike<object>>(
+  factory: Factory,
+  options?: McpServerWrapperOptions,
+): Factory {
+  return function (this: ThisParameterType<Factory>, ...args: Parameters<Factory>): ReturnType<Factory> {
+    let result: ReturnType<Factory>;
+    try {
+      result = Reflect.apply(factory, this, args) as ReturnType<Factory>;
+    } catch (error) {
+      captureError(error, 'protocol', { method_name: 'server_factory' });
+      throw error;
+    }
+
+    if (isThenable(result)) {
+      return result.then(
+        (server: object) => wrapMcpServerWithSentry(server, options),
+        (error: unknown) => {
+          captureError(error, 'protocol', { method_name: 'server_factory' });
+          throw error;
+        },
+      ) as ReturnType<Factory>;
+    }
+
+    return wrapMcpServerWithSentry(result, options);
+  } as unknown as Factory;
 }

--- a/packages/core/src/integrations/mcp-server/methodConfig.ts
+++ b/packages/core/src/integrations/mcp-server/methodConfig.ts
@@ -2,14 +2,22 @@
  * Method configuration and request processing for MCP server instrumentation
  */
 
-import { isObjectLike } from '../../utils/is';
+import { isPlainObject } from '../../utils/is';
 import {
+  LEGACY_MCP_PROMPT_NAME_ATTRIBUTE,
+  LEGACY_MCP_TOOL_NAME_ATTRIBUTE,
+  MCP_PROMPT_VARIABLE_ATTRIBUTE_PREFIX,
   MCP_PROMPT_NAME_ATTRIBUTE,
   MCP_REQUEST_ARGUMENT,
   MCP_RESOURCE_URI_ATTRIBUTE,
+  MCP_TOOL_ARGUMENTS_ATTRIBUTE,
   MCP_TOOL_NAME_ATTRIBUTE,
 } from './attributes';
-import type { MethodConfig } from './types';
+import { getBoundedMcpString, serializeLegacyMcpValue, serializeMcpValue } from './serialization';
+import type { McpAttributes, MethodConfig } from './types';
+
+const MAX_CAPTURED_ARGUMENTS = 32;
+const MAX_ARGUMENT_NAME_LENGTH = 128;
 
 /**
  * Configuration for MCP methods to extract targets and arguments
@@ -19,6 +27,8 @@ const METHOD_CONFIGS: Record<string, MethodConfig> = {
   'tools/call': {
     targetField: 'name',
     targetAttribute: MCP_TOOL_NAME_ATTRIBUTE,
+    legacyTargetAttribute: LEGACY_MCP_TOOL_NAME_ATTRIBUTE,
+    includeTargetInSpanName: true,
     captureArguments: true,
     argumentsField: 'arguments',
   },
@@ -38,6 +48,8 @@ const METHOD_CONFIGS: Record<string, MethodConfig> = {
   'prompts/get': {
     targetField: 'name',
     targetAttribute: MCP_PROMPT_NAME_ATTRIBUTE,
+    legacyTargetAttribute: LEGACY_MCP_PROMPT_NAME_ATTRIBUTE,
+    includeTargetInSpanName: true,
     captureName: true,
     captureArguments: true,
     argumentsField: 'arguments',
@@ -55,6 +67,7 @@ export function extractTargetInfo(
   params: Record<string, unknown>,
 ): {
   target?: string;
+  includeTargetInSpanName?: boolean;
   attributes: Record<string, string>;
 } {
   const config = METHOD_CONFIGS[method];
@@ -64,12 +77,19 @@ export function extractTargetInfo(
 
   const target =
     config.targetField && typeof params?.[config.targetField] === 'string'
-      ? (params[config.targetField] as string)
+      ? getBoundedMcpString(params[config.targetField] as string)
       : undefined;
 
   return {
     target,
-    attributes: target && config.targetAttribute ? { [config.targetAttribute]: target } : {},
+    includeTargetInSpanName: config.includeTargetInSpanName,
+    attributes:
+      target && config.targetAttribute
+        ? {
+            [config.targetAttribute]: target,
+            ...(config.legacyTargetAttribute ? { [config.legacyTargetAttribute]: target } : {}),
+          }
+        : {},
   };
 }
 
@@ -79,29 +99,51 @@ export function extractTargetInfo(
  * @param params - Method parameters
  * @returns Arguments as span attributes with mcp.request.argument prefix
  */
-export function getRequestArguments(method: string, params: Record<string, unknown>): Record<string, string> {
-  const args: Record<string, string> = {};
+export function getRequestArguments(method: string, params: Record<string, unknown>): McpAttributes {
+  const args: McpAttributes = {};
   const config = METHOD_CONFIGS[method];
 
   if (!config) {
     return args;
   }
 
-  if (config.captureArguments && config.argumentsField && params?.[config.argumentsField]) {
+  if (config.captureArguments && config.argumentsField && params[config.argumentsField] !== undefined) {
     const argumentsObj = params[config.argumentsField];
-    if (isObjectLike(argumentsObj)) {
-      for (const [key, value] of Object.entries(argumentsObj as Record<string, unknown>)) {
-        args[`${MCP_REQUEST_ARGUMENT}.${key.toLowerCase()}`] = JSON.stringify(value);
+    const serializedArguments = isPlainObject(argumentsObj) ? serializeMcpValue(argumentsObj) : undefined;
+
+    if (method === 'tools/call' && serializedArguments !== undefined) {
+      args[MCP_TOOL_ARGUMENTS_ATTRIBUTE] = serializedArguments;
+    }
+
+    if (isPlainObject(argumentsObj)) {
+      for (const [key, value] of Object.entries(argumentsObj).slice(0, MAX_CAPTURED_ARGUMENTS)) {
+        const boundedKey = getBoundedMcpString(key, MAX_ARGUMENT_NAME_LENGTH);
+        const legacySerializedValue = serializeLegacyMcpValue(value);
+        const serializedValue = serializeMcpValue(value);
+        if (legacySerializedValue !== undefined) {
+          args[`${MCP_REQUEST_ARGUMENT}.${boundedKey.toLowerCase()}`] = legacySerializedValue;
+        }
+        if (serializedValue !== undefined) {
+          if (method === 'prompts/get') {
+            args[`${MCP_PROMPT_VARIABLE_ATTRIBUTE_PREFIX}.${boundedKey}`] = serializedValue;
+          }
+        }
       }
     }
   }
 
-  if (config.captureUri && params?.uri) {
-    args[`${MCP_REQUEST_ARGUMENT}.uri`] = JSON.stringify(params.uri);
+  if (config.captureUri && params.uri !== undefined) {
+    const uri = serializeLegacyMcpValue(params.uri);
+    if (uri !== undefined) {
+      args[`${MCP_REQUEST_ARGUMENT}.uri`] = uri;
+    }
   }
 
-  if (config.captureName && params?.name) {
-    args[`${MCP_REQUEST_ARGUMENT}.name`] = JSON.stringify(params.name);
+  if (config.captureName && params.name !== undefined) {
+    const name = serializeLegacyMcpValue(params.name);
+    if (name !== undefined) {
+      args[`${MCP_REQUEST_ARGUMENT}.name`] = name;
+    }
   }
 
   return args;

--- a/packages/core/src/integrations/mcp-server/outcome.ts
+++ b/packages/core/src/integrations/mcp-server/outcome.ts
@@ -1,0 +1,36 @@
+import { ERROR_TYPE_ATTRIBUTE, RPC_RESPONSE_STATUS_CODE_ATTRIBUTE } from './attributes';
+import type { JsonRpcError, McpAttributes } from './types';
+
+const JSON_RPC_CALLER_ERROR_CODES = new Set([-32700, -32600, -32601, -32602]);
+const LEGACY_RESOURCE_NOT_FOUND_ERROR_CODE = -32002;
+const MODERN_CALLER_ERROR_CODES = new Set([-32020, -32021, -32022]);
+const STATELESS_MCP_PROTOCOL_VERSION = '2026-07-28';
+
+function isStatelessMcpProtocolVersion(protocolVersion?: string): boolean {
+  return (
+    typeof protocolVersion === 'string' &&
+    /^\d{4}-\d{2}-\d{2}$/.test(protocolVersion) &&
+    protocolVersion >= STATELESS_MCP_PROTOCOL_VERSION
+  );
+}
+
+/** Whether a JSON-RPC response represents a server-side operation failure. */
+export function isMcpServerError(error: JsonRpcError, protocolVersion?: string): boolean {
+  if (JSON_RPC_CALLER_ERROR_CODES.has(error.code)) {
+    return false;
+  }
+
+  if (isStatelessMcpProtocolVersion(protocolVersion)) {
+    return !MODERN_CALLER_ERROR_CODES.has(error.code);
+  }
+
+  return error.code !== LEGACY_RESOURCE_NOT_FOUND_ERROR_CODE;
+}
+
+/** Builds OTel JSON-RPC outcome attributes for an MCP server span. */
+export function getJsonRpcErrorAttributes(error: JsonRpcError, protocolVersion?: string): McpAttributes {
+  return {
+    [RPC_RESPONSE_STATUS_CODE_ATTRIBUTE]: String(error.code),
+    ...(isMcpServerError(error, protocolVersion) ? { [ERROR_TYPE_ATTRIBUTE]: String(error.code) } : {}),
+  };
+}

--- a/packages/core/src/integrations/mcp-server/piiFiltering.ts
+++ b/packages/core/src/integrations/mcp-server/piiFiltering.ts
@@ -6,13 +6,24 @@
  * separately via recordInputs/recordOutputs options.
  */
 import type { SpanAttributeValue } from '../../types/span';
-import { CLIENT_ADDRESS_ATTRIBUTE, CLIENT_PORT_ATTRIBUTE, MCP_RESOURCE_URI_ATTRIBUTE } from './attributes';
+import {
+  CLIENT_ADDRESS_ATTRIBUTE,
+  CLIENT_PORT_ATTRIBUTE,
+  MCP_REQUEST_ARGUMENT,
+  MCP_RESOURCE_URI_ATTRIBUTE,
+  MCP_TOOL_RESULT_ATTRIBUTE,
+} from './attributes';
 
 /**
  * Network PII attributes that should be removed when dataCollection.userInfo is false
  * @internal
  */
-const NETWORK_PII_ATTRIBUTES = new Set([CLIENT_ADDRESS_ATTRIBUTE, CLIENT_PORT_ATTRIBUTE, MCP_RESOURCE_URI_ATTRIBUTE]);
+const NETWORK_PII_ATTRIBUTES = new Set([
+  CLIENT_ADDRESS_ATTRIBUTE,
+  CLIENT_PORT_ATTRIBUTE,
+  MCP_RESOURCE_URI_ATTRIBUTE,
+  `${MCP_REQUEST_ARGUMENT}.uri`,
+]);
 
 /**
  * Checks if an attribute key should be considered network PII.
@@ -27,7 +38,7 @@ const NETWORK_PII_ATTRIBUTES = new Set([CLIENT_ADDRESS_ATTRIBUTE, CLIENT_PORT_AT
  * @internal
  */
 function isNetworkPiiAttribute(key: string): boolean {
-  return NETWORK_PII_ATTRIBUTES.has(key);
+  return NETWORK_PII_ATTRIBUTES.has(key) || key.endsWith('.uri') || key.endsWith('.resource_uri');
 }
 
 /**
@@ -47,10 +58,30 @@ export function filterMcpPiiFromSpanData(
   return Object.entries(spanData).reduce(
     (acc, [key, value]) => {
       if (!isNetworkPiiAttribute(key)) {
-        acc[key] = value as SpanAttributeValue;
+        if (key === MCP_TOOL_RESULT_ATTRIBUTE && typeof value === 'string') {
+          const redactedResult = redactMcpResultUris(value);
+          if (redactedResult !== undefined) {
+            acc[key] = redactedResult;
+          }
+        } else {
+          acc[key] = value as SpanAttributeValue;
+        }
       }
       return acc;
     },
     {} as Record<string, SpanAttributeValue>,
   );
+}
+
+function redactMcpResultUris(serializedResult: string): string | undefined {
+  try {
+    return JSON.stringify(
+      JSON.parse(serializedResult, (key, value) => {
+        const normalizedKey = key.toLowerCase();
+        return normalizedKey === 'uri' || normalizedKey.endsWith('_uri') ? undefined : value;
+      }),
+    );
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/core/src/integrations/mcp-server/registrationHandlers.ts
+++ b/packages/core/src/integrations/mcp-server/registrationHandlers.ts
@@ -1,0 +1,219 @@
+import { isObjectLike } from '../../utils/is';
+import { fill } from '../../utils/object';
+import {
+  callWithHandlerRegistration,
+  createWrappedHandler,
+  type HandlerKind,
+  type HandlerState,
+} from './handlerErrorCapture';
+import type { MCPHandler, MCPServerInstance } from './types';
+
+type RegisteredHandlerMethod = 'tool' | 'resource' | 'prompt' | 'registerTool' | 'registerResource' | 'registerPrompt';
+type ExecutionProperty = 'executor' | 'readCallback' | 'handler' | 'callback';
+
+type RegistrationHandleState = HandlerState & {
+  callbackPipelineInstrumented: boolean;
+  executionProperty: ExecutionProperty;
+};
+
+const wrappedRegistrationHandles = new WeakMap<object, RegistrationHandleState>();
+
+export function wrapRegistrationMethod(serverInstance: MCPServerInstance, methodName: RegisteredHandlerMethod): void {
+  fill(serverInstance, methodName, originalMethod => {
+    return function (this: MCPServerInstance, name: string, ...args: unknown[]) {
+      const handler = args[args.length - 1];
+      if (typeof handler !== 'function') {
+        return (originalMethod as (...methodArgs: unknown[]) => unknown).call(this, name, ...args);
+      }
+
+      const state: RegistrationHandleState = {
+        callbackPipelineInstrumented: true,
+        executionProperty: getDefaultExecutionProperty(getHandlerKind(methodName)),
+        handlerKind: getHandlerKind(methodName),
+        handlerName: name,
+      };
+      const wrapped = createWrappedHandler(handler as MCPHandler, state);
+      const registrationHandle = callWithHandlerRegistration(wrapped.handler, () =>
+        (originalMethod as (...methodArgs: unknown[]) => unknown).call(
+          this,
+          name,
+          ...args.slice(0, -1),
+          wrapped.handler,
+        ),
+      );
+      const effectiveState = wrapped.state as RegistrationHandleState;
+
+      effectiveState.executionProperty = getExecutionProperty(registrationHandle, effectiveState.handlerKind);
+      wrapRegistrationHandle(registrationHandle, effectiveState);
+
+      return registrationHandle;
+    };
+  });
+}
+
+/**
+ * SDK 1.x and 2.x keep high-level registrations in private maps and read their callable
+ * properties at dispatch time. The property names differ by version, so discovery is based
+ * on each registration's runtime shape instead of assuming the currently installed SDK.
+ */
+export function wrapExistingHandlers(serverInstance: MCPServerInstance): void {
+  const server = serverInstance as unknown as Record<string, unknown>;
+
+  wrapExistingRegistry(server, '_registeredTools', 'tool', (name, _registration) => name);
+  wrapExistingRegistry(server, '_registeredResources', 'resource', (_key, registration) => {
+    return getStringProperty(registration, 'name') || 'unknown';
+  });
+  wrapExistingRegistry(server, '_registeredResourceTemplates', 'resource', name => name);
+  wrapExistingRegistry(server, '_registeredPrompts', 'prompt', name => name);
+}
+
+function wrapExistingRegistry(
+  server: Record<string, unknown>,
+  registryProperty: string,
+  handlerKind: Exclude<HandlerKind, 'protocol'>,
+  getHandlerName: (key: string, registration: Record<string, unknown>) => string,
+): void {
+  const registry = getProperty(server, registryProperty);
+  if (!isObjectLike(registry)) {
+    return;
+  }
+
+  let registrations: Array<[string, Record<string, unknown>]>;
+  try {
+    registrations = Object.entries(registry as Record<string, Record<string, unknown>>);
+  } catch {
+    return;
+  }
+
+  for (const [key, registration] of registrations) {
+    if (!isObjectLike(registration) || wrappedRegistrationHandles.has(registration)) {
+      continue;
+    }
+
+    const executionProperty = getExecutionProperty(registration, handlerKind);
+    if (typeof getProperty(registration, executionProperty) !== 'function') {
+      continue;
+    }
+
+    const state: RegistrationHandleState = {
+      callbackPipelineInstrumented: false,
+      executionProperty,
+      handlerKind,
+      handlerName: getHandlerName(key, registration),
+    };
+    wrapExecutionProperty(registration, state);
+    wrapRegistrationHandle(registration, state);
+  }
+}
+
+function wrapRegistrationHandle(registrationHandle: unknown, state: RegistrationHandleState): void {
+  if (!isObjectLike(registrationHandle) || typeof getProperty(registrationHandle, 'update') !== 'function') {
+    return;
+  }
+
+  const handle = registrationHandle as Record<string, unknown>;
+  const existingState = wrappedRegistrationHandles.get(handle);
+  if (existingState) {
+    if (state.callbackPipelineInstrumented) {
+      existingState.callbackPipelineInstrumented = true;
+    }
+    return;
+  }
+
+  fill(handle, 'update', originalUpdate => {
+    return function (this: unknown, updates: unknown, ...args: unknown[]): unknown {
+      const updateObject = isObjectLike(updates) ? (updates as Record<string, unknown>) : undefined;
+      const updatedName = getStringProperty(updateObject, 'name') || state.handlerName;
+      const callback = getProperty(updateObject, 'callback');
+      const forwardedUpdates =
+        typeof callback === 'function'
+          ? { ...(updateObject || {}), callback: createWrappedHandler(callback as MCPHandler, state).handler }
+          : updates;
+      const executionHandlerBeforeUpdate = getProperty(handle, state.executionProperty);
+      const result = (originalUpdate as (...updateArgs: unknown[]) => unknown).call(this, forwardedUpdates, ...args);
+
+      state.handlerName = updatedName;
+
+      if (typeof callback === 'function') {
+        state.callbackPipelineInstrumented = true;
+      } else if (
+        !state.callbackPipelineInstrumented &&
+        typeof getProperty(handle, state.executionProperty) === 'function' &&
+        getProperty(handle, state.executionProperty) !== executionHandlerBeforeUpdate
+      ) {
+        wrapExecutionProperty(handle, state);
+      }
+
+      return result;
+    };
+  });
+
+  wrappedRegistrationHandles.set(handle, state);
+}
+
+function wrapExecutionProperty(registrationHandle: Record<string, unknown>, state: RegistrationHandleState): void {
+  const executionHandler = getProperty(registrationHandle, state.executionProperty);
+  if (typeof executionHandler !== 'function') {
+    return;
+  }
+
+  try {
+    registrationHandle[state.executionProperty] = createWrappedHandler(executionHandler as MCPHandler, state).handler;
+  } catch {
+    // noop
+  }
+}
+
+function getExecutionProperty(registrationHandle: unknown, handlerKind: HandlerKind): ExecutionProperty {
+  if (handlerKind === 'tool') {
+    return hasFunctionProperty(registrationHandle, 'executor') ? 'executor' : 'handler';
+  }
+  if (handlerKind === 'resource') {
+    return 'readCallback';
+  }
+  if (handlerKind === 'prompt') {
+    return hasFunctionProperty(registrationHandle, 'handler') ? 'handler' : 'callback';
+  }
+  return 'handler';
+}
+
+function getDefaultExecutionProperty(handlerKind: HandlerKind): ExecutionProperty {
+  if (handlerKind === 'tool') {
+    return 'executor';
+  }
+  if (handlerKind === 'resource') {
+    return 'readCallback';
+  }
+  return 'handler';
+}
+
+function getHandlerKind(methodName: RegisteredHandlerMethod): Exclude<HandlerKind, 'protocol'> {
+  if (methodName === 'tool' || methodName === 'registerTool') {
+    return 'tool';
+  }
+  if (methodName === 'resource' || methodName === 'registerResource') {
+    return 'resource';
+  }
+  return 'prompt';
+}
+
+function hasFunctionProperty(value: unknown, key: string): boolean {
+  return typeof getProperty(value, key) === 'function';
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+  const property = getProperty(value, key);
+  return typeof property === 'string' ? property : undefined;
+}
+
+function getProperty(value: unknown, key: string): unknown {
+  if (!isObjectLike(value)) {
+    return undefined;
+  }
+
+  try {
+    return value[key];
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/integrations/mcp-server/requestHandlers.ts
+++ b/packages/core/src/integrations/mcp-server/requestHandlers.ts
@@ -1,0 +1,98 @@
+import { isObjectLike } from '../../utils/is';
+import { fill } from '../../utils/object';
+import { callWithHandlerRegistration, createWrappedHandler } from './handlerErrorCapture';
+import type { MCPHandler, MCPServerInstance } from './types';
+
+const wrappedRequestHandlerServers = new WeakSet<object>();
+
+export function wrapRequestHandlers(serverInstance: MCPServerInstance): void {
+  if (wrappedRequestHandlerServers.has(serverInstance)) {
+    return;
+  }
+
+  wrappedRequestHandlerServers.add(serverInstance);
+  wrapExistingRequestHandlers(serverInstance);
+
+  if (typeof serverInstance.setRequestHandler !== 'function') {
+    return;
+  }
+
+  fill(serverInstance, 'setRequestHandler', originalSetRequestHandler => {
+    return function (this: MCPServerInstance, methodOrSchema: unknown, ...args: unknown[]): unknown {
+      const handler = args[args.length - 1];
+      if (typeof handler !== 'function') {
+        return (originalSetRequestHandler as (...requestHandlerArgs: unknown[]) => unknown).call(
+          this,
+          methodOrSchema,
+          ...args,
+        );
+      }
+
+      const wrapped = createWrappedHandler(handler as MCPHandler, {
+        handlerKind: 'protocol',
+        handlerName: getRequestHandlerName(methodOrSchema),
+      });
+
+      return callWithHandlerRegistration(wrapped.handler, () =>
+        (originalSetRequestHandler as (...requestHandlerArgs: unknown[]) => unknown).call(
+          this,
+          methodOrSchema,
+          ...args.slice(0, -1),
+          wrapped.handler,
+        ),
+      );
+    };
+  });
+}
+
+function wrapExistingRequestHandlers(serverInstance: MCPServerInstance): void {
+  // Both SDK generations store their fully composed low-level handlers in this map.
+  const requestHandlers = getProperty(serverInstance, '_requestHandlers');
+  if (!(requestHandlers instanceof Map)) {
+    return;
+  }
+
+  for (const [method, handler] of requestHandlers.entries()) {
+    if (typeof method !== 'string' || typeof handler !== 'function') {
+      continue;
+    }
+
+    try {
+      requestHandlers.set(
+        method,
+        createWrappedHandler(handler as MCPHandler, { handlerKind: 'protocol', handlerName: method }).handler,
+      );
+    } catch {
+      // noop
+    }
+  }
+}
+
+function getRequestHandlerName(methodOrSchema: unknown): string {
+  if (typeof methodOrSchema === 'string') {
+    return methodOrSchema;
+  }
+
+  const shape = getProperty(methodOrSchema, 'shape');
+  const methodSchema = getProperty(shape, 'method');
+  const literalValue = getProperty(methodSchema, 'value');
+  if (typeof literalValue === 'string') {
+    return literalValue;
+  }
+
+  const definition = getProperty(methodSchema, '_def');
+  const definitionValue = getProperty(definition, 'value');
+  return typeof definitionValue === 'string' ? definitionValue : 'unknown';
+}
+
+function getProperty(value: unknown, key: string): unknown {
+  if (!isObjectLike(value)) {
+    return undefined;
+  }
+
+  try {
+    return value[key];
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/integrations/mcp-server/resultExtraction.ts
+++ b/packages/core/src/integrations/mcp-server/resultExtraction.ts
@@ -4,13 +4,37 @@
  * Handles extraction of attributes from tool and prompt execution results.
  */
 
+import { isPlainObject } from '../../utils/is';
 import {
+  ERROR_TYPE_ATTRIBUTE,
+  MCP_CACHE_SCOPE_ATTRIBUTE,
+  MCP_CACHE_TTL_ATTRIBUTE,
+  MCP_PAGINATION_NEXT_CURSOR_PRESENT_ATTRIBUTE,
+  MCP_RESOURCE_RESULT_MIME_TYPES_ATTRIBUTE,
+  MCP_DISCOVERY_EXTENSION_IDS_ATTRIBUTE,
+  MCP_DISCOVERY_PROTOCOL_VERSIONS_ATTRIBUTE,
+  MCP_INPUT_REQUEST_COUNT_ATTRIBUTE,
+  MCP_INPUT_REQUEST_METHODS_ATTRIBUTE,
   MCP_PROMPT_RESULT_DESCRIPTION_ATTRIBUTE,
   MCP_PROMPT_RESULT_MESSAGE_COUNT_ATTRIBUTE,
+  MCP_REQUEST_STATE_PRESENT_ATTRIBUTE,
+  MCP_RESULT_COUNT_ATTRIBUTE,
+  MCP_RESULT_HAS_MORE_ATTRIBUTE,
+  MCP_RESULT_TOTAL_COUNT_ATTRIBUTE,
+  MCP_RESULT_TYPE_ATTRIBUTE,
+  MCP_SERVER_CAPABILITIES_ATTRIBUTE,
+  MCP_SUBSCRIPTION_ID_ATTRIBUTE,
+  MCP_TOOL_RESULT_ATTRIBUTE,
   MCP_TOOL_RESULT_CONTENT_COUNT_ATTRIBUTE,
   MCP_TOOL_RESULT_IS_ERROR_ATTRIBUTE,
 } from './attributes';
+import { getBoundedMcpString, getBoundedMcpStringList, serializeMcpValue } from './serialization';
+import type { McpAttributes } from './types';
 import { isValidContentItem } from './validation';
+
+const MAX_CAPTURED_RESULT_ITEMS = 32;
+const MAX_PROTOCOL_VERSION_LENGTH = 64;
+const MCP_SUBSCRIPTION_ID_META_KEY = 'io.modelcontextprotocol/subscriptionId';
 
 /**
  * Build attributes for tool result content items
@@ -18,15 +42,12 @@ import { isValidContentItem } from './validation';
  * @param includeContent - Whether to include actual content (text, URIs) or just metadata
  * @returns Attributes extracted from each content item
  */
-function buildAllContentItemAttributes(
-  content: unknown[],
-  includeContent: boolean,
-): Record<string, string | number | boolean> {
-  const attributes: Record<string, string | number> = {
+function buildAllContentItemAttributes(content: unknown[], includeContent: boolean): McpAttributes {
+  const attributes: McpAttributes = {
     [MCP_TOOL_RESULT_CONTENT_COUNT_ATTRIBUTE]: content.length,
   };
 
-  for (const [i, item] of content.entries()) {
+  for (const [i, item] of content.slice(0, MAX_CAPTURED_RESULT_ITEMS).entries()) {
     if (!isValidContentItem(item)) {
       continue;
     }
@@ -34,13 +55,13 @@ function buildAllContentItemAttributes(
     const prefix = content.length === 1 ? 'mcp.tool.result' : `mcp.tool.result.${i}`;
 
     if (typeof item.type === 'string') {
-      attributes[`${prefix}.content_type`] = item.type;
+      attributes[`${prefix}.content_type`] = getBoundedMcpString(item.type);
     }
 
     if (includeContent) {
       const safeSet = (key: string, value: unknown): void => {
         if (typeof value === 'string') {
-          attributes[`${prefix}.${key}`] = value;
+          attributes[`${prefix}.${key}`] = getBoundedMcpString(value);
         }
       };
 
@@ -49,7 +70,7 @@ function buildAllContentItemAttributes(
       safeSet('name', item.name);
 
       if (typeof item.text === 'string') {
-        attributes[`${prefix}.content`] = item.text;
+        attributes[`${prefix}.content`] = getBoundedMcpString(item.text, 10_000);
       }
 
       if (typeof item.data === 'string') {
@@ -73,10 +94,7 @@ function buildAllContentItemAttributes(
  * @param recordOutputs - Whether to include actual content or just metadata (counts, error status)
  * @returns Attributes extracted from tool result content
  */
-export function extractToolResultAttributes(
-  result: unknown,
-  recordOutputs: boolean,
-): Record<string, string | number | boolean> {
+export function extractToolResultAttributes(result: unknown, recordOutputs: boolean): McpAttributes {
   if (!isValidContentItem(result)) {
     return {};
   }
@@ -85,6 +103,29 @@ export function extractToolResultAttributes(
 
   if (typeof result.isError === 'boolean') {
     attributes[MCP_TOOL_RESULT_IS_ERROR_ATTRIBUTE] = result.isError;
+    if (result.isError) {
+      attributes[ERROR_TYPE_ATTRIBUTE] = 'tool_error';
+    }
+  }
+
+  const isCompletedResult = result.resultType === undefined || result.resultType === 'complete';
+  if (
+    recordOutputs &&
+    result.isError !== true &&
+    isCompletedResult &&
+    (result.structuredContent !== undefined || result.content !== undefined)
+  ) {
+    const structuredContent = result.structuredContent;
+    const toolResult =
+      structuredContent !== undefined
+        ? isPlainObject(structuredContent)
+          ? structuredContent
+          : { structuredContent }
+        : { content: result.content };
+    const serializedResult = serializeMcpValue(toolResult);
+    if (serializedResult !== undefined) {
+      attributes[MCP_TOOL_RESULT_ATTRIBUTE] = serializedResult;
+    }
   }
 
   return attributes;
@@ -96,17 +137,14 @@ export function extractToolResultAttributes(
  * @param recordOutputs - Whether to include actual content or just metadata (counts)
  * @returns Attributes extracted from prompt result
  */
-export function extractPromptResultAttributes(
-  result: unknown,
-  recordOutputs: boolean,
-): Record<string, string | number | boolean> {
-  const attributes: Record<string, string | number | boolean> = {};
+export function extractPromptResultAttributes(result: unknown, recordOutputs: boolean): McpAttributes {
+  const attributes: McpAttributes = {};
   if (!isValidContentItem(result)) {
     return attributes;
   }
 
   if (recordOutputs && typeof result.description === 'string') {
-    attributes[MCP_PROMPT_RESULT_DESCRIPTION_ATTRIBUTE] = result.description;
+    attributes[MCP_PROMPT_RESULT_DESCRIPTION_ATTRIBUTE] = getBoundedMcpString(result.description, 10_000);
   }
 
   if (Array.isArray(result.messages)) {
@@ -114,7 +152,7 @@ export function extractPromptResultAttributes(
 
     if (recordOutputs) {
       const messages = result.messages;
-      for (const [i, message] of messages.entries()) {
+      for (const [i, message] of messages.slice(0, MAX_CAPTURED_RESULT_ITEMS).entries()) {
         if (!isValidContentItem(message)) {
           continue;
         }
@@ -124,7 +162,7 @@ export function extractPromptResultAttributes(
         const safeSet = (key: string, value: unknown): void => {
           if (typeof value === 'string') {
             const attrName = messages.length === 1 ? `${prefix}.message_${key}` : `${prefix}.${key}`;
-            attributes[attrName] = value;
+            attributes[attrName] = getBoundedMcpString(value);
           }
         };
 
@@ -134,10 +172,119 @@ export function extractPromptResultAttributes(
           const content = message.content;
           if (typeof content.text === 'string') {
             const attrName = messages.length === 1 ? `${prefix}.message_content` : `${prefix}.content`;
-            attributes[attrName] = content.text;
+            attributes[attrName] = getBoundedMcpString(content.text, 10_000);
           }
         }
       }
+    }
+  }
+
+  return attributes;
+}
+
+const RESULT_COLLECTION_FIELDS: Record<string, string> = {
+  'tools/list': 'tools',
+  'resources/list': 'resources',
+  'resources/templates/list': 'resourceTemplates',
+  'prompts/list': 'prompts',
+};
+
+/** Extracts attributes shared by modern results and extension-defined task results. */
+export function extractCommonResultAttributes(method: string, result: unknown): McpAttributes {
+  if (!isValidContentItem(result)) {
+    return {};
+  }
+
+  const attributes: McpAttributes = {};
+  if (typeof result.resultType === 'string') {
+    attributes[MCP_RESULT_TYPE_ATTRIBUTE] = getBoundedMcpString(result.resultType);
+  }
+  if (typeof result.ttlMs === 'number' && Number.isFinite(result.ttlMs) && result.ttlMs >= 0) {
+    attributes[MCP_CACHE_TTL_ATTRIBUTE] = result.ttlMs;
+  }
+  if (result.cacheScope === 'public' || result.cacheScope === 'private') {
+    attributes[MCP_CACHE_SCOPE_ATTRIBUTE] = result.cacheScope;
+  }
+  if (typeof result.requestState === 'string') {
+    attributes[MCP_REQUEST_STATE_PRESENT_ATTRIBUTE] = true;
+  }
+  if (isValidContentItem(result._meta)) {
+    const subscriptionId = result._meta[MCP_SUBSCRIPTION_ID_META_KEY];
+    if (typeof subscriptionId === 'string' || typeof subscriptionId === 'number') {
+      attributes[MCP_SUBSCRIPTION_ID_ATTRIBUTE] = getBoundedMcpString(String(subscriptionId));
+    }
+  }
+  const collectionField = RESULT_COLLECTION_FIELDS[method];
+  if (collectionField && Array.isArray(result[collectionField])) {
+    attributes[MCP_RESULT_COUNT_ATTRIBUTE] = result[collectionField].length;
+  }
+  if (collectionField && typeof result.nextCursor === 'string') {
+    attributes[MCP_PAGINATION_NEXT_CURSOR_PRESENT_ATTRIBUTE] = true;
+  }
+
+  if (method === 'resources/read' && Array.isArray(result.contents)) {
+    attributes[MCP_RESULT_COUNT_ATTRIBUTE] = result.contents.length;
+    const mimeTypes = getBoundedMcpStringList(
+      Array.from(
+        new Set(
+          result.contents
+            .slice(0, MAX_CAPTURED_RESULT_ITEMS)
+            .map(content => (isValidContentItem(content) ? content.mimeType : undefined))
+            .filter((mimeType): mimeType is string => typeof mimeType === 'string'),
+        ),
+      ).sort(),
+    );
+    if (mimeTypes.length > 0) {
+      attributes[MCP_RESOURCE_RESULT_MIME_TYPES_ATTRIBUTE] = mimeTypes;
+    }
+  }
+
+  if (method === 'completion/complete' && isValidContentItem(result.completion)) {
+    const completion = result.completion;
+    if (Array.isArray(completion.values)) {
+      attributes[MCP_RESULT_COUNT_ATTRIBUTE] = completion.values.length;
+    }
+    if (typeof completion.total === 'number' && Number.isFinite(completion.total) && completion.total >= 0) {
+      attributes[MCP_RESULT_TOTAL_COUNT_ATTRIBUTE] = completion.total;
+    }
+    if (typeof completion.hasMore === 'boolean') {
+      attributes[MCP_RESULT_HAS_MORE_ATTRIBUTE] = completion.hasMore;
+    }
+  }
+
+  if (method === 'server/discover') {
+    if (Array.isArray(result.supportedVersions)) {
+      attributes[MCP_DISCOVERY_PROTOCOL_VERSIONS_ATTRIBUTE] = getBoundedMcpStringList(
+        result.supportedVersions,
+        MAX_CAPTURED_RESULT_ITEMS,
+        MAX_PROTOCOL_VERSION_LENGTH,
+      );
+    }
+    if (isValidContentItem(result.capabilities) && isValidContentItem(result.capabilities.extensions)) {
+      attributes[MCP_DISCOVERY_EXTENSION_IDS_ATTRIBUTE] = getBoundedMcpStringList(
+        Object.keys(result.capabilities.extensions).sort(),
+      );
+    }
+    if (isValidContentItem(result.capabilities)) {
+      attributes[MCP_SERVER_CAPABILITIES_ATTRIBUTE] = getBoundedMcpStringList(
+        Object.keys(result.capabilities)
+          .filter(capability => capability !== 'experimental' && capability !== 'extensions')
+          .sort(),
+      );
+    }
+  }
+
+  if (isValidContentItem(result.inputRequests)) {
+    const allInputRequests = Object.values(result.inputRequests);
+    const inputRequests = allInputRequests.slice(0, MAX_CAPTURED_RESULT_ITEMS);
+    const inputRequestMethods = inputRequests
+      .map(inputRequest => (isValidContentItem(inputRequest) ? inputRequest.method : undefined))
+      .filter((methodName): methodName is string => typeof methodName === 'string');
+    attributes[MCP_INPUT_REQUEST_COUNT_ATTRIBUTE] = allInputRequests.length;
+    if (inputRequestMethods.length > 0) {
+      attributes[MCP_INPUT_REQUEST_METHODS_ATTRIBUTE] = getBoundedMcpStringList(
+        Array.from(new Set(inputRequestMethods)).sort(),
+      );
     }
   }
 

--- a/packages/core/src/integrations/mcp-server/serialization.ts
+++ b/packages/core/src/integrations/mcp-server/serialization.ts
@@ -1,0 +1,58 @@
+import { stringify } from '../../utils/string';
+
+const MAX_MCP_ATTRIBUTE_LENGTH = 10_000;
+const MAX_MCP_METADATA_STRING_LENGTH = 256;
+const MAX_MCP_ATTRIBUTE_LIST_LENGTH = 32;
+
+function truncateMcpString(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return maxLength <= 3 ? value.slice(0, maxLength) : `${value.slice(0, maxLength - 3)}...`;
+}
+
+/** Bounds an untrusted MCP metadata value before adding it to a span. */
+export function getBoundedMcpString(value: string, maxLength: number = MAX_MCP_METADATA_STRING_LENGTH): string {
+  return truncateMcpString(value, maxLength);
+}
+
+/** Bounds an untrusted MCP metadata list before adding it to a span. */
+export function getBoundedMcpStringList(
+  values: unknown[],
+  maxItems: number = MAX_MCP_ATTRIBUTE_LIST_LENGTH,
+  maxStringLength: number = MAX_MCP_METADATA_STRING_LENGTH,
+): string[] {
+  return values
+    .filter((value): value is string => typeof value === 'string')
+    .slice(0, maxItems)
+    .map(value => getBoundedMcpString(value, maxStringLength));
+}
+
+/** Serializes untrusted MCP content into a bounded span attribute value. */
+export function serializeMcpValue(value: unknown): string | undefined {
+  const serialized = stringify(value, '{"_sentry":{"unserializable":true}}');
+  if (serialized === undefined) {
+    return undefined;
+  }
+  if (serialized.length <= MAX_MCP_ATTRIBUTE_LENGTH) {
+    return serialized;
+  }
+
+  if (typeof value === 'string') {
+    return truncateMcpString(serialized, MAX_MCP_ATTRIBUTE_LENGTH);
+  }
+
+  // Slicing serialized JSON would produce an invalid value for OTel's object-valued GenAI attributes.
+  return JSON.stringify({ _sentry: { truncated: true, originalLength: serialized.length } });
+}
+
+/** Preserves the historical MCP attributes' JSON encoding, including quoted strings. */
+export function serializeLegacyMcpValue(value: unknown): string | undefined {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? undefined : truncateMcpString(serialized, MAX_MCP_ATTRIBUTE_LENGTH);
+  } catch {
+    return '[unserializable]';
+  }
+}

--- a/packages/core/src/integrations/mcp-server/sessionExtraction.ts
+++ b/packages/core/src/integrations/mcp-server/sessionExtraction.ts
@@ -7,33 +7,40 @@
 import {
   CLIENT_ADDRESS_ATTRIBUTE,
   CLIENT_PORT_ATTRIBUTE,
+  MCP_CLIENT_CAPABILITIES_ATTRIBUTE,
+  MCP_CLIENT_EXTENSION_IDS_ATTRIBUTE,
+  MCP_CLIENT_NAME_ATTRIBUTE,
+  MCP_CLIENT_TITLE_ATTRIBUTE,
+  MCP_CLIENT_VERSION_ATTRIBUTE,
   MCP_PROTOCOL_VERSION_ATTRIBUTE,
   MCP_SERVER_NAME_ATTRIBUTE,
   MCP_SERVER_TITLE_ATTRIBUTE,
   MCP_SERVER_VERSION_ATTRIBUTE,
   MCP_SESSION_ID_ATTRIBUTE,
   MCP_TRANSPORT_ATTRIBUTE,
-  NETWORK_PROTOCOL_VERSION_ATTRIBUTE,
+  NETWORK_PROTOCOL_NAME_ATTRIBUTE,
   NETWORK_TRANSPORT_ATTRIBUTE,
 } from './attributes';
-import {
-  getClientInfoForTransport,
-  getProtocolVersionForTransport,
-  getSessionDataForTransport,
-} from './sessionManagement';
-import type {
-  ExtraHandlerData,
-  JsonRpcNotification,
-  JsonRpcRequest,
-  MCPTransport,
-  PartyInfo,
-  SessionData,
-} from './types';
+import { getProtocolVersionForTransport, getSessionDataForTransport } from './sessionManagement';
+import { getBoundedMcpString, getBoundedMcpStringList } from './serialization';
+import type { ExtraHandlerData, JsonRpcRequest, McpAttributes, MCPTransport, PartyInfo, SessionData } from './types';
 import { isValidContentItem } from './validation';
 
 const MCP_PROTOCOL_VERSION_META_KEY = 'io.modelcontextprotocol/protocolVersion';
 const MCP_CLIENT_INFO_META_KEY = 'io.modelcontextprotocol/clientInfo';
+const MCP_CLIENT_CAPABILITIES_META_KEY = 'io.modelcontextprotocol/clientCapabilities';
 const MCP_SERVER_INFO_META_KEY = 'io.modelcontextprotocol/serverInfo';
+
+const STATELESS_MCP_PROTOCOL_VERSION = '2026-07-28';
+const MAX_MCP_PROTOCOL_VERSION_LENGTH = 64;
+
+function isStatelessMcpProtocolVersion(protocolVersion?: string): boolean {
+  return (
+    typeof protocolVersion === 'string' &&
+    /^\d{4}-\d{2}-\d{2}$/.test(protocolVersion) &&
+    protocolVersion >= STATELESS_MCP_PROTOCOL_VERSION
+  );
+}
 
 /**
  * Extracts and validates PartyInfo from an unknown object
@@ -45,13 +52,13 @@ function extractPartyInfo(obj: unknown): PartyInfo {
 
   if (isValidContentItem(obj)) {
     if (typeof obj.name === 'string') {
-      partyInfo.name = obj.name;
+      partyInfo.name = getBoundedMcpString(obj.name);
     }
     if (typeof obj.title === 'string') {
-      partyInfo.title = obj.title;
+      partyInfo.title = getBoundedMcpString(obj.title);
     }
     if (typeof obj.version === 'string') {
-      partyInfo.version = obj.version;
+      partyInfo.version = getBoundedMcpString(obj.version);
     }
   }
 
@@ -67,7 +74,10 @@ export function extractSessionDataFromInitializeRequest(request: JsonRpcRequest)
   const sessionData: SessionData = {};
   if (isValidContentItem(request.params)) {
     if (typeof request.params.protocolVersion === 'string') {
-      sessionData.protocolVersion = request.params.protocolVersion;
+      sessionData.protocolVersion = getBoundedMcpString(
+        request.params.protocolVersion,
+        MAX_MCP_PROTOCOL_VERSION_LENGTH,
+      );
     }
     if (request.params.clientInfo) {
       sessionData.clientInfo = extractPartyInfo(request.params.clientInfo);
@@ -78,20 +88,34 @@ export function extractSessionDataFromInitializeRequest(request: JsonRpcRequest)
 }
 
 /**
- * Extracts session data from an MCP 2026-07-28 request or notification envelope.
- * @param message - JSON-RPC message containing modern request metadata
+ * Extracts per-request data from an MCP 2026-07-28 request envelope.
+ * @param message - JSON-RPC request containing modern request metadata
  * @returns Session data extracted from the message
  */
-export function extractSessionDataFromMessage(message: JsonRpcRequest | JsonRpcNotification): SessionData {
+export function extractSessionDataFromMessage(message: JsonRpcRequest): SessionData {
   const sessionData: SessionData = {};
   if (isValidContentItem(message.params)) {
     if (isValidContentItem(message.params._meta)) {
       const meta = message.params._meta;
       if (typeof meta[MCP_PROTOCOL_VERSION_META_KEY] === 'string') {
-        sessionData.protocolVersion = meta[MCP_PROTOCOL_VERSION_META_KEY];
+        sessionData.protocolVersion = getBoundedMcpString(
+          meta[MCP_PROTOCOL_VERSION_META_KEY],
+          MAX_MCP_PROTOCOL_VERSION_LENGTH,
+        );
       }
       if (meta[MCP_CLIENT_INFO_META_KEY]) {
         sessionData.clientInfo = extractPartyInfo(meta[MCP_CLIENT_INFO_META_KEY]);
+      }
+      if (isValidContentItem(meta[MCP_CLIENT_CAPABILITIES_META_KEY])) {
+        const capabilities = meta[MCP_CLIENT_CAPABILITIES_META_KEY];
+        sessionData.clientCapabilities = getBoundedMcpStringList(
+          Object.keys(capabilities)
+            .filter(capability => capability !== 'experimental' && capability !== 'extensions')
+            .sort(),
+        );
+        if (isValidContentItem(capabilities.extensions)) {
+          sessionData.clientExtensionIds = getBoundedMcpStringList(Object.keys(capabilities.extensions).sort());
+        }
       }
     }
   }
@@ -108,7 +132,7 @@ export function extractSessionDataFromInitializeResponse(result: unknown): Parti
   const sessionData: Partial<SessionData> = {};
   if (isValidContentItem(result)) {
     if (typeof result.protocolVersion === 'string') {
-      sessionData.protocolVersion = result.protocolVersion;
+      sessionData.protocolVersion = getBoundedMcpString(result.protocolVersion, MAX_MCP_PROTOCOL_VERSION_LENGTH);
     }
     if (result.serverInfo) {
       sessionData.serverInfo = extractPartyInfo(result.serverInfo);
@@ -138,18 +162,30 @@ export function extractSessionDataFromResponse(result: unknown): Partial<Session
  * @param transport - MCP transport instance
  * @returns Client attributes for span instrumentation
  */
-export function getClientAttributes(transport: MCPTransport): Record<string, string> {
-  const clientInfo = getClientInfoForTransport(transport);
-  const attributes: Record<string, string> = {};
+export function getClientAttributes(transport: MCPTransport): McpAttributes {
+  const sessionData = getSessionDataForTransport(transport);
+  return buildClientAttributes(sessionData);
+}
+
+/** Build bounded client identity and capability attributes for one MCP operation. */
+export function buildClientAttributes(sessionData?: SessionData): McpAttributes {
+  const clientInfo = sessionData?.clientInfo;
+  const attributes: McpAttributes = {};
 
   if (clientInfo?.name) {
-    attributes['mcp.client.name'] = clientInfo.name;
+    attributes[MCP_CLIENT_NAME_ATTRIBUTE] = getBoundedMcpString(clientInfo.name);
   }
   if (clientInfo?.title) {
-    attributes['mcp.client.title'] = clientInfo.title;
+    attributes[MCP_CLIENT_TITLE_ATTRIBUTE] = getBoundedMcpString(clientInfo.title);
   }
   if (clientInfo?.version) {
-    attributes['mcp.client.version'] = clientInfo.version;
+    attributes[MCP_CLIENT_VERSION_ATTRIBUTE] = getBoundedMcpString(clientInfo.version);
+  }
+  if (sessionData?.clientCapabilities?.length) {
+    attributes[MCP_CLIENT_CAPABILITIES_ATTRIBUTE] = getBoundedMcpStringList(sessionData.clientCapabilities);
+  }
+  if (sessionData?.clientExtensionIds?.length) {
+    attributes[MCP_CLIENT_EXTENSION_IDS_ATTRIBUTE] = getBoundedMcpStringList(sessionData.clientExtensionIds);
   }
 
   return attributes;
@@ -164,13 +200,13 @@ export function buildClientAttributesFromInfo(clientInfo?: PartyInfo): Record<st
   const attributes: Record<string, string> = {};
 
   if (clientInfo?.name) {
-    attributes['mcp.client.name'] = clientInfo.name;
+    attributes[MCP_CLIENT_NAME_ATTRIBUTE] = getBoundedMcpString(clientInfo.name);
   }
   if (clientInfo?.title) {
-    attributes['mcp.client.title'] = clientInfo.title;
+    attributes[MCP_CLIENT_TITLE_ATTRIBUTE] = getBoundedMcpString(clientInfo.title);
   }
   if (clientInfo?.version) {
-    attributes['mcp.client.version'] = clientInfo.version;
+    attributes[MCP_CLIENT_VERSION_ATTRIBUTE] = getBoundedMcpString(clientInfo.version);
   }
 
   return attributes;
@@ -186,13 +222,13 @@ export function getServerAttributes(transport: MCPTransport): Record<string, str
   const attributes: Record<string, string> = {};
 
   if (serverInfo?.name) {
-    attributes[MCP_SERVER_NAME_ATTRIBUTE] = serverInfo.name;
+    attributes[MCP_SERVER_NAME_ATTRIBUTE] = getBoundedMcpString(serverInfo.name);
   }
   if (serverInfo?.title) {
-    attributes[MCP_SERVER_TITLE_ATTRIBUTE] = serverInfo.title;
+    attributes[MCP_SERVER_TITLE_ATTRIBUTE] = getBoundedMcpString(serverInfo.title);
   }
   if (serverInfo?.version) {
-    attributes[MCP_SERVER_VERSION_ATTRIBUTE] = serverInfo.version;
+    attributes[MCP_SERVER_VERSION_ATTRIBUTE] = getBoundedMcpString(serverInfo.version);
   }
 
   return attributes;
@@ -207,13 +243,13 @@ export function buildServerAttributesFromInfo(serverInfo?: PartyInfo): Record<st
   const attributes: Record<string, string> = {};
 
   if (serverInfo?.name) {
-    attributes[MCP_SERVER_NAME_ATTRIBUTE] = serverInfo.name;
+    attributes[MCP_SERVER_NAME_ATTRIBUTE] = getBoundedMcpString(serverInfo.name);
   }
   if (serverInfo?.title) {
-    attributes[MCP_SERVER_TITLE_ATTRIBUTE] = serverInfo.title;
+    attributes[MCP_SERVER_TITLE_ATTRIBUTE] = getBoundedMcpString(serverInfo.title);
   }
   if (serverInfo?.version) {
-    attributes[MCP_SERVER_VERSION_ATTRIBUTE] = serverInfo.version;
+    attributes[MCP_SERVER_VERSION_ATTRIBUTE] = getBoundedMcpString(serverInfo.version);
   }
 
   return attributes;
@@ -243,23 +279,33 @@ export function extractClientInfo(extra: ExtraHandlerData): {
  * @param transport - MCP transport instance
  * @returns Transport type mapping for span attributes
  */
-export function getTransportTypes(transport: MCPTransport): { mcpTransport: string; networkTransport: string } {
+export function getTransportTypes(transport: MCPTransport): {
+  mcpTransport: string;
+  networkTransport: string;
+  networkProtocolName?: string;
+} {
   if (!transport?.constructor) {
     return { mcpTransport: 'unknown', networkTransport: 'unknown' };
   }
   const transportName = typeof transport.constructor?.name === 'string' ? transport.constructor.name : 'unknown';
   let networkTransport = 'unknown';
+  let networkProtocolName: string | undefined;
 
   const lowerTransportName = transportName.toLowerCase();
   if (lowerTransportName.includes('stdio')) {
     networkTransport = 'pipe';
+  } else if (lowerTransportName.includes('websocket')) {
+    networkTransport = 'tcp';
+    networkProtocolName = 'websocket';
   } else if (lowerTransportName.includes('http') || lowerTransportName.includes('sse')) {
     networkTransport = 'tcp';
+    networkProtocolName = 'http';
   }
 
   return {
     mcpTransport: transportName,
     networkTransport,
+    networkProtocolName,
   };
 }
 
@@ -273,22 +319,30 @@ export function getTransportTypes(transport: MCPTransport): { mcpTransport: stri
 export function buildTransportAttributes(
   transport: MCPTransport,
   extra?: ExtraHandlerData,
-): Record<string, string | number> {
+  operationSessionData?: SessionData,
+): McpAttributes {
   const sessionId = transport && 'sessionId' in transport ? transport.sessionId : undefined;
   const clientInfo = extra ? extractClientInfo(extra) : {};
-  const { mcpTransport, networkTransport } = getTransportTypes(transport);
-  const clientAttributes = getClientAttributes(transport);
+  const { mcpTransport, networkTransport, networkProtocolName } = getTransportTypes(transport);
+  const clientAttributes = operationSessionData
+    ? buildClientAttributes(operationSessionData)
+    : getClientAttributes(transport);
   const serverAttributes = getServerAttributes(transport);
   const protocolVersion = getProtocolVersionForTransport(transport);
+  const operationProtocolVersion = operationSessionData?.protocolVersion || protocolVersion;
 
   const attributes = {
-    ...(sessionId && { [MCP_SESSION_ID_ATTRIBUTE]: sessionId }),
+    ...(sessionId && !isStatelessMcpProtocolVersion(operationProtocolVersion)
+      ? { [MCP_SESSION_ID_ATTRIBUTE]: getBoundedMcpString(sessionId) }
+      : {}),
     ...(clientInfo.address && { [CLIENT_ADDRESS_ATTRIBUTE]: clientInfo.address }),
     ...(clientInfo.port && { [CLIENT_PORT_ATTRIBUTE]: clientInfo.port }),
     [MCP_TRANSPORT_ATTRIBUTE]: mcpTransport,
     [NETWORK_TRANSPORT_ATTRIBUTE]: networkTransport,
-    [NETWORK_PROTOCOL_VERSION_ATTRIBUTE]: '2.0',
-    ...(protocolVersion && { [MCP_PROTOCOL_VERSION_ATTRIBUTE]: protocolVersion }),
+    ...(networkProtocolName && { [NETWORK_PROTOCOL_NAME_ATTRIBUTE]: networkProtocolName }),
+    ...(operationProtocolVersion && {
+      [MCP_PROTOCOL_VERSION_ATTRIBUTE]: getBoundedMcpString(operationProtocolVersion, MAX_MCP_PROTOCOL_VERSION_LENGTH),
+    }),
     ...clientAttributes,
     ...serverAttributes,
   };

--- a/packages/core/src/integrations/mcp-server/sessionManagement.ts
+++ b/packages/core/src/integrations/mcp-server/sessionManagement.ts
@@ -1,50 +1,28 @@
 /**
  * Session data management for MCP server instrumentation
  *
- * Uses sessionId as the primary key for stateful transports. This handles the wrapper
- * transport pattern (e.g., NodeStreamableHTTPServerTransport wrapping WebStandardStreamableHTTPServerTransport)
- * where different methods may receive different `this` values but share the same sessionId.
- *
- * Falls back to WeakMap by transport instance for stateless transports (no sessionId).
+ * Session data is scoped to the transport captured by the instrumentation wrapper. Session ids
+ * are peer-controlled and can be reused by independent transports.
  */
 
 import type { MCPTransport, PartyInfo, SessionData } from './types';
 
-/**
- * Session-scoped data storage for stateful transports (with sessionId)
- * @internal Using sessionId as key handles wrapper transport patterns
- */
-const sessionToSessionData = new Map<string, SessionData>();
+const transportToSessionData = new WeakMap<MCPTransport, SessionData>();
 
 /**
- * Transport-scoped data storage fallback for stateless transports (no sessionId)
- * @internal WeakMap allows automatic cleanup when transport is garbage collected
- */
-const statelessSessionData = new WeakMap<MCPTransport, SessionData>();
-
-/**
- * Gets session data for a transport, checking sessionId first then fallback
+ * Gets session data for a transport identity.
  * @internal
  */
 function getSessionData(transport: MCPTransport): SessionData | undefined {
-  const sessionId = transport.sessionId;
-  if (sessionId) {
-    return sessionToSessionData.get(sessionId);
-  }
-  return statelessSessionData.get(transport);
+  return transportToSessionData.get(transport);
 }
 
 /**
- * Sets session data for a transport, using sessionId when available
+ * Sets session data for a transport identity.
  * @internal
  */
 function setSessionData(transport: MCPTransport, data: SessionData): void {
-  const sessionId = transport.sessionId;
-  if (sessionId) {
-    sessionToSessionData.set(sessionId, data);
-  } else {
-    statelessSessionData.set(transport, data);
-  }
+  transportToSessionData.set(transport, data);
 }
 
 /**
@@ -53,8 +31,6 @@ function setSessionData(transport: MCPTransport, data: SessionData): void {
  * @param sessionData - Session data to store
  */
 export function storeSessionDataForTransport(transport: MCPTransport, sessionData: SessionData): void {
-  // For stateful transports, always store (sessionId is the key)
-  // For stateless transports, also store (transport instance is the key)
   setSessionData(transport, sessionData);
 }
 
@@ -100,10 +76,5 @@ export function getSessionDataForTransport(transport: MCPTransport): SessionData
  * @param transport - MCP transport instance
  */
 export function cleanupSessionDataForTransport(transport: MCPTransport): void {
-  const sessionId = transport.sessionId;
-  if (sessionId) {
-    sessionToSessionData.delete(sessionId);
-  }
-  // Note: WeakMap entries are automatically cleaned up when transport is GC'd
-  // No explicit delete needed for statelessSessionData
+  transportToSessionData.delete(transport);
 }

--- a/packages/core/src/integrations/mcp-server/spanCompletion.ts
+++ b/packages/core/src/integrations/mcp-server/spanCompletion.ts
@@ -1,0 +1,225 @@
+import { SPAN_STATUS_ERROR } from '../../tracing';
+import {
+  ERROR_TYPE_ATTRIBUTE,
+  MCP_PROTOCOL_VERSION_ATTRIBUTE,
+  MCP_REQUEST_OUTCOME_ATTRIBUTE,
+  RPC_RESPONSE_STATUS_CODE_ATTRIBUTE,
+} from './attributes';
+import {
+  deleteSpanForOutgoingRequest,
+  deleteSpanForResponseSend,
+  finishSpan,
+  takePendingSpansForTransport,
+  takeSpanForCancelledRequest,
+  takeSpanForOutgoingRequest,
+  takeSpanForOutgoingResponse,
+  takeSpanForRequest,
+} from './correlation';
+import { getJsonRpcErrorAttributes, isMcpServerError } from './outcome';
+import { filterMcpPiiFromSpanData } from './piiFiltering';
+import {
+  extractCommonResultAttributes,
+  extractPromptResultAttributes,
+  extractToolResultAttributes,
+} from './resultExtraction';
+import { getBoundedMcpString } from './serialization';
+import {
+  buildServerAttributesFromInfo,
+  extractSessionDataFromInitializeResponse,
+  extractSessionDataFromResponse,
+} from './sessionExtraction';
+import { updateSessionDataForTransport } from './sessionManagement';
+import type { JsonRpcError, MCPTransport, RequestId, RequestSpanMapValue, ResolvedMcpOptions } from './types';
+
+export function completeSpanWithResults(
+  transport: MCPTransport,
+  requestId: RequestId,
+  result: unknown,
+  options: ResolvedMcpOptions,
+  error?: JsonRpcError,
+): void {
+  const spanData = takeSpanForRequest(transport, requestId);
+  if (spanData) {
+    completeTakenSpanWithResults(transport, spanData, result, options, error);
+  }
+}
+
+export function completeTakenSpanWithResults(
+  transport: MCPTransport,
+  spanData: RequestSpanMapValue,
+  result: unknown,
+  options: ResolvedMcpOptions,
+  error?: JsonRpcError,
+): void {
+  deleteSpanForResponseSend(transport, spanData);
+  if (spanData.finished) {
+    return;
+  }
+
+  const { span, method, protocolVersion } = spanData;
+  const responseSessionData =
+    method === 'initialize' ? extractSessionDataFromInitializeResponse(result) : extractSessionDataFromResponse(result);
+  if (method === 'initialize' && (responseSessionData.protocolVersion || responseSessionData.serverInfo)) {
+    updateSessionDataForTransport(transport, responseSessionData);
+  }
+  const responseAttributes: Record<string, string | number> = {
+    ...buildServerAttributesFromInfo(responseSessionData.serverInfo),
+  };
+  if (responseSessionData.protocolVersion) {
+    responseAttributes[MCP_PROTOCOL_VERSION_ATTRIBUTE] = responseSessionData.protocolVersion;
+  }
+  if (Object.keys(responseAttributes).length > 0) {
+    span.setAttributes(responseAttributes);
+  }
+
+  if (error) {
+    span.setAttributes(getJsonRpcErrorAttributes(error, protocolVersion));
+    if (isMcpServerError(error, protocolVersion)) {
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: getBoundedMcpString(error.message, 256) });
+    }
+  } else {
+    const resultAttributes = extractCommonResultAttributes(method, result);
+    if (method === 'tools/call') {
+      Object.assign(resultAttributes, extractToolResultAttributes(result, options.recordOutputs));
+    } else if (method === 'prompts/get') {
+      Object.assign(resultAttributes, extractPromptResultAttributes(result, options.recordOutputs));
+    }
+    if (Object.keys(resultAttributes).length > 0) {
+      span.setAttributes(filterMcpPiiFromSpanData(resultAttributes, spanData.includeUserInfo));
+    }
+    if (resultAttributes[ERROR_TYPE_ATTRIBUTE] === 'tool_error') {
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: 'tool_error' });
+    }
+  }
+
+  finishSpan(spanData, currentSpan => currentSpan.end());
+}
+
+export function cancelSpanForRequest(transport: MCPTransport, requestId: RequestId): void {
+  cancelSpan(takeSpanForCancelledRequest(transport, requestId));
+}
+
+export function failSpanForResponseSend(transport: MCPTransport, spanData: RequestSpanMapValue, error: unknown): void {
+  deleteSpanForResponseSend(transport, spanData);
+  failSpan(spanData, error, 'send_error');
+}
+
+export function completeSpanForOutgoingResponse(
+  transport: MCPTransport,
+  requestId: RequestId,
+  result: unknown,
+  error?: JsonRpcError,
+): void {
+  const spanData = takeSpanForOutgoingResponse(transport, requestId);
+  if (!spanData) {
+    return;
+  }
+
+  completeTakenSpanForOutgoingResponse(transport, spanData, result, error);
+}
+
+export function completeTakenSpanForOutgoingResponse(
+  transport: MCPTransport,
+  spanData: RequestSpanMapValue,
+  result: unknown,
+  error?: JsonRpcError,
+): void {
+  deleteSpanForOutgoingRequest(transport, spanData);
+  finishSpan(spanData, span => {
+    if (error) {
+      span.setAttributes({
+        [ERROR_TYPE_ATTRIBUTE]: String(error.code),
+        [RPC_RESPONSE_STATUS_CODE_ATTRIBUTE]: String(error.code),
+      });
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: getBoundedMcpString(error.message, 256) });
+    } else {
+      const resultAttributes = extractCommonResultAttributes(spanData.method, result);
+      if (Object.keys(resultAttributes).length > 0) {
+        span.setAttributes(filterMcpPiiFromSpanData(resultAttributes, spanData.includeUserInfo));
+      }
+    }
+    span.end();
+  });
+}
+
+export function failSpanForOutgoingRequest(
+  transport: MCPTransport,
+  requestId: RequestId,
+  error: unknown,
+  outcome: 'send_error' | 'response_error',
+): void {
+  const spanData = takeSpanForOutgoingRequest(transport, requestId);
+  if (spanData) {
+    failTakenSpanForOutgoingRequest(transport, spanData, error, outcome);
+  }
+}
+
+export function failTakenSpanForOutgoingRequest(
+  transport: MCPTransport,
+  spanData: RequestSpanMapValue,
+  error: unknown,
+  outcome: 'send_error' | 'response_error',
+): void {
+  deleteSpanForOutgoingRequest(transport, spanData);
+  failSpan(spanData, error, outcome);
+}
+
+export function cancelTakenSpanForOutgoingRequest(transport: MCPTransport, spanData: RequestSpanMapValue): void {
+  deleteSpanForOutgoingRequest(transport, spanData);
+  cancelSpan(spanData);
+}
+
+export function cleanupPendingSpansForTransport(transport: MCPTransport): void {
+  for (const spanData of takePendingSpansForTransport(transport)) {
+    cancelSpan(spanData);
+  }
+}
+
+function cancelSpan(spanData?: RequestSpanMapValue): void {
+  if (!spanData) {
+    return;
+  }
+  finishSpan(spanData, span => {
+    span.setAttributes({ [MCP_REQUEST_OUTCOME_ATTRIBUTE]: 'cancelled' });
+    span.end();
+  });
+}
+
+function failSpan(
+  spanData: RequestSpanMapValue | undefined,
+  error: unknown,
+  outcome: 'send_error' | 'response_error',
+): void {
+  if (!spanData) {
+    return;
+  }
+  finishSpan(spanData, span => {
+    span.setAttributes({
+      [ERROR_TYPE_ATTRIBUTE]: getErrorType(error),
+      [MCP_REQUEST_OUTCOME_ATTRIBUTE]: outcome,
+    });
+    span.setStatus({
+      code: SPAN_STATUS_ERROR,
+      message: outcome === 'send_error' ? 'transport_send_error' : 'response_processing_error',
+    });
+    span.end();
+  });
+}
+
+function getErrorType(error: unknown): string {
+  try {
+    if (error && typeof error === 'object') {
+      const name = (error as { name?: unknown }).name;
+      if (typeof name === 'string' && name) {
+        return name;
+      }
+      const constructorName = (error as { constructor?: { name?: unknown } }).constructor?.name;
+      if (typeof constructorName === 'string' && constructorName) {
+        return constructorName;
+      }
+    }
+  } catch {
+    // Ignore hostile error objects and fall back to their primitive type.
+  }
+  return typeof error;
+}

--- a/packages/core/src/integrations/mcp-server/spans.ts
+++ b/packages/core/src/integrations/mcp-server/spans.ts
@@ -6,12 +6,11 @@
  */
 
 import { getClient } from '../../currentScopes';
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
-} from '../../semanticAttributes';
-import { startSpan } from '../../tracing';
+import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
+import { startInactiveSpan, startSpan } from '../../tracing';
+import type { SpanLink } from '../../types/link';
+import type { Span } from '../../types/span';
+import type { StartSpanOptions } from '../../types/startSpanOptions';
 import { buildTransportAttributes, buildTypeSpecificAttributes } from './attributeExtraction';
 import {
   MCP_FUNCTION_ORIGIN_VALUE,
@@ -19,19 +18,24 @@ import {
   MCP_NOTIFICATION_CLIENT_TO_SERVER_OP_VALUE,
   MCP_NOTIFICATION_ORIGIN_VALUE,
   MCP_NOTIFICATION_SERVER_TO_CLIENT_OP_VALUE,
-  MCP_ROUTE_SOURCE_VALUE,
   MCP_SERVER_OP_VALUE,
+  SENTRY_KIND_ATTRIBUTE,
 } from './attributes';
 import { extractTargetInfo } from './methodConfig';
 import { filterMcpPiiFromSpanData } from './piiFiltering';
+import { getBoundedMcpString } from './serialization';
 import type {
   ExtraHandlerData,
   JsonRpcNotification,
   JsonRpcRequest,
+  McpAttributes,
   McpSpanConfig,
   MCPTransport,
   ResolvedMcpOptions,
+  SessionData,
 } from './types';
+
+const MCP_CLIENT_OP_VALUE = 'mcp.client';
 
 /**
  * Creates a span name based on the method and target
@@ -53,26 +57,35 @@ function createSpanName(method: string, target?: string): string {
 function buildSentryAttributes(type: McpSpanConfig['type']): Record<string, string> {
   let op: string;
   let origin: string;
+  let spanKind: 'client' | 'server';
 
   switch (type) {
     case 'request':
       op = MCP_SERVER_OP_VALUE;
       origin = MCP_FUNCTION_ORIGIN_VALUE;
+      spanKind = 'server';
+      break;
+    case 'request-outgoing':
+      op = MCP_CLIENT_OP_VALUE;
+      origin = MCP_FUNCTION_ORIGIN_VALUE;
+      spanKind = 'client';
       break;
     case 'notification-incoming':
       op = MCP_NOTIFICATION_CLIENT_TO_SERVER_OP_VALUE;
       origin = MCP_NOTIFICATION_ORIGIN_VALUE;
+      spanKind = 'server';
       break;
     case 'notification-outgoing':
       op = MCP_NOTIFICATION_SERVER_TO_CLIENT_OP_VALUE;
       origin = MCP_NOTIFICATION_ORIGIN_VALUE;
+      spanKind = 'client';
       break;
   }
 
   return {
     [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: origin,
-    [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: MCP_ROUTE_SOURCE_VALUE,
+    [SENTRY_KIND_ATTRIBUTE]: spanKind,
   };
 }
 
@@ -83,39 +96,44 @@ function buildSentryAttributes(type: McpSpanConfig['type']): Record<string, stri
  * @returns Created span
  */
 function createMcpSpan(config: McpSpanConfig): unknown {
-  const { type, message, transport, extra, callback, options } = config;
-  const { method } = message;
+  const { type, message, transport, extra, callback, options, operationSessionData, links, parentSpan } = config;
+  const method = getBoundedMcpString(message.method);
   const params = message.params;
 
   // Determine span name based on type and OTEL conventions
   let spanName: string;
-  if (type === 'request') {
+  if (type === 'request' || type === 'request-outgoing') {
     const targetInfo = extractTargetInfo(method, params || {});
-    spanName = createSpanName(method, targetInfo.target);
+    spanName = createSpanName(method, targetInfo.includeTargetInSpanName ? targetInfo.target : undefined);
   } else {
     // For notifications, use method name directly per OpenTelemetry conventions
     spanName = method;
   }
 
-  const rawAttributes: Record<string, string | number> = {
-    ...buildTransportAttributes(transport, extra),
+  const rawAttributes: McpAttributes = {
+    ...buildTransportAttributes(transport, extra, operationSessionData),
     [MCP_METHOD_NAME_ATTRIBUTE]: method,
-    ...buildTypeSpecificAttributes(type, message, params, options?.recordInputs),
+    ...buildTypeSpecificAttributes(
+      type === 'request-outgoing' ? 'request' : type,
+      message,
+      params,
+      options?.recordInputs,
+    ),
     ...buildSentryAttributes(type),
   };
 
   const client = getClient();
   const userInfo = Boolean(client?.getDataCollectionOptions().userInfo);
-  const attributes = filterMcpPiiFromSpanData(rawAttributes, userInfo) as Record<string, string | number>;
+  const attributes = filterMcpPiiFromSpanData(rawAttributes, userInfo);
+  const spanOptions: StartSpanOptions = { name: spanName, attributes };
+  if (links) {
+    spanOptions.links = links;
+  }
+  if (parentSpan) {
+    spanOptions.parentSpan = parentSpan;
+  }
 
-  return startSpan(
-    {
-      name: spanName,
-      forceTransaction: true,
-      attributes,
-    },
-    callback,
-  );
+  return startSpan(spanOptions, callback);
 }
 
 /**
@@ -133,6 +151,9 @@ export function createMcpNotificationSpan(
   extra: ExtraHandlerData,
   options: ResolvedMcpOptions,
   callback: () => unknown,
+  operationSessionData?: SessionData,
+  links?: SpanLink[],
+  parentSpan?: Span,
 ): unknown {
   return createMcpSpan({
     type: 'notification-incoming',
@@ -141,6 +162,9 @@ export function createMcpNotificationSpan(
     extra,
     callback,
     options,
+    operationSessionData,
+    links,
+    parentSpan,
   });
 }
 
@@ -157,6 +181,8 @@ export function createMcpOutgoingNotificationSpan(
   transport: MCPTransport,
   options: ResolvedMcpOptions,
   callback: () => unknown,
+  operationSessionData?: SessionData,
+  parentSpan?: Span,
 ): unknown {
   return createMcpSpan({
     type: 'notification-outgoing',
@@ -164,7 +190,40 @@ export function createMcpOutgoingNotificationSpan(
     transport,
     options,
     callback,
+    operationSessionData,
+    parentSpan,
   });
+}
+
+/** Creates a long-lived client span for a server-to-client request. */
+export function createMcpOutgoingRequestSpan(
+  jsonRpcMessage: JsonRpcRequest,
+  transport: MCPTransport,
+  options: ResolvedMcpOptions,
+  operationSessionData?: SessionData,
+  parentSpan?: Span,
+): Span {
+  const { params } = jsonRpcMessage;
+  const method = getBoundedMcpString(jsonRpcMessage.method);
+  const targetInfo = extractTargetInfo(method, params || {});
+  const rawAttributes: McpAttributes = {
+    ...buildTransportAttributes(transport, undefined, operationSessionData),
+    [MCP_METHOD_NAME_ATTRIBUTE]: method,
+    ...buildTypeSpecificAttributes('request', jsonRpcMessage, params, options.recordInputs),
+    ...buildSentryAttributes('request-outgoing'),
+  };
+  const client = getClient();
+  const userInfo = Boolean(client?.getDataCollectionOptions().userInfo);
+  const spanOptions: StartSpanOptions = {
+    name: createSpanName(method, targetInfo.includeTargetInSpanName ? targetInfo.target : undefined),
+    op: MCP_CLIENT_OP_VALUE,
+    attributes: filterMcpPiiFromSpanData(rawAttributes, userInfo),
+  };
+  if (parentSpan) {
+    spanOptions.parentSpan = parentSpan;
+  }
+
+  return startInactiveSpan(spanOptions);
 }
 
 /**
@@ -180,20 +239,18 @@ export function buildMcpServerSpanConfig(
   transport: MCPTransport,
   extra?: ExtraHandlerData,
   options?: ResolvedMcpOptions,
-): {
-  name: string;
-  op: string;
-  forceTransaction: boolean;
-  attributes: Record<string, string | number>;
-} {
-  const { method } = jsonRpcMessage;
+  operationSessionData?: SessionData,
+  links?: SpanLink[],
+  parentSpan?: Span,
+): StartSpanOptions {
+  const method = getBoundedMcpString(jsonRpcMessage.method);
   const params = jsonRpcMessage.params;
 
   const targetInfo = extractTargetInfo(method, params || {});
-  const spanName = createSpanName(method, targetInfo.target);
+  const spanName = createSpanName(method, targetInfo.includeTargetInSpanName ? targetInfo.target : undefined);
 
-  const rawAttributes: Record<string, string | number> = {
-    ...buildTransportAttributes(transport, extra),
+  const rawAttributes: McpAttributes = {
+    ...buildTransportAttributes(transport, extra, operationSessionData),
     [MCP_METHOD_NAME_ATTRIBUTE]: method,
     ...buildTypeSpecificAttributes('request', jsonRpcMessage, params, options?.recordInputs),
     ...buildSentryAttributes('request'),
@@ -201,12 +258,18 @@ export function buildMcpServerSpanConfig(
 
   const client = getClient();
   const userInfo = Boolean(client?.getDataCollectionOptions().userInfo);
-  const attributes = filterMcpPiiFromSpanData(rawAttributes, userInfo) as Record<string, string | number>;
+  const attributes = filterMcpPiiFromSpanData(rawAttributes, userInfo);
 
-  return {
+  const spanOptions: StartSpanOptions = {
     name: spanName,
     op: MCP_SERVER_OP_VALUE,
-    forceTransaction: true,
     attributes,
   };
+  if (links) {
+    spanOptions.links = links;
+  }
+  if (parentSpan) {
+    spanOptions.parentSpan = parentSpan;
+  }
+  return spanOptions;
 }

--- a/packages/core/src/integrations/mcp-server/tracePropagation.ts
+++ b/packages/core/src/integrations/mcp-server/tracePropagation.ts
@@ -1,0 +1,94 @@
+import type { SpanContextData } from '../../types/span';
+import { MAX_BAGGAGE_STRING_LENGTH } from '../../utils/baggage';
+import { isPlainObject } from '../../utils/is';
+
+const ZERO_TRACE_ID = '00000000000000000000000000000000';
+const ZERO_SPAN_ID = '0000000000000000';
+const MAX_TRACEPARENT_LENGTH = 512;
+const MAX_TRACESTATE_LENGTH = 512;
+const W3C_TRACEPARENT_REGEXP = /^\s?((?!ff)[0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})(-.*)?\s?$/;
+
+/** Trace propagation values extracted from an MCP request's `params._meta`. */
+export interface McpTraceContext {
+  /** The original W3C traceparent value. */
+  traceparent: string;
+  /** The traceparent converted to the format accepted by `continueTrace`. */
+  sentryTrace: string;
+  /** W3C baggage, passed through for Sentry dynamic sampling context extraction. */
+  baggage?: string;
+  /** W3C tracestate, preserved for callers which support it. */
+  tracestate?: string;
+  /** The remote parent context, suitable for use in a span link. */
+  parentContext: SpanContextData;
+}
+
+/**
+ * Extracts the W3C trace context carried in an MCP request's `params._meta`.
+ *
+ * Sentry's `continueTrace` consumes the Sentry trace header format, so a valid
+ * W3C traceparent is converted while its original parent context is retained.
+ */
+export function extractMcpTraceContext(params: unknown): McpTraceContext | undefined {
+  if (!isPlainObject(params) || !isPlainObject(params._meta)) {
+    return undefined;
+  }
+
+  const { traceparent, baggage, tracestate } = params._meta;
+  const parsedTraceparent = parseW3CTraceparent(traceparent);
+
+  if (!parsedTraceparent) {
+    return undefined;
+  }
+
+  const { traceId, parentSpanId, sampled } = parsedTraceparent;
+
+  return {
+    traceparent: parsedTraceparent.traceparent,
+    sentryTrace: `${traceId}-${parentSpanId}-${sampled ? '1' : '0'}`,
+    ...(isValidOptionalPropagationField(baggage, MAX_BAGGAGE_STRING_LENGTH) ? { baggage } : {}),
+    ...(isValidOptionalPropagationField(tracestate, MAX_TRACESTATE_LENGTH) ? { tracestate } : {}),
+    parentContext: {
+      traceId,
+      spanId: parentSpanId,
+      isRemote: true,
+      traceFlags: sampled ? 1 : 0,
+    },
+  };
+}
+
+function parseW3CTraceparent(
+  traceparent: unknown,
+): { traceparent: string; traceId: string; parentSpanId: string; sampled: boolean } | undefined {
+  if (typeof traceparent !== 'string' || traceparent.length > MAX_TRACEPARENT_LENGTH) {
+    return undefined;
+  }
+
+  const match = W3C_TRACEPARENT_REGEXP.exec(traceparent);
+  if (!match) {
+    return undefined;
+  }
+
+  const version = match[1];
+  const traceId = match[2];
+  const parentSpanId = match[3];
+  const flags = match[4];
+  const extraFields = match[5];
+
+  if (
+    !version ||
+    !traceId ||
+    !parentSpanId ||
+    !flags ||
+    traceId === ZERO_TRACE_ID ||
+    parentSpanId === ZERO_SPAN_ID ||
+    (version === '00' && extraFields)
+  ) {
+    return undefined;
+  }
+
+  return { traceparent, traceId, parentSpanId, sampled: Number.parseInt(flags, 16) % 2 === 1 };
+}
+
+function isValidOptionalPropagationField(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= maxLength;
+}

--- a/packages/core/src/integrations/mcp-server/transport.ts
+++ b/packages/core/src/integrations/mcp-server/transport.ts
@@ -6,21 +6,32 @@
  */
 
 import { getIsolationScope, withIsolationScope } from '../../currentScopes';
-import { startInactiveSpan, withActiveSpan } from '../../tracing';
-import { isObjectLike } from '../../utils/is';
+import { continueTrace, startInactiveSpan, startNewTrace, withActiveSpan } from '../../tracing';
+import type { SpanLink } from '../../types/link';
+import { chainAndCopyPromiseLike } from '../../utils/chain-and-copy-promiselike';
+import { isThenable } from '../../utils/is';
 import { fill } from '../../utils/object';
-import { MCP_PROTOCOL_VERSION_ATTRIBUTE } from './attributes';
-import { cleanupPendingSpansForTransport, completeSpanWithResults, storeSpanForRequest } from './correlation';
+import { getActiveSpan } from '../../utils/spanUtils';
+import { storeSpanForRequest, takeSpanForOutgoingResponse } from './correlation';
 import { captureError } from './errorCapture';
+import { extractSessionDataFromInitializeRequest, extractSessionDataFromMessage } from './sessionExtraction';
 import {
-  buildClientAttributesFromInfo,
-  extractSessionDataFromInitializeRequest,
-  extractSessionDataFromMessage,
-} from './sessionExtraction';
-import { cleanupSessionDataForTransport, updateSessionDataForTransport } from './sessionManagement';
-import { buildMcpServerSpanConfig, createMcpNotificationSpan, createMcpOutgoingNotificationSpan } from './spans';
+  cleanupSessionDataForTransport,
+  getSessionDataForTransport,
+  updateSessionDataForTransport,
+} from './sessionManagement';
+import {
+  cancelSpanForRequest,
+  cleanupPendingSpansForTransport,
+  completeTakenSpanForOutgoingResponse,
+  failTakenSpanForOutgoingRequest,
+} from './spanCompletion';
+import { buildMcpServerSpanConfig, createMcpNotificationSpan } from './spans';
+import { extractMcpTraceContext } from './tracePropagation';
 import type { ExtraHandlerData, MCPTransport, ResolvedMcpOptions, SessionData } from './types';
 import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse } from './validation';
+
+export { wrapTransportSend } from './transportSend';
 
 /**
  * Wraps transport.onmessage to create spans for incoming messages.
@@ -33,6 +44,34 @@ export function wrapTransportOnMessage(transport: MCPTransport, options: Resolve
   if (transport.onmessage) {
     fill(transport, 'onmessage', originalOnMessage => {
       return function (this: MCPTransport, message: unknown, extra?: unknown) {
+        const response = isJsonRpcResponse(message) ? message : undefined;
+        if (response?.id != null) {
+          const responseId = response.id;
+          const spanData = takeSpanForOutgoingResponse(transport, responseId);
+          if (spanData) {
+            return withActiveSpan(spanData.span, () => {
+              let result: unknown;
+              try {
+                result = (originalOnMessage as (...args: unknown[]) => unknown).call(this, response, extra);
+              } catch (error) {
+                failTakenSpanForOutgoingRequest(transport, spanData, error, 'response_error');
+                throw error;
+              }
+
+              if (isThenable(result)) {
+                return chainAndCopyPromiseLike(
+                  result as PromiseLike<unknown> & Record<string, unknown>,
+                  () => completeTakenSpanForOutgoingResponse(transport, spanData, response.result, response.error),
+                  error => failTakenSpanForOutgoingRequest(transport, spanData, error, 'response_error'),
+                );
+              }
+
+              completeTakenSpanForOutgoingResponse(transport, spanData, response.result, response.error);
+              return result;
+            });
+          }
+        }
+
         const request = isJsonRpcRequest(message) ? message : undefined;
         const notification = isJsonRpcNotification(message) ? message : undefined;
         const jsonRpcMessage = request || notification;
@@ -40,11 +79,12 @@ export function wrapTransportOnMessage(transport: MCPTransport, options: Resolve
 
         if (jsonRpcMessage) {
           try {
-            messageSessionData =
-              request?.method === 'initialize'
+            messageSessionData = request
+              ? request.method === 'initialize'
                 ? extractSessionDataFromInitializeRequest(request)
-                : extractSessionDataFromMessage(jsonRpcMessage);
-            if (messageSessionData.protocolVersion || messageSessionData.clientInfo) {
+                : applyModernTransportRevision(extractSessionDataFromMessage(request), extra as ExtraHandlerData)
+              : extractNotificationSessionData(extra as ExtraHandlerData);
+            if (request?.method === 'initialize') {
               updateSessionDataForTransport(transport, messageSessionData);
             }
           } catch {
@@ -52,33 +92,78 @@ export function wrapTransportOnMessage(transport: MCPTransport, options: Resolve
           }
         }
 
-        if (request) {
+        if (jsonRpcMessage) {
+          const ambientSpan = getActiveSpan();
+          const traceContext = extractMcpTraceContext(jsonRpcMessage.params);
+          const links =
+            ambientSpan && traceContext
+              ? getAmbientSpanLinks(ambientSpan.spanContext(), traceContext?.parentContext)
+              : undefined;
+          const parentSpan = traceContext ? undefined : ambientSpan;
           const isolationScope = getIsolationScope().clone();
 
           return withIsolationScope(isolationScope, () => {
-            const spanConfig = buildMcpServerSpanConfig(request, transport, extra as ExtraHandlerData, options);
-            const span = startInactiveSpan(spanConfig);
+            const runWithMessageTrace = (): unknown => {
+              const operationSessionData =
+                request?.method === 'initialize' || messageSessionData?.protocolVersion
+                  ? messageSessionData
+                  : undefined;
 
-            if (request.method === 'initialize' && messageSessionData) {
-              span.setAttributes({
-                ...buildClientAttributesFromInfo(messageSessionData.clientInfo),
-                ...(messageSessionData.protocolVersion && {
-                  [MCP_PROTOCOL_VERSION_ATTRIBUTE]: messageSessionData.protocolVersion,
-                }),
-              });
+              if (request) {
+                const spanConfig = buildMcpServerSpanConfig(
+                  request,
+                  transport,
+                  extra as ExtraHandlerData,
+                  options,
+                  operationSessionData,
+                  links,
+                  parentSpan,
+                );
+                const span = startInactiveSpan(spanConfig);
+
+                storeSpanForRequest(
+                  transport,
+                  request.id,
+                  span,
+                  request.method,
+                  operationSessionData ?? getSessionDataForTransport(transport),
+                  traceContext,
+                );
+
+                return withActiveSpan(span, () => {
+                  return (originalOnMessage as (...args: unknown[]) => unknown).call(this, request, extra);
+                });
+              }
+
+              if (notification!.method === 'notifications/cancelled') {
+                const cancelledRequestId = notification!.params?.requestId;
+                if (typeof cancelledRequestId === 'string' || typeof cancelledRequestId === 'number') {
+                  cancelSpanForRequest(transport, cancelledRequestId);
+                }
+              }
+
+              return createMcpNotificationSpan(
+                notification!,
+                transport,
+                extra as ExtraHandlerData,
+                options,
+                () => {
+                  return (originalOnMessage as (...args: unknown[]) => unknown).call(this, notification, extra);
+                },
+                operationSessionData,
+                links,
+                parentSpan,
+              );
+            };
+
+            if (traceContext) {
+              return continueTrace(
+                { sentryTrace: traceContext.sentryTrace, baggage: traceContext.baggage },
+                runWithMessageTrace,
+              );
             }
 
-            storeSpanForRequest(transport, request.id, span, request.method);
-
-            return withActiveSpan(span, () => {
-              return (originalOnMessage as (...args: unknown[]) => unknown).call(this, request, extra);
-            });
-          });
-        }
-
-        if (notification) {
-          return createMcpNotificationSpan(notification, transport, extra as ExtraHandlerData, options, () => {
-            return (originalOnMessage as (...args: unknown[]) => unknown).call(this, notification, extra);
+            return ambientSpan ? runWithMessageTrace() : startNewTrace(runWithMessageTrace);
           });
         }
 
@@ -88,39 +173,30 @@ export function wrapTransportOnMessage(transport: MCPTransport, options: Resolve
   }
 }
 
-/**
- * Wraps transport.send to handle outgoing messages and response correlation.
- * Extracts and stores protocol version and server info from legacy initialize
- * responses and modern result metadata.
- * @param transport - MCP transport instance to wrap
- * @param options - Resolved MCP options
- */
-export function wrapTransportSend(transport: MCPTransport, options: ResolvedMcpOptions): void {
-  if (transport.send) {
-    fill(transport, 'send', originalSend => {
-      return async function (this: MCPTransport, ...args: unknown[]) {
-        const [message] = args;
+function extractNotificationSessionData(extra: ExtraHandlerData): SessionData {
+  return applyModernTransportRevision({}, extra);
+}
 
-        if (isJsonRpcNotification(message)) {
-          return createMcpOutgoingNotificationSpan(message, transport, options, () => {
-            return (originalSend as (...args: unknown[]) => unknown).call(this, ...args);
-          });
-        }
+function applyModernTransportRevision(sessionData: SessionData, extra: ExtraHandlerData): SessionData {
+  const classification = extra?.classification;
+  return classification?.era === 'modern' && typeof classification.revision === 'string'
+    ? { ...sessionData, protocolVersion: classification.revision }
+    : sessionData;
+}
 
-        if (isJsonRpcResponse(message)) {
-          if (message.id !== null && message.id !== undefined) {
-            if (message.error) {
-              captureJsonRpcErrorResponse(message.error);
-            }
-
-            completeSpanWithResults(transport, message.id, message.result, options, !!message.error);
-          }
-        }
-
-        return (originalSend as (...args: unknown[]) => unknown).call(this, ...args);
-      };
-    });
+function getAmbientSpanLinks(
+  ambientContext: ReturnType<NonNullable<ReturnType<typeof getActiveSpan>>['spanContext']>,
+  remoteContext?: ReturnType<NonNullable<ReturnType<typeof getActiveSpan>>['spanContext']>,
+): SpanLink[] | undefined {
+  if (
+    remoteContext &&
+    ambientContext.traceId === remoteContext.traceId &&
+    ambientContext.spanId === remoteContext.spanId
+  ) {
+    return undefined;
   }
+
+  return [{ context: ambientContext }];
 }
 
 /**
@@ -131,9 +207,14 @@ export function wrapTransportOnClose(transport: MCPTransport): void {
   if (transport.onclose) {
     fill(transport, 'onclose', originalOnClose => {
       return function (this: MCPTransport, ...args: unknown[]) {
-        cleanupPendingSpansForTransport(transport);
-        cleanupSessionDataForTransport(transport);
-        return (originalOnClose as (...args: unknown[]) => unknown).call(this, ...args);
+        try {
+          return (originalOnClose as (...args: unknown[]) => unknown).call(this, ...args);
+        } finally {
+          setTimeout(() => {
+            cleanupPendingSpansForTransport(transport);
+            cleanupSessionDataForTransport(transport);
+          });
+        }
       };
     });
   }
@@ -151,32 +232,6 @@ export function wrapTransportError(transport: MCPTransport): void {
         return originalOnError.call(this, error);
       };
     });
-  }
-}
-
-/**
- * Captures JSON-RPC error responses for server-side errors.
- * @see https://www.jsonrpc.org/specification#error_object
- * @internal
- * @param errorResponse - JSON-RPC error response
- */
-function captureJsonRpcErrorResponse(errorResponse: unknown): void {
-  try {
-    if (isObjectLike(errorResponse) && 'code' in errorResponse && 'message' in errorResponse) {
-      const jsonRpcError = errorResponse as { code: number; message: string; data?: unknown };
-
-      const isServerError =
-        jsonRpcError.code === -32603 || (jsonRpcError.code >= -32099 && jsonRpcError.code <= -32000);
-
-      if (isServerError) {
-        const error = new Error(jsonRpcError.message);
-        error.name = `JsonRpcError_${jsonRpcError.code}`;
-
-        captureError(error, 'protocol');
-      }
-    }
-  } catch {
-    // noop
   }
 }
 

--- a/packages/core/src/integrations/mcp-server/transportSend.ts
+++ b/packages/core/src/integrations/mcp-server/transportSend.ts
@@ -1,0 +1,255 @@
+import { withActiveSpan } from '../../tracing';
+import { MAX_BAGGAGE_STRING_LENGTH, mergeBaggageHeaders } from '../../utils/baggage';
+import { chainAndCopyPromiseLike } from '../../utils/chain-and-copy-promiselike';
+import { isPlainObject, isThenable } from '../../utils/is';
+import { fill } from '../../utils/object';
+import { getActiveSpan } from '../../utils/spanUtils';
+import { getTraceData } from '../../utils/traceData';
+import {
+  getSpanForOutgoingRequest,
+  getSpanForRequest,
+  storeSpanForOutgoingRequest,
+  takeSpanForResponseSend,
+} from './correlation';
+import { getSessionDataForTransport } from './sessionManagement';
+import {
+  cancelTakenSpanForOutgoingRequest,
+  completeTakenSpanWithResults,
+  failSpanForResponseSend,
+  failTakenSpanForOutgoingRequest,
+} from './spanCompletion';
+import { createMcpOutgoingNotificationSpan, createMcpOutgoingRequestSpan } from './spans';
+import type {
+  JsonRpcNotification,
+  JsonRpcRequest,
+  MCPTransport,
+  RequestSpanMapValue,
+  ResolvedMcpOptions,
+} from './types';
+import { isJsonRpcNotification, isJsonRpcRequest, isJsonRpcResponse } from './validation';
+
+const MAX_TRACEPARENT_LENGTH = 512;
+const MAX_TRACESTATE_LENGTH = 512;
+
+/** Wraps transport.send to trace outgoing messages and correlate terminal responses. */
+export function wrapTransportSend(transport: MCPTransport, options: ResolvedMcpOptions): void {
+  if (!transport.send) {
+    return;
+  }
+
+  fill(transport, 'send', originalSend => {
+    return function (this: MCPTransport, ...args: unknown[]) {
+      const [message] = args;
+
+      if (isJsonRpcNotification(message)) {
+        return sendNotification(transport, originalSend, this, message, args.slice(1), options);
+      }
+      if (isJsonRpcRequest(message)) {
+        return sendRequest(transport, originalSend, this, message, args.slice(1), options);
+      }
+      if (isJsonRpcResponse(message) && message.id != null) {
+        const spanData = takeSpanForResponseSend(transport, message.id);
+        if (spanData) {
+          return sendResponse(transport, originalSend, this, args, message.result, message.error, spanData, options);
+        }
+      }
+
+      return (originalSend as (...sendArgs: unknown[]) => unknown).call(this, ...args);
+    };
+  });
+}
+
+function sendNotification(
+  transport: MCPTransport,
+  originalSend: unknown,
+  receiver: MCPTransport,
+  message: JsonRpcNotification,
+  trailingArgs: unknown[],
+  options: ResolvedMcpOptions,
+): unknown {
+  const cancelledRequestId =
+    message.method === 'notifications/cancelled' ? getRequestId(message.params?.requestId) : undefined;
+  const cancelledSpanData =
+    cancelledRequestId !== undefined ? getSpanForOutgoingRequest(transport, cancelledRequestId) : undefined;
+  const relatedSpanData = cancelledSpanData ?? getRelatedRequestSpan(transport, trailingArgs[0]);
+  const sendResult = createMcpOutgoingNotificationSpan(
+    message,
+    transport,
+    options,
+    () => {
+      const outgoingMessage = injectMcpTraceContext(message, relatedSpanData);
+      return (originalSend as (...sendArgs: unknown[]) => unknown).call(receiver, outgoingMessage, ...trailingArgs);
+    },
+    relatedSpanData?.sessionData,
+    relatedSpanData?.span,
+  );
+  if (cancelledRequestId === undefined) {
+    return sendResult;
+  }
+  if (isThenable(sendResult)) {
+    return chainAndCopyPromiseLike(
+      sendResult as PromiseLike<unknown> & Record<string, unknown>,
+      () => {
+        if (cancelledSpanData) {
+          cancelTakenSpanForOutgoingRequest(transport, cancelledSpanData);
+        }
+      },
+      () => {},
+    );
+  }
+
+  if (cancelledSpanData) {
+    cancelTakenSpanForOutgoingRequest(transport, cancelledSpanData);
+  }
+  return sendResult;
+}
+
+function sendRequest(
+  transport: MCPTransport,
+  originalSend: unknown,
+  receiver: MCPTransport,
+  message: JsonRpcRequest,
+  trailingArgs: unknown[],
+  options: ResolvedMcpOptions,
+): unknown {
+  const relatedSpanData = getRelatedRequestSpan(transport, trailingArgs[0]);
+  const sessionData = relatedSpanData?.sessionData ?? getSessionDataForTransport(transport);
+  const span = createMcpOutgoingRequestSpan(
+    message,
+    transport,
+    options,
+    sessionData,
+    relatedSpanData?.span ?? getActiveSpan(),
+  );
+  const spanData = storeSpanForOutgoingRequest(
+    transport,
+    message.id,
+    span,
+    message.method,
+    sessionData,
+    relatedSpanData,
+  );
+
+  let sendResult: unknown;
+  try {
+    sendResult = withActiveSpan(span, () => {
+      const outgoingMessage = injectMcpTraceContext(message, relatedSpanData);
+      return (originalSend as (...sendArgs: unknown[]) => unknown).call(receiver, outgoingMessage, ...trailingArgs);
+    });
+  } catch (error) {
+    failTakenSpanForOutgoingRequest(transport, spanData, error, 'send_error');
+    throw error;
+  }
+
+  return isThenable(sendResult)
+    ? chainAndCopyPromiseLike(
+        sendResult as PromiseLike<unknown> & Record<string, unknown>,
+        () => {},
+        error => failTakenSpanForOutgoingRequest(transport, spanData, error, 'send_error'),
+      )
+    : sendResult;
+}
+
+function sendResponse(
+  transport: MCPTransport,
+  originalSend: unknown,
+  receiver: MCPTransport,
+  args: unknown[],
+  result: unknown,
+  error: Parameters<typeof completeTakenSpanWithResults>[4],
+  spanData: RequestSpanMapValue,
+  options: ResolvedMcpOptions,
+): unknown {
+  let sendResult: unknown;
+  try {
+    sendResult = (originalSend as (...sendArgs: unknown[]) => unknown).call(receiver, ...args);
+  } catch (sendError) {
+    failSpanForResponseSend(transport, spanData, sendError);
+    throw sendError;
+  }
+
+  if (isThenable(sendResult)) {
+    return chainAndCopyPromiseLike(
+      sendResult as PromiseLike<unknown> & Record<string, unknown>,
+      () => completeTakenSpanWithResults(transport, spanData, result, options, error),
+      sendError => failSpanForResponseSend(transport, spanData, sendError),
+    );
+  }
+
+  completeTakenSpanWithResults(transport, spanData, result, options, error);
+  return sendResult;
+}
+
+function getRequestId(value: unknown): string | number | undefined {
+  return typeof value === 'string' || typeof value === 'number' ? value : undefined;
+}
+
+function getRelatedRequestSpan(transport: MCPTransport, sendOptions: unknown): RequestSpanMapValue | undefined {
+  if (!isPlainObject(sendOptions)) {
+    return undefined;
+  }
+  const relatedRequestId = sendOptions.relatedRequestId;
+  return typeof relatedRequestId === 'string' || typeof relatedRequestId === 'number'
+    ? getSpanForRequest(transport, relatedRequestId)
+    : undefined;
+}
+
+function injectMcpTraceContext<T extends JsonRpcNotification | JsonRpcRequest>(
+  message: T,
+  relatedSpanData?: RequestSpanMapValue,
+): T {
+  if (message.params !== undefined && !isPlainObject(message.params)) {
+    return message;
+  }
+
+  const params = message.params ?? {};
+  const meta = isPlainObject(params._meta) ? params._meta : {};
+  const hadPropagationFields =
+    meta.traceparent !== undefined || meta.tracestate !== undefined || meta.baggage !== undefined;
+  const customMeta = { ...meta };
+  delete customMeta.traceparent;
+  delete customMeta.tracestate;
+  delete customMeta.baggage;
+  const traceData = getMcpTraceData();
+  const existingBaggage =
+    getValidPropagationField(meta.baggage, MAX_BAGGAGE_STRING_LENGTH) ??
+    getValidPropagationField(relatedSpanData?.baggage, MAX_BAGGAGE_STRING_LENGTH);
+  const currentBaggage = getValidPropagationField(traceData.baggage, MAX_BAGGAGE_STRING_LENGTH);
+  const baggage =
+    currentBaggage && existingBaggage
+      ? mergeBaggageHeaders(existingBaggage, currentBaggage)
+      : (existingBaggage ?? currentBaggage);
+  const traceparent = getValidPropagationField(traceData.traceparent, MAX_TRACEPARENT_LENGTH);
+  const tracestate =
+    getValidPropagationField(meta.tracestate, MAX_TRACESTATE_LENGTH) ??
+    getValidPropagationField(relatedSpanData?.tracestate, MAX_TRACESTATE_LENGTH);
+
+  if (!traceparent && !tracestate && !baggage && !hadPropagationFields) {
+    return message;
+  }
+
+  return {
+    ...message,
+    params: {
+      ...params,
+      _meta: {
+        ...customMeta,
+        ...(traceparent ? { traceparent } : {}),
+        ...(tracestate ? { tracestate } : {}),
+        ...(baggage ? { baggage } : {}),
+      },
+    },
+  };
+}
+
+function getValidPropagationField(value: unknown, maxLength: number): string | undefined {
+  return typeof value === 'string' && value.length > 0 && value.length <= maxLength ? value : undefined;
+}
+
+function getMcpTraceData(): ReturnType<typeof getTraceData> {
+  try {
+    return getTraceData({ propagateTraceparent: true });
+  } catch {
+    return {};
+  }
+}

--- a/packages/core/src/integrations/mcp-server/types.ts
+++ b/packages/core/src/integrations/mcp-server/types.ts
@@ -1,4 +1,5 @@
-import type { Span } from '../../types/span';
+import type { SpanLink } from '../../types/link';
+import type { Span, SpanAttributes } from '../../types/span';
 
 /** Types for MCP server instrumentation */
 
@@ -9,6 +10,8 @@ import type { Span } from '../../types/span';
 export type MethodConfig = {
   targetField: string;
   targetAttribute: string;
+  legacyTargetAttribute?: string;
+  includeTargetInSpanName?: boolean;
   captureArguments?: boolean;
   argumentsField?: string;
   captureUri?: boolean;
@@ -98,42 +101,45 @@ export interface MCPServerInstance {
    * Supported in `@modelcontextprotocol/sdk` v1.x alongside `registerResource`.
    * @deprecated Removed in `@modelcontextprotocol/sdk` v2.0.0 — use `registerResource` instead.
    */
-  resource?: (name: string, ...args: unknown[]) => void;
+  resource?: (name: string, ...args: unknown[]) => unknown;
 
   /**
    * Register a tool handler.
    * Supported in `@modelcontextprotocol/sdk` v1.x alongside `registerTool`.
    * @deprecated Removed in `@modelcontextprotocol/sdk` v2.0.0 — use `registerTool` instead.
    */
-  tool?: (name: string, ...args: unknown[]) => void;
+  tool?: (name: string, ...args: unknown[]) => unknown;
 
   /**
    * Register a prompt handler.
    * Supported in `@modelcontextprotocol/sdk` v1.x alongside `registerPrompt`.
    * @deprecated Removed in `@modelcontextprotocol/sdk` v2.0.0 — use `registerPrompt` instead.
    */
-  prompt?: (name: string, ...args: unknown[]) => void;
+  prompt?: (name: string, ...args: unknown[]) => unknown;
 
   /**
    * Register a resource handler.
    * Available in `@modelcontextprotocol/sdk` v1.x (alongside the legacy `resource` method)
    * and the only supported form in v2.0.0+.
    */
-  registerResource?: (name: string, ...args: unknown[]) => void;
+  registerResource?: (name: string, ...args: unknown[]) => unknown;
 
   /**
    * Register a tool handler.
    * Available in `@modelcontextprotocol/sdk` v1.x (alongside the legacy `tool` method)
    * and the only supported form in v2.0.0+.
    */
-  registerTool?: (name: string, ...args: unknown[]) => void;
+  registerTool?: (name: string, ...args: unknown[]) => unknown;
 
   /**
    * Register a prompt handler.
    * Available in `@modelcontextprotocol/sdk` v1.x (alongside the legacy `prompt` method)
    * and the only supported form in v2.0.0+.
    */
-  registerPrompt?: (name: string, ...args: unknown[]) => void;
+  registerPrompt?: (name: string, ...args: unknown[]) => unknown;
+
+  /** Low-level request registration API exposed by `@modelcontextprotocol/server`. */
+  setRequestHandler?: (...args: unknown[]) => unknown;
 
   /** Connect the server to a transport */
   connect(transport: MCPTransport): Promise<void>;
@@ -141,6 +147,10 @@ export interface MCPServerInstance {
 
 /** Client connection information for handlers */
 export interface ExtraHandlerData {
+  classification?: {
+    era: 'legacy' | 'modern';
+    revision?: string;
+  };
   requestInfo?: { remoteAddress?: string; remotePort?: number };
   clientAddress?: string;
   clientPort?: number;
@@ -151,7 +161,7 @@ export interface ExtraHandlerData {
 }
 
 /** Types of MCP spans */
-export type McpSpanType = 'request' | 'notification-incoming' | 'notification-outgoing';
+export type McpSpanType = 'request' | 'request-outgoing' | 'notification-incoming' | 'notification-outgoing';
 
 /**
  * Configuration for creating MCP spans
@@ -164,6 +174,9 @@ export interface McpSpanConfig {
   extra?: ExtraHandlerData;
   callback: () => unknown;
   options?: ResolvedMcpOptions;
+  operationSessionData?: SessionData;
+  links?: SpanLink[];
+  parentSpan?: Span;
 }
 
 export type SessionId = string;
@@ -174,9 +187,16 @@ export type RequestId = string | number;
  * @internal
  */
 export type RequestSpanMapValue = {
+  requestId: RequestId;
   span: Span;
   method: string;
+  protocolVersion?: string;
+  sessionData?: SessionData;
+  baggage?: string;
+  tracestate?: string;
   startTime: number;
+  includeUserInfo: boolean;
+  finished?: boolean;
 };
 
 /** Generic MCP handler function */
@@ -217,6 +237,8 @@ export type PartyInfo = {
  */
 export type SessionData = {
   clientInfo?: PartyInfo;
+  clientCapabilities?: string[];
+  clientExtensionIds?: string[];
   protocolVersion?: string;
   serverInfo?: PartyInfo;
 };
@@ -236,3 +258,6 @@ export type McpServerWrapperOptions = {
  * @internal
  */
 export type ResolvedMcpOptions = Required<McpServerWrapperOptions>;
+
+/** Attribute maps emitted by MCP extraction helpers. */
+export type McpAttributes = SpanAttributes;

--- a/packages/core/src/integrations/mcp-server/validation.ts
+++ b/packages/core/src/integrations/mcp-server/validation.ts
@@ -16,7 +16,10 @@ import type { JsonRpcNotification, JsonRpcRequest, JsonRpcResponse } from './typ
  */
 export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
   return (
-    isObjectLike(message) && 'jsonrpc' in message && message.jsonrpc === '2.0' && 'method' in message && 'id' in message
+    isObjectLike(message) &&
+    message.jsonrpc === '2.0' &&
+    typeof message.method === 'string' &&
+    (typeof message.id === 'string' || typeof message.id === 'number')
   );
 }
 
@@ -26,13 +29,7 @@ export function isJsonRpcRequest(message: unknown): message is JsonRpcRequest {
  * @returns True if message is a JSON-RPC notification
  */
 export function isJsonRpcNotification(message: unknown): message is JsonRpcNotification {
-  return (
-    isObjectLike(message) &&
-    'jsonrpc' in message &&
-    message.jsonrpc === '2.0' &&
-    'method' in message &&
-    !('id' in message)
-  );
+  return isObjectLike(message) && message.jsonrpc === '2.0' && typeof message.method === 'string' && !('id' in message);
 }
 
 /**
@@ -59,12 +56,22 @@ export function isJsonRpcResponse(message: unknown): message is JsonRpcResponse 
  * @returns True if instance has required MCP server methods
  */
 export function validateMcpServerInstance(instance: unknown): boolean {
-  if (
-    isObjectLike(instance) &&
-    'connect' in instance &&
-    (('tool' in instance && 'resource' in instance && 'prompt' in instance) ||
-      ('registerTool' in instance && 'registerResource' in instance && 'registerPrompt' in instance))
-  ) {
+  if (!isObjectLike(instance) || typeof instance.connect !== 'function') {
+    DEBUG_BUILD && debug.warn('Did not patch MCP server. Interface is incompatible.');
+    return false;
+  }
+
+  const hasLegacyFacade =
+    typeof instance.tool === 'function' &&
+    typeof instance.resource === 'function' &&
+    typeof instance.prompt === 'function';
+  const hasModernFacade =
+    typeof instance.registerTool === 'function' &&
+    typeof instance.registerResource === 'function' &&
+    typeof instance.registerPrompt === 'function';
+  const hasLowLevelApi = typeof instance.setRequestHandler === 'function';
+
+  if (hasLegacyFacade || hasModernFacade || hasLowLevelApi) {
     return true;
   }
   DEBUG_BUILD && debug.warn('Did not patch MCP server. Interface is incompatible.');

--- a/packages/core/src/server-exports.ts
+++ b/packages/core/src/server-exports.ts
@@ -8,7 +8,7 @@ export type { ServerRuntimeClientOptions } from './server-runtime-client';
 export { ServerRuntimeClient } from './server-runtime-client';
 export type { ServerRuntimeOptions } from './types/options';
 export { trpcMiddleware } from './trpc';
-export { wrapMcpServerWithSentry } from './integrations/mcp-server';
+export { wrapMcpServerFactoryWithSentry, wrapMcpServerWithSentry } from './integrations/mcp-server';
 export { isNodeEnv, loadModule } from './utils/node';
 export { filenameIsInApp, node, nodeStackLineParser } from './utils/node-stack-trace';
 export { vercelWaitUntil } from './utils/vercelWaitUntil';

--- a/packages/core/test/lib/integrations/mcp-server/handlerWrapping.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/handlerWrapping.test.ts
@@ -1,0 +1,458 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureError } from '../../../../src/integrations/mcp-server/errorCapture';
+import {
+  wrapAllMCPHandlers,
+  wrapExistingHandlers,
+  wrapToolHandlers,
+} from '../../../../src/integrations/mcp-server/handlers';
+import type { MCPServerInstance } from '../../../../src/integrations/mcp-server/types';
+
+vi.mock('../../../../src/integrations/mcp-server/errorCapture', () => ({
+  captureError: vi.fn(),
+}));
+
+type TestHandler = (...args: unknown[]) => unknown;
+
+type RegistrationUpdate = {
+  argsSchema?: unknown;
+  callback?: TestHandler;
+  name?: string | null;
+  paramsSchema?: unknown;
+};
+
+type RegistrationHandle = Record<string, unknown> & {
+  update: (updates: RegistrationUpdate) => void;
+};
+
+type V2LikeServer = {
+  _registeredPrompts: Record<string, RegistrationHandle>;
+  _registeredResources: Record<string, RegistrationHandle>;
+  _registeredResourceTemplates: Record<string, RegistrationHandle>;
+  _registeredTools: Record<string, RegistrationHandle>;
+  connect: ReturnType<typeof vi.fn>;
+  registerPrompt: (name: string, config: unknown, callback: TestHandler) => RegistrationHandle;
+  registerResource: (name: string, uri: string, config: unknown, callback: TestHandler) => RegistrationHandle;
+  registerTool: (name: string, config: unknown, callback: TestHandler) => RegistrationHandle;
+};
+
+function createV2LikeServer(): V2LikeServer {
+  const registeredTools: Record<string, RegistrationHandle> = {};
+  const registeredResources: Record<string, RegistrationHandle> = {};
+  const registeredPrompts: Record<string, RegistrationHandle> = {};
+
+  return {
+    _registeredTools: registeredTools,
+    _registeredResources: registeredResources,
+    _registeredResourceTemplates: {},
+    _registeredPrompts: registeredPrompts,
+    connect: vi.fn(),
+    registerTool(name, _config, callback) {
+      let currentCallback = callback;
+      const handle: RegistrationHandle = {
+        handler: currentCallback,
+        executor: (...args: unknown[]) => currentCallback(...args),
+        update(updates) {
+          if (updates.callback) {
+            currentCallback = updates.callback;
+            handle.handler = currentCallback;
+          }
+
+          if (updates.callback || updates.paramsSchema) {
+            handle.executor = (...args: unknown[]) => currentCallback(...args);
+          }
+        },
+      };
+
+      registeredTools[name] = handle;
+      return handle;
+    },
+    registerResource(name, _uri, _config, callback) {
+      const handle: RegistrationHandle = {
+        name,
+        readCallback: callback,
+        update(updates) {
+          if (typeof updates.name === 'string') {
+            handle.name = updates.name;
+          }
+
+          if (updates.callback) {
+            handle.readCallback = updates.callback;
+          }
+        },
+      };
+
+      registeredResources[name] = handle;
+      return handle;
+    },
+    registerPrompt(name, _config, callback) {
+      let currentCallback = callback;
+      const handle: RegistrationHandle = {
+        handler: (...args: unknown[]) => currentCallback(...args),
+        update(updates) {
+          if (updates.callback) {
+            currentCallback = updates.callback;
+          }
+
+          if (updates.callback || updates.argsSchema) {
+            handle.handler = (...args: unknown[]) => currentCallback(...args);
+          }
+        },
+      };
+
+      registeredPrompts[name] = handle;
+      return handle;
+    },
+  };
+}
+
+function registerHandler(
+  server: V2LikeServer,
+  method: 'registerPrompt' | 'registerResource' | 'registerTool',
+  name: string,
+  callback: TestHandler,
+): RegistrationHandle {
+  if (method === 'registerResource') {
+    return server.registerResource(name, `test://${name}`, {}, callback);
+  }
+
+  return server[method](name, {}, callback);
+}
+
+describe('MCP handler wrapping', () => {
+  const captureErrorMock = vi.mocked(captureError);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('executes a synchronously throwing handler once and rethrows the same error', () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const handlerError = new Error('synchronous failure');
+    const handler = vi.fn(() => {
+      throw handlerError;
+    });
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('sync-tool', {}, handler);
+
+    let thrownError: unknown;
+    try {
+      registeredHandler?.();
+    } catch (error) {
+      thrownError = error;
+    }
+
+    expect(thrownError).toBe(handlerError);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'tool_execution', { tool_name: 'sync-tool' });
+  });
+
+  it('executes an asynchronously rejecting handler once and rejects with the same error', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const handlerError = new Error('asynchronous failure');
+    const handler = vi.fn().mockRejectedValue(handlerError);
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('async-tool', {}, handler);
+
+    await expect(registeredHandler?.()).rejects.toBe(handlerError);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'tool_execution', { tool_name: 'async-tool' });
+  });
+
+  it('does not report a handler rejection caused by MCP request cancellation', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const cancellationError = new Error('Not connected');
+    const handler = vi.fn().mockRejectedValue(cancellationError);
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('cancelled-tool', {}, handler);
+    const abortController = new AbortController();
+    abortController.abort(cancellationError);
+
+    await expect(registeredHandler?.({}, { mcpReq: { signal: abortController.signal } })).rejects.toBe(
+      cancellationError,
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('reports a rejection when only a handler input contains a spoofed cancellation signal', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const handlerError = new Error('spoofed cancellation input');
+    const handler = vi.fn().mockRejectedValue(handlerError);
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('input-sensitive-tool', {}, handler);
+
+    await expect(
+      registeredHandler?.(
+        { mcpReq: { signal: { aborted: true } } },
+        { mcpReq: { signal: new AbortController().signal } },
+      ),
+    ).rejects.toBe(handlerError);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'tool_execution', {
+      tool_name: 'input-sensitive-tool',
+    });
+  });
+
+  it('normalizes a synchronously thrown primitive before capture', () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const handler = vi.fn(() => {
+      throw 'primitive synchronous failure';
+    });
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('primitive-sync-tool', {}, handler);
+
+    expect(() => registeredHandler?.()).toThrow('primitive synchronous failure');
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(new Error('primitive synchronous failure'), 'tool_execution', {
+      tool_name: 'primitive-sync-tool',
+    });
+  });
+
+  it('normalizes an asynchronously rejected primitive before capture', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const handler = vi.fn().mockRejectedValue(null);
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('primitive-async-tool', {}, handler);
+
+    await expect(registeredHandler?.()).rejects.toBeNull();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(new Error('null'), 'tool_execution', {
+      tool_name: 'primitive-async-tool',
+    });
+  });
+
+  describe.each([
+    {
+      method: 'registerTool' as const,
+      executionProperty: 'executor',
+      errorType: 'tool_execution' as const,
+      errorData: { tool_name: 'updated-handler' },
+    },
+    {
+      method: 'registerResource' as const,
+      executionProperty: 'readCallback',
+      errorType: 'resource_execution' as const,
+      errorData: { resource_name: 'updated-handler' },
+    },
+    {
+      method: 'registerPrompt' as const,
+      executionProperty: 'handler',
+      errorType: 'prompt_execution' as const,
+      errorData: { prompt_name: 'updated-handler' },
+    },
+  ])('$method update wrapping', ({ method, executionProperty, errorType, errorData }) => {
+    it.each(['before', 'after'] as const)(
+      'preserves instrumentation when Sentry wraps %s registration',
+      async wrappingOrder => {
+        const server = createV2LikeServer();
+
+        if (wrappingOrder === 'before') {
+          wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+        }
+
+        const handle = registerHandler(server, method, 'updated-handler', vi.fn());
+
+        if (wrappingOrder === 'after') {
+          wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+          wrapExistingHandlers(server as unknown as MCPServerInstance);
+        }
+
+        const handlerError = new Error(`${method} update failed`);
+        const updatedHandler = vi.fn(() => {
+          throw handlerError;
+        });
+
+        handle.update({ callback: updatedHandler });
+
+        const execute = handle[executionProperty] as TestHandler;
+        await expect(Promise.resolve().then(() => execute())).rejects.toBe(handlerError);
+        expect(updatedHandler).toHaveBeenCalledTimes(1);
+        expect(captureErrorMock).toHaveBeenCalledTimes(1);
+        expect(captureErrorMock).toHaveBeenCalledWith(handlerError, errorType, errorData);
+      },
+    );
+
+    it.each(['before', 'after'] as const)(
+      'uses the renamed handler when Sentry wraps %s registration',
+      async wrappingOrder => {
+        const server = createV2LikeServer();
+
+        if (wrappingOrder === 'before') {
+          wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+        }
+
+        const handlerError = new Error(`${method} renamed handler failed`);
+        const handler = vi.fn(() => {
+          throw handlerError;
+        });
+        const handle = registerHandler(server, method, 'original-handler', handler);
+
+        if (wrappingOrder === 'after') {
+          wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+          wrapExistingHandlers(server as unknown as MCPServerInstance);
+        }
+
+        handle.update({ name: 'updated-handler' });
+
+        const execute = handle[executionProperty] as TestHandler;
+        await expect(Promise.resolve().then(() => execute())).rejects.toBe(handlerError);
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(captureErrorMock).toHaveBeenCalledTimes(1);
+        expect(captureErrorMock).toHaveBeenCalledWith(handlerError, errorType, errorData);
+      },
+    );
+  });
+
+  it.each([
+    { method: 'registerTool' as const, executionProperty: 'executor', schemaUpdate: { paramsSchema: {} } },
+    { method: 'registerPrompt' as const, executionProperty: 'handler', schemaUpdate: { argsSchema: {} } },
+  ])(
+    'rewraps $method execution regenerated by a schema update',
+    async ({ method, executionProperty, schemaUpdate }) => {
+      const server = createV2LikeServer();
+      const handlerError = new Error(`${method} schema update failed`);
+      const handler = vi.fn(() => {
+        throw handlerError;
+      });
+      const handle = registerHandler(server, method, 'schema-handler', handler);
+
+      wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+      wrapExistingHandlers(server as unknown as MCPServerInstance);
+      handle.update(schemaUpdate);
+
+      const execute = handle[executionProperty] as TestHandler;
+      await expect(Promise.resolve().then(() => execute())).rejects.toBe(handlerError);
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('uses a preregistered resource name without exposing its URI', async () => {
+    const handlerError = new Error('private resource failed');
+    const readCallback = vi.fn(() => {
+      throw handlerError;
+    });
+    const resource = {
+      name: 'customer-profile',
+      readCallback,
+      update: vi.fn(),
+    };
+    const server = {
+      _registeredPrompts: {},
+      _registeredResources: {
+        'https://api.example.com/customers/42?api_key=private-token': resource,
+      },
+      _registeredResourceTemplates: {},
+      _registeredTools: {},
+      connect: vi.fn(),
+    };
+
+    wrapExistingHandlers(server as unknown as MCPServerInstance);
+
+    await expect(Promise.resolve().then(() => resource.readCallback())).rejects.toBe(handlerError);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'resource_execution', {
+      resource_name: 'customer-profile',
+    });
+  });
+
+  it('wraps the two-argument low-level setRequestHandler form', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const setRequestHandler = vi.fn((...args: unknown[]) => {
+      registeredHandler = args[args.length - 1] as TestHandler;
+    });
+    const server = {
+      connect: vi.fn(),
+      setRequestHandler,
+    };
+    const handlerError = new Error('ping request failed');
+    const handler = vi.fn().mockRejectedValue(handlerError);
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+    server.setRequestHandler('ping', handler);
+
+    await expect(registeredHandler?.({}, { mcpReq: { signal: new AbortController().signal } })).rejects.toBe(
+      handlerError,
+    );
+    expect(setRequestHandler).toHaveBeenCalledWith('ping', expect.any(Function));
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'protocol', { method_name: 'ping' });
+  });
+
+  it('wraps the three-argument custom low-level setRequestHandler form', () => {
+    let registeredHandler: TestHandler | undefined;
+    const setRequestHandler = vi.fn((...args: unknown[]) => {
+      registeredHandler = args[args.length - 1] as TestHandler;
+    });
+    const server = {
+      connect: vi.fn(),
+      setRequestHandler,
+    };
+    const schemas = {
+      params: { vendor: 'standard-schema', version: 1 },
+      result: { vendor: 'standard-schema', version: 1 },
+    };
+    const handlerError = new Error('custom search failed');
+    const handler = vi.fn(() => {
+      throw handlerError;
+    });
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+    server.setRequestHandler('acme/search', schemas, handler);
+
+    expect(() => registeredHandler?.({}, { mcpReq: { signal: new AbortController().signal } })).toThrow(handlerError);
+    expect(setRequestHandler).toHaveBeenCalledWith('acme/search', schemas, expect.any(Function));
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'protocol', { method_name: 'acme/search' });
+  });
+});

--- a/packages/core/test/lib/integrations/mcp-server/handlerWrappingLegacy.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/handlerWrappingLegacy.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureError } from '../../../../src/integrations/mcp-server/errorCapture';
+import { wrapAllMCPHandlers, wrapExistingHandlers } from '../../../../src/integrations/mcp-server/handlers';
+import type { MCPServerInstance } from '../../../../src/integrations/mcp-server/types';
+
+vi.mock('../../../../src/integrations/mcp-server/errorCapture', () => ({
+  captureError: vi.fn(),
+}));
+
+type TestHandler = (...args: unknown[]) => unknown;
+
+type LegacyRegistration = Record<string, unknown> & {
+  update: (updates: { callback?: TestHandler; name?: string | null }) => void;
+};
+
+function createLegacyRegistration(executionProperty: 'handler' | 'callback', handler: TestHandler): LegacyRegistration {
+  const registration: LegacyRegistration = {
+    [executionProperty]: handler,
+    update(updates) {
+      if (updates.callback) {
+        registration[executionProperty] = updates.callback;
+      }
+    },
+  };
+  return registration;
+}
+
+describe('legacy MCP handler wrapping', () => {
+  const captureErrorMock = vi.mocked(captureError);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    {
+      errorData: { tool_name: 'legacy-tool' },
+      errorType: 'tool_execution' as const,
+      executionProperty: 'handler' as const,
+      registry: '_registeredTools' as const,
+      registrationName: 'legacy-tool',
+    },
+    {
+      errorData: { prompt_name: 'legacy-prompt' },
+      errorType: 'prompt_execution' as const,
+      executionProperty: 'callback' as const,
+      registry: '_registeredPrompts' as const,
+      registrationName: 'legacy-prompt',
+    },
+  ])(
+    'wraps a preregistered $registry callback from SDK v1',
+    async ({ errorData, errorType, executionProperty, registry, registrationName }) => {
+      const handlerError = new Error(`${registrationName} failed`);
+      const handler = vi.fn().mockRejectedValue(handlerError);
+      const registration = createLegacyRegistration(executionProperty, handler);
+      const server = {
+        _registeredPrompts: {},
+        _registeredResources: {},
+        _registeredResourceTemplates: {},
+        _registeredTools: {},
+        [registry]: { [registrationName]: registration },
+        connect: vi.fn(),
+      };
+
+      wrapExistingHandlers(server as unknown as MCPServerInstance);
+
+      const execute = registration[executionProperty] as TestHandler;
+      await expect(execute({}, { signal: new AbortController().signal })).rejects.toBe(handlerError);
+      expect(captureErrorMock).toHaveBeenCalledTimes(1);
+      expect(captureErrorMock).toHaveBeenCalledWith(handlerError, errorType, errorData);
+    },
+  );
+
+  it.each([
+    {
+      errorData: { tool_name: 'renamed-legacy-handler' },
+      errorType: 'tool_execution' as const,
+      executionProperty: 'handler' as const,
+      registry: '_registeredTools' as const,
+      registrationName: 'legacy-tool',
+    },
+    {
+      errorData: { prompt_name: 'renamed-legacy-handler' },
+      errorType: 'prompt_execution' as const,
+      executionProperty: 'callback' as const,
+      registry: '_registeredPrompts' as const,
+      registrationName: 'legacy-prompt',
+    },
+  ])(
+    'keeps a preregistered $registry callback instrumented after update',
+    async ({ errorData, errorType, executionProperty, registry, registrationName }) => {
+      const registration = createLegacyRegistration(executionProperty, vi.fn());
+      const server = {
+        _registeredPrompts: {},
+        _registeredResources: {},
+        _registeredResourceTemplates: {},
+        _registeredTools: {},
+        [registry]: { [registrationName]: registration },
+        connect: vi.fn(),
+      };
+      const handlerError = new Error(`${registrationName} update failed`);
+      const updatedHandler = vi.fn().mockRejectedValue(handlerError);
+
+      wrapExistingHandlers(server as unknown as MCPServerInstance);
+      registration.update({ callback: updatedHandler, name: 'renamed-legacy-handler' });
+
+      const execute = registration[executionProperty] as TestHandler;
+      await expect(execute({}, { signal: new AbortController().signal })).rejects.toBe(handlerError);
+      expect(captureErrorMock).toHaveBeenCalledTimes(1);
+      expect(captureErrorMock).toHaveBeenCalledWith(handlerError, errorType, errorData);
+    },
+  );
+
+  it('does not share mutable names when a wrapped callback is reused by another registration', async () => {
+    const originalError = new Error('shared callback failed');
+    const originalHandler = vi.fn().mockRejectedValue(originalError);
+    const firstRegistration = createLegacyRegistration('handler', originalHandler);
+    const firstServer = {
+      _registeredPrompts: {},
+      _registeredResources: {},
+      _registeredResourceTemplates: {},
+      _registeredTools: { 'first-tool': firstRegistration },
+      connect: vi.fn(),
+    };
+
+    wrapExistingHandlers(firstServer as unknown as MCPServerInstance);
+
+    const reusedCallback = firstRegistration.handler as TestHandler;
+    const secondRegistration = createLegacyRegistration('handler', reusedCallback);
+    const secondServer = {
+      _registeredPrompts: {},
+      _registeredResources: {},
+      _registeredResourceTemplates: {},
+      _registeredTools: { 'second-tool': secondRegistration },
+      connect: vi.fn(),
+    };
+    wrapExistingHandlers(secondServer as unknown as MCPServerInstance);
+    secondRegistration.update({ name: 'renamed-second-tool' });
+
+    await expect((firstRegistration.handler as TestHandler)()).rejects.toBe(originalError);
+    expect(captureErrorMock).toHaveBeenCalledWith(originalError, 'tool_execution', { tool_name: 'first-tool' });
+
+    vi.clearAllMocks();
+    await expect((secondRegistration.handler as TestHandler)()).rejects.toBe(originalError);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(originalError, 'tool_execution', {
+      tool_name: 'renamed-second-tool',
+    });
+  });
+
+  it('captures once when a legacy facade delegates to registerTool', async () => {
+    let registration: LegacyRegistration | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool(_name: string, _config: unknown, callback: TestHandler) {
+        registration = createLegacyRegistration('handler', callback);
+        return registration;
+      },
+      tool(name: string, callback: TestHandler) {
+        return this.registerTool(name, {}, callback);
+      },
+    };
+    const handlerError = new Error('delegated handler failed');
+    const handler = vi.fn().mockRejectedValue(handlerError);
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+    server.tool('delegated-tool', handler);
+
+    await expect((registration?.handler as TestHandler)()).rejects.toBe(handlerError);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'tool_execution', {
+      tool_name: 'delegated-tool',
+    });
+  });
+});

--- a/packages/core/test/lib/integrations/mcp-server/mcpServerFactoryWrapper.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/mcpServerFactoryWrapper.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as currentScopes from '../../../../src/currentScopes';
+import * as exports from '../../../../src/exports';
+import { wrapMcpServerFactoryWithSentry } from '../../../../src/integrations/mcp-server';
+import { createMockClient, createMockMcpServer } from './testUtils';
+
+describe('wrapMcpServerFactoryWithSentry', () => {
+  const getClientSpy = vi.spyOn(currentScopes, 'getClient');
+  const captureExceptionSpy = vi.spyOn(exports, 'captureException');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getClientSpy.mockReturnValue(createMockClient(true));
+  });
+
+  it('preserves arguments, this, and the server identity for synchronous factories', () => {
+    const server = createMockMcpServer();
+    const originalConnect = server.connect;
+    const context = { prefix: 'tenant' };
+    const factory = vi.fn(function (this: typeof context, tenant: string, era: 'legacy' | 'modern') {
+      expect(this).toBe(context);
+      expect(tenant).toBe('acme');
+      expect(era).toBe('modern');
+      return server;
+    });
+    const wrappedFactory = wrapMcpServerFactoryWithSentry(factory);
+
+    const result = wrappedFactory.call(context, 'acme', 'modern');
+
+    expect(result).toBe(server);
+    expect(result.connect).not.toBe(originalConnect);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('instruments every server produced by a synchronous factory', () => {
+    const firstServer = createMockMcpServer();
+    const secondServer = createMockMcpServer();
+    const firstConnect = firstServer.connect;
+    const secondConnect = secondServer.connect;
+    const factory = vi.fn().mockReturnValueOnce(firstServer).mockReturnValueOnce(secondServer);
+    const wrappedFactory = wrapMcpServerFactoryWithSentry(factory);
+
+    const firstResult = wrappedFactory();
+    const secondResult = wrappedFactory();
+
+    expect(firstResult).toBe(firstServer);
+    expect(firstResult.connect).not.toBe(firstConnect);
+    expect(secondResult).toBe(secondServer);
+    expect(secondResult.connect).not.toBe(secondConnect);
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows the exact error from synchronous factories', () => {
+    const factoryError = new Error('factory failed');
+    const factory = vi.fn(() => {
+      throw factoryError;
+    });
+    const wrappedFactory = wrapMcpServerFactoryWithSentry(factory);
+
+    expect(() => wrappedFactory()).toThrow(factoryError);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(factoryError, {
+      mechanism: {
+        type: 'auto.ai.mcp_server',
+        handled: false,
+        data: { error_type: 'protocol', method_name: 'server_factory' },
+      },
+    });
+  });
+
+  it('preserves arguments, this, and the server identity for asynchronous factories', async () => {
+    const server = createMockMcpServer();
+    const originalConnect = server.connect;
+    const context = { prefix: 'tenant' };
+    const factory = vi.fn(async function (this: typeof context, tenant: string, era: 'legacy' | 'modern') {
+      expect(this).toBe(context);
+      expect(tenant).toBe('acme');
+      expect(era).toBe('modern');
+      return server;
+    });
+    const wrappedFactory = wrapMcpServerFactoryWithSentry(factory);
+
+    const result = await wrappedFactory.call(context, 'acme', 'modern');
+
+    expect(result).toBe(server);
+    expect(result.connect).not.toBe(originalConnect);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects with the exact reason from asynchronous factories', async () => {
+    const factoryError = new Error('async factory failed');
+    const factory = vi.fn(() => Promise.reject(factoryError));
+    const wrappedFactory = wrapMcpServerFactoryWithSentry(factory);
+
+    await expect(wrappedFactory()).rejects.toBe(factoryError);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(factoryError, {
+      mechanism: {
+        type: 'auto.ai.mcp_server',
+        handled: false,
+        data: { error_type: 'protocol', method_name: 'server_factory' },
+      },
+    });
+  });
+
+  it('returns invalid factory products unchanged', async () => {
+    const invalidServer = { connect: vi.fn() };
+    const syncFactory = wrapMcpServerFactoryWithSentry(() => invalidServer);
+    const asyncFactory = wrapMcpServerFactoryWithSentry(async () => invalidServer);
+
+    const syncResult = syncFactory();
+    const asyncResult = await asyncFactory();
+
+    expect(syncResult).toBe(invalidServer);
+    expect(asyncResult).toBe(invalidServer);
+  });
+});

--- a/packages/core/test/lib/integrations/mcp-server/piiFiltering.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/piiFiltering.test.ts
@@ -133,6 +133,27 @@ describe('MCP Server PII Filtering', () => {
       expect(result).toHaveProperty('mcp.session.id', 'test-session-123');
     });
 
+    it('should redact nested URIs without dropping canonical tool output', () => {
+      const result = filterMcpPiiFromSpanData(
+        {
+          'gen_ai.tool.call.result': JSON.stringify({
+            content: [
+              { type: 'text', text: 'safe output' },
+              { type: 'resource_link', uri: 'file:///private/secret.txt' },
+            ],
+            resource_uri: 'https://example.invalid/private',
+          }),
+        },
+        false,
+      );
+
+      expect(result).toEqual({
+        'gen_ai.tool.call.result': JSON.stringify({
+          content: [{ type: 'text', text: 'safe output' }, { type: 'resource_link' }],
+        }),
+      });
+    });
+
     it('should handle empty span data', () => {
       const result = filterMcpPiiFromSpanData({}, false);
       expect(result).toEqual({});

--- a/packages/core/test/lib/integrations/mcp-server/requestHandlerWrapping.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/requestHandlerWrapping.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { captureError } from '../../../../src/integrations/mcp-server/errorCapture';
+import { wrapAllMCPHandlers, wrapToolHandlers } from '../../../../src/integrations/mcp-server/handlers';
+import type { MCPServerInstance } from '../../../../src/integrations/mcp-server/types';
+
+vi.mock('../../../../src/integrations/mcp-server/errorCapture', () => ({
+  captureError: vi.fn(),
+}));
+
+type TestHandler = (...args: unknown[]) => unknown;
+
+describe('low-level MCP request handler wrapping', () => {
+  const captureErrorMock = vi.mocked(captureError);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('wraps the SDK v1 schema-based setRequestHandler form', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const setRequestHandler = vi.fn((_schema: unknown, handler: TestHandler) => {
+      registeredHandler = handler;
+    });
+    const server = { connect: vi.fn(), setRequestHandler };
+    const requestSchema = { shape: { method: { value: 'legacy/search' } } };
+    const handlerError = new Error('legacy request failed');
+    const handler = vi.fn().mockRejectedValue(handlerError);
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+    server.setRequestHandler(requestSchema, handler);
+
+    await expect(
+      registeredHandler?.({ method: 'legacy/search' }, { signal: new AbortController().signal }),
+    ).rejects.toBe(handlerError);
+    expect(setRequestHandler).toHaveBeenCalledWith(requestSchema, expect.any(Function));
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'protocol', { method_name: 'legacy/search' });
+  });
+
+  it('wraps a low-level handler registered before Sentry', async () => {
+    const handlerError = new Error('preexisting request failed');
+    const handler = vi.fn().mockRejectedValue(handlerError);
+    const requestHandlers = new Map<string, TestHandler>([['acme/preexisting', handler]]);
+    const server = {
+      _requestHandlers: requestHandlers,
+      connect: vi.fn(),
+      setRequestHandler: vi.fn(),
+    };
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+
+    const registeredHandler = requestHandlers.get('acme/preexisting');
+    await expect(registeredHandler?.({}, { mcpReq: { signal: new AbortController().signal } })).rejects.toBe(
+      handlerError,
+    );
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'protocol', {
+      method_name: 'acme/preexisting',
+    });
+  });
+
+  it('does not capture caller protocol errors from a preexisting composed handler', async () => {
+    const protocolError = Object.assign(new Error('Invalid params'), { code: -32602 });
+    const handler = vi.fn().mockRejectedValue(protocolError);
+    const requestHandlers = new Map<string, TestHandler>([['prompts/get', handler]]);
+    const server = {
+      _requestHandlers: requestHandlers,
+      connect: vi.fn(),
+      setRequestHandler: vi.fn(),
+    };
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+
+    await expect(requestHandlers.get('prompts/get')?.()).rejects.toBe(protocolError);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('does not capture modern capability errors from a preexisting composed handler', async () => {
+    const protocolError = Object.assign(new Error('Missing required client capability'), { code: -32021 });
+    const handler = vi.fn().mockRejectedValue(protocolError);
+    const requestHandlers = new Map<string, TestHandler>([['tools/call', handler]]);
+    const server = {
+      _requestHandlers: requestHandlers,
+      connect: vi.fn(),
+      setRequestHandler: vi.fn(),
+    };
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+
+    await expect(
+      requestHandlers.get('tools/call')?.({
+        params: {
+          _meta: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' },
+        },
+      }),
+    ).rejects.toBe(protocolError);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('does not capture legacy URL elicitation control flow', async () => {
+    const protocolError = Object.assign(new Error('URL elicitation required'), { code: -32042 });
+    const handler = vi.fn().mockRejectedValue(protocolError);
+    const requestHandlers = new Map<string, TestHandler>([['tools/call', handler]]);
+    const server = {
+      _requestHandlers: requestHandlers,
+      connect: vi.fn(),
+      setRequestHandler: vi.fn(),
+    };
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+
+    await expect(requestHandlers.get('tools/call')?.({ params: {} })).rejects.toBe(protocolError);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('still captures an implementation-defined legacy error that overlaps a modern caller code', async () => {
+    const protocolError = Object.assign(new Error('Legacy implementation failed'), { code: -32021 });
+    const handler = vi.fn().mockRejectedValue(protocolError);
+    const requestHandlers = new Map<string, TestHandler>([['tools/call', handler]]);
+    const server = {
+      _requestHandlers: requestHandlers,
+      connect: vi.fn(),
+      setRequestHandler: vi.fn(),
+    };
+
+    wrapAllMCPHandlers(server as unknown as MCPServerInstance);
+
+    await expect(requestHandlers.get('tools/call')?.({ params: {} })).rejects.toBe(protocolError);
+    expect(captureErrorMock).toHaveBeenCalledWith(protocolError, 'protocol', { method_name: 'tools/call' });
+  });
+
+  it.each([
+    { context: (signal: AbortSignal) => ({ mcpReq: { signal } }), sdkVersion: 'v2' },
+    { context: (signal: AbortSignal) => ({ signal }), sdkVersion: 'v1' },
+  ])('does not capture a genuine $sdkVersion cancellation', async ({ context }) => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const cancellationError = new DOMException('The request was aborted', 'AbortError');
+    const abortController = new AbortController();
+    abortController.abort(cancellationError);
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('cancelled-tool', {}, vi.fn().mockRejectedValue(cancellationError));
+
+    await expect(registeredHandler?.({}, context(abortController.signal))).rejects.toBe(cancellationError);
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('captures a business error even when its request was also aborted', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const cancellationReason = new DOMException('The request was aborted', 'AbortError');
+    const businessError = new Error('database write failed');
+    const abortController = new AbortController();
+    abortController.abort(cancellationReason);
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('database-tool', {}, vi.fn().mockRejectedValue(businessError));
+
+    await expect(registeredHandler?.({}, { mcpReq: { signal: abortController.signal } })).rejects.toBe(businessError);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(businessError, 'tool_execution', { tool_name: 'database-tool' });
+  });
+
+  it('normalizes an object rejection without invoking its toString method', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const toString = vi.fn(() => 'secret-token');
+    const rejectedValue = { toString };
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('safe-normalization-tool', {}, vi.fn().mockRejectedValue(rejectedValue));
+
+    await expect(registeredHandler?.()).rejects.toBe(rejectedValue);
+    expect(toString).not.toHaveBeenCalled();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      new Error('Non-Error exception thrown by MCP handler'),
+      'tool_execution',
+      { tool_name: 'safe-normalization-tool' },
+    );
+  });
+
+  it('captures a revoked Proxy rejection without inspecting it', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const revocable = Proxy.revocable({}, {});
+    const rejectedValue = revocable.proxy;
+    revocable.revoke();
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool('proxy-safe-tool', {}, vi.fn().mockRejectedValue(rejectedValue));
+
+    await expect(registeredHandler?.()).rejects.toBe(rejectedValue);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      new Error('Non-Error exception thrown by MCP handler'),
+      'tool_execution',
+      { tool_name: 'proxy-safe-tool' },
+    );
+  });
+
+  it('bounds handler names stored in issue mechanism data', async () => {
+    let registeredHandler: TestHandler | undefined;
+    const server = {
+      connect: vi.fn(),
+      registerTool: vi.fn((_name: string, _config: unknown, callback: TestHandler) => {
+        registeredHandler = callback;
+        return { update: vi.fn() };
+      }),
+    };
+    const handlerError = new Error('long-name tool failed');
+    const longName = 'x'.repeat(300);
+
+    wrapToolHandlers(server as unknown as MCPServerInstance);
+    server.registerTool(longName, {}, vi.fn().mockRejectedValue(handlerError));
+
+    await expect(registeredHandler?.()).rejects.toBe(handlerError);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(captureErrorMock).toHaveBeenCalledWith(handlerError, 'tool_execution', {
+      tool_name: `${'x'.repeat(253)}...`,
+    });
+  });
+});

--- a/packages/core/test/lib/integrations/mcp-server/semanticConventions.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/semanticConventions.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as currentScopes from '../../../../src/currentScopes';
 import { wrapMcpServerWithSentry } from '../../../../src/integrations/mcp-server';
+import { buildTypeSpecificAttributes } from '../../../../src/integrations/mcp-server/attributeExtraction';
+import { getRequestArguments } from '../../../../src/integrations/mcp-server/methodConfig';
+import { getJsonRpcErrorAttributes } from '../../../../src/integrations/mcp-server/outcome';
+import {
+  extractCommonResultAttributes,
+  extractToolResultAttributes,
+} from '../../../../src/integrations/mcp-server/resultExtraction';
 import * as tracingModule from '../../../../src/tracing';
 import { createMockClient, createMockMcpServer, createMockTransport } from './testUtils';
 
@@ -48,8 +55,11 @@ describe('MCP Server Semantic Conventions', () => {
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         name: 'tools/call get-weather',
         op: 'mcp.server',
-        forceTransaction: true,
         attributes: {
+          'gen_ai.operation.name': 'execute_tool',
+          'gen_ai.tool.call.arguments': '{"location":"Seattle, WA"}',
+          'gen_ai.tool.name': 'get-weather',
+          'jsonrpc.request.id': 'req-1',
           'mcp.method.name': 'tools/call',
           'mcp.tool.name': 'get-weather',
           'mcp.request.id': 'req-1',
@@ -58,11 +68,11 @@ describe('MCP Server Semantic Conventions', () => {
           'client.port': 54321,
           'mcp.transport': 'StreamableHTTPServerTransport',
           'network.transport': 'tcp',
-          'network.protocol.version': '2.0',
+          'network.protocol.name': 'http',
           'mcp.request.argument.location': '"Seattle, WA"',
+          'sentry.kind': 'server',
           'sentry.op': 'mcp.server',
           'sentry.origin': 'auto.function.mcp_server',
-          'sentry.source': 'route',
         },
       });
     });
@@ -80,23 +90,38 @@ describe('MCP Server Semantic Conventions', () => {
       mockTransport.onmessage?.(jsonRpcRequest, {});
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
-        name: 'resources/read file:///docs/api.md',
+        name: 'resources/read',
         op: 'mcp.server',
-        forceTransaction: true,
         attributes: {
+          'jsonrpc.request.id': 'req-2',
           'mcp.method.name': 'resources/read',
           'mcp.resource.uri': 'file:///docs/api.md',
           'mcp.request.id': 'req-2',
           'mcp.session.id': 'test-session-123',
           'mcp.transport': 'StreamableHTTPServerTransport',
           'network.transport': 'tcp',
-          'network.protocol.version': '2.0',
+          'network.protocol.name': 'http',
           'mcp.request.argument.uri': '"file:///docs/api.md"',
+          'sentry.kind': 'server',
           'sentry.op': 'mcp.server',
           'sentry.origin': 'auto.function.mcp_server',
-          'sentry.source': 'route',
         },
       });
+    });
+
+    it('bounds peer-controlled custom method names', async () => {
+      await wrappedMcpServer.connect(mockTransport);
+      const method = `com.example/${'m'.repeat(500)}`;
+      const boundedMethod = `${method.slice(0, 253)}...`;
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method, id: 'custom-method' }, {});
+
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: boundedMethod,
+          attributes: expect.objectContaining({ 'mcp.method.name': boundedMethod }),
+        }),
+      );
     });
 
     it('should create spans with correct attributes for prompt operations', async () => {
@@ -114,19 +139,20 @@ describe('MCP Server Semantic Conventions', () => {
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         name: 'prompts/get analyze-code',
         op: 'mcp.server',
-        forceTransaction: true,
         attributes: {
+          'gen_ai.prompt.name': 'analyze-code',
+          'jsonrpc.request.id': 'req-3',
           'mcp.method.name': 'prompts/get',
           'mcp.prompt.name': 'analyze-code',
           'mcp.request.id': 'req-3',
           'mcp.session.id': 'test-session-123',
           'mcp.transport': 'StreamableHTTPServerTransport',
           'network.transport': 'tcp',
-          'network.protocol.version': '2.0',
+          'network.protocol.name': 'http',
           'mcp.request.argument.name': '"analyze-code"',
+          'sentry.kind': 'server',
           'sentry.op': 'mcp.server',
           'sentry.origin': 'auto.function.mcp_server',
-          'sentry.source': 'route',
         },
       });
     });
@@ -145,16 +171,15 @@ describe('MCP Server Semantic Conventions', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'notifications/tools/list_changed',
-          forceTransaction: true,
           attributes: {
             'mcp.method.name': 'notifications/tools/list_changed',
             'mcp.session.id': 'test-session-123',
             'mcp.transport': 'StreamableHTTPServerTransport',
             'network.transport': 'tcp',
-            'network.protocol.version': '2.0',
+            'network.protocol.name': 'http',
+            'sentry.kind': 'server',
             'sentry.op': 'mcp.notification.client_to_server',
             'sentry.origin': 'auto.mcp.notification',
-            'sentry.source': 'route',
           },
         },
         expect.any(Function),
@@ -179,25 +204,22 @@ describe('MCP Server Semantic Conventions', () => {
 
       mockTransport.onmessage?.(jsonRpcRequest, {});
 
-      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: 'tools/list',
-          forceTransaction: true,
-          attributes: expect.objectContaining({
-            'mcp.method.name': 'tools/list',
-            'mcp.request.id': 'req-4',
-            'mcp.session.id': 'test-session-123',
-            // Transport attributes
-            'mcp.transport': 'StreamableHTTPServerTransport',
-            'network.transport': 'tcp',
-            'network.protocol.version': '2.0',
-            // Sentry-specific
-            'sentry.op': 'mcp.server',
-            'sentry.origin': 'auto.function.mcp_server',
-            'sentry.source': 'route',
-          }),
-        }),
-      );
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith({
+        name: 'tools/list',
+        op: 'mcp.server',
+        attributes: {
+          'jsonrpc.request.id': 'req-4',
+          'mcp.method.name': 'tools/list',
+          'mcp.request.id': 'req-4',
+          'mcp.session.id': 'test-session-123',
+          'mcp.transport': 'StreamableHTTPServerTransport',
+          'network.protocol.name': 'http',
+          'network.transport': 'tcp',
+          'sentry.kind': 'server',
+          'sentry.op': 'mcp.server',
+          'sentry.origin': 'auto.function.mcp_server',
+        },
+      });
     });
 
     it('should create spans with logging attributes for notifications/message', async () => {
@@ -218,20 +240,19 @@ describe('MCP Server Semantic Conventions', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'notifications/message',
-          forceTransaction: true,
           attributes: {
             'mcp.method.name': 'notifications/message',
             'mcp.session.id': 'test-session-123',
             'mcp.transport': 'StreamableHTTPServerTransport',
             'network.transport': 'tcp',
-            'network.protocol.version': '2.0',
+            'network.protocol.name': 'http',
             'mcp.logging.level': 'info',
             'mcp.logging.logger': 'math-service',
             'mcp.logging.data_type': 'string',
             'mcp.logging.message': 'Addition completed: 2 + 5 = 7',
+            'sentry.kind': 'server',
             'sentry.op': 'mcp.notification.client_to_server',
             'sentry.origin': 'auto.mcp.notification',
-            'sentry.source': 'route',
           },
         },
         expect.any(Function),
@@ -260,9 +281,9 @@ describe('MCP Server Semantic Conventions', () => {
             'mcp.method.name': 'notifications/cancelled',
             'mcp.cancelled.request_id': 'req-123',
             'mcp.cancelled.reason': 'user_requested',
+            'sentry.kind': 'server',
             'sentry.op': 'mcp.notification.client_to_server',
             'sentry.origin': 'auto.mcp.notification',
-            'sentry.source': 'route',
           }),
         }),
         expect.any(Function),
@@ -289,18 +310,20 @@ describe('MCP Server Semantic Conventions', () => {
           name: 'notifications/progress',
           attributes: expect.objectContaining({
             'mcp.method.name': 'notifications/progress',
-            'mcp.progress.token': 'token-456',
             'mcp.progress.current': 75,
             'mcp.progress.total': 100,
             'mcp.progress.percentage': 75,
             'mcp.progress.message': 'Processing files...',
+            'sentry.kind': 'server',
             'sentry.op': 'mcp.notification.client_to_server',
             'sentry.origin': 'auto.mcp.notification',
-            'sentry.source': 'route',
           }),
         }),
         expect.any(Function),
       );
+      const progressAttributes = startSpanSpy.mock.calls[0]?.[0].attributes;
+      expect(progressAttributes).not.toHaveProperty('mcp.progress.token');
+      expect(JSON.stringify(progressAttributes)).not.toContain('token-456');
 
       vi.clearAllMocks();
 
@@ -321,10 +344,9 @@ describe('MCP Server Semantic Conventions', () => {
           attributes: expect.objectContaining({
             'mcp.method.name': 'notifications/resources/updated',
             'mcp.resource.uri': 'file:///tmp/data.json',
-            'mcp.resource.protocol': 'file',
+            'sentry.kind': 'server',
             'sentry.op': 'mcp.notification.client_to_server',
             'sentry.origin': 'auto.mcp.notification',
-            'sentry.source': 'route',
           }),
         }),
         expect.any(Function),
@@ -346,9 +368,9 @@ describe('MCP Server Semantic Conventions', () => {
           name: 'notifications/tools/list_changed',
           attributes: expect.objectContaining({
             'mcp.method.name': 'notifications/tools/list_changed',
+            'sentry.kind': 'client',
             'sentry.op': 'mcp.notification.server_to_client',
             'sentry.origin': 'auto.mcp.notification',
-            'sentry.source': 'route',
           }),
         }),
         expect.any(Function),
@@ -388,8 +410,11 @@ describe('MCP Server Semantic Conventions', () => {
         expect.objectContaining({
           name: 'tools/call weather-lookup',
           op: 'mcp.server',
-          forceTransaction: true,
           attributes: expect.objectContaining({
+            'gen_ai.operation.name': 'execute_tool',
+            'gen_ai.tool.call.arguments': '{"location":"San Francisco","units":"celsius"}',
+            'gen_ai.tool.name': 'weather-lookup',
+            'jsonrpc.request.id': 'req-tool-result',
             'mcp.method.name': 'tools/call',
             'mcp.tool.name': 'weather-lookup',
             'mcp.request.id': 'req-tool-result',
@@ -413,11 +438,13 @@ describe('MCP Server Semantic Conventions', () => {
       };
 
       // Simulate the outgoing response (this should trigger span completion)
-      mockTransport.send?.(toolResponse);
+      await mockTransport.send?.(toolResponse);
 
       // Verify that the span was enriched with tool result attributes
       expect(setAttributesSpy).toHaveBeenCalledWith(
         expect.objectContaining({
+          'gen_ai.tool.call.result':
+            '{"content":[{"type":"text","text":"The weather in San Francisco is 18°C with partly cloudy skies."}]}',
           'mcp.tool.result.is_error': false,
           'mcp.tool.result.content_count': 1,
           'mcp.tool.result.content_type': 'text',
@@ -461,8 +488,11 @@ describe('MCP Server Semantic Conventions', () => {
         expect.objectContaining({
           name: 'prompts/get code-review',
           op: 'mcp.server',
-          forceTransaction: true,
           attributes: expect.objectContaining({
+            'gen_ai.prompt.name': 'code-review',
+            'gen_ai.prompt.variable.complexity': 'high',
+            'gen_ai.prompt.variable.language': 'typescript',
+            'jsonrpc.request.id': 'req-prompt-result',
             'mcp.method.name': 'prompts/get',
             'mcp.prompt.name': 'code-review',
             'mcp.request.id': 'req-prompt-result',
@@ -487,7 +517,7 @@ describe('MCP Server Semantic Conventions', () => {
         },
       };
 
-      mockTransport.send?.(promptResponse);
+      await mockTransport.send?.(promptResponse);
 
       expect(setAttributesSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -502,6 +532,274 @@ describe('MCP Server Semantic Conventions', () => {
       expect(endSpy).toHaveBeenCalled();
     });
 
+    it('should capture modern MRTR metadata without recording request state', async () => {
+      await wrappedMcpServer.connect(mockTransport);
+
+      const setAttributesSpy = vi.fn();
+      const mockSpan = { setAttributes: setAttributesSpy, setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(
+        mockSpan as unknown as ReturnType<typeof tracingModule.startInactiveSpan>,
+      );
+
+      mockTransport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          id: 'req-mrtr',
+          params: {
+            name: 'approval',
+            inputResponses: {
+              first: { result: 'approved' },
+              second: { result: 'denied' },
+            },
+            requestState: 'opaque-sensitive-state',
+          },
+        },
+        {},
+      );
+
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: expect.objectContaining({
+            'mcp.input_response.count': 2,
+            'mcp.request_state.present': true,
+          }),
+        }),
+      );
+      const requestAttributes = startInactiveSpanSpy.mock.calls[0]?.[0].attributes;
+      expect(Object.values(requestAttributes ?? {})).not.toContain('opaque-sensitive-state');
+
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        id: 'req-mrtr',
+        result: {
+          resultType: 'input_required',
+          inputRequests: {
+            tool: { method: 'tools/call' },
+            elicitation: { method: 'elicitation/create' },
+          },
+        },
+      });
+
+      expect(setAttributesSpy).toHaveBeenCalledWith({
+        'mcp.input_request.count': 2,
+        'mcp.input_request.methods': ['elicitation/create', 'tools/call'],
+        'mcp.result.type': 'input_required',
+      });
+      expect(mockSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('should capture cache hints and collection size for a modern cacheable result', async () => {
+      await wrappedMcpServer.connect(mockTransport);
+
+      const setAttributesSpy = vi.fn();
+      const mockSpan = { setAttributes: setAttributesSpy, setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(
+        mockSpan as unknown as ReturnType<typeof tracingModule.startInactiveSpan>,
+      );
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'req-list', params: {} }, {});
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        id: 'req-list',
+        result: {
+          resultType: 'complete',
+          ttlMs: 5_000,
+          cacheScope: 'public',
+          tools: [{ name: 'weather' }, { name: 'search' }],
+        },
+      });
+
+      expect(setAttributesSpy).toHaveBeenCalledWith({
+        'mcp.cache.scope': 'public',
+        'mcp.cache.ttl_ms': 5_000,
+        'mcp.result.count': 2,
+        'mcp.result.type': 'complete',
+      });
+      expect(mockSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('should treat modern request metadata as request-scoped and omit legacy session identity', async () => {
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          id: 'req-modern-metadata',
+          params: {
+            _meta: {
+              progressToken: 'progress-123',
+              'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+              'io.modelcontextprotocol/clientCapabilities': {},
+              'io.modelcontextprotocol/logLevel': 'warning',
+            },
+          },
+        },
+        {},
+      );
+
+      const attributes = startInactiveSpanSpy.mock.calls[0]?.[0].attributes;
+      expect(attributes).toMatchObject({
+        'mcp.logging.requested_level': 'warning',
+        'mcp.protocol.version': '2026-07-28',
+      });
+      expect(attributes).not.toHaveProperty('mcp.progress.token');
+      expect(JSON.stringify(attributes)).not.toContain('progress-123');
+      expect(attributes).not.toHaveProperty('mcp.session.id');
+    });
+
+    it('should record result request state and subscription identity without recording opaque state', () => {
+      const attributes = extractCommonResultAttributes('subscriptions/listen', {
+        resultType: 'input_required',
+        requestState: 'opaque-sensitive-state',
+        _meta: { 'io.modelcontextprotocol/subscriptionId': 42 },
+      });
+
+      expect(attributes).toEqual({
+        'mcp.request_state.present': true,
+        'mcp.result.type': 'input_required',
+        'mcp.subscription.id': '42',
+      });
+      expect(Object.values(attributes)).not.toContain('opaque-sensitive-state');
+    });
+
+    it('records pagination state without recording opaque cursors', () => {
+      const requestAttributes = buildTypeSpecificAttributes(
+        'request',
+        {
+          jsonrpc: '2.0',
+          id: 'paginated-request',
+          method: 'tools/list',
+          params: { cursor: 'opaque-sensitive-cursor' },
+        },
+        { cursor: 'opaque-sensitive-cursor' },
+        false,
+      );
+      const resultAttributes = extractCommonResultAttributes('tools/list', {
+        resultType: 'complete',
+        nextCursor: 'opaque-sensitive-next-cursor',
+        tools: [{ name: 'weather' }],
+      });
+
+      expect(requestAttributes).toEqual({
+        'jsonrpc.request.id': 'paginated-request',
+        'mcp.pagination.cursor.present': true,
+        'mcp.request.id': 'paginated-request',
+      });
+      expect(resultAttributes).toEqual({
+        'mcp.pagination.next_cursor.present': true,
+        'mcp.result.count': 1,
+        'mcp.result.type': 'complete',
+      });
+      expect(Object.values({ ...requestAttributes, ...resultAttributes })).not.toContain('opaque-sensitive-cursor');
+      expect(Object.values({ ...requestAttributes, ...resultAttributes })).not.toContain(
+        'opaque-sensitive-next-cursor',
+      );
+    });
+
+    it('records bounded resource result metadata without resource content', () => {
+      const attributes = extractCommonResultAttributes('resources/read', {
+        resultType: 'complete',
+        contents: [
+          { uri: 'file:///secret/a.txt', mimeType: 'text/plain', text: 'sensitive text' },
+          { uri: 'file:///secret/b.json', mimeType: 'application/json', text: '{"secret":true}' },
+          { uri: 'file:///secret/c.txt', mimeType: 'text/plain', text: 'more sensitive text' },
+        ],
+      });
+
+      expect(attributes).toEqual({
+        'mcp.resource.result.mime_types': ['application/json', 'text/plain'],
+        'mcp.result.count': 3,
+        'mcp.result.type': 'complete',
+      });
+      expect(JSON.stringify(attributes)).not.toContain('file:///secret');
+      expect(JSON.stringify(attributes)).not.toContain('sensitive text');
+    });
+
+    it('records completion shape without completion values', () => {
+      const requestAttributes = buildTypeSpecificAttributes(
+        'request',
+        {
+          jsonrpc: '2.0',
+          id: 'completion-request',
+          method: 'completion/complete',
+          params: { ref: { type: 'ref/resource', uri: 'file:///secret/{name}' } },
+        },
+        { ref: { type: 'ref/resource', uri: 'file:///secret/{name}' } },
+        false,
+      );
+      const resultAttributes = extractCommonResultAttributes('completion/complete', {
+        resultType: 'complete',
+        completion: {
+          values: ['sensitive-first', 'sensitive-second'],
+          total: 10,
+          hasMore: true,
+        },
+      });
+
+      expect(requestAttributes).toEqual({
+        'jsonrpc.request.id': 'completion-request',
+        'mcp.completion.reference.type': 'ref/resource',
+        'mcp.request.id': 'completion-request',
+      });
+      expect(resultAttributes).toEqual({
+        'mcp.result.count': 2,
+        'mcp.result.has_more': true,
+        'mcp.result.total_count': 10,
+        'mcp.result.type': 'complete',
+      });
+      expect(JSON.stringify({ ...requestAttributes, ...resultAttributes })).not.toContain('file:///secret');
+      expect(JSON.stringify({ ...requestAttributes, ...resultAttributes })).not.toContain('sensitive-first');
+    });
+
+    it('should encode structured tool output as a bounded OTel object JSON value', () => {
+      const primitiveAttributes = extractToolResultAttributes(
+        { resultType: 'complete', structuredContent: ['first', 'second'] },
+        true,
+      );
+      const primitiveResult = primitiveAttributes['gen_ai.tool.call.result'];
+      expect(typeof primitiveResult).toBe('string');
+      expect(JSON.parse(primitiveResult as string)).toEqual({ structuredContent: ['first', 'second'] });
+
+      const oversizedAttributes = extractToolResultAttributes(
+        { resultType: 'complete', structuredContent: { payload: 'x'.repeat(11_000) } },
+        true,
+      );
+      const oversizedResult = oversizedAttributes['gen_ai.tool.call.result'];
+      expect(typeof oversizedResult).toBe('string');
+      expect((oversizedResult as string).length).toBeLessThanOrEqual(10_000);
+      expect(JSON.parse(oversizedResult as string)).toEqual({
+        _sentry: { originalLength: 11_014, truncated: true },
+      });
+    });
+
+    it('should only emit object-shaped canonical tool arguments and bound dynamic argument attributes', () => {
+      expect(getRequestArguments('tools/call', { arguments: ['not', 'an', 'object'] })).toEqual({});
+
+      const manyArguments = Object.fromEntries(Array.from({ length: 40 }, (_, index) => [`argument-${index}`, index]));
+      const attributes = getRequestArguments('tools/call', { arguments: manyArguments });
+
+      expect(JSON.parse(attributes['gen_ai.tool.call.arguments'] as string)).toEqual(manyArguments);
+      expect(Object.keys(attributes).filter(key => key.startsWith('mcp.request.argument.'))).toHaveLength(32);
+    });
+
+    it('should classify protocol-defined caller errors according to the negotiated revision', () => {
+      const error = { code: -32020, message: 'Request headers do not match request metadata' };
+
+      expect(getJsonRpcErrorAttributes(error, '2026-07-28')).toEqual({
+        'rpc.response.status_code': '-32020',
+      });
+      expect(getJsonRpcErrorAttributes(error, '2025-11-25')).toEqual({
+        'error.type': '-32020',
+        'rpc.response.status_code': '-32020',
+      });
+      expect(getJsonRpcErrorAttributes({ code: -32002, message: 'Resource not found' }, '2026-07-28')).toEqual({
+        'error.type': '-32002',
+        'rpc.response.status_code': '-32002',
+      });
+    });
+
     it('should capture tool result metadata but not content when recordOutputs is false', async () => {
       const server = wrapMcpServerWithSentry(createMockMcpServer(), { recordOutputs: false });
       const transport = createMockTransport();
@@ -514,7 +812,7 @@ describe('MCP Server Semantic Conventions', () => {
       );
 
       transport.onmessage?.({ jsonrpc: '2.0', method: 'tools/call', id: 'req-1', params: { name: 'tool' } }, {});
-      transport.send?.({
+      await transport.send?.({
         jsonrpc: '2.0',
         id: 'req-1',
         result: {
@@ -541,7 +839,7 @@ describe('MCP Server Semantic Conventions', () => {
       );
 
       transport.onmessage?.({ jsonrpc: '2.0', method: 'prompts/get', id: 'req-1', params: { name: 'prompt' } }, {});
-      transport.send?.({
+      await transport.send?.({
         jsonrpc: '2.0',
         id: 'req-1',
         result: {
@@ -582,6 +880,66 @@ describe('MCP Server Semantic Conventions', () => {
 
       const lastCall = startSpanSpy.mock.calls[startSpanSpy.mock.calls.length - 1];
       expect(lastCall?.[0]?.attributes).not.toHaveProperty('mcp.logging.message');
+    });
+
+    it('never records request progress tokens when sensitive input collection is disabled', async () => {
+      getClientSpy.mockReturnValue(createMockClient(false, { inputs: false, outputs: false }));
+      const server = wrapMcpServerWithSentry(createMockMcpServer(), { recordInputs: false });
+      const transport = createMockTransport();
+      await server.connect(transport);
+      const privateProgressToken = 'Bearer private-progress-token-for-customer-42';
+
+      transport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          id: 'private-progress-request',
+          params: {
+            _meta: {
+              progressToken: privateProgressToken,
+              'io.modelcontextprotocol/logLevel': 'warning',
+            },
+          },
+        },
+        {},
+      );
+
+      const lastCall = startInactiveSpanSpy.mock.calls[startInactiveSpanSpy.mock.calls.length - 1];
+      const attributes = lastCall?.[0].attributes;
+      expect(attributes).toHaveProperty('mcp.logging.requested_level', 'warning');
+      expect(attributes).not.toHaveProperty('mcp.progress.token');
+      expect(JSON.stringify(attributes)).not.toContain(privateProgressToken);
+    });
+
+    it('never records notification progress tokens when sensitive input collection is disabled', async () => {
+      getClientSpy.mockReturnValue(createMockClient(false, { inputs: false, outputs: false }));
+      const server = wrapMcpServerWithSentry(createMockMcpServer(), { recordInputs: false });
+      const transport = createMockTransport();
+      await server.connect(transport);
+      const privateProgressToken = 'session=user-42&authorization=private-progress-token';
+
+      transport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'notifications/progress',
+          params: {
+            progressToken: privateProgressToken,
+            progress: 3,
+            total: 12,
+            message: 'Private processing details',
+          },
+        },
+        {},
+      );
+
+      const lastCall = startSpanSpy.mock.calls[startSpanSpy.mock.calls.length - 1];
+      const attributes = lastCall?.[0].attributes;
+      expect(attributes).toHaveProperty('mcp.progress.current', 3);
+      expect(attributes).toHaveProperty('mcp.progress.total', 12);
+      expect(attributes).toHaveProperty('mcp.progress.percentage', 25);
+      expect(attributes).not.toHaveProperty('mcp.progress.token');
+      expect(attributes).not.toHaveProperty('mcp.progress.message');
+      expect(JSON.stringify(attributes)).not.toContain(privateProgressToken);
     });
   });
 });

--- a/packages/core/test/lib/integrations/mcp-server/tracePropagation.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/tracePropagation.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import { extractMcpTraceContext } from '../../../../src/integrations/mcp-server/tracePropagation';
+
+const TRACE_ID = '0af7651916cd43dd8448eb211c80319c';
+const PARENT_SPAN_ID = '00f067aa0ba902b7';
+
+describe('extractMcpTraceContext', () => {
+  it('extracts sampled trace context and converts it for continueTrace', () => {
+    const traceparent = `00-${TRACE_ID}-${PARENT_SPAN_ID}-01`;
+
+    expect(
+      extractMcpTraceContext({
+        _meta: {
+          traceparent,
+          tracestate: 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE',
+          baggage: 'sentry-environment=production,sentry-release=1.0.0',
+        },
+      }),
+    ).toEqual({
+      traceparent,
+      sentryTrace: `${TRACE_ID}-${PARENT_SPAN_ID}-1`,
+      tracestate: 'rojo=00f067aa0ba902b7,congo=t61rcWkgMzE',
+      baggage: 'sentry-environment=production,sentry-release=1.0.0',
+      parentContext: {
+        traceId: TRACE_ID,
+        spanId: PARENT_SPAN_ID,
+        isRemote: true,
+        traceFlags: 1,
+      },
+    });
+  });
+
+  it('extracts an unsampled trace context without optional propagation fields', () => {
+    const traceparent = `00-${TRACE_ID}-${PARENT_SPAN_ID}-00`;
+
+    expect(extractMcpTraceContext({ _meta: { traceparent } })).toEqual({
+      traceparent,
+      sentryTrace: `${TRACE_ID}-${PARENT_SPAN_ID}-0`,
+      parentContext: {
+        traceId: TRACE_ID,
+        spanId: PARENT_SPAN_ID,
+        isRemote: true,
+        traceFlags: 0,
+      },
+    });
+  });
+
+  it.each([
+    ['sampled', '03', 1, '1'],
+    ['unsampled', '02', 0, '0'],
+    ['all flags set', 'ff', 1, '1'],
+  ])('uses only the sampling bit for %s flags', (_description, flags, expectedTraceFlags, expectedSampled) => {
+    const traceparent = `00-${TRACE_ID}-${PARENT_SPAN_ID}-${flags}`;
+
+    expect(extractMcpTraceContext({ _meta: { traceparent } })).toEqual({
+      traceparent,
+      sentryTrace: `${TRACE_ID}-${PARENT_SPAN_ID}-${expectedSampled}`,
+      parentContext: {
+        traceId: TRACE_ID,
+        spanId: PARENT_SPAN_ID,
+        isRemote: true,
+        traceFlags: expectedTraceFlags,
+      },
+    });
+  });
+
+  it.each([
+    ['without additional fields', `01-${TRACE_ID}-${PARENT_SPAN_ID}-01`, 1, '1'],
+    ['with additional fields', `01-${TRACE_ID}-${PARENT_SPAN_ID}-03-vendor-data`, 1, '1'],
+    ['at the highest supported version', `fe-${TRACE_ID}-${PARENT_SPAN_ID}-00-future`, 0, '0'],
+  ])('accepts a future traceparent version %s', (_description, traceparent, expectedTraceFlags, expectedSampled) => {
+    expect(extractMcpTraceContext({ _meta: { traceparent } })).toEqual({
+      traceparent,
+      sentryTrace: `${TRACE_ID}-${PARENT_SPAN_ID}-${expectedSampled}`,
+      parentContext: {
+        traceId: TRACE_ID,
+        spanId: PARENT_SPAN_ID,
+        isRemote: true,
+        traceFlags: expectedTraceFlags,
+      },
+    });
+  });
+
+  it('ignores non-string baggage and tracestate values', () => {
+    const traceparent = `00-${TRACE_ID}-${PARENT_SPAN_ID}-01`;
+
+    expect(
+      extractMcpTraceContext({
+        _meta: {
+          traceparent,
+          baggage: ['sentry-environment=production'],
+          tracestate: 123,
+        },
+      }),
+    ).toEqual({
+      traceparent,
+      sentryTrace: `${TRACE_ID}-${PARENT_SPAN_ID}-1`,
+      parentContext: {
+        traceId: TRACE_ID,
+        spanId: PARENT_SPAN_ID,
+        isRemote: true,
+        traceFlags: 1,
+      },
+    });
+  });
+
+  it.each([
+    ['empty', '', ''],
+    ['oversized', `tenant=${'a'.repeat(8186)}`, `vendor=${'a'.repeat(506)}`],
+  ])(
+    'ignores %s optional propagation fields without discarding valid traceparent',
+    (_description, baggage, tracestate) => {
+      const traceparent = `00-${TRACE_ID}-${PARENT_SPAN_ID}-01`;
+
+      expect(extractMcpTraceContext({ _meta: { traceparent, baggage, tracestate } })).toEqual({
+        traceparent,
+        sentryTrace: `${TRACE_ID}-${PARENT_SPAN_ID}-1`,
+        parentContext: {
+          traceId: TRACE_ID,
+          spanId: PARENT_SPAN_ID,
+          isRemote: true,
+          traceFlags: 1,
+        },
+      });
+    },
+  );
+
+  it('accepts optional propagation fields at their maximum lengths', () => {
+    const traceparent = `00-${TRACE_ID}-${PARENT_SPAN_ID}-01`;
+    const baggage = `key=${'a'.repeat(8188)}`;
+    const tracestate = `key=${'a'.repeat(508)}`;
+
+    expect(extractMcpTraceContext({ _meta: { traceparent, baggage, tracestate } })).toEqual(
+      expect.objectContaining({ traceparent, baggage, tracestate }),
+    );
+  });
+
+  it.each([
+    ['missing params', undefined],
+    ['null params', null],
+    ['array params', []],
+    ['missing _meta', {}],
+    ['null _meta', { _meta: null }],
+    ['array _meta', { _meta: [] }],
+    ['missing traceparent', { _meta: {} }],
+    ['non-string traceparent', { _meta: { traceparent: 123 } }],
+  ])('does not extract context for %s', (_description, params) => {
+    expect(extractMcpTraceContext(params)).toBeUndefined();
+  });
+
+  it.each([
+    ['the forbidden ff version', `ff-${TRACE_ID}-${PARENT_SPAN_ID}-01`],
+    ['an uppercase version', `FF-${TRACE_ID}-${PARENT_SPAN_ID}-01`],
+    ['an all-zero trace id', `00-00000000000000000000000000000000-${PARENT_SPAN_ID}-01`],
+    ['an all-zero parent span id', `00-${TRACE_ID}-0000000000000000-01`],
+    ['a one-character trace flag', `00-${TRACE_ID}-${PARENT_SPAN_ID}-1`],
+    ['an uppercase trace id', `00-${TRACE_ID.toUpperCase()}-${PARENT_SPAN_ID}-01`],
+    ['an uppercase parent span id', `00-${TRACE_ID}-${PARENT_SPAN_ID.toUpperCase()}-01`],
+    ['a truncated trace id', `00-${TRACE_ID.slice(1)}-${PARENT_SPAN_ID}-01`],
+    ['a truncated parent span id', `00-${TRACE_ID}-${PARENT_SPAN_ID.slice(1)}-01`],
+    ['an extra field on version 00', `00-${TRACE_ID}-${PARENT_SPAN_ID}-01-extra`],
+    ['more than one leading whitespace character', `  00-${TRACE_ID}-${PARENT_SPAN_ID}-01`],
+    ['more than one trailing whitespace character', `00-${TRACE_ID}-${PARENT_SPAN_ID}-01  `],
+    ['an oversized value', `01-${TRACE_ID}-${PARENT_SPAN_ID}-01-${'a'.repeat(512)}`],
+  ])('rejects traceparent with %s', (_description, traceparent) => {
+    expect(extractMcpTraceContext({ _meta: { traceparent } })).toBeUndefined();
+  });
+
+  it.each([
+    ['leading whitespace', ` 00-${TRACE_ID}-${PARENT_SPAN_ID}-01`],
+    ['trailing whitespace', `00-${TRACE_ID}-${PARENT_SPAN_ID}-01 `],
+  ])('accepts traceparent with a single %s character', (_description, traceparent) => {
+    expect(extractMcpTraceContext({ _meta: { traceparent } })?.parentContext).toEqual({
+      traceId: TRACE_ID,
+      spanId: PARENT_SPAN_ID,
+      isRemote: true,
+      traceFlags: 1,
+    });
+  });
+});

--- a/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as currentScopes from '../../../../src/currentScopes';
+import * as exports from '../../../../src/exports';
 import { wrapMcpServerWithSentry } from '../../../../src/integrations/mcp-server';
 import {
   buildTransportAttributes,
@@ -25,6 +26,8 @@ import {
   wrapTransportSend,
 } from '../../../../src/integrations/mcp-server/transport';
 import * as tracingModule from '../../../../src/tracing';
+import * as spanUtils from '../../../../src/utils/spanUtils';
+import * as traceDataModule from '../../../../src/utils/traceData';
 import {
   createMockClient,
   createMockMcpServer,
@@ -37,11 +40,18 @@ import {
 describe('MCP Server Transport Instrumentation', () => {
   const startSpanSpy = vi.spyOn(tracingModule, 'startSpan');
   const startInactiveSpanSpy = vi.spyOn(tracingModule, 'startInactiveSpan');
+  const startNewTraceSpy = vi.spyOn(tracingModule, 'startNewTrace');
+  const continueTraceSpy = vi.spyOn(tracingModule, 'continueTrace');
+  const getActiveSpanSpy = vi.spyOn(spanUtils, 'getActiveSpan');
+  const getTraceDataSpy = vi.spyOn(traceDataModule, 'getTraceData');
   const getClientSpy = vi.spyOn(currentScopes, 'getClient');
+  const captureExceptionSpy = vi.spyOn(exports, 'captureException');
 
   beforeEach(() => {
     vi.clearAllMocks();
     getClientSpy.mockReturnValue(createMockClient(true));
+    getActiveSpanSpy.mockReturnValue(undefined);
+    getTraceDataSpy.mockReturnValue({});
   });
 
   describe('Transport-level instrumentation', () => {
@@ -117,7 +127,94 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(startInactiveSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'tools/call get-weather',
-          forceTransaction: true,
+          attributes: expect.objectContaining({
+            'gen_ai.operation.name': 'execute_tool',
+            'gen_ai.tool.name': 'get-weather',
+            'jsonrpc.request.id': 'req-1',
+            'sentry.kind': 'server',
+          }),
+        }),
+      );
+    });
+
+    it('uses the ambient transport span as parent when no MCP context is provided', async () => {
+      const ambientContext = {
+        traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        spanId: 'bbbbbbbbbbbbbbbb',
+        traceFlags: 1,
+      };
+      const ambientSpan = {
+        spanContext: () => ambientContext,
+        isRecording: vi.fn().mockReturnValue(true),
+      };
+      getActiveSpanSpy.mockReturnValue(ambientSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          id: 'no-mcp-context',
+        },
+        {},
+      );
+
+      expect(startNewTraceSpy).not.toHaveBeenCalled();
+      expect(continueTraceSpy).not.toHaveBeenCalled();
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools/list',
+          parentSpan: ambientSpan,
+        }),
+      );
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(expect.not.objectContaining({ links: expect.anything() }));
+    });
+
+    it('continues MCP trace context and links the independent ambient transport span', async () => {
+      const ambientContext = {
+        traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        spanId: 'bbbbbbbbbbbbbbbb',
+        traceFlags: 1,
+      };
+      getActiveSpanSpy.mockReturnValue({
+        spanContext: () => ambientContext,
+        isRecording: vi.fn().mockReturnValue(true),
+      } as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/list',
+          id: 'continued-mcp-context',
+          params: {
+            _meta: {
+              traceparent: '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+              tracestate: 'vendor=value',
+              baggage: 'sentry-release=1.0.0',
+            },
+          },
+        },
+        {},
+      );
+
+      expect(continueTraceSpy).toHaveBeenCalledWith(
+        {
+          sentryTrace: '4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-1',
+          baggage: 'sentry-release=1.0.0',
+        },
+        expect.any(Function),
+      );
+      expect(startNewTraceSpy).not.toHaveBeenCalled();
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'tools/list',
+          links: [{ context: ambientContext }],
+          attributes: expect.not.objectContaining({
+            baggage: expect.anything(),
+            traceparent: expect.anything(),
+            tracestate: expect.anything(),
+          }),
         }),
       );
     });
@@ -137,7 +234,9 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'notifications/initialized',
-          forceTransaction: true,
+          attributes: expect.objectContaining({
+            'sentry.kind': 'server',
+          }),
         }),
         expect.any(Function),
       );
@@ -158,7 +257,9 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'notifications/tools/list_changed',
-          forceTransaction: true,
+          attributes: expect.objectContaining({
+            'sentry.kind': 'client',
+          }),
         }),
         expect.any(Function),
       );
@@ -209,9 +310,57 @@ describe('MCP Server Transport Instrumentation', () => {
       };
       await mockTransport.send?.(jsonRpcErrorResponse as any);
 
-      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 2, message: 'internal_error' });
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': '-32603',
+        'rpc.response.status_code': '-32603',
+      });
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({
+        code: 2,
+        message: 'Internal error: tool threw an exception',
+      });
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
       expect(mockSpan.end).toHaveBeenCalled();
     });
+
+    it.each([-32020, -32021, -32022])(
+      'should treat JSON-RPC error %s as a caller fault without creating an Issue',
+      async errorCode => {
+        const mockSpan = {
+          setAttributes: vi.fn(),
+          setStatus: vi.fn(),
+          end: vi.fn(),
+          isRecording: vi.fn().mockReturnValue(true),
+        };
+        startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+
+        await wrappedMcpServer.connect(mockTransport);
+        mockTransport.onmessage?.(
+          {
+            jsonrpc: '2.0',
+            method: 'tools/call',
+            id: `req-caller-${errorCode}`,
+            params: {
+              name: 'caller-error',
+              _meta: { 'io.modelcontextprotocol/protocolVersion': '2026-07-28' },
+            },
+          },
+          {},
+        );
+
+        await mockTransport.send?.({
+          jsonrpc: '2.0',
+          id: `req-caller-${errorCode}`,
+          error: { code: errorCode, message: 'The client request is not acceptable' },
+        });
+
+        expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+          'rpc.response.status_code': String(errorCode),
+        });
+        expect(mockSpan.setStatus).not.toHaveBeenCalled();
+        expect(captureExceptionSpy).not.toHaveBeenCalled();
+        expect(mockSpan.end).toHaveBeenCalledOnce();
+      },
+    );
 
     it('should not set error span status for successful JSON-RPC responses', async () => {
       const mockSpan = {
@@ -242,6 +391,680 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(mockSpan.setStatus).not.toHaveBeenCalled();
       expect(mockSpan.end).toHaveBeenCalled();
     });
+
+    it('completes an in-flight response before deferred close cleanup', async () => {
+      let resolveSend: (() => void) | undefined;
+      mockTransport.send = vi.fn(
+        () =>
+          new Promise<void>(resolve => {
+            resolveSend = resolve;
+          }),
+      );
+      const mockSpan = {
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+        isRecording: vi.fn().mockReturnValue(true),
+      };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'response-in-flight', params: {} }, {});
+      const sendPromise = mockTransport.send?.({
+        jsonrpc: '2.0',
+        id: 'response-in-flight',
+        result: { tools: [{ name: 'weather' }] },
+      });
+
+      expect(mockSpan.end).not.toHaveBeenCalled();
+      mockTransport.onclose?.();
+      expect(mockSpan.end).not.toHaveBeenCalled();
+
+      resolveSend?.();
+      await sendPromise;
+
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith({ 'mcp.result.count': 1 });
+      expect(mockSpan.setAttributes).not.toHaveBeenCalledWith({ 'mcp.request.outcome': 'cancelled' });
+      expect(mockSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('does not let a per-request transport close beat response completion', async () => {
+      const mockSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+      mockTransport.send = vi.fn(message => {
+        if ('result' in message || 'error' in message) {
+          queueMicrotask(() => mockTransport.onclose?.());
+        }
+        return Promise.resolve();
+      });
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'per-request-close' }, {});
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        id: 'per-request-close',
+        result: { tools: [{ name: 'weather' }] },
+      });
+      await new Promise(resolve => setTimeout(resolve));
+
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith({ 'mcp.result.count': 1 });
+      expect(mockSpan.setAttributes).not.toHaveBeenCalledWith({ 'mcp.request.outcome': 'cancelled' });
+      expect(mockSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('cleans up pending spans when the original onclose handler throws', async () => {
+      const closeError = new Error('close handler failed');
+      const mockSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+      mockTransport.onclose = vi.fn(() => {
+        throw closeError;
+      });
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'throwing-close' }, {});
+      expect(() => mockTransport.onclose?.()).toThrow(closeError);
+      await new Promise(resolve => setTimeout(resolve));
+
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith({ 'mcp.request.outcome': 'cancelled' });
+      expect(mockSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('marks the request span as failed and preserves an asynchronous response send rejection', async () => {
+      const sendError = new Error('socket closed');
+      mockTransport.send = vi.fn().mockRejectedValue(sendError);
+      const mockSpan = {
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+        isRecording: vi.fn().mockReturnValue(true),
+      };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'send-rejected', params: {} }, {});
+
+      await expect(mockTransport.send?.({ jsonrpc: '2.0', id: 'send-rejected', result: { tools: [] } })).rejects.toBe(
+        sendError,
+      );
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': 'Error',
+        'mcp.request.outcome': 'send_error',
+      });
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 2, message: 'transport_send_error' });
+      expect(mockSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('marks the request span as failed and preserves a synchronous response send error', async () => {
+      const sendError = new TypeError('invalid response state');
+      mockTransport.send = vi.fn(() => {
+        throw sendError;
+      });
+      const mockSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'send-threw', params: {} }, {});
+
+      expect(() => mockTransport.send?.({ jsonrpc: '2.0', id: 'send-threw', result: { tools: [] } })).toThrow(
+        sendError,
+      );
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': 'TypeError',
+        'mcp.request.outcome': 'send_error',
+      });
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 2, message: 'transport_send_error' });
+      expect(mockSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('ends only the explicitly cancelled request while the connection remains open', async () => {
+      const firstSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const secondSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(firstSpan as any).mockReturnValueOnce(secondSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.(
+        { jsonrpc: '2.0', method: 'tools/call', id: 'cancel-me', params: { name: 'slow' } },
+        {},
+      );
+      mockTransport.onmessage?.(
+        { jsonrpc: '2.0', method: 'tools/call', id: 'keep-running', params: { name: 'fast' } },
+        {},
+      );
+      mockTransport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'notifications/cancelled',
+          params: { requestId: 'cancel-me', reason: 'user requested' },
+        },
+        {},
+      );
+
+      expect(firstSpan.setAttributes).toHaveBeenCalledWith({ 'mcp.request.outcome': 'cancelled' });
+      expect(firstSpan.setStatus).not.toHaveBeenCalled();
+      expect(firstSpan.end).toHaveBeenCalledOnce();
+      expect(secondSpan.end).not.toHaveBeenCalled();
+
+      await mockTransport.send?.({ jsonrpc: '2.0', id: 'cancel-me', result: {} });
+      expect(firstSpan.end).toHaveBeenCalledOnce();
+      await mockTransport.send?.({ jsonrpc: '2.0', id: 'keep-running', result: {} });
+      expect(secondSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('injects outgoing notification trace context and preserves related MCP metadata', async () => {
+      const originalSend = mockTransport.send;
+      const requestSpan = {
+        spanContext: () => ({ traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', spanId: 'bbbbbbbbbbbbbbbb' }),
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+      };
+      startInactiveSpanSpy.mockReturnValue(requestSpan as any);
+      getTraceDataSpy.mockReturnValue({
+        'sentry-trace': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-cccccccccccccccc-1',
+        traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-cccccccccccccccc-01',
+        baggage: 'sentry-release=2.0.0',
+      });
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          method: 'tools/call',
+          id: 'related-request',
+          params: {
+            name: 'slow',
+            _meta: {
+              traceparent: '00-11111111111111111111111111111111-2222222222222222-01',
+              tracestate: 'vendor=value',
+              baggage: 'tenant=alpha',
+              'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+            },
+          },
+        },
+        {},
+      );
+      await mockTransport.send?.(
+        {
+          jsonrpc: '2.0',
+          method: 'notifications/progress',
+          params: {
+            progressToken: 'progress-1',
+            progress: 1,
+            _meta: { 'io.modelcontextprotocol/subscriptionId': 'subscription-1', baggage: 'tenant=beta' },
+          },
+        },
+        { relatedRequestId: 'related-request' },
+      );
+
+      expect(startSpanSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'notifications/progress',
+          parentSpan: requestSpan,
+          attributes: expect.objectContaining({
+            'mcp.protocol.version': '2026-07-28',
+            'sentry.kind': 'client',
+          }),
+        }),
+        expect.any(Function),
+      );
+      expect(originalSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            _meta: {
+              'io.modelcontextprotocol/subscriptionId': 'subscription-1',
+              traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-cccccccccccccccc-01',
+              tracestate: 'vendor=value',
+              baggage: 'tenant=beta,sentry-release=2.0.0',
+            },
+          }),
+        }),
+        { relatedRequestId: 'related-request' },
+      );
+    });
+
+    it('drops a stale traceparent when no current context can be injected', async () => {
+      const originalSend = mockTransport.send;
+      await wrappedMcpServer.connect(mockTransport);
+
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params: {
+          progressToken: 'progress-1',
+          progress: 1,
+          _meta: {
+            traceparent: '00-11111111111111111111111111111111-2222222222222222-01',
+            'com.example/custom': 'preserved',
+          },
+        },
+      });
+
+      expect(originalSend).toHaveBeenCalledWith({
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params: {
+          progressToken: 'progress-1',
+          progress: 1,
+          _meta: { 'com.example/custom': 'preserved' },
+        },
+      });
+    });
+
+    it('correlates R=O=0 independently and accepts a string response id for the numeric outgoing id', async () => {
+      const originalSend = mockTransport.send;
+      const incomingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const outgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(incomingSpan as any).mockReturnValueOnce(outgoingSpan as any);
+      getTraceDataSpy.mockReturnValue({
+        traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+        baggage: 'sentry-release=2.0.0',
+      });
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/call', id: 0, params: { name: 'delegate' } }, {});
+      await mockTransport.send?.(
+        {
+          jsonrpc: '2.0',
+          method: 'sampling/createMessage',
+          id: 0,
+          params: {
+            messages: [],
+            _meta: {
+              traceparent: '00-11111111111111111111111111111111-2222222222222222-00',
+              tracestate: `vendor=${'a'.repeat(506)}`,
+              baggage: `tenant=${'a'.repeat(8186)}`,
+              'com.example/custom': 'preserved',
+            },
+          },
+        },
+        { relatedRequestId: 0 },
+      );
+
+      expect(startInactiveSpanSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          name: 'sampling/createMessage',
+          op: 'mcp.client',
+          parentSpan: incomingSpan,
+          attributes: expect.objectContaining({
+            'jsonrpc.request.id': '0',
+            'mcp.method.name': 'sampling/createMessage',
+            'sentry.kind': 'client',
+          }),
+        }),
+      );
+      expect(originalSend).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            _meta: {
+              traceparent: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+              baggage: 'sentry-release=2.0.0',
+              'com.example/custom': 'preserved',
+            },
+          }),
+        }),
+        { relatedRequestId: 0 },
+      );
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', id: '0', result: { model: 'test-model' } }, {});
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+      expect(incomingSpan.end).not.toHaveBeenCalled();
+
+      await mockTransport.send?.({ jsonrpc: '2.0', id: 0, result: { content: [] } });
+      expect(incomingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('matches the SDK numeric coercion for legacy response ids', async () => {
+      const outgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      await mockTransport.send?.({ jsonrpc: '2.0', method: 'sampling/createMessage', id: 0 });
+      mockTransport.onmessage?.({ jsonrpc: '2.0', id: '00', result: {} }, {});
+
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('stores outgoing correlation before a transport synchronously delivers the response', async () => {
+      const outgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      mockTransport.send = vi.fn(message => {
+        if ('method' in message && 'id' in message) {
+          mockTransport.onmessage?.({ jsonrpc: '2.0', id: message.id, result: { model: 'test-model' } }, {});
+        }
+        return Promise.resolve();
+      });
+      await wrappedMcpServer.connect(mockTransport);
+
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'synchronous-response',
+        params: { messages: [] },
+      });
+
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('keeps an outgoing span open until asynchronous response processing completes', async () => {
+      let resolveResponse: (() => void) | undefined;
+      mockTransport.onmessage = vi.fn(
+        () =>
+          new Promise<void>(resolve => {
+            resolveResponse = resolve;
+          }),
+      ) as any;
+      const outgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'async-response',
+        params: { messages: [] },
+      });
+
+      const responsePromise = mockTransport.onmessage?.(
+        { jsonrpc: '2.0', id: 'async-response', result: { model: 'test-model' } },
+        {},
+      ) as unknown as Promise<void>;
+      expect(outgoingSpan.end).not.toHaveBeenCalled();
+
+      resolveResponse?.();
+      await responsePromise;
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('fails an outgoing span when asynchronous response processing rejects', async () => {
+      const responseError = new TypeError('response handler rejected');
+      mockTransport.onmessage = vi.fn().mockRejectedValue(responseError) as any;
+      const outgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'response-rejection',
+        params: { messages: [] },
+      });
+
+      await expect(
+        mockTransport.onmessage?.({ jsonrpc: '2.0', id: 'response-rejection', result: {} }, {}) as unknown,
+      ).rejects.toBe(responseError);
+      expect(outgoingSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': 'TypeError',
+        'mcp.request.outcome': 'response_error',
+      });
+      expect(outgoingSpan.setStatus).toHaveBeenCalledWith({ code: 2, message: 'response_processing_error' });
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('records every outgoing JSON-RPC error and bounds its status message', async () => {
+      const outgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'client-error-response',
+        params: { messages: [] },
+      });
+
+      mockTransport.onmessage?.(
+        {
+          jsonrpc: '2.0',
+          id: 'client-error-response',
+          error: { code: -32601, message: 'x'.repeat(1_000) },
+        },
+        {},
+      );
+
+      expect(outgoingSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': '-32601',
+        'rpc.response.status_code': '-32601',
+      });
+      expect(outgoingSpan.setStatus).toHaveBeenCalledWith({ code: 2, message: `${'x'.repeat(253)}...` });
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('fails an outgoing request span when its asynchronous send rejects', async () => {
+      const sendError = new Error('client disconnected');
+      const outgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      mockTransport.send = vi.fn().mockRejectedValue(sendError);
+      await wrappedMcpServer.connect(mockTransport);
+
+      await expect(
+        mockTransport.send?.({
+          jsonrpc: '2.0',
+          method: 'sampling/createMessage',
+          id: 'outgoing-send-error',
+          params: { messages: [] },
+        }),
+      ).rejects.toBe(sendError);
+
+      expect(outgoingSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': 'Error',
+        'mcp.request.outcome': 'send_error',
+      });
+      expect(outgoingSpan.setStatus).toHaveBeenCalledWith({ code: 2, message: 'transport_send_error' });
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('cancels an outgoing request exactly once when sending notifications/cancelled', async () => {
+      let resolveCancellation: (() => void) | undefined;
+      const outgoingSpan = {
+        spanContext: () => ({ traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', spanId: 'bbbbbbbbbbbbbbbb' }),
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+      };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      mockTransport.send = vi.fn(message =>
+        'method' in message && message.method === 'notifications/cancelled'
+          ? new Promise<void>(resolve => {
+              resolveCancellation = resolve;
+            })
+          : Promise.resolve(),
+      );
+      await wrappedMcpServer.connect(mockTransport);
+
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'cancel-outgoing',
+        params: { messages: [] },
+      });
+      const cancellationPromise = mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'notifications/cancelled',
+        params: { requestId: 'cancel-outgoing', reason: 'server stopped' },
+      });
+
+      expect(outgoingSpan.end).not.toHaveBeenCalled();
+      resolveCancellation?.();
+      await cancellationPromise;
+
+      expect(outgoingSpan.setAttributes).toHaveBeenCalledWith({ 'mcp.request.outcome': 'cancelled' });
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+
+      mockTransport.onclose?.();
+      await new Promise(resolve => setTimeout(resolve));
+      mockTransport.onmessage?.({ jsonrpc: '2.0', id: 'cancel-outgoing', result: {} }, {});
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('waits for cancellation delivery and leaves the request open when delivery rejects', async () => {
+      const sendError = new Error('cancellation delivery failed');
+      const outgoingSpan = {
+        spanContext: () => ({ traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', spanId: 'bbbbbbbbbbbbbbbb' }),
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+      };
+      startInactiveSpanSpy.mockReturnValue(outgoingSpan as any);
+      mockTransport.send = vi.fn(message =>
+        'method' in message && message.method === 'notifications/cancelled'
+          ? Promise.reject(sendError)
+          : Promise.resolve(),
+      );
+      await wrappedMcpServer.connect(mockTransport);
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'failed-cancellation',
+        params: { messages: [] },
+      });
+
+      await expect(
+        mockTransport.send?.({
+          jsonrpc: '2.0',
+          method: 'notifications/cancelled',
+          params: { requestId: 'failed-cancellation' },
+        }),
+      ).rejects.toBe(sendError);
+      expect(outgoingSpan.setAttributes).not.toHaveBeenCalledWith({ 'mcp.request.outcome': 'cancelled' });
+      expect(outgoingSpan.end).not.toHaveBeenCalled();
+
+      mockTransport.onclose?.();
+      await new Promise(resolve => setTimeout(resolve));
+      expect(outgoingSpan.setAttributes).toHaveBeenCalledWith({ 'mcp.request.outcome': 'cancelled' });
+      expect(outgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('does not let delayed cancellation delivery finish a replacement with the same id', async () => {
+      let resolveCancellation: (() => void) | undefined;
+      const firstOutgoingSpan = {
+        spanContext: () => ({ traceId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', spanId: 'bbbbbbbbbbbbbbbb' }),
+        setAttributes: vi.fn(),
+        setStatus: vi.fn(),
+        end: vi.fn(),
+      };
+      const replacementSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(firstOutgoingSpan as any).mockReturnValueOnce(replacementSpan as any);
+      mockTransport.send = vi.fn(message =>
+        'method' in message && message.method === 'notifications/cancelled'
+          ? new Promise<void>(resolve => {
+              resolveCancellation = resolve;
+            })
+          : Promise.resolve(),
+      );
+      await wrappedMcpServer.connect(mockTransport);
+
+      await mockTransport.send?.({ jsonrpc: '2.0', method: 'sampling/createMessage', id: 'reused-cancellation' });
+      const cancellationPromise = mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'notifications/cancelled',
+        params: { requestId: 'reused-cancellation' },
+      });
+      await mockTransport.send?.({ jsonrpc: '2.0', method: 'sampling/createMessage', id: 'reused-cancellation' });
+
+      resolveCancellation?.();
+      await cancellationPromise;
+      expect(firstOutgoingSpan.end).toHaveBeenCalledOnce();
+      expect(replacementSpan.end).not.toHaveBeenCalled();
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', id: 'reused-cancellation', result: {} }, {});
+      expect(replacementSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('terminates duplicate ids in each direction instead of silently overwriting spans', async () => {
+      const firstIncomingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const secondIncomingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const firstOutgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const secondOutgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy
+        .mockReturnValueOnce(firstIncomingSpan as any)
+        .mockReturnValueOnce(secondIncomingSpan as any)
+        .mockReturnValueOnce(firstOutgoingSpan as any)
+        .mockReturnValueOnce(secondOutgoingSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'duplicate-incoming' }, {});
+      mockTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'duplicate-incoming' }, {});
+      expect(firstIncomingSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': 'duplicate_request_id',
+        'mcp.request.outcome': 'request_id_reused',
+      });
+      expect(firstIncomingSpan.end).toHaveBeenCalledOnce();
+      expect(secondIncomingSpan.end).not.toHaveBeenCalled();
+
+      await mockTransport.send?.({ jsonrpc: '2.0', method: 'sampling/createMessage', id: 'duplicate-outgoing' });
+      await mockTransport.send?.({ jsonrpc: '2.0', method: 'sampling/createMessage', id: 'duplicate-outgoing' });
+      expect(firstOutgoingSpan.setAttributes).toHaveBeenCalledWith({
+        'error.type': 'duplicate_request_id',
+        'mcp.request.outcome': 'request_id_reused',
+      });
+      expect(firstOutgoingSpan.end).toHaveBeenCalledOnce();
+      expect(secondOutgoingSpan.end).not.toHaveBeenCalled();
+    });
+
+    it('does not let a late rejection for a reused id finish the replacement outgoing span', async () => {
+      let rejectFirstSend: ((error: Error) => void) | undefined;
+      const firstSendError = new Error('first send failed late');
+      const firstOutgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const secondOutgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(firstOutgoingSpan as any).mockReturnValueOnce(secondOutgoingSpan as any);
+      mockTransport.send = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              rejectFirstSend = reject;
+            }),
+        )
+        .mockResolvedValueOnce(undefined);
+      await wrappedMcpServer.connect(mockTransport);
+
+      const firstSend = mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'reused-outgoing',
+      });
+      await mockTransport.send?.({
+        jsonrpc: '2.0',
+        method: 'sampling/createMessage',
+        id: 'reused-outgoing',
+      });
+      rejectFirstSend?.(firstSendError);
+      await expect(firstSend).rejects.toBe(firstSendError);
+
+      expect(firstOutgoingSpan.end).toHaveBeenCalledOnce();
+      expect(secondOutgoingSpan.end).not.toHaveBeenCalled();
+      mockTransport.onmessage?.({ jsonrpc: '2.0', id: 'reused-outgoing', result: {} }, {});
+      expect(secondOutgoingSpan.end).toHaveBeenCalledOnce();
+    });
+
+    it('does not let delayed processing for a reused response id finish the replacement outgoing span', async () => {
+      let resolveFirstResponse: (() => void) | undefined;
+      const originalOnMessage = mockTransport.onmessage;
+      mockTransport.onmessage = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>(resolve => {
+              resolveFirstResponse = resolve;
+            }),
+        )
+        .mockImplementation((...args: unknown[]) => originalOnMessage?.(...args)) as any;
+      const firstOutgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const secondOutgoingSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(firstOutgoingSpan as any).mockReturnValueOnce(secondOutgoingSpan as any);
+      await wrappedMcpServer.connect(mockTransport);
+      await mockTransport.send?.({ jsonrpc: '2.0', method: 'sampling/createMessage', id: 'reused-response' });
+
+      const firstResponse = mockTransport.onmessage?.(
+        { jsonrpc: '2.0', id: 'reused-response', result: { model: 'first' } },
+        {},
+      ) as unknown as Promise<void>;
+      await mockTransport.send?.({ jsonrpc: '2.0', method: 'sampling/createMessage', id: 'reused-response' });
+      expect(firstOutgoingSpan.end).toHaveBeenCalledOnce();
+
+      resolveFirstResponse?.();
+      await firstResponse;
+      expect(secondOutgoingSpan.end).not.toHaveBeenCalled();
+      mockTransport.onmessage?.({ jsonrpc: '2.0', id: 'reused-response', result: { model: 'second' } }, {});
+      expect(secondOutgoingSpan.end).toHaveBeenCalledOnce();
+    });
   });
 
   describe('Stdio Transport Tests', () => {
@@ -271,19 +1094,21 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         name: 'tools/call process-file',
         op: 'mcp.server',
-        forceTransaction: true,
         attributes: {
+          'gen_ai.operation.name': 'execute_tool',
+          'gen_ai.tool.call.arguments': '{"path":"/tmp/data.txt"}',
+          'gen_ai.tool.name': 'process-file',
+          'jsonrpc.request.id': 'req-stdio-1',
           'mcp.method.name': 'tools/call',
           'mcp.tool.name': 'process-file',
           'mcp.request.id': 'req-stdio-1',
           'mcp.session.id': 'stdio-session-456',
           'mcp.transport': 'StdioServerTransport',
           'network.transport': 'pipe', // Should be pipe, not tcp
-          'network.protocol.version': '2.0',
           'mcp.request.argument.path': '"/tmp/data.txt"',
+          'sentry.kind': 'server',
           'sentry.op': 'mcp.server',
           'sentry.origin': 'auto.function.mcp_server',
-          'sentry.source': 'route',
         },
       });
     });
@@ -345,7 +1170,7 @@ describe('MCP Server Transport Instrumentation', () => {
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          name: 'resources/read https://api.example.com/data',
+          name: 'resources/read',
           attributes: expect.objectContaining({
             'mcp.method.name': 'resources/read',
             'mcp.resource.uri': 'https://api.example.com/data',
@@ -421,8 +1246,11 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(config).toEqual({
         name: 'tools/call test-tool',
         op: 'mcp.server',
-        forceTransaction: true,
-        attributes: expect.objectContaining({
+        attributes: {
+          'gen_ai.operation.name': 'execute_tool',
+          'gen_ai.tool.call.arguments': '{"input":"test"}',
+          'gen_ai.tool.name': 'test-tool',
+          'jsonrpc.request.id': 'req-direct-test',
           'mcp.method.name': 'tools/call',
           'mcp.tool.name': 'test-tool',
           'mcp.request.id': 'req-direct-test',
@@ -431,12 +1259,12 @@ describe('MCP Server Transport Instrumentation', () => {
           'client.port': 8080,
           'mcp.transport': 'StreamableHTTPServerTransport',
           'network.transport': 'tcp',
-          'network.protocol.version': '2.0',
+          'network.protocol.name': 'http',
           'mcp.request.argument.input': '"test"',
+          'sentry.kind': 'server',
           'sentry.op': 'mcp.server',
           'sentry.origin': 'auto.function.mcp_server',
-          'sentry.source': 'route',
-        }),
+        },
       });
     });
   });
@@ -512,6 +1340,13 @@ describe('MCP Server Transport Instrumentation', () => {
               title: 'Modern Client',
               version: '2.0.0',
             },
+            'io.modelcontextprotocol/clientCapabilities': {
+              roots: {},
+              sampling: {},
+              extensions: {
+                'com.example/approval': {},
+              },
+            },
           },
           name: 'weather',
         },
@@ -526,6 +1361,8 @@ describe('MCP Server Transport Instrumentation', () => {
           title: 'Modern Client',
           version: '2.0.0',
         },
+        clientCapabilities: ['roots', 'sampling'],
+        clientExtensionIds: ['com.example/approval'],
       });
     });
 
@@ -594,6 +1431,23 @@ describe('MCP Server Transport Instrumentation', () => {
       });
     });
 
+    it('isolates session data for transports that reuse the same session id', () => {
+      const firstTransport = createMockTransport();
+      const secondTransport = createMockTransport();
+      firstTransport.sessionId = 'shared-session-id';
+      secondTransport.sessionId = 'shared-session-id';
+
+      storeSessionDataForTransport(firstTransport, { protocolVersion: '2025-06-18' });
+      storeSessionDataForTransport(secondTransport, { protocolVersion: '2026-07-28' });
+
+      expect(getProtocolVersionForTransport(firstTransport)).toBe('2025-06-18');
+      expect(getProtocolVersionForTransport(secondTransport)).toBe('2026-07-28');
+
+      cleanupSessionDataForTransport(firstTransport);
+      expect(getSessionDataForTransport(firstTransport)).toBeUndefined();
+      expect(getProtocolVersionForTransport(secondTransport)).toBe('2026-07-28');
+    });
+
     it('should clean up session data', () => {
       const sessionData = {
         protocolVersion: '2025-06-18',
@@ -607,20 +1461,19 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(getSessionDataForTransport(mockTransport)).toBeUndefined();
     });
 
-    it('should store data for transports without sessionId using WeakMap fallback', () => {
+    it('stores data by transport identity even when no session id is present', () => {
       const transportWithoutSession = {
         onmessage: vi.fn(),
         onclose: vi.fn(),
         onerror: vi.fn(),
         send: vi.fn().mockResolvedValue(undefined),
         protocolVersion: '2025-06-18',
-        // No sessionId - uses WeakMap fallback
+        // No sessionId
       };
 
       const sessionData = { protocolVersion: '2025-06-18' };
 
       storeSessionDataForTransport(transportWithoutSession, sessionData);
-      // With the WeakMap fallback, data IS stored even for transports without sessionId
       expect(getSessionDataForTransport(transportWithoutSession)).toEqual(sessionData);
     });
   });
@@ -729,13 +1582,16 @@ describe('MCP Server Transport Instrumentation', () => {
         {},
       );
 
-      expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          'mcp.client.name': 'test-client',
-          'mcp.client.version': '1.0.0',
-          'mcp.protocol.version': '2025-06-18',
+          attributes: expect.objectContaining({
+            'mcp.client.name': 'test-client',
+            'mcp.client.version': '1.0.0',
+            'mcp.protocol.version': '2025-06-18',
+          }),
         }),
       );
+      expect(mockSpan.setAttributes).not.toHaveBeenCalled();
     });
 
     it('should add server info to initialize span on response', async () => {
@@ -794,6 +1650,10 @@ describe('MCP Server Transport Instrumentation', () => {
             _meta: {
               'io.modelcontextprotocol/protocolVersion': '2026-07-28',
               'io.modelcontextprotocol/clientInfo': { name: 'modern-client', version: '2.0.0' },
+              'io.modelcontextprotocol/clientCapabilities': {
+                roots: {},
+                extensions: { 'com.example/approval': {} },
+              },
             },
             name: 'weather',
           },
@@ -806,6 +1666,8 @@ describe('MCP Server Transport Instrumentation', () => {
           attributes: expect.objectContaining({
             'mcp.client.name': 'modern-client',
             'mcp.client.version': '2.0.0',
+            'mcp.client.capabilities': ['roots'],
+            'mcp.client.extension_ids': ['com.example/approval'],
             'mcp.protocol.version': '2026-07-28',
           }),
         }),
@@ -848,7 +1710,7 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(mockSpan.end).toHaveBeenCalledOnce();
     });
 
-    it('adds modern protocol and client info to notification spans', async () => {
+    it('uses transport classification for the protocol version of modern notification spans', async () => {
       const mockMcpServer = createMockMcpServer();
       const wrappedMcpServer = wrapMcpServerWithSentry(mockMcpServer);
       const transport = createMockTransport();
@@ -860,12 +1722,7 @@ describe('MCP Server Transport Instrumentation', () => {
         {
           jsonrpc: '2.0',
           method: 'notifications/tools/list_changed',
-          params: {
-            _meta: {
-              'io.modelcontextprotocol/protocolVersion': '2026-07-28',
-              'io.modelcontextprotocol/clientInfo': { name: 'modern-client', version: '2.0.0' },
-            },
-          },
+          params: {},
         },
         { classification: { era: 'modern', revision: '2026-07-28' } },
       );
@@ -873,18 +1730,15 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'notifications/tools/list_changed',
-          forceTransaction: true,
           attributes: {
             'mcp.transport': 'StreamableHTTPServerTransport',
             'network.transport': 'tcp',
-            'network.protocol.version': '2.0',
+            'network.protocol.name': 'http',
             'mcp.protocol.version': '2026-07-28',
-            'mcp.client.name': 'modern-client',
-            'mcp.client.version': '2.0.0',
             'mcp.method.name': 'notifications/tools/list_changed',
+            'sentry.kind': 'server',
             'sentry.op': 'mcp.notification.client_to_server',
             'sentry.origin': 'auto.mcp.notification',
-            'sentry.source': 'route',
           },
         },
         expect.any(Function),
@@ -932,6 +1786,13 @@ describe('MCP Server Transport Instrumentation', () => {
         'mcp.server.name': 'modern-server',
         'mcp.server.version': '2.0.0',
       });
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'gen_ai.tool.call.result': '{"content":[{"type":"text","text":"Sunny"}]}',
+          'mcp.result.type': 'complete',
+          'mcp.tool.result.content_count': 1,
+        }),
+      );
       expect(mockSpan.end).toHaveBeenCalledOnce();
     });
   });
@@ -993,6 +1854,48 @@ describe('MCP Server Transport Instrumentation', () => {
       );
     });
 
+    it.each([
+      [false, false],
+      [true, true],
+    ])('captures tool-result URIs only when userInfo=%s', async (userInfo, shouldCaptureUri) => {
+      getClientSpy.mockReturnValue(createMockClient(userInfo, { inputs: true, outputs: true }));
+      const mockSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValue(mockSpan as any);
+      const wrappedMcpServer = wrapMcpServerWithSentry(createMockMcpServer());
+      const transport = createMockTransport();
+      await wrappedMcpServer.connect(transport);
+
+      transport.onmessage?.(
+        { jsonrpc: '2.0', method: 'tools/call', id: 'uri-result', params: { name: 'read-secret' } },
+        {},
+      );
+      await transport.send?.({
+        jsonrpc: '2.0',
+        id: 'uri-result',
+        result: { content: [{ type: 'resource_link', uri: 'file:///private/secret.txt' }] },
+      });
+
+      const uriAttributes = expect.objectContaining({
+        'gen_ai.tool.call.result': expect.stringContaining('file:///private/secret.txt'),
+        'mcp.tool.result.uri': 'file:///private/secret.txt',
+      });
+      if (shouldCaptureUri) {
+        expect(mockSpan.setAttributes).toHaveBeenCalledWith(uriAttributes);
+      } else {
+        expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+          expect.objectContaining({
+            'gen_ai.tool.call.result': '{"content":[{"type":"resource_link"}]}',
+          }),
+        );
+        expect(mockSpan.setAttributes).not.toHaveBeenCalledWith(
+          expect.objectContaining({ 'mcp.tool.result.uri': expect.anything() }),
+        );
+        expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+          expect.objectContaining({ 'mcp.tool.result.content_count': 1 }),
+        );
+      }
+    });
+
     it('should allow explicit override of defaults', async () => {
       getClientSpy.mockReturnValue(createMockClient(true));
 
@@ -1030,8 +1933,8 @@ describe('MCP Server Transport Instrumentation', () => {
      * and proxies onmessage/onclose via getters/setters. This causes Sentry's instrumentation
      * to see different `this` values in onmessage (inner transport) vs send (outer transport).
      *
-     * The fix uses sessionId as the correlation key instead of transport object reference,
-     * since both inner and outer transports share the same sessionId.
+     * Instrumentation captures the outer transport identity while the proxied handler can run
+     * with the inner transport as `this`.
      *
      * @see https://github.com/getsentry/sentry-mcp/issues/767
      */
@@ -1076,6 +1979,30 @@ describe('MCP Server Transport Instrumentation', () => {
 
       // The span should be completed (this was broken before the fix)
       expect(mockSpan.end).toHaveBeenCalled();
+    });
+
+    it('isolates request correlation for transports that reuse the same session id', async () => {
+      const firstTransport = createMockTransport();
+      const secondTransport = createMockTransport();
+      firstTransport.sessionId = 'shared-session-id';
+      secondTransport.sessionId = 'shared-session-id';
+      const firstServer = wrapMcpServerWithSentry(createMockMcpServer());
+      const secondServer = wrapMcpServerWithSentry(createMockMcpServer());
+      const firstSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      const secondSpan = { setAttributes: vi.fn(), setStatus: vi.fn(), end: vi.fn() };
+      startInactiveSpanSpy.mockReturnValueOnce(firstSpan as any).mockReturnValueOnce(secondSpan as any);
+      await firstServer.connect(firstTransport);
+      await secondServer.connect(secondTransport);
+
+      firstTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'same-request-id' }, {});
+      secondTransport.onmessage?.({ jsonrpc: '2.0', method: 'tools/list', id: 'same-request-id' }, {});
+
+      await firstTransport.send?.({ jsonrpc: '2.0', id: 'same-request-id', result: { tools: [] } });
+      expect(firstSpan.end).toHaveBeenCalledOnce();
+      expect(secondSpan.end).not.toHaveBeenCalled();
+
+      await secondTransport.send?.({ jsonrpc: '2.0', id: 'same-request-id', result: { tools: [] } });
+      expect(secondSpan.end).toHaveBeenCalledOnce();
     });
 
     it('should correlate spans correctly for stateless wrapper transports', async () => {
@@ -1202,11 +2129,12 @@ describe('MCP Server Transport Instrumentation', () => {
         },
       });
 
-      // Span should have client and server info attributes
-      expect(mockSpan.setAttributes).toHaveBeenCalledWith(
+      expect(startInactiveSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          'mcp.client.name': 'test-client',
-          'mcp.client.version': '1.0.0',
+          attributes: expect.objectContaining({
+            'mcp.client.name': 'test-client',
+            'mcp.client.version': '1.0.0',
+          }),
         }),
       );
       expect(mockSpan.setAttributes).toHaveBeenCalledWith(
@@ -1241,19 +2169,18 @@ describe('MCP Server Transport Instrumentation', () => {
 
       // Close the transport (should cleanup pending spans)
       wrapper.onclose?.();
+      await new Promise(resolve => setTimeout(resolve));
 
-      // Span should be ended with cancelled status
-      expect(mockSpan.setStatus).toHaveBeenCalledWith({
-        code: 2, // SPAN_STATUS_ERROR
-        message: 'cancelled',
+      expect(mockSpan.setAttributes).toHaveBeenCalledWith({
+        'mcp.request.outcome': 'cancelled',
       });
+      expect(mockSpan.setStatus).not.toHaveBeenCalled();
       expect(mockSpan.end).toHaveBeenCalled();
     });
 
-    it('should verify inner and outer transports share the same sessionId', () => {
+    it('should preserve the wrapper session id for span attributes', () => {
       const { wrapper, inner } = createMockWrapperTransport('shared-session-test');
 
-      // This is the key invariant that makes our fix work
       expect(wrapper.sessionId).toBe(inner.sessionId);
       expect(wrapper.sessionId).toBe('shared-session-test');
     });

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -93,6 +93,7 @@ export {
   spanToTraceHeader,
   spanToBaggageHeader,
   updateSpanName,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   featureFlagsIntegration,
   metrics,

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -142,6 +142,7 @@ export {
   consoleLoggingIntegration,
   createConsolaReporter,
   createSentryWinstonTransport,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   featureFlagsIntegration,
   launchDarklyIntegration,

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -147,6 +147,7 @@ export {
   logger,
   consoleLoggingIntegration,
   createConsolaReporter,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   NODE_VERSION,
   featureFlagsIntegration,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -147,6 +147,7 @@ export {
   profiler,
   consoleLoggingIntegration,
   createConsolaReporter,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   featureFlagsIntegration,
   spanStreamingIntegration,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -92,6 +92,7 @@ export {
   spanToJSON,
   spanToTraceHeader,
   spanToBaggageHeader,
+  wrapMcpServerFactoryWithSentry,
   wrapMcpServerWithSentry,
   consoleLoggingIntegration,
   createConsolaReporter,


### PR DESCRIPTION
Adds observability support for MCP specification `2026-07-28` across the JavaScript server integrations while preserving SDK 1.x behavior and the attributes consumed by the current MCP dashboard.

## Why

MCP 2026 makes each request self-describing and removes the protocol session model. The stable TypeScript SDK also constructs fresh server instances per request, while part of its HTTP entry lifecycle runs outside the connected `McpServer` instance. The existing integration depended on session-shaped state, legacy attribute names, and an instance-only wrapping pattern, so it could not reliably correlate modern requests, propagate trace context, or classify the new protocol outcomes.

OpenTelemetry's current MCP conventions also use canonical JSON-RPC and GenAI attributes which differ from the historical Sentry fields. Supporting those conventions without breaking the current product requires a compatibility window rather than an immediate replacement.

## Decisions

- Treat canonical OpenTelemetry attributes as the primary contract and temporarily dual-write only the legacy aliases still needed by the MCP UI.
- Correlate work by transport identity, request direction, and JSON-RPC ID. Modern requests do not create an MCP session, while legacy session metadata remains supported.
- Add `wrapMcpServerFactoryWithSentry` for synchronous and asynchronous per-request factories and expose it from every server runtime which already exposes the instance wrapper.
- Continue incoming W3C context from MCP `_meta`, link an independent ambient HTTP span when present, and inject context into outgoing requests and notifications.
- Represent JSON-RPC/control-flow failures on spans without synthesizing Issues. Genuine handler and factory exceptions are still captured once with their original error.
- Bound untrusted protocol metadata and serialized results, avoid recording opaque request state or raw progress tokens, and keep resource URIs behind the existing user-info policy.
- Keep SDK 1.x, legacy SSE/Streamable HTTP, low-level `Server`, Cloudflare, and stable SDK v2 behavior covered alongside literal `2026-07-28` wire requests.
- Preserve Cloudflare children which finish after a static HTTP segment by using the existing deferred segment-capture strategy: ordinary children remain embedded, while genuinely late work is emitted in the same trace with its original parent relationship.

## Follow-ups

The public server/factory seam cannot observe SDK-entry rejections which occur before a server is connected, or the entry-owned `subscriptions/listen` acknowledgement and event bus. Complete coverage there needs an upstream SDK hook or a dedicated entry wrapper.

The Sentry frontend should migrate grouping, filters, trace-node detection, onboarding, and detail panels to canonical attributes with legacy fallback before the temporary aliases are removed. Tasks and other provisional extensions should be handled separately from core MCP semantics.

Fixes #21482
Fixes #17152
