### PR TITLE
feat: Emit low-cardinality pageload span names when streaming spans

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -610,6 +610,51 @@ These changes are not caught by TypeScript. If you filter, group, or alert on sp
 | `browser.TLS/SSL`               | `browser.tls_ssl`                  |
 | `browser.DNS`                   | `browser.dns`                      |
 
+### Span name changes
+
+Affected SDKs: All SDKs running in the browser.
+
+With [span streaming](#span-streaming-is-now-the-default) (the default), span names have to be **low cardinality**, following the [Sentry span name conventions](https://getsentry.github.io/sentry-conventions/names/). A raw URL must never end up in a span name, so where the SDK previously fell back to the URL it now uses a static name per span op. The URL remains available on the `url.path` and `url.full` attributes, and `sentry.source` is unchanged.
+
+In v11, this only affects `pageload` spans. Further ops will follow in future releases. With `traceLifecycle: 'static'`, span names are unchanged.
+
+| Span op    | Before                                                                                      | After                                                      |
+| ---------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `pageload` | The parameterized route, or the raw URL path if the SDK couldn't resolve one (`/users/123`) | The parameterized route, or `Pageload` if the SDK has none |
+
+For example, for a pageload of `https://example.com/users/123`:
+
+```js
+// Before (and still the case with `traceLifecycle: 'static'`)
+{ name: '/users/123', attributes: { 'sentry.op': 'pageload', 'sentry.source': 'url' } }
+
+// After, if the SDK resolved the route (most framework SDKs)
+{ name: '/users/:id', attributes: { 'sentry.op': 'pageload', 'sentry.source': 'route', 'url.template': '/users/:id' } }
+
+// After, if no route information is available (e.g. `@sentry/browser` without a router)
+{ name: 'Pageload', attributes: { 'sentry.op': 'pageload', 'sentry.source': 'url', 'url.path': '/users/123' } }
+```
+
+Pageload spans start with this name. Most routing instrumentations only resolve the route after the span was started, so a pageload span is commonly named `Pageload` first and renamed to the route once it is known — it is never named after the raw URL in between.
+
+Three knock-on effects to be aware of:
+
+- Child spans of a pageload span carry its name in their `sentry.segment.name` attribute, so that changes with it. If you group or filter spans by segment name in dashboards or alerts, update those references.
+- Errors captured during a pageload get the pageload span's name as their `transaction`, so an error on an unparameterized pageload is now grouped under `Pageload` rather than the URL.
+- `ui.action.click` spans are named after the route the interaction happened on, which is the pageload span's name until a navigation replaces it.
+
+`ignoreSpans` is evaluated when a span **starts**, at which point a pageload span without a resolved route is already named `Pageload`, so filters matching a URL path no longer apply to it. Match on attributes instead:
+
+```js
+Sentry.init({
+  // Before
+  ignoreSpans: ['/health'],
+
+  // After
+  ignoreSpans: [{ attributes: { 'sentry.op': 'pageload', 'url.path': '/health' } }],
+});
+```
+
 ### LangGraph no longer emits `create_agent` spans
 
 Affected SDKs: All server-side SDKs.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -614,36 +614,22 @@ These changes are not caught by TypeScript. If you filter, group, or alert on sp
 
 Affected SDKs: All SDKs running in the browser.
 
-With [span streaming](#span-streaming-is-now-the-default) (the default), span names have to be **low cardinality**, following the [Sentry span name conventions](https://getsentry.github.io/sentry-conventions/names/). A raw URL must never end up in a span name, so where the SDK previously fell back to the URL it now uses a static name per span op. The URL remains available on the `url.path` and `url.full` attributes, and `sentry.source` is unchanged.
+With [span streaming](#span-streaming-is-now-the-default) enabled(the default), span names are now **low cardinality**, following the [Sentry span name conventions](https://getsentry.github.io/sentry-conventions/names/).
 
-In v11, this only affects `pageload` spans. Further ops will follow in future releases. With `traceLifecycle: 'static'`, span names are unchanged.
+In v11, this only affects `pageload` spans. Further ops will follow in future releases.
+If you [opt out of span streaming](#opting-out-of-span-streaming), span names remain unchanged.
+
+The following span names were adjusted:
 
 | Span op    | Before                                                                                      | After                                                      |
 | ---------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | `pageload` | The parameterized route, or the raw URL path if the SDK couldn't resolve one (`/users/123`) | The parameterized route, or `Pageload` if the SDK has none |
 
-For example, for a pageload of `https://example.com/users/123`:
+Some consequences to be aware of:
 
-```js
-// Before (and still the case with `traceLifecycle: 'static'`)
-{ name: '/users/123', attributes: { 'sentry.op': 'pageload', 'sentry.source': 'url' } }
+Child spans of a pageload span carry its name in their `sentry.segment.name` attribute, so that changes with it. If you group or filter spans by segment name in dashboards or alerts, update those references.
 
-// After, if the SDK resolved the route (most framework SDKs)
-{ name: '/users/:id', attributes: { 'sentry.op': 'pageload', 'sentry.source': 'route', 'url.template': '/users/:id' } }
-
-// After, if no route information is available (e.g. `@sentry/browser` without a router)
-{ name: 'Pageload', attributes: { 'sentry.op': 'pageload', 'sentry.source': 'url', 'url.path': '/users/123' } }
-```
-
-Pageload spans start with this name. Most routing instrumentations only resolve the route after the span was started, so a pageload span is commonly named `Pageload` first and renamed to the route once it is known — it is never named after the raw URL in between.
-
-Three knock-on effects to be aware of:
-
-- Child spans of a pageload span carry its name in their `sentry.segment.name` attribute, so that changes with it. If you group or filter spans by segment name in dashboards or alerts, update those references.
-- Errors captured during a pageload get the pageload span's name as their `transaction`, so an error on an unparameterized pageload is now grouped under `Pageload` rather than the URL.
-- `ui.action.click` spans are named after the route the interaction happened on, which is the pageload span's name until a navigation replaces it.
-
-`ignoreSpans` is evaluated when a span **starts**, at which point a pageload span without a resolved route is already named `Pageload`, so filters matching a URL path no longer apply to it. Match on attributes instead:
+`ignoreSpans` is evaluated when a span **starts**, at which point a pageload span without a resolved route is already named `'Pageload'`, so filters matching a URL path no longer apply to it. Match on attributes instead:
 
 ```js
 Sentry.init({
@@ -651,7 +637,7 @@ Sentry.init({
   ignoreSpans: ['/health'],
 
   // After
-  ignoreSpans: [{ attributes: { 'sentry.op': 'pageload', 'url.path': '/health' } }],
+  ignoreSpans: [{ name: 'Pageload', attributes: { 'sentry.op': 'pageload', 'url.path': '/health' } }],
 });
 ```
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -99,7 +99,7 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
       },
       [SENTRY_SEGMENT_NAME]: {
         type: 'string',
-        value: '/index.html',
+        value: 'Pageload',
       },
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: {
         type: 'string',
@@ -116,7 +116,8 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
     },
     end_timestamp: expect.any(Number),
     is_segment: true,
-    name: '/index.html',
+    // Interaction spans are named after the current route, which is the pageload span's name.
+    name: 'Pageload',
     span_id: interactionSegmentSpan!.span_id,
     start_timestamp: expect.any(Number),
     status: 'ok',
@@ -155,7 +156,7 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
       },
       [SENTRY_SEGMENT_NAME]: {
         type: 'string',
-        value: '/index.html',
+        value: 'Pageload',
       },
       [SEMANTIC_ATTRIBUTE_SENTRY_ENVIRONMENT]: {
         type: 'string',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -68,7 +68,7 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ brow
   expect(navigationTraceId).toBeDefined();
   expect(pageloadTraceId).not.toEqual(navigationTraceId);
 
-  expect(pageloadSpan.name).toEqual('/index.html');
+  expect(pageloadSpan.name).toEqual('Pageload');
 
   expect(navigationSpan).toEqual({
     attributes: {

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -159,7 +159,7 @@ sentryTest(
         },
         [SENTRY_SEGMENT_NAME]: {
           type: 'string',
-          value: '/index.html',
+          value: 'Pageload',
         },
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: {
           type: 'string',
@@ -180,7 +180,9 @@ sentryTest(
       },
       end_timestamp: expect.any(Number),
       is_segment: true,
-      name: '/index.html',
+      // The raw URL stays in `url.path`/`url.full`: with span streaming, a pageload span name is
+      // low cardinality and falls back to 'Pageload' when there is no parameterized route.
+      name: 'Pageload',
       span_id: expect.stringMatching(/^[\da-f]{16}$/),
       start_timestamp: expect.any(Number),
       status: 'ok',

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
@@ -39,7 +39,9 @@ sentryTest('captures CLS as a streamed span with source attributes', async ({ ge
   expect(clsSpan.attributes['user_agent.original']?.value).toEqual(expect.stringContaining('Chrome'));
 
   // Check the CLS span carries the segment name it belongs to
-  expect(clsSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: 'Pageload' });
+  // NOTE: taken from the scope's transaction name, which keeps the URL, rather than from the
+  // pageload segment span, which is named 'Pageload'.
+  expect(clsSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: '/index.html' });
 
   // Check browser.web_vital.cls.source attributes
   expect(clsSpan.attributes['browser.web_vital.cls.source.1']?.value).toEqual(

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
@@ -39,9 +39,7 @@ sentryTest('captures CLS as a streamed span with source attributes', async ({ ge
   expect(clsSpan.attributes['user_agent.original']?.value).toEqual(expect.stringContaining('Chrome'));
 
   // Check the CLS span carries the segment name it belongs to
-  // NOTE: taken from the scope's transaction name, which keeps the URL, rather than from the
-  // pageload segment span, which is named 'Pageload'.
-  expect(clsSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: '/index.html' });
+  expect(clsSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: 'Pageload' });
 
   // Check browser.web_vital.cls.source attributes
   expect(clsSpan.attributes['browser.web_vital.cls.source.1']?.value).toEqual(

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls-streamed-spans/test.ts
@@ -39,7 +39,7 @@ sentryTest('captures CLS as a streamed span with source attributes', async ({ ge
   expect(clsSpan.attributes['user_agent.original']?.value).toEqual(expect.stringContaining('Chrome'));
 
   // Check the CLS span carries the segment name it belongs to
-  expect(clsSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: '/index.html' });
+  expect(clsSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: 'Pageload' });
 
   // Check browser.web_vital.cls.source attributes
   expect(clsSpan.attributes['browser.web_vital.cls.source.1']?.value).toEqual(

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-streamed-spans/test.ts
@@ -32,8 +32,8 @@ sentryTest('captures INP click as a streamed span', async ({ getLocalTestUrl, pa
   expect(inpSpan.attributes['user_agent.original']?.value).toEqual(expect.stringContaining('Chrome'));
 
   // Check the INP span carries the transaction/segment name it belongs to
-  expect(inpSpan.attributes['sentry.transaction']).toEqual({ type: 'string', value: '/index.html' });
-  expect(inpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: '/index.html' });
+  expect(inpSpan.attributes['sentry.transaction']).toEqual({ type: 'string', value: 'Pageload' });
+  expect(inpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: 'Pageload' });
 
   const inpValue = inpSpan.attributes['browser.web_vital.inp.value']?.value as number;
   expect(inpValue).toBeGreaterThan(0);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
@@ -41,7 +41,9 @@ sentryTest('captures LCP as a streamed span with element attributes', async ({ g
   expect(lcpSpan.attributes['user_agent.original']?.value).toEqual(expect.stringContaining('Chrome'));
 
   // Check the LCP span carries the segment name it belongs to
-  expect(lcpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: 'Pageload' });
+  // NOTE: taken from the scope's transaction name, which keeps the URL, rather than from the
+  // pageload segment span, which is named 'Pageload'.
+  expect(lcpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: '/index.html' });
 
   // Check browser.web_vital.lcp.* attributes
   expect(lcpSpan.attributes['browser.web_vital.lcp.element']?.value).toEqual(expect.stringContaining('body > img'));

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
@@ -41,7 +41,7 @@ sentryTest('captures LCP as a streamed span with element attributes', async ({ g
   expect(lcpSpan.attributes['user_agent.original']?.value).toEqual(expect.stringContaining('Chrome'));
 
   // Check the LCP span carries the segment name it belongs to
-  expect(lcpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: '/index.html' });
+  expect(lcpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: 'Pageload' });
 
   // Check browser.web_vital.lcp.* attributes
   expect(lcpSpan.attributes['browser.web_vital.lcp.element']?.value).toEqual(expect.stringContaining('body > img'));

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
@@ -41,9 +41,7 @@ sentryTest('captures LCP as a streamed span with element attributes', async ({ g
   expect(lcpSpan.attributes['user_agent.original']?.value).toEqual(expect.stringContaining('Chrome'));
 
   // Check the LCP span carries the segment name it belongs to
-  // NOTE: taken from the scope's transaction name, which keeps the URL, rather than from the
-  // pageload segment span, which is named 'Pageload'.
-  expect(lcpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: '/index.html' });
+  expect(lcpSpan.attributes['sentry.segment.name']).toEqual({ type: 'string', value: 'Pageload' });
 
   // Check browser.web_vital.lcp.* attributes
   expect(lcpSpan.attributes['browser.web_vital.lcp.element']?.value).toEqual(expect.stringContaining('body > img'));

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/tests/cacheComponents.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/tests/cacheComponents.spec.ts
@@ -81,8 +81,8 @@ test('Prerendered shell does not stitch the pageload onto a stale trace', async 
   const [serverSpan, pageloadSpan] = await Promise.all([serverSpanPromise, pageloadSpanPromise]);
 
   expect(pageloadSpan.attributes).toMatchObject({
-    ['sentry.segment.name.source']: 'url',
-    ['url.pathname']: '/pageload-tracing',
+    ['sentry.segment.name.source']: { value: 'url', type: 'string' },
+    ['url.pathname']: { value: '/pageload-tracing', type: 'string' },
   });
   // Under Cache Components the can be prerendered and rendered in a context detached from the
   // runtime server request, so a `sentry-trace` meta tag would carry a stale/unrelated trace. The

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/tests/cacheComponents.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/tests/cacheComponents.spec.ts
@@ -71,7 +71,7 @@ test('Prerendered shell does not stitch the pageload onto a stale trace', async 
   });
 
   const pageloadSpanPromise = waitForStreamedSpan('nextjs-16-streaming-cacheComponents', span => {
-    return span.name === '/pageload-tracing' && getSpanOp(span) === 'pageload' && span.is_segment;
+    return span.name === 'Pageload' && getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto('/pageload-tracing');
@@ -80,6 +80,10 @@ test('Prerendered shell does not stitch the pageload onto a stale trace', async 
 
   const [serverSpan, pageloadSpan] = await Promise.all([serverSpanPromise, pageloadSpanPromise]);
 
+  expect(pageloadSpan.attributes).toMatchObject({
+    ['sentry.segment.name.source']: 'url',
+    ['url.pathname']: '/pageload-tracing',
+  });
   // Under Cache Components the can be prerendered and rendered in a context detached from the
   // runtime server request, so a `sentry-trace` meta tag would carry a stale/unrelated trace. The
   // SDK therefore does not enable the trace meta tags, and the browser pageload starts a fresh trace

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/tests/cacheComponents.spec.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/tests/cacheComponents.spec.ts
@@ -82,7 +82,7 @@ test('Prerendered shell does not stitch the pageload onto a stale trace', async 
 
   expect(pageloadSpan.attributes).toMatchObject({
     ['sentry.segment.name.source']: { value: 'url', type: 'string' },
-    ['url.pathname']: { value: '/pageload-tracing', type: 'string' },
+    ['url.path']: { value: '/pageload-tracing', type: 'string' },
   });
   // Under Cache Components the can be prerendered and rendered in a context detached from the
   // runtime server request, so a `sentry-trace` meta tag would carry a stale/unrelated trace. The

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/pageload-tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/pageload-tracing.test.ts
@@ -18,6 +18,6 @@ test('Server and client pageload spans should share the same trace', async ({ pa
   expect(serverSpan.trace_id).toBe(pageloadSpan.trace_id);
   expect(pageloadSpan.attributes).toMatchObject({
     ['sentry.segment.name.source']: { value: 'url', type: 'string' },
-    ['url.pathname']: { value: '/pageload-tracing', type: 'string' },
+    ['url.path']: { value: '/pageload-tracing', type: 'string' },
   });
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/pageload-tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/pageload-tracing.test.ts
@@ -17,7 +17,7 @@ test('Server and client pageload spans should share the same trace', async ({ pa
   expect(pageloadSpan.trace_id).toBeTruthy();
   expect(serverSpan.trace_id).toBe(pageloadSpan.trace_id);
   expect(pageloadSpan.attributes).toMatchObject({
-    ['sentry.segment.name.source']: 'url',
-    ['url.pathname']: '/pageload-tracing',
+    ['sentry.segment.name.source']: { value: 'url', type: 'string' },
+    ['url.pathname']: { value: '/pageload-tracing', type: 'string' },
   });
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/pageload-tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/pageload-tracing.test.ts
@@ -7,7 +7,7 @@ test('Server and client pageload spans should share the same trace', async ({ pa
   });
 
   const pageloadSpanPromise = waitForStreamedSpan('nextjs-16-streaming', span => {
-    return span.name === '/pageload-tracing' && getSpanOp(span) === 'pageload' && span.is_segment;
+    return span.name === 'Pageload' && getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto(`/pageload-tracing`);
@@ -16,4 +16,8 @@ test('Server and client pageload spans should share the same trace', async ({ pa
 
   expect(pageloadSpan.trace_id).toBeTruthy();
   expect(serverSpan.trace_id).toBe(pageloadSpan.trace_id);
+  expect(pageloadSpan.attributes).toMatchObject({
+    ['sentry.segment.name.source']: 'url',
+    ['url.pathname']: '/pageload-tracing',
+  });
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/parameterized-routes.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/parameterized-routes.test.ts
@@ -29,8 +29,8 @@ test('should create a static streamed span when the `app` directory is used and 
   expect(span.name).toBe('Pageload');
   expect(span.trace_id).toMatch(/[a-f0-9]{32}/);
   expect(span.attributes).toMatchObject({
-    ['sentry.segment.name.source']: 'url',
-    ['url.pathname']: '/parameterized/static',
+    ['sentry.segment.name.source']: { value: 'url', type: 'string' },
+    ['url.pathname']: { value: '/parameterized/static', type: 'string' },
   });
 });
 

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/parameterized-routes.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/parameterized-routes.test.ts
@@ -30,7 +30,7 @@ test('should create a static streamed span when the `app` directory is used and 
   expect(span.trace_id).toMatch(/[a-f0-9]{32}/);
   expect(span.attributes).toMatchObject({
     ['sentry.segment.name.source']: { value: 'url', type: 'string' },
-    ['url.pathname']: { value: '/parameterized/static', type: 'string' },
+    ['url.path']: { value: '/parameterized/static', type: 'string' },
   });
 });
 

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/parameterized-routes.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/tests/parameterized-routes.test.ts
@@ -19,16 +19,19 @@ test('should create a static streamed span when the `app` directory is used and 
   page,
 }) => {
   const spanPromise = waitForStreamedSpan('nextjs-16-streaming', span => {
-    return span.name === '/parameterized/static' && getSpanOp(span) === 'pageload' && span.is_segment;
+    return span.name === 'Pageload' && getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto(`/parameterized/static`);
 
   const span = await spanPromise;
 
-  expect(span.name).toBe('/parameterized/static');
+  expect(span.name).toBe('Pageload');
   expect(span.trace_id).toMatch(/[a-f0-9]{32}/);
-  expect(span.attributes['sentry.source']?.value).toBe('url');
+  expect(span.attributes).toMatchObject({
+    ['sentry.segment.name.source']: 'url',
+    ['url.pathname']: '/parameterized/static',
+  });
 });
 
 test('should create a partially parameterized streamed span when the `app` directory is used', async ({ page }) => {

--- a/packages/astro/src/client/browserTracingIntegration.ts
+++ b/packages/astro/src/client/browserTracingIntegration.ts
@@ -3,10 +3,11 @@ import {
   startBrowserTracingPageLoadSpan,
   WINDOW,
 } from '@sentry/browser';
-import type { Integration, TransactionSource } from '@sentry/core';
+import type { Client, Integration, TransactionSource } from '@sentry/core';
 import {
   browserPerformanceTimeOrigin,
   debug,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
@@ -40,7 +41,7 @@ export function browserTracingIntegration(
         if (options.instrumentPageLoad != false) {
           const origin = browserPerformanceTimeOrigin();
 
-          const { name, source } = getPageloadSpanName();
+          const { name, source } = getPageloadSpanName(client);
 
           startBrowserTracingPageLoadSpan(client, {
             name,
@@ -58,7 +59,7 @@ export function browserTracingIntegration(
   };
 }
 
-function getPageloadSpanName(): { name: string; source: TransactionSource } {
+function getPageloadSpanName(client: Client): { name: string; source: TransactionSource } {
   try {
     const routeNameFromMetaTags = getMetaContent('sentry-route-name');
     if (routeNameFromMetaTags) {
@@ -75,7 +76,8 @@ function getPageloadSpanName(): { name: string; source: TransactionSource } {
     // fail silently if decoding or reading the meta tag fails
   }
   return {
-    name: WINDOW.location.pathname,
+    // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+    name: hasSpanStreamingEnabled(client) ? 'Pageload' : WINDOW.location.pathname,
     source: 'url',
   };
 }

--- a/packages/astro/src/client/browserTracingIntegration.ts
+++ b/packages/astro/src/client/browserTracingIntegration.ts
@@ -8,6 +8,7 @@ import {
   browserPerformanceTimeOrigin,
   debug,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
@@ -77,7 +78,7 @@ function getPageloadSpanName(client: Client): { name: string; source: Transactio
   }
   return {
     // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
-    name: hasSpanStreamingEnabled(client) ? 'Pageload' : WINDOW.location.pathname,
+    name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : WINDOW.location.pathname,
     source: 'url',
   };
 }

--- a/packages/browser-utils/src/web-vitals/spans.ts
+++ b/packages/browser-utils/src/web-vitals/spans.ts
@@ -90,7 +90,12 @@ export function _emitWebVitalSpan(options: WebVitalSpanOptions): void {
     standalone,
   } = options;
 
-  const routeName = getCurrentScope().getScopeData().transactionName;
+  // Taken off the segment span itself, so it can't diverge from it: a routing instrumentation may
+  // rename that span (a pageload span is named `Pageload` until its route resolves), and the scope's
+  // transaction name is deliberately not kept in sync with it. Only a standalone span, which is sent
+  // without its segment span, has to fall back to the scope.
+  const segmentSpan = parentSpan && getRootSpan(parentSpan);
+  const segmentName = segmentSpan ? spanToJSON(segmentSpan).name : getCurrentScope().getScopeData().transactionName;
 
   const attributes: SpanAttributes = {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: origin,
@@ -98,8 +103,8 @@ export function _emitWebVitalSpan(options: WebVitalSpanOptions): void {
     [SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME]: 0,
     [`browser.web_vital.${metricName}.value`]: value,
     // oxlint-disable-next-line typescript-eslint/no-deprecated
-    [SENTRY_TRANSACTION]: routeName,
-    [SENTRY_SEGMENT_NAME]: routeName,
+    [SENTRY_TRANSACTION]: segmentName,
+    [SENTRY_SEGMENT_NAME]: segmentName,
     // Web vital score calculation relies on the user agent
     'user_agent.original': WINDOW.navigator?.userAgent,
     ...passedAttributes,
@@ -343,7 +348,6 @@ export function _sendInpSpan(inpValue: number, entry: PerformanceEventTiming, st
   const rootSpan = activeSpan ? getRootSpan(activeSpan) : undefined;
 
   const spanToUse = cachedContext?.span || rootSpan;
-  const routeName = spanToUse ? spanToJSON(spanToUse).name : getCurrentScope().getScopeData().transactionName;
   const name = cachedContext?.elementName || htmlTreeAsString(entry.target);
 
   _emitWebVitalSpan({
@@ -354,9 +358,6 @@ export function _sendInpSpan(inpValue: number, entry: PerformanceEventTiming, st
     value: inpValue,
     attributes: {
       [SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME]: entry.duration,
-      // oxlint-disable-next-line typescript-eslint/no-deprecated
-      [SENTRY_TRANSACTION]: routeName,
-      [SENTRY_SEGMENT_NAME]: routeName,
     },
     startTime,
     endTime: startTime + duration,

--- a/packages/browser-utils/test/web-vitals/spans.test.ts
+++ b/packages/browser-utils/test/web-vitals/spans.test.ts
@@ -64,6 +64,8 @@ describe('_emitWebVitalSpan', () => {
     vi.mocked(SentryCore.getCurrentScope).mockReturnValue(mockScope as any);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
+    // A root span is its own root, which is what the web vital spans are parented to.
+    vi.mocked(SentryCore.getRootSpan).mockImplementation(span => span);
     vi.mocked(SentryCore.getClient).mockReturnValue({ getIntegrationByName: () => undefined } as any);
   });
 
@@ -101,6 +103,31 @@ describe('_emitWebVitalSpan', () => {
     );
 
     expect(mockSpan.end).toHaveBeenCalledWith(1.5);
+  });
+
+  it("takes 'sentry.segment.name' from the span it is parented to, not from the scope", () => {
+    const parentSpan = { spanContext: () => ({ spanId: 'pageload-1' }) } as any;
+    vi.mocked(SentryCore.getRootSpan).mockReturnValue(parentSpan);
+    vi.mocked(SentryCore.spanToJSON).mockReturnValue({ name: 'Pageload', attributes: {} } as any);
+
+    _emitWebVitalSpan({
+      name: 'Test Vital',
+      op: 'ui.webvital.lcp',
+      origin: 'auto.http.browser.lcp',
+      metricName: 'lcp',
+      value: 100,
+      startTime: 1.5,
+      parentSpan,
+    });
+
+    expect(SentryCore.startInactiveSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          'sentry.segment.name': 'Pageload',
+          'sentry.transaction': 'Pageload',
+        }),
+      }),
+    );
   });
 
   it('marks the span as standalone when standalone is set', () => {
@@ -187,6 +214,8 @@ describe('_emitWebVitalSpan', () => {
   it('includes pageload span id when parentSpan is a pageload span', () => {
     const mockPageloadSpan = createMockPageloadSpan('abc123');
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({
+      // The web vital span takes its segment name off the pageload span it is parented to.
+      name: 'test-route',
       attributes: { 'sentry.op': 'pageload' },
     } as any);
 
@@ -308,6 +337,8 @@ describe('_sendLcpSpan', () => {
     vi.mocked(htmlTreeAsString).mockImplementation((node: any) => `<${node?.tagName || 'div'}>`);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({
+      // The web vital span takes its segment name off the pageload span it is parented to.
+      name: 'test-route',
       attributes: { 'sentry.op': 'pageload' },
     } as any);
   });
@@ -395,6 +426,8 @@ describe('_sendClsSpan', () => {
     vi.mocked(htmlTreeAsString).mockImplementation((node: any) => `<${node?.tagName || 'div'}>`);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({
+      // The web vital span takes its segment name off the pageload span it is parented to.
+      name: 'test-route',
       attributes: { 'sentry.op': 'pageload' },
     } as any);
   });
@@ -478,6 +511,8 @@ describe('_sendInpSpan', () => {
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.getActiveSpan).mockReturnValue(undefined);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
+    // A root span is its own root, which is what the web vital spans are parented to.
+    vi.mocked(SentryCore.getRootSpan).mockImplementation(span => span);
   });
 
   afterEach(() => {
@@ -595,6 +630,8 @@ describe('trackInpAsSpan', () => {
     vi.mocked(SentryCore.getActiveSpan).mockReturnValue(undefined);
     vi.mocked(SentryCore.startInactiveSpan).mockReturnValue({ end: vi.fn() } as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
+    // A root span is its own root, which is what the web vital spans are parented to.
+    vi.mocked(SentryCore.getRootSpan).mockImplementation(span => span);
     vi.mocked(htmlTreeAsString).mockReturnValue('<button>');
     vi.spyOn(inpModule, 'getCachedInteractionContext').mockReturnValue(undefined);
     vi.spyOn(instrument, 'addInpInstrumentationHandler').mockImplementation((cb: any) => {

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -23,6 +23,7 @@ import {
   GLOBAL_OBJ,
   hasSpansEnabled,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   isURLObjectRelative,
   parseStringToURLObject,
   propagationContextFromHeaders,
@@ -639,7 +640,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
           startBrowserTracingPageLoadSpan(client, {
             // With span streaming, span names have to be low cardinality, and there is no route
             // information available here.
-            name: hasSpanStreamingEnabled(client) ? 'Pageload' : WINDOW.location.pathname,
+            name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : WINDOW.location.pathname,
             // pageload should always start at timeOrigin (and needs to be in s, not ms)
             startTime: origin ? origin / 1000 : undefined,
             attributes: {
@@ -720,7 +721,11 @@ export function startBrowserTracingPageLoadSpan(
   traceOptions?: { sentryTrace?: string | undefined; baggage?: string | undefined },
 ): Span | undefined {
   client.emit('startPageLoadSpan', spanOptions, traceOptions);
-  getCurrentScope().setTransactionName(spanOptions.name);
+
+  // `Pageload` is a low-cardinality span name, not a description of the page. The scope's
+  // transaction name is what error events are grouped by, so it keeps the URL instead.
+  const isFallbackSpanName = spanOptions.name === PAGELOAD_SPAN_NAME_FALLBACK;
+  getCurrentScope().setTransactionName(isFallbackSpanName ? WINDOW.location?.pathname : spanOptions.name);
 
   const pageloadSpan = getActiveIdleSpan(client);
 

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -637,7 +637,9 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         if (instrumentPageLoad) {
           const origin = browserPerformanceTimeOrigin();
           startBrowserTracingPageLoadSpan(client, {
-            name: WINDOW.location.pathname,
+            // With span streaming, span names have to be low cardinality, and there is no route
+            // information available here.
+            name: hasSpanStreamingEnabled(client) ? 'Pageload' : WINDOW.location.pathname,
             // pageload should always start at timeOrigin (and needs to be in s, not ms)
             startTime: origin ? origin / 1000 : undefined,
             attributes: {

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -171,7 +171,7 @@ describe('browserTracingIntegration', () => {
     expect(span).toBeDefined();
     expect(spanIsSampled(span!)).toBe(true);
     expect(spanToJSON(span!)).toEqual({
-      name: '/',
+      name: 'Pageload',
       status: 'ok',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -260,7 +260,7 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span)).toBe(true);
     expect(span.isRecording()).toBe(true);
     expect(spanToJSON(span)).toEqual({
-      name: '/',
+      name: 'Pageload',
       status: 'ok',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -381,7 +381,7 @@ describe('browserTracingIntegration', () => {
     expect(spanIsSampled(span)).toBe(true);
     expect(span.isRecording()).toBe(true);
     expect(spanToJSON(span)).toEqual({
-      name: '/',
+      name: 'Pageload',
       status: 'ok',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -604,6 +604,22 @@ describe('browserTracingIntegration', () => {
       expect(getCurrentScope().getScopeData().transactionName).toBe('test pageload span');
     });
 
+    it("never sets the low-cardinality 'Pageload' span name on `scope.transactionName`", () => {
+      const client = new BrowserClient(
+        getDefaultBrowserClientOptions({
+          tracesSampleRate: 1,
+          integrations: [browserTracingIntegration()],
+        }),
+      );
+      setCurrentClient(client);
+      client.init();
+
+      // The pageload span the integration starts is named 'Pageload' with span streaming enabled,
+      // but errors have to stay grouped by the actual page.
+      expect(spanToJSON(getActiveSpan()!).name).toBe('Pageload');
+      expect(getCurrentScope().getScopeData().transactionName).toBe('/');
+    });
+
     it('removes the readystatechange listener once the auto-finish signal is emitted', () => {
       const addEventListenerSpy = vi.spyOn(WINDOW.document!, 'addEventListener');
       const removeEventListenerSpy = vi.spyOn(WINDOW.document!, 'removeEventListener');

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,2 +1,11 @@
 export const DEFAULT_ENVIRONMENT = 'production';
 export const DEV_ENVIRONMENT = 'development';
+
+/**
+ * The name of a pageload span when span streaming is enabled and no parameterized route is
+ * available. Span names have to be low cardinality, so a raw URL must never be used instead.
+ *
+ * This is a span name only: it must never be set as the scope's transaction name, which is what
+ * error events are grouped by.
+ */
+export const PAGELOAD_SPAN_NAME_FALLBACK = 'Pageload';

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -136,7 +136,7 @@ export {
   MAX_BODY_BYTE_LENGTH,
 } from './utils/request';
 export type { MaxRequestBodySize } from './utils/request';
-export { DEFAULT_ENVIRONMENT, DEV_ENVIRONMENT } from './constants';
+export { DEFAULT_ENVIRONMENT, DEV_ENVIRONMENT, PAGELOAD_SPAN_NAME_FALLBACK } from './constants';
 export { spanKindToName } from './spanKind';
 export type { SpanKind, SpanKindNumber } from './spanKind';
 export { addBreadcrumb } from './breadcrumbs';

--- a/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
+++ b/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
@@ -17,6 +17,7 @@ import {
   filterCollectedUrl,
   getCurrentScope,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   spanToJSON,
   type Client,
   type Span,
@@ -67,7 +68,7 @@ export function instrumentEmberAppInstanceForPerformance(
       name: routeInfo
         ? `route:${routeInfo.name}`
         : hasSpanStreamingEnabled(client)
-          ? 'Pageload'
+          ? PAGELOAD_SPAN_NAME_FALLBACK
           : url || WINDOW.location.pathname,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeInfo ? 'route' : 'url',

--- a/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
+++ b/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
@@ -13,7 +13,14 @@ import {
   WINDOW,
 } from '@sentry/browser';
 import { SENTRY_OP, URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
-import { filterCollectedUrl, getCurrentScope, spanToJSON, type Client, type Span } from '@sentry/core';
+import {
+  filterCollectedUrl,
+  getCurrentScope,
+  hasSpanStreamingEnabled,
+  spanToJSON,
+  type Client,
+  type Span,
+} from '@sentry/core';
 import { getBackburner } from './utils.ts';
 
 interface EmberRouterMain {
@@ -56,7 +63,12 @@ export function instrumentEmberAppInstanceForPerformance(
     const routeInfo = url ? routerService.recognize(url) : undefined;
 
     activeRootSpan = startBrowserTracingPageLoadSpan(client, {
-      name: routeInfo ? `route:${routeInfo.name}` : url || WINDOW.location.pathname,
+      // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+      name: routeInfo
+        ? `route:${routeInfo.name}`
+        : hasSpanStreamingEnabled(client)
+          ? 'Pageload'
+          : url || WINDOW.location.pathname,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeInfo ? 'route' : 'url',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.ember',

--- a/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
@@ -2,6 +2,7 @@ import type { Client, Span } from '@sentry/core';
 import {
   browserPerformanceTimeOrigin,
   GLOBAL_OBJ,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -61,7 +62,8 @@ export function appRouterInstrumentPageLoad(client: Client): void {
   const parameterizedPathname = maybeParameterizeRoute(pathname);
   const origin = browserPerformanceTimeOrigin();
   startBrowserTracingPageLoadSpan(client, {
-    name: parameterizedPathname ?? pathname,
+    // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+    name: parameterizedPathname ?? (hasSpanStreamingEnabled(client) ? 'Pageload' : pathname),
     // pageload should always start at timeOrigin (and needs to be in s, not ms)
     startTime: origin ? origin / 1000 : undefined,
     attributes: {

--- a/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
@@ -3,6 +3,7 @@ import {
   browserPerformanceTimeOrigin,
   GLOBAL_OBJ,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -63,7 +64,7 @@ export function appRouterInstrumentPageLoad(client: Client): void {
   const origin = browserPerformanceTimeOrigin();
   startBrowserTracingPageLoadSpan(client, {
     // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
-    name: parameterizedPathname ?? (hasSpanStreamingEnabled(client) ? 'Pageload' : pathname),
+    name: parameterizedPathname ?? (hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : pathname),
     // pageload should always start at timeOrigin (and needs to be in s, not ms)
     startTime: origin ? origin / 1000 : undefined,
     attributes: {

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -3,6 +3,7 @@ import {
   browserPerformanceTimeOrigin,
   debug,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   parseBaggageHeader,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -113,7 +114,7 @@ export function pagesRouterInstrumentPageLoad(client: Client): void {
   const { route, params, sentryTrace, baggage } = extractNextDataTagInformation();
   const parsedBaggage = parseBaggageHeader(baggage);
   // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
-  let name = route || (hasSpanStreamingEnabled(client) ? 'Pageload' : globalObject.location.pathname);
+  let name = route || (hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : globalObject.location.pathname);
 
   // /_error is the fallback page for all errors. If there is a transaction name for /_error, use that instead
   if (parsedBaggage?.['sentry-transaction'] && name === '/_error') {

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -2,6 +2,7 @@ import type { Client, TransactionSource } from '@sentry/core';
 import {
   browserPerformanceTimeOrigin,
   debug,
+  hasSpanStreamingEnabled,
   parseBaggageHeader,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -111,7 +112,8 @@ function extractNextDataTagInformation(): NextDataTagInfo {
 export function pagesRouterInstrumentPageLoad(client: Client): void {
   const { route, params, sentryTrace, baggage } = extractNextDataTagInformation();
   const parsedBaggage = parseBaggageHeader(baggage);
-  let name = route || globalObject.location.pathname;
+  // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+  let name = route || (hasSpanStreamingEnabled(client) ? 'Pageload' : globalObject.location.pathname);
 
   // /_error is the fallback page for all errors. If there is a transaction name for /_error, use that instead
   if (parsedBaggage?.['sentry-transaction'] && name === '/_error') {

--- a/packages/react-router/src/client/hydratedRouter.ts
+++ b/packages/react-router/src/client/hydratedRouter.ts
@@ -49,12 +49,14 @@ export function instrumentHydratedRouter(): void {
       const pageloadSpan = getActiveRootSpan();
 
       if (pageloadSpan) {
-        const pageloadName = spanToJSON(pageloadSpan).name;
+        // Matched against `url.path` rather than the span name: with span streaming, the pageload
+        // span is named `Pageload` until a route is resolved, so the name may not hold the pathname.
+        const pageloadPath = spanToJSON(pageloadSpan).attributes[URL_PATH];
         const parameterizePageloadRoute = getParameterizedRoute(router.state);
         if (
-          pageloadName &&
+          typeof pageloadPath === 'string' &&
           // this event is for the currently active pageload
-          normalizePathname(router.state.location.pathname) === normalizePathname(pageloadName)
+          normalizePathname(router.state.location.pathname) === normalizePathname(pageloadPath)
         ) {
           pageloadSpan.updateName(parameterizePageloadRoute);
           pageloadSpan.setAttributes({

--- a/packages/react-router/test/client/hydratedRouter.test.ts
+++ b/packages/react-router/test/client/hydratedRouter.test.ts
@@ -64,8 +64,11 @@ describe('instrumentHydratedRouter', () => {
     (core.getRootSpan as any).mockImplementation((span: any) => span);
     (core.spanToJSON as any).mockImplementation((span: any) => ({
       name: '/foo/bar',
-      // Distinguish so the subscribe callback can branch on op (pageload vs. navigation).
-      attributes: { 'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload' },
+      attributes: {
+        // Distinguish so the subscribe callback can branch on op (pageload vs. navigation).
+        'sentry.op': span === mockNavigationSpan ? 'navigation' : 'pageload',
+        'url.path': '/foo/bar',
+      },
     }));
     (core.getClient as any).mockReturnValue({});
     (browser.startBrowserTracingNavigationSpan as any).mockReturnValue(mockNavigationSpan);

--- a/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
+++ b/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
@@ -15,6 +15,7 @@ import {
   getClient,
   getCurrentScope,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -725,7 +726,7 @@ export function createReactRouterV6CompatibleTracingIntegration(
         startBrowserTracingPageLoadSpan(client, {
           // With span streaming, span names have to be low cardinality. The route is only resolved
           // once the router renders, which updates the span name then.
-          name: hasSpanStreamingEnabled(client) ? 'Pageload' : initPathName,
+          name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : initPathName,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -1137,7 +1138,7 @@ function updatePageloadTransaction({
       // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
       const client = getClient();
       const isUnparameterizedStreamedPageload = source !== 'route' && !!client && hasSpanStreamingEnabled(client);
-      activeRootSpan.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : name);
+      activeRootSpan.updateName(isUnparameterizedStreamedPageload ? PAGELOAD_SPAN_NAME_FALLBACK : name);
       activeRootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
       if (source === 'route') {
         activeRootSpan.setAttribute(URL_TEMPLATE, name);
@@ -1240,7 +1241,7 @@ function tryUpdateSpanNameBeforeEnd(
       const client = getClient();
       const isUnparameterizedStreamedPageload =
         spanType === 'pageload' && source !== 'route' && !!client && hasSpanStreamingEnabled(client);
-      span.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : name);
+      span.updateName(isUnparameterizedStreamedPageload ? PAGELOAD_SPAN_NAME_FALLBACK : name);
       span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
       if (source === 'route') {
         span.setAttribute(URL_TEMPLATE, name);

--- a/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
+++ b/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
@@ -14,6 +14,7 @@ import {
   debug,
   getClient,
   getCurrentScope,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -722,7 +723,9 @@ export function createReactRouterV6CompatibleTracingIntegration(
       const initPathName = WINDOW.location?.pathname;
       if (instrumentPageLoad && initPathName) {
         startBrowserTracingPageLoadSpan(client, {
-          name: initPathName,
+          // With span streaming, span names have to be low cardinality. The route is only resolved
+          // once the router renders, which updates the span name then.
+          name: hasSpanStreamingEnabled(client) ? 'Pageload' : initPathName,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -1131,7 +1134,10 @@ function updatePageloadTransaction({
     getCurrentScope().setTransactionName(name || '/');
 
     if (activeRootSpan) {
-      activeRootSpan.updateName(name);
+      // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+      const client = getClient();
+      const isUnparameterizedStreamedPageload = source !== 'route' && !!client && hasSpanStreamingEnabled(client);
+      activeRootSpan.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : name);
       activeRootSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
       if (source === 'route') {
         activeRootSpan.setAttribute(URL_TEMPLATE, name);
@@ -1230,7 +1236,11 @@ function tryUpdateSpanNameBeforeEnd(
     const spanNotEnded = spanType === 'pageload' || !spanJson.end_timestamp;
 
     if (isImprovement && spanNotEnded) {
-      span.updateName(name);
+      // With span streaming, a pageload span name has to be low cardinality, so we can't fall back to the URL.
+      const client = getClient();
+      const isUnparameterizedStreamedPageload =
+        spanType === 'pageload' && source !== 'route' && !!client && hasSpanStreamingEnabled(client);
+      span.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : name);
       span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
       if (source === 'route') {
         span.setAttribute(URL_TEMPLATE, name);

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -9,6 +9,7 @@ import {
   getActiveSpan,
   getCurrentScope,
   getRootSpan,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -158,7 +159,8 @@ function instrumentReactRouter(
     if (initPathName) {
       const [name, source] = normalizeTransactionName(initPathName);
       startBrowserTracingPageLoadSpan(client, {
-        name,
+        // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+        name: source === 'route' || !hasSpanStreamingEnabled(client) ? name : 'Pageload',
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.pageload.react.${instrumentationName}`,

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -10,6 +10,7 @@ import {
   getCurrentScope,
   getRootSpan,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -160,7 +161,7 @@ function instrumentReactRouter(
       const [name, source] = normalizeTransactionName(initPathName);
       startBrowserTracingPageLoadSpan(client, {
         // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
-        name: source === 'route' || !hasSpanStreamingEnabled(client) ? name : 'Pageload',
+        name: source === 'route' || !hasSpanStreamingEnabled(client) ? name : PAGELOAD_SPAN_NAME_FALLBACK,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.pageload.react.${instrumentationName}`,

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -7,6 +7,7 @@ import {
 import type { Integration, TransactionSource } from '@sentry/core/browser';
 import {
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -66,7 +67,7 @@ export function reactRouterV3BrowserTracingIntegration(
           (localName: string, source: ReactRouterV3TransactionSource = 'url') => {
             startBrowserTracingPageLoadSpan(client, {
               // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
-              name: source === 'route' || !hasSpanStreamingEnabled(client) ? localName : 'Pageload',
+              name: source === 'route' || !hasSpanStreamingEnabled(client) ? localName : PAGELOAD_SPAN_NAME_FALLBACK,
               attributes: {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v3',

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -6,6 +6,7 @@ import {
 } from '@sentry/browser';
 import type { Integration, TransactionSource } from '@sentry/core/browser';
 import {
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -64,7 +65,8 @@ export function reactRouterV3BrowserTracingIntegration(
           match,
           (localName: string, source: ReactRouterV3TransactionSource = 'url') => {
             startBrowserTracingPageLoadSpan(client, {
-              name: localName,
+              // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+              name: source === 'route' || !hasSpanStreamingEnabled(client) ? localName : 'Pageload',
               attributes: {
                 [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v3',

--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -6,7 +6,7 @@ import {
   WINDOW,
 } from '@sentry/browser';
 import type { Integration } from '@sentry/core/browser';
-import { filterCollectedUrl, hasSpanStreamingEnabled } from '@sentry/core';
+import { filterCollectedUrl, hasSpanStreamingEnabled, PAGELOAD_SPAN_NAME_FALLBACK } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -93,7 +93,7 @@ export function tanstackRouterBrowserTracingIntegration(
           name: routeMatch
             ? routeMatch.routeId
             : hasSpanStreamingEnabled(client)
-              ? 'Pageload'
+              ? PAGELOAD_SPAN_NAME_FALLBACK
               : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -117,7 +117,7 @@ export function tanstackRouterBrowserTracingIntegration(
             pageloadSpan,
             resolvedMatch,
             toLocation,
-            hasSpanStreamingEnabled(client) ? 'Pageload' : toLocation.pathname,
+            hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : toLocation.pathname,
           );
         });
       }

--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -6,7 +6,7 @@ import {
   WINDOW,
 } from '@sentry/browser';
 import type { Integration } from '@sentry/core/browser';
-import { filterCollectedUrl } from '@sentry/core';
+import { filterCollectedUrl, hasSpanStreamingEnabled } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -89,7 +89,12 @@ export function tanstackRouterBrowserTracingIntegration(
         );
 
         const pageloadSpan = startBrowserTracingPageLoadSpan(client, {
-          name: routeMatch ? routeMatch.routeId : initialWindowLocation.pathname,
+          // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+          name: routeMatch
+            ? routeMatch.routeId
+            : hasSpanStreamingEnabled(client)
+              ? 'Pageload'
+              : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.tanstack_router',
@@ -108,7 +113,12 @@ export function tanstackRouterBrowserTracingIntegration(
           }
           const { toLocation } = onResolvedArgs;
           const resolvedMatch = resolveRouteMatch(toLocation.pathname, toLocation.search);
-          applyRouteMatch(pageloadSpan, resolvedMatch, toLocation, toLocation.pathname);
+          applyRouteMatch(
+            pageloadSpan,
+            resolvedMatch,
+            toLocation,
+            hasSpanStreamingEnabled(client) ? 'Pageload' : toLocation.pathname,
+          );
         });
       }
 

--- a/packages/react/test/reactrouterv4.test.tsx
+++ b/packages/react/test/reactrouterv4.test.tsx
@@ -102,9 +102,7 @@ describe('browserTracingReactRouterV4', () => {
 
     client.init();
 
-    // The scope transaction name follows the pageload span name, which is low cardinality with
-    // span streaming enabled.
-    expect(getCurrentScope().getScopeData().transactionName).toEqual('Pageload');
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
   });
 
   it('starts a navigation transaction', () => {

--- a/packages/react/test/reactrouterv4.test.tsx
+++ b/packages/react/test/reactrouterv4.test.tsx
@@ -84,7 +84,7 @@ describe('browserTracingReactRouterV4', () => {
 
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
-      name: '/',
+      name: 'Pageload',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v4',
@@ -102,7 +102,9 @@ describe('browserTracingReactRouterV4', () => {
 
     client.init();
 
-    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
+    // The scope transaction name follows the pageload span name, which is low cardinality with
+    // span streaming enabled.
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('Pageload');
   });
 
   it('starts a navigation transaction', () => {

--- a/packages/react/test/reactrouterv5.test.tsx
+++ b/packages/react/test/reactrouterv5.test.tsx
@@ -102,9 +102,7 @@ describe('browserTracingReactRouterV5', () => {
 
     client.init();
 
-    // The scope transaction name follows the pageload span name, which is low cardinality with
-    // span streaming enabled.
-    expect(getCurrentScope().getScopeData().transactionName).toEqual('Pageload');
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
   });
 
   it('starts a navigation transaction', () => {

--- a/packages/react/test/reactrouterv5.test.tsx
+++ b/packages/react/test/reactrouterv5.test.tsx
@@ -84,7 +84,7 @@ describe('browserTracingReactRouterV5', () => {
 
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
-      name: '/',
+      name: 'Pageload',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v5',
@@ -102,7 +102,9 @@ describe('browserTracingReactRouterV5', () => {
 
     client.init();
 
-    expect(getCurrentScope().getScopeData().transactionName).toEqual('/');
+    // The scope transaction name follows the pageload span name, which is low cardinality with
+    // span streaming enabled.
+    expect(getCurrentScope().getScopeData().transactionName).toEqual('Pageload');
   });
 
   it('starts a navigation transaction', () => {

--- a/packages/react/test/reactrouterv6.test.tsx
+++ b/packages/react/test/reactrouterv6.test.tsx
@@ -130,7 +130,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
 
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
-      name: '/',
+      name: 'Pageload',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -177,7 +177,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
 
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
     expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
-      name: '/',
+      name: 'Pageload',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -214,7 +214,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
 
       expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
       expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
-        name: '/',
+        name: 'Pageload',
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -799,7 +799,7 @@ describe('reactRouterV6BrowserTracingIntegration', () => {
 
       expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
       expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
-        name: '/',
+        name: 'Pageload',
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',

--- a/packages/remix/src/client/performance.tsx
+++ b/packages/remix/src/client/performance.tsx
@@ -4,6 +4,7 @@ import {
   getActiveSpan,
   getCurrentScope,
   getRootSpan,
+  hasSpanStreamingEnabled,
   isNodeEnv,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -99,7 +100,8 @@ export function startPageloadSpan(client: Client): void {
   const source = parameterizedRoute ? 'route' : 'url';
 
   const spanContext: StartSpanOptions = {
-    name: spanName,
+    // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+    name: source === 'route' || !hasSpanStreamingEnabled(client) ? spanName : 'Pageload',
     op: 'pageload',
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.remix',
@@ -183,7 +185,11 @@ export function withSentry<P extends Record<string, unknown>, R extends React.Co
           const transaction = getRootSpan(activeRootSpan);
 
           if (transaction) {
-            transaction.updateName(name);
+            // This runs on mount, so the root span is the pageload span. With span streaming, its
+            // name has to be low cardinality, so we can't fall back to the URL.
+            const client = getClient();
+            const isUnparameterizedStreamedPageload = source !== 'route' && !!client && hasSpanStreamingEnabled(client);
+            transaction.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : name);
             transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
             if (source === 'route') {
               transaction.setAttribute(URL_TEMPLATE, name);

--- a/packages/remix/src/client/performance.tsx
+++ b/packages/remix/src/client/performance.tsx
@@ -5,6 +5,7 @@ import {
   getCurrentScope,
   getRootSpan,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   isNodeEnv,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -101,7 +102,7 @@ export function startPageloadSpan(client: Client): void {
 
   const spanContext: StartSpanOptions = {
     // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
-    name: source === 'route' || !hasSpanStreamingEnabled(client) ? spanName : 'Pageload',
+    name: source === 'route' || !hasSpanStreamingEnabled(client) ? spanName : PAGELOAD_SPAN_NAME_FALLBACK,
     op: 'pageload',
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.remix',
@@ -189,7 +190,7 @@ export function withSentry<P extends Record<string, unknown>, R extends React.Co
             // name has to be low cardinality, so we can't fall back to the URL.
             const client = getClient();
             const isUnparameterizedStreamedPageload = source !== 'route' && !!client && hasSpanStreamingEnabled(client);
-            transaction.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : name);
+            transaction.updateName(isUnparameterizedStreamedPageload ? PAGELOAD_SPAN_NAME_FALLBACK : name);
             transaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, source);
             if (source === 'route') {
               transaction.setAttribute(URL_TEMPLATE, name);

--- a/packages/solid/src/tanstackrouter.ts
+++ b/packages/solid/src/tanstackrouter.ts
@@ -14,6 +14,7 @@ import {
 } from '@sentry/conventions/attributes';
 import type { Integration } from '@sentry/core';
 import {
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -85,7 +86,12 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
         );
 
         const pageloadSpan = startBrowserTracingPageLoadSpan(client, {
-          name: routeMatch ? routeMatch.routeId : initialWindowLocation.pathname,
+          // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+          name: routeMatch
+            ? routeMatch.routeId
+            : hasSpanStreamingEnabled(client)
+              ? 'Pageload'
+              : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.solid.tanstack_router',
@@ -105,7 +111,12 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
           const { toLocation } = onResolvedArgs;
           const resolvedMatch = resolveRouteMatch(toLocation.pathname, toLocation.search);
           if (resolvedMatch) {
-            applyRouteMatch(pageloadSpan, resolvedMatch, toLocation, toLocation.pathname);
+            applyRouteMatch(
+              pageloadSpan,
+              resolvedMatch,
+              toLocation,
+              hasSpanStreamingEnabled(client) ? 'Pageload' : toLocation.pathname,
+            );
           }
         });
       }

--- a/packages/solid/src/tanstackrouter.ts
+++ b/packages/solid/src/tanstackrouter.ts
@@ -15,6 +15,7 @@ import {
 import type { Integration } from '@sentry/core';
 import {
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -90,7 +91,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
           name: routeMatch
             ? routeMatch.routeId
             : hasSpanStreamingEnabled(client)
-              ? 'Pageload'
+              ? PAGELOAD_SPAN_NAME_FALLBACK
               : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -115,7 +116,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
               pageloadSpan,
               resolvedMatch,
               toLocation,
-              hasSpanStreamingEnabled(client) ? 'Pageload' : toLocation.pathname,
+              hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : toLocation.pathname,
             );
           }
         });

--- a/packages/solid/test/solidrouter.test.tsx
+++ b/packages/solid/test/solidrouter.test.tsx
@@ -71,7 +71,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: '/',
+        name: 'Pageload',
         attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -102,7 +102,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).not.toHaveBeenCalledWith(
       expect.objectContaining({
-        name: '/',
+        name: 'Pageload',
         attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',

--- a/packages/solidstart/test/client/solidrouter.test.tsx
+++ b/packages/solidstart/test/client/solidrouter.test.tsx
@@ -71,7 +71,7 @@ describe('solidRouterBrowserTracingIntegration', () => {
 
     expect(spanStartMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: '/',
+        name: 'Pageload',
         attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',

--- a/packages/sveltekit/src/client/svelte4BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte4BrowserTracing.ts
@@ -1,5 +1,9 @@
 import type { Client, Span } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
+import {
+  hasSpanStreamingEnabled,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from '@sentry/core';
 import {
   getCurrentScope,
   startBrowserTracingNavigationSpan,
@@ -37,7 +41,9 @@ function _instrumentPageload(client: Client, pageStore: Readable<Page>): void {
   const initialPath = WINDOW.location?.pathname;
 
   const pageloadSpan = startBrowserTracingPageLoadSpan(client, {
-    name: initialPath,
+    // With span streaming, span names have to be low cardinality. The route id is only available
+    // asynchronously, which updates the span name then.
+    name: hasSpanStreamingEnabled(client) ? 'Pageload' : initialPath,
     op: 'pageload',
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',

--- a/packages/sveltekit/src/client/svelte4BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte4BrowserTracing.ts
@@ -1,6 +1,7 @@
 import type { Client, Span } from '@sentry/core';
 import {
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
@@ -43,7 +44,7 @@ function _instrumentPageload(client: Client, pageStore: Readable<Page>): void {
   const pageloadSpan = startBrowserTracingPageLoadSpan(client, {
     // With span streaming, span names have to be low cardinality. The route id is only available
     // asynchronously, which updates the span name then.
-    name: hasSpanStreamingEnabled(client) ? 'Pageload' : initialPath,
+    name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : initialPath,
     op: 'pageload',
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',

--- a/packages/sveltekit/src/client/svelte5BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte5BrowserTracing.ts
@@ -1,5 +1,9 @@
 import type { Client, Span } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
+import {
+  hasSpanStreamingEnabled,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from '@sentry/core';
 import {
   getCurrentScope,
   startBrowserTracingNavigationSpan,
@@ -33,7 +37,9 @@ function _instrumentPageLoad(client: Client): void {
   const initialPath = WINDOW.location?.pathname;
 
   const pageLoadSpan = startBrowserTracingPageLoadSpan(client, {
-    name: initialPath,
+    // With span streaming, span names have to be low cardinality. The route id is only available
+    // asynchronously, which updates the span name then.
+    name: hasSpanStreamingEnabled(client) ? 'Pageload' : initialPath,
     op: 'pageload',
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',

--- a/packages/sveltekit/src/client/svelte5BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte5BrowserTracing.ts
@@ -1,6 +1,7 @@
 import type { Client, Span } from '@sentry/core';
 import {
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
@@ -39,7 +40,7 @@ function _instrumentPageLoad(client: Client): void {
   const pageLoadSpan = startBrowserTracingPageLoadSpan(client, {
     // With span streaming, span names have to be low cardinality. The route id is only available
     // asynchronously, which updates the span name then.
-    name: hasSpanStreamingEnabled(client) ? 'Pageload' : initialPath,
+    name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : initialPath,
     op: 'pageload',
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',

--- a/packages/sveltekit/test/client/svelte5BrowserTracing.test.ts
+++ b/packages/sveltekit/test/client/svelte5BrowserTracing.test.ts
@@ -63,7 +63,7 @@ describe('svelte5 browser tracing', () => {
     () => ({ setTransactionName: setTransactionNameSpy }) as unknown as ReturnType<typeof SentrySvelte.getCurrentScope>,
   );
 
-  const client = {} as Parameters<typeof instrumentSvelteKitTracing>[0];
+  const client = { getOptions: () => ({}) } as Parameters<typeof instrumentSvelteKitTracing>[0];
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -9,8 +9,10 @@ import {
 import type { Span, SpanAttributes, StartSpanOptions, TransactionSource } from '@sentry/core';
 import {
   getActiveSpan,
+  getClient,
   getCurrentScope,
   getRootSpan,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   spanToJSON,
@@ -117,7 +119,11 @@ export function instrumentVueRouter(
     if (options.instrumentPageLoad && activePageLoadSpan) {
       const existingAttributes = spanToJSON(activePageLoadSpan).attributes;
       if (existingAttributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] !== 'custom') {
-        activePageLoadSpan.updateName(spanName);
+        // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+        const client = getClient();
+        const isUnparameterizedStreamedPageload =
+          transactionSource === 'url' && !!client && hasSpanStreamingEnabled(client);
+        activePageLoadSpan.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : spanName);
         activePageLoadSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, transactionSource);
       }
 

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -13,6 +13,7 @@ import {
   getCurrentScope,
   getRootSpan,
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
   spanToJSON,
@@ -123,7 +124,7 @@ export function instrumentVueRouter(
         const client = getClient();
         const isUnparameterizedStreamedPageload =
           transactionSource === 'url' && !!client && hasSpanStreamingEnabled(client);
-        activePageLoadSpan.updateName(isUnparameterizedStreamedPageload ? 'Pageload' : spanName);
+        activePageLoadSpan.updateName(isUnparameterizedStreamedPageload ? PAGELOAD_SPAN_NAME_FALLBACK : spanName);
         activePageLoadSpan.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, transactionSource);
       }
 

--- a/packages/vue/src/tanstackrouter.ts
+++ b/packages/vue/src/tanstackrouter.ts
@@ -14,6 +14,7 @@ import {
 } from '@sentry/conventions/attributes';
 import type { Integration } from '@sentry/core';
 import {
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -91,7 +92,12 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
         );
 
         const pageloadSpan = startBrowserTracingPageLoadSpan(client, {
-          name: routeMatch ? routeMatch.routeId : initialWindowLocation.pathname,
+          // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
+          name: routeMatch
+            ? routeMatch.routeId
+            : hasSpanStreamingEnabled(client)
+              ? 'Pageload'
+              : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.vue.tanstack_router',
@@ -111,7 +117,12 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
           }
           const { toLocation } = onResolvedArgs as TanstackRouterSubscribeArgs;
           const resolvedMatch = resolveRouteMatch(toLocation.pathname, toLocation.search);
-          applyRouteMatch(pageloadSpan, resolvedMatch, toLocation, toLocation.pathname);
+          applyRouteMatch(
+            pageloadSpan,
+            resolvedMatch,
+            toLocation,
+            hasSpanStreamingEnabled(client) ? 'Pageload' : toLocation.pathname,
+          );
         });
       }
 

--- a/packages/vue/src/tanstackrouter.ts
+++ b/packages/vue/src/tanstackrouter.ts
@@ -15,6 +15,7 @@ import {
 import type { Integration } from '@sentry/core';
 import {
   hasSpanStreamingEnabled,
+  PAGELOAD_SPAN_NAME_FALLBACK,
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
@@ -96,7 +97,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
           name: routeMatch
             ? routeMatch.routeId
             : hasSpanStreamingEnabled(client)
-              ? 'Pageload'
+              ? PAGELOAD_SPAN_NAME_FALLBACK
               : initialWindowLocation.pathname,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
@@ -121,7 +122,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
             pageloadSpan,
             resolvedMatch,
             toLocation,
-            hasSpanStreamingEnabled(client) ? 'Pageload' : toLocation.pathname,
+            hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : toLocation.pathname,
           );
         });
       }


### PR DESCRIPTION
This PR adjusts all `sentry.op: 'pageload'` spans to only emit low cardinality span names if span streaming is enabled.

Concretely, for pageload spans, this means that we want to never set a raw URL as a span name, which was the current fallback for transaction-based span names. Instead, we now fall back to a static `"Pageload"` span name.

The new low-cardinality pageload span names now adhere to the rules set in [conventions](https://getsentry.github.io/sentry-conventions/names/#browser-pageload).

ref #22350 