### PR TITLE
ref(core)!: Remove `startIdleSpan` from server exports

### DIFF
--- a/packages/core/src/browser-exports.ts
+++ b/packages/core/src/browser-exports.ts
@@ -8,9 +8,10 @@ export {
   startSpan,
   startInactiveSpan,
   startSpanManual,
-  startIdleSpan,
   _INTERNAL_ensureBrowserSpanStreaming,
 } from './tracing/browserSpanApi';
+
+export { startIdleSpan } from './tracing/idleSpan';
 
 export { spanStreamingIntegration } from './integrations/browserSpanStreaming';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,5 @@ export * from './browser-exports';
 // `server-exports` and `browser-exports` both export these APIs.
 // We need to re-export them here to disambiguate the exports for anyone importing
 // from `@sentry/core`. Server exports win over browser exports.
-export { startSpan, startInactiveSpan, startSpanManual } from './tracing/trace';
-export { startIdleSpan } from './tracing/idleSpan';
-export { spanStreamingIntegration } from './integrations/spanStreaming';
+export { startSpan, startInactiveSpan, startSpanManual } from './server-exports';
+export { spanStreamingIntegration } from './server-exports';

--- a/packages/core/src/server-exports.ts
+++ b/packages/core/src/server-exports.ts
@@ -5,7 +5,6 @@
  */
 
 export { startSpan, startInactiveSpan, startSpanManual } from './tracing/trace';
-export { startIdleSpan } from './tracing/idleSpan';
 export { spanStreamingIntegration } from './integrations/spanStreaming';
 
 export type { ServerRuntimeClientOptions } from './server-runtime-client';

--- a/packages/core/src/tracing/browserSpanApi.ts
+++ b/packages/core/src/tracing/browserSpanApi.ts
@@ -3,7 +3,6 @@ import { getClient } from '../currentScopes';
 import { spanStreamingIntegration } from '../integrations/browserSpanStreaming';
 import type { Span } from '../types/span';
 import type { StartSpanOptions } from '../types/startSpanOptions';
-import { startIdleSpan as coreStartIdleSpan } from './idleSpan';
 import { hasSpanStreamingEnabled } from './spans/hasSpanStreamingEnabled';
 import {
   startInactiveSpan as coreStartInactiveSpan,
@@ -70,16 +69,3 @@ export function startInactiveSpan(options: StartSpanOptions): Span {
   _INTERNAL_ensureBrowserSpanStreaming();
   return coreStartInactiveSpan(options);
 }
-
-/**
- * Starts an idle span that automatically ends once no activity happens for a while.
- *
- * See {@link startIdleSpan} in `@sentry/core` for details.
- *
- * Typed via `typeof` because `IdleSpanOptions` is intentionally not part of the public type surface,
- * and re-declaring the signature here would have to widen it.
- */
-export const startIdleSpan: typeof coreStartIdleSpan = (startSpanOptions, options) => {
-  _INTERNAL_ensureBrowserSpanStreaming();
-  return coreStartIdleSpan(startSpanOptions, options);
-};

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -16,6 +16,7 @@ import {
   spanToStaticSpanJSON,
 } from '../utils/spanUtils';
 import { timestampInSeconds } from '../utils/time';
+import { _INTERNAL_ensureBrowserSpanStreaming } from './browserSpanApi';
 import { SentryNonRecordingSpan, spanIsNonRecordingSpan } from './sentryNonRecordingSpan';
 import { SentrySpan } from './sentrySpan';
 import { SPAN_STATUS_ERROR, SPAN_STATUS_OK } from './spanstatus';
@@ -89,6 +90,9 @@ interface IdleSpanOptions {
  * An idle span is always the active span.
  */
 export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Partial<IdleSpanOptions> = {}): Span {
+  const client = getClient();
+  _INTERNAL_ensureBrowserSpanStreaming(client);
+
   // Activities store a list of active spans
   const activities = new Map<string, boolean>();
 
@@ -115,7 +119,6 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
     trimIdleSpanEndTimestamp = true,
   } = options;
 
-  const client = getClient();
   const scope = getCurrentScope();
 
   if (!client || !hasSpansEnabled()) {

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -134,7 +134,10 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
   }
 
   const previousActiveSpan = getActiveSpan();
-  const span = _startIdleSpan(startSpanOptions);
+
+  const span = startInactiveSpan(startSpanOptions);
+  _setSpanForScope(getCurrentScope(), span);
+  DEBUG_BUILD && debug.log('[Tracing] Started span is an idle span');
 
   // We patch span.end to ensure we can run some things before the span is ended
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -413,16 +416,6 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
       span.end();
     }
   }, finalTimeout);
-
-  return span;
-}
-
-function _startIdleSpan(options: StartSpanOptions): Span {
-  const span = startInactiveSpan(options);
-
-  _setSpanForScope(getCurrentScope(), span);
-
-  DEBUG_BUILD && debug.log('[Tracing] Started span is an idle span');
 
   return span;
 }

--- a/packages/core/test/exports.test.ts
+++ b/packages/core/test/exports.test.ts
@@ -5,7 +5,6 @@ import { spanStreamingIntegration as browserSpanStreamingIntegration } from '../
 import { spanStreamingIntegration as plainSpanStreamingIntegration } from '../src/integrations/spanStreaming';
 import * as serverEntry from '../src/server';
 import * as browserSpanApi from '../src/tracing/browserSpanApi';
-import { startIdleSpan as plainStartIdleSpan } from '../src/tracing/idleSpan';
 import {
   startInactiveSpan as plainStartInactiveSpan,
   startSpan as plainStartSpan,

--- a/packages/core/test/exports.test.ts
+++ b/packages/core/test/exports.test.ts
@@ -21,7 +21,6 @@ describe('entry point resolution', () => {
     ['startSpan', plainStartSpan, browserSpanApi.startSpan],
     ['startInactiveSpan', plainStartInactiveSpan, browserSpanApi.startInactiveSpan],
     ['startSpanManual', plainStartSpanManual, browserSpanApi.startSpanManual],
-    ['startIdleSpan', plainStartIdleSpan, browserSpanApi.startIdleSpan],
     ['spanStreamingIntegration', plainSpanStreamingIntegration, browserSpanStreamingIntegration],
   ] as const;
 


### PR DESCRIPTION
The `startIdleSpan` API is exported from `@sentry/core` but is only used in browser SDKs. It should not be used anywhere else. Therefore, this PR removes the API from `@sentry/core/server`. It can still be imported from the shared top-level exports because these re-export everything. Something I think we should change but I currently don't have the time to look at in more depth.