### PR TITLE
chore(ember): Gitignore stray declaration output at the package root

### DIFF
--- a/packages/ember/.gitignore
+++ b/packages/ember/.gitignore
@@ -19,3 +19,10 @@ node_modules/
 
 # potentially containing secrets
 *.local
+
+# stray declaration output at the package root
+# The build emits declarations to `declarations/` (see rollup.config.mjs), but the pre-v2-addon
+# layout emitted them here. Paths are anchored so `src/` is unaffected.
+/*.d.ts
+/utils/*.d.ts
+/instance-initializers/*.d.ts


### PR DESCRIPTION
Declaration files can appear at the root of `packages/ember` (`index.d.ts`, `runloop.d.ts`, `types.d.ts`, `utils/*.d.ts`, `instance-initializers/*.d.ts`) and show up as untracked in every `git status`. They also get picked up by `yarn lint`, which reports errors on generated code.

The build emits declarations to `declarations/` (`rollup.config.mjs`), which is already ignored, and `package.json#files` never shipped the root-level ones — so these are leftovers rather than current output. `runloop` and `instance-initializers` do not exist under `src/` at all, so they date from the pre-v2-addon layout.

Paths are anchored with a leading `/` so `src/` is unaffected.

Worth noting I could not reproduce these from a current build — deleting them and running `yarn build` in the package does not bring them back. This is defensive: it keeps stale copies out of `git status` for anyone who still has them on disk. If we would rather not carry ignore rules for paths nothing emits, closing this is reasonable.