### PR TITLE
fix(cloudflare): Preserve late static child spans

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -477,7 +477,7 @@ module.exports = [
     ignore: [...builtinModules, ...nodePrefixedBuiltinModules],
     gzip: false,
     brotli: false,
-    limit: '524 KiB',
+    limit: '529 KiB',
     disablePlugins: ['@size-limit/webpack'],
     webpack: false,
     modifyEsbuildConfig: function (config) {

--- a/dev-packages/cloudflare-integration-tests/runner.ts
+++ b/dev-packages/cloudflare-integration-tests/runner.ts
@@ -8,6 +8,7 @@ import { inspect } from 'util';
 import { expect } from 'vitest';
 
 const CLEANUP_STEPS = new Set<() => void>();
+const STRICT_ENVELOPE_QUIET_WINDOW_MS = 250;
 
 export function cleanupChildProcesses(): void {
   for (const step of CLEANUP_STEPS) {
@@ -161,6 +162,7 @@ export function createRunner(...paths: string[]) {
 
   // controls whether envelopes are expected in predefined order or not
   let unordered = false;
+  let strict = false;
 
   if (!existsSync(testPath)) {
     throw new Error(`Test scenario not found: ${testPath}`);
@@ -193,6 +195,10 @@ export function createRunner(...paths: string[]) {
     },
     unordered: function () {
       unordered = true;
+      return this;
+    },
+    strict: function () {
+      strict = true;
       return this;
     },
     ignore: function (...types: EnvelopeItemType[]) {
@@ -238,8 +244,17 @@ export function createRunner(...paths: string[]) {
       function expectCallbackCalled(): void {
         envelopeCount++;
         if (envelopeCount === expectedEnvelopeCount) {
-          resolve();
+          if (strict) {
+            // Keep the server open briefly so envelopes emitted just after the final match cannot escape cardinality checks.
+            setTimeout(resolve, STRICT_ENVELOPE_QUIET_WINDOW_MS);
+          } else {
+            resolve();
+          }
         }
+      }
+
+      function rejectUnexpectedEnvelope(envelopeItemType: EnvelopeItemType): void {
+        reject(new Error(`Received unexpected ${envelopeItemType} envelope in strict mode`));
       }
 
       function waitForEnvelope(expected: Expected): Promise<void> {
@@ -297,6 +312,9 @@ export function createRunner(...paths: string[]) {
 
             // no match found
             if (matchIndex < 0) {
+              if (strict) {
+                rejectUnexpectedEnvelope(envelopeItemType);
+              }
               return;
             }
 
@@ -307,6 +325,9 @@ export function createRunner(...paths: string[]) {
             const expected = expectedEnvelopes.shift();
 
             if (!expected) {
+              if (strict) {
+                rejectUnexpectedEnvelope(envelopeItemType);
+              }
               return;
             }
 

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/late-static-child/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/late-static-child/index.ts
@@ -1,0 +1,32 @@
+import * as Sentry from '@sentry/cloudflare';
+
+interface Env {
+  SENTRY_DSN: string;
+}
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    traceLifecycle: 'static',
+    tracesSampleRate: 1,
+  }),
+  {
+    async fetch(_request, _env, context) {
+      const lateSpan = Sentry.startInactiveSpan({
+        name: 'late waitUntil child',
+        op: 'test.wait_until',
+      });
+
+      context.waitUntil(
+        new Promise<void>(resolve => {
+          setTimeout(() => {
+            lateSpan.end();
+            resolve();
+          }, 25);
+        }),
+      );
+
+      return new Response(null, { status: 204 });
+    },
+  } satisfies ExportedHandler<Env>,
+);

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/late-static-child/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/late-static-child/test.ts
@@ -1,0 +1,49 @@
+import type { TransactionEvent } from '@sentry/core';
+import { expect, it } from 'vitest';
+import { createRunner } from '../../../runner';
+
+it('preserves a static child span that ends in waitUntil after the response', async ({ signal }) => {
+  let requestTraceId: string | undefined;
+  let requestSpanId: string | undefined;
+  let lateTraceId: string | undefined;
+  let lateParentSpanId: string | undefined;
+
+  const runner = createRunner(__dirname)
+    .expect(envelope => {
+      expect(envelope[1]).toHaveLength(1);
+      expect(envelope[1][0]?.[0].type).toBe('transaction');
+
+      const transaction = envelope[1][0]?.[1] as TransactionEvent;
+      expect(transaction.transaction).toBe('GET /late-child');
+      expect(transaction.contexts?.trace?.op).toBe('http.server');
+      expect(transaction.spans).toHaveLength(0);
+
+      requestTraceId = transaction.contexts?.trace?.trace_id;
+      requestSpanId = transaction.contexts?.trace?.span_id;
+    })
+    .expect(envelope => {
+      expect(envelope[1]).toHaveLength(1);
+      expect(envelope[1][0]?.[0].type).toBe('transaction');
+
+      const transaction = envelope[1][0]?.[1] as TransactionEvent;
+      expect(transaction.transaction).toBe('late waitUntil child');
+      expect(transaction.contexts?.trace?.op).toBe('test.wait_until');
+      expect(transaction.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+      expect(transaction.spans).toHaveLength(0);
+
+      lateTraceId = transaction.contexts?.trace?.trace_id;
+      lateParentSpanId = transaction.contexts?.trace?.parent_span_id;
+    })
+    .unordered()
+    .strict()
+    .start(signal);
+
+  const response = await runner.makeRequest('get', '/late-child');
+  expect(response).toBe('');
+  await runner.completed();
+
+  expect(requestTraceId).toBeDefined();
+  expect(lateTraceId).toBe(requestTraceId);
+  expect(requestSpanId).toBeDefined();
+  expect(lateParentSpanId).toBe(requestSpanId);
+});

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/late-static-child/wrangler.jsonc
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/late-static-child/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "name": "late-static-child",
+  "compatibility_date": "2025-06-17",
+  "main": "index.ts",
+  "compatibility_flags": ["nodejs_compat"],
+}

--- a/packages/cloudflare/src/client.ts
+++ b/packages/cloudflare/src/client.ts
@@ -1,6 +1,7 @@
 import type { ClientOptions, Options, ServerRuntimeClientOptions } from '@sentry/core';
 import {
   _INTERNAL_clearAiProviderSkips,
+  _INTERNAL_setDeferSegmentSpanCapture,
   applySdkMetadata,
   debug,
   ServerRuntimeClient,
@@ -46,6 +47,10 @@ export class CloudflareClient extends ServerRuntimeClient {
 
     super(clientOptions);
     this._flushLock = flushLock;
+
+    // Durable Object and waitUntil work can end after the request segment. Deferring static capture
+    // preserves those late children; the strategy is inert for Cloudflare's default stream lifecycle.
+    _INTERNAL_setDeferSegmentSpanCapture(this);
 
     // Track span lifecycle to know when to flush
     this._unsubscribeSpanStart = this.on('spanStart', span => {

--- a/packages/cloudflare/test/instrumentations/worker/instrumentEmail.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentEmail.test.ts
@@ -17,9 +17,11 @@ const MOCK_ENV_WITHOUT_DSN = {
   SENTRY_RELEASE: '1.1.1',
 };
 
-function createMockExecutionContext(): ExecutionContext {
+function createMockExecutionContext(waitUntilPromises: Promise<unknown>[] = []): ExecutionContext {
   return {
-    waitUntil: vi.fn(),
+    waitUntil: vi.fn(promise => {
+      waitUntilPromises.push(promise);
+    }),
     passThroughOnException: vi.fn(),
   };
 }
@@ -255,7 +257,9 @@ describe('instrumentEmail', () => {
       );
 
       const emailMessage = createMockEmailMessage();
-      await wrappedHandler.email?.(emailMessage, MOCK_ENV, createMockExecutionContext());
+      const waitUntilPromises: Promise<unknown>[] = [];
+      await wrappedHandler.email?.(emailMessage, MOCK_ENV, createMockExecutionContext(waitUntilPromises));
+      await Promise.all(waitUntilPromises);
 
       expect(sentryEvent.transaction).toEqual(`Handle Email ${emailMessage.to}`);
       expect(sentryEvent.spans).toHaveLength(0);

--- a/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentQueue.test.ts
@@ -17,9 +17,11 @@ const MOCK_ENV_WITHOUT_DSN = {
   SENTRY_RELEASE: '1.1.1',
 };
 
-function createMockExecutionContext(): ExecutionContext {
+function createMockExecutionContext(waitUntilPromises: Promise<unknown>[] = []): ExecutionContext {
   return {
-    waitUntil: vi.fn(),
+    waitUntil: vi.fn(promise => {
+      waitUntilPromises.push(promise);
+    }),
     passThroughOnException: vi.fn(),
   };
 }
@@ -268,7 +270,9 @@ describe('instrumentQueue', () => {
       );
 
       const batch = createMockQueueBatch();
-      await wrappedHandler.queue?.(batch, MOCK_ENV, createMockExecutionContext());
+      const waitUntilPromises: Promise<unknown>[] = [];
+      await wrappedHandler.queue?.(batch, MOCK_ENV, createMockExecutionContext(waitUntilPromises));
+      await Promise.all(waitUntilPromises);
 
       expect(sentryEvent.transaction).toEqual(`process ${batch.queue}`);
       expect(sentryEvent.spans).toHaveLength(0);

--- a/packages/cloudflare/test/instrumentations/worker/instrumentScheduled.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentScheduled.test.ts
@@ -17,9 +17,11 @@ const MOCK_ENV_WITHOUT_DSN = {
   SENTRY_RELEASE: '1.1.1',
 };
 
-function createMockExecutionContext(): ExecutionContext {
+function createMockExecutionContext(waitUntilPromises: Promise<unknown>[] = []): ExecutionContext {
   return {
-    waitUntil: vi.fn(),
+    waitUntil: vi.fn(promise => {
+      waitUntilPromises.push(promise);
+    }),
     passThroughOnException: vi.fn(),
   };
 }
@@ -249,7 +251,13 @@ describe('instrumentScheduled', () => {
         handler,
       );
 
-      await wrappedHandler.scheduled?.(createMockScheduledController(), MOCK_ENV, createMockExecutionContext());
+      const waitUntilPromises: Promise<unknown>[] = [];
+      await wrappedHandler.scheduled?.(
+        createMockScheduledController(),
+        MOCK_ENV,
+        createMockExecutionContext(waitUntilPromises),
+      );
+      await Promise.all(waitUntilPromises);
 
       expect(sentryEvent.transaction).toEqual('Scheduled Cron 0 0 0 * * *');
       expect(sentryEvent.spans).toHaveLength(0);

--- a/packages/cloudflare/test/staticSpanCapture.test.ts
+++ b/packages/cloudflare/test/staticSpanCapture.test.ts
@@ -1,0 +1,120 @@
+import {
+  type Event,
+  setCurrentClient,
+  spanStreamingIntegration,
+  startInactiveSpan,
+  withActiveSpan,
+} from '@sentry/core';
+import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CloudflareClient, type CloudflareClientOptions } from '../src/client';
+import { flushAndDispose } from '../src/flush';
+import { resetSdk } from './testUtils';
+
+const dsn = 'https://public@dsn.ingest.sentry.io/1337';
+
+function createClient(options: Partial<CloudflareClientOptions> = {}): {
+  client: CloudflareClient;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const send = vi.fn().mockResolvedValue({});
+  const client = new CloudflareClient({
+    dsn,
+    stackParser: () => [],
+    integrations: [],
+    tracesSampleRate: 1,
+    traceLifecycle: 'static',
+    transport: () => ({
+      send,
+      flush: vi.fn().mockResolvedValue(true),
+    }),
+    ...options,
+  });
+  setCurrentClient(client);
+  client.init();
+  return { client, send };
+}
+
+describe('CloudflareClient static span capture', () => {
+  beforeEach(() => {
+    resetSdk();
+    setAsyncLocalStorageAsyncContextStrategy();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    resetSdk();
+  });
+
+  it('preserves a child that ends after its segment was sent', () => {
+    vi.useFakeTimers();
+    const transactions: Event[] = [];
+    const { client } = createClient();
+    client.on('beforeSendEvent', event => {
+      transactions.push(event);
+    });
+    const root = startInactiveSpan({ name: 'cloudflare request' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'background agent work' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(2);
+    expect(transactions.map(transaction => transaction.transaction)).toEqual([
+      'cloudflare request',
+      'background agent work',
+    ]);
+    expect(transactions[1]?.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+  });
+
+  it('drains a deferred transaction before disposing the client', async () => {
+    const { client, send } = createClient();
+    const root = startInactiveSpan({ name: 'cloudflare request' });
+
+    root.end();
+
+    expect(send).not.toHaveBeenCalled();
+
+    await flushAndDispose(client, 3_000);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(client.getTransport()).toBeUndefined();
+  });
+
+  it('does not duplicate spans that use the streaming lifecycle', async () => {
+    const { client, send } = createClient({
+      integrations: [spanStreamingIntegration()],
+      traceLifecycle: 'stream',
+    });
+    const root = startInactiveSpan({ name: 'cloudflare request' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'streamed child' }));
+
+    child.end();
+    root.end();
+    await client.flush(3_000);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith([
+      expect.any(Object),
+      [
+        [
+          {
+            type: 'span',
+            item_count: 2,
+            content_type: 'application/vnd.sentry.items.span.v2+json',
+          },
+          {
+            version: 2,
+            items: [
+              expect.objectContaining({ name: 'streamed child' }),
+              expect.objectContaining({ name: 'cloudflare request' }),
+            ],
+          },
+        ],
+      ],
+    ]);
+  });
+});

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -42,6 +42,7 @@ import { createClientReportEnvelope } from './utils/clientreport';
 import { consoleSandbox, debug } from './utils/debug-logger';
 import { dsnToString, makeDsn } from './utils/dsn';
 import { addItemToEnvelope, createAttachmentEnvelopeItem } from './utils/envelope';
+import { copyEventCaptureDecision, notifyEventCaptureDecision } from './utils/eventCaptureDecision';
 import { getPossibleEventMessages } from './utils/eventUtils';
 import { isObjectLike, isParameterizedString, isPlainObject, isPrimitive, isThenable } from './utils/is';
 import { merge } from './utils/merge';
@@ -372,6 +373,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     // ensure we haven't captured this very object before
     if (hint?.originalException && checkOrSetAlreadyCaught(hint.originalException)) {
       DEBUG_BUILD && debug.log(ALREADY_SEEN_ERROR);
+      notifyEventCaptureDecision(hint, 'rejected');
       return eventId;
     }
 
@@ -379,6 +381,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
       event_id: eventId,
       ...hint,
     };
+    copyEventCaptureDecision(hint, hintWithEventId);
 
     const sdkProcessingMetadata = event.sdkProcessingMetadata || {};
     const capturedSpanScope: Scope | undefined = sdkProcessingMetadata.capturedSpanScope;
@@ -388,6 +391,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
     this._process(
       () => this._captureEvent(event, hintWithEventId, capturedSpanScope || currentScope, capturedSpanIsolationScope),
       dataCategory,
+      hintWithEventId,
     );
 
     return hintWithEventId.event_id;
@@ -1448,6 +1452,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
         return finalEvent.event_id;
       },
       reason => {
+        notifyEventCaptureDecision(hint, 'rejected');
         if (DEBUG_BUILD) {
           if (_isDoNotSendEventError(reason)) {
             debug.log(reason.message);
@@ -1583,16 +1588,24 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   /**
    * Occupies the client with processing and event
    */
-  protected _process<T>(taskProducer: () => PromiseLike<T>, dataCategory: DataCategory): void {
+  protected _process<T>(taskProducer: () => PromiseLike<T>, dataCategory: DataCategory, eventHint?: EventHint): void {
     this._numProcessing++;
 
     void this._promiseBuffer.add(taskProducer).then(
       value => {
+        if (eventHint) {
+          // Decision callbacks may synchronously capture follow-up telemetry and need the slot which the
+          // promise buffer's earlier settlement handler has just released.
+          notifyEventCaptureDecision(eventHint, 'accepted');
+        }
         this._numProcessing--;
         return value;
       },
       reason => {
         this._numProcessing--;
+        if (eventHint) {
+          notifyEventCaptureDecision(eventHint, 'rejected');
+        }
 
         if (reason === SENTRY_BUFFER_FULL_ERROR) {
           this.recordDroppedEvent('queue_overflow', dataCategory);

--- a/packages/core/src/tracing/deferSegmentSpanCapture.ts
+++ b/packages/core/src/tracing/deferSegmentSpanCapture.ts
@@ -1,17 +1,113 @@
 import type { Client } from '../client';
 import type { Scope } from '../scope';
+import type { TransactionEvent } from '../types/event';
 import type { Span } from '../types/span';
 import { debounce } from '../utils/debounce';
+import { setEventCaptureDecisionCallback } from '../utils/eventCaptureDecision';
+import { INTERNAL_getParentSpan } from '../utils/spanUtils';
 import { getSegmentSpanCaptureStrategy, setSegmentSpanCaptureStrategy } from './segmentSpanCaptureStrategy';
 import type { SegmentSpanConverter } from './segmentSpanCaptureStrategy';
+import { hasSpanStreamingEnabled } from './spans/hasSpanStreamingEnabled';
 
 // Spans already sent in a transaction, so a child ending after its segment can be emitted as its own
 // orphan transaction instead of being dropped or sent twice.
 const CAPTURED_SPANS = new WeakSet<Span>();
-const isSpanAlreadyCaptured = (span: Span): boolean => CAPTURED_SPANS.has(span);
 const markSpanCaptured = (span: Span): void => {
   CAPTURED_SPANS.add(span);
 };
+
+// A transaction is only considered captured after it survives event preparation and all before-send hooks.
+// Reserve its spans while that decision is pending so concurrent late-span captures cannot send duplicates.
+const PENDING_CAPTURED_SPANS = new WeakSet<Span>();
+
+// Rejection is terminal for a segment. Keeping this separate from pending state lets pending markers
+// be cleared at every terminal decision while preventing not-yet-accepted descendants from being emitted.
+const REJECTED_SEGMENT_SPANS = new WeakSet<Span>();
+
+function hasRejectedAncestor(span: Span): boolean {
+  const visited = new Set<Span>();
+  let ancestor = INTERNAL_getParentSpan(span);
+  while (ancestor && !visited.has(ancestor)) {
+    if (REJECTED_SEGMENT_SPANS.has(ancestor)) {
+      return true;
+    }
+
+    visited.add(ancestor);
+    ancestor = INTERNAL_getParentSpan(ancestor);
+  }
+  return false;
+}
+
+const isSpanCapturedOrUnavailable = (span: Span): boolean =>
+  CAPTURED_SPANS.has(span) ||
+  PENDING_CAPTURED_SPANS.has(span) ||
+  REJECTED_SEGMENT_SPANS.has(span) ||
+  hasRejectedAncestor(span);
+
+function getPendingCaptureAncestor(span: Span, rootSpan: Span): Span | undefined {
+  const visited = new Set<Span>();
+  let ancestor = INTERNAL_getParentSpan(span);
+  while (ancestor && !visited.has(ancestor)) {
+    if (PENDING_CHILD_CAPTURES.has(ancestor)) {
+      return ancestor;
+    }
+
+    visited.add(ancestor);
+    ancestor = INTERNAL_getParentSpan(ancestor);
+  }
+
+  return PENDING_CHILD_CAPTURES.has(rootSpan) ? rootSpan : undefined;
+}
+
+function queueUnderPendingAncestor(
+  span: Span,
+  rootSpan: Span,
+  client: Client | undefined,
+  capture: () => void,
+): boolean {
+  const pendingCaptureAncestor = getPendingCaptureAncestor(span, rootSpan);
+  if (!pendingCaptureAncestor || pendingCaptureAncestor === span) {
+    return false;
+  }
+
+  const pendingCaptureClient = PENDING_CAPTURE_CLIENTS.get(pendingCaptureAncestor);
+  if (pendingCaptureClient && client !== pendingCaptureClient) {
+    return false;
+  }
+
+  const previousPendingAncestor = PENDING_PARENT_CAPTURES.get(span);
+  if (previousPendingAncestor === pendingCaptureAncestor) {
+    return true;
+  }
+
+  if (previousPendingAncestor) {
+    const previousPendingCaptures = PENDING_CHILD_CAPTURES.get(previousPendingAncestor);
+    if (previousPendingCaptures) {
+      for (const pendingCapture of previousPendingCaptures) {
+        if (pendingCapture.span === span) {
+          previousPendingCaptures.delete(pendingCapture);
+        }
+      }
+    }
+  }
+
+  ensurePendingChildCaptures(span, client);
+  PENDING_PARENT_CAPTURES.set(span, pendingCaptureAncestor);
+  PENDING_CHILD_CAPTURES.get(pendingCaptureAncestor)?.add({ span, capture });
+  return true;
+}
+
+// Children ending while their segment's snapshot is queued or its event is still being processed must wait
+// for that event's decision. They are emitted if the segment is accepted and discarded if it is rejected.
+// The weak-keyed set is removed at either decision, so no queue of child closures remains afterward.
+interface PendingChildCapture {
+  span: Span;
+  capture: () => void;
+}
+const PENDING_CHILD_CAPTURES = new WeakMap<Span, Set<PendingChildCapture>>();
+// An ended span can move from an outer pending segment to a nearer ancestor which ends later.
+const PENDING_PARENT_CAPTURES = new WeakMap<Span, Span>();
+const PENDING_CAPTURE_CLIENTS = new WeakMap<Span, Client>();
 
 // One debounced queue per client, drained on the client's `flush`/`close`. Mirrors the OpenTelemetry
 // span exporter, which holds one such buffer per instance, and the debounce window matches it. The
@@ -29,9 +125,11 @@ const CLIENT_QUEUES = new WeakMap<Client, (capture: () => void) => void>();
  * `SentrySpan` otherwise assembles the transaction synchronously the instant a segment span ends, which
  * drops children whose async instrumentation closes them later (a diagnostics-channel `asyncEnd`
  * callback in the same tick, or engine spans replayed on a later tick). The debounced snapshot delays
- * capture just enough for those later span ends to land first; a child that still ends after it is
- * emitted as its own orphan transaction. Pending captures drain on the client's `flush` hook, so
- * `Sentry.flush()` / `client.close()` cannot resolve before they run.
+ * capture just enough for those later span ends to land first. In the static lifecycle, a child that
+ * ends after an accepted segment is emitted as its own orphan transaction; if the segment is dropped,
+ * its pending descendants remain suppressed. Pending captures drain on the client's `flush` hook, so
+ * `Sentry.flush()` / `client.close()` cannot resolve before they run. The strategy is inert for span
+ * streaming.
  */
 export function _INTERNAL_setDeferSegmentSpanCapture(client: Client): void {
   if (!getSegmentSpanCaptureStrategy()) {
@@ -65,8 +163,12 @@ export function _INTERNAL_setDeferSegmentSpanCapture(client: Client): void {
 }
 
 const deferredSegmentSpanCaptureStrategy = {
-  onSegmentSpanEnded(convert: SegmentSpanConverter, scope: Scope): void {
+  onSegmentSpanEnded(segmentSpan: Span, convert: SegmentSpanConverter, scope: Scope): void {
     const client = scope.getClient();
+    if (client && hasSpanStreamingEnabled(client)) {
+      return;
+    }
+
     const enqueue = client && CLIENT_QUEUES.get(client);
     if (!enqueue) {
       // The capturing client didn't enable deferral: capture synchronously.
@@ -77,40 +179,165 @@ const deferredSegmentSpanCaptureStrategy = {
       return;
     }
 
+    ensurePendingChildCaptures(segmentSpan, client);
     enqueue(() => {
-      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      const spansInTransaction: Span[] = [];
+      const transactionEvent = convert({
+        isSpanAlreadyCaptured: isSpanCapturedOrUnavailable,
+        onSpanCaptured: span => spansInTransaction.push(span),
+      });
       if (transactionEvent) {
-        client.captureEvent(transactionEvent);
+        captureDeferredTransaction(client, segmentSpan, transactionEvent, spansInTransaction);
+      } else {
+        rejectDeferredSegment(segmentSpan, spansInTransaction);
       }
     });
   },
 
   onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter, scope: Scope): void {
-    // Only a late child of an already-captured segment is an orphan. Inert under span streaming, where
-    // `CAPTURED_SPANS` is never populated.
-    if (CAPTURED_SPANS.has(span) || !CAPTURED_SPANS.has(rootSpan)) {
+    const client = scope.getClient();
+    if (client && hasSpanStreamingEnabled(client)) {
       return;
     }
 
-    const client = scope.getClient();
+    if (REJECTED_SEGMENT_SPANS.has(rootSpan) || hasRejectedAncestor(span)) {
+      return;
+    }
+
+    // Only a late child of an already-captured segment is an orphan. Stream clients return above before
+    // consulting this module-global capture state.
+    if (isSpanCapturedOrUnavailable(span)) {
+      return;
+    }
+
     const enqueue = client && CLIENT_QUEUES.get(client);
 
     const captureOrphan = (): void => {
-      const transactionEvent = convert({ isSpanAlreadyCaptured, onSpanCaptured: markSpanCaptured });
+      const queuedUnderPendingAncestor = queueUnderPendingAncestor(span, rootSpan, client, captureOrphan);
+
+      // A queued ancestor can include this span before its own orphan capture executes.
+      if (isSpanCapturedOrUnavailable(span) || hasRejectedAncestor(span)) {
+        PENDING_PARENT_CAPTURES.delete(span);
+        return;
+      }
+
+      if (queuedUnderPendingAncestor) {
+        return;
+      }
+
+      const spansInTransaction: Span[] = [];
+      const transactionEvent = convert({
+        isSpanAlreadyCaptured: isSpanCapturedOrUnavailable,
+        onSpanCaptured: capturedSpan => spansInTransaction.push(capturedSpan),
+      });
       if (transactionEvent?.contexts?.trace?.data) {
         // Tag orphans so they're distinguishable downstream (mirrors the OTel span exporter).
         transactionEvent.contexts.trace.data['sentry.parent_span_already_sent'] = true;
       }
       if (transactionEvent) {
-        client?.captureEvent(transactionEvent);
+        if (client) {
+          PENDING_PARENT_CAPTURES.delete(span);
+          captureDeferredTransaction(client, span, transactionEvent, spansInTransaction);
+        }
       }
     };
 
+    if (queueUnderPendingAncestor(span, rootSpan, client, captureOrphan)) {
+      return;
+    }
+
+    if (!CAPTURED_SPANS.has(rootSpan)) {
+      return;
+    }
+
     // Defer when the capturing client batches; otherwise emit now so the orphan isn't dropped.
     if (enqueue) {
+      ensurePendingChildCaptures(span, client);
       enqueue(captureOrphan);
     } else {
       captureOrphan();
     }
   },
 };
+
+/**
+ * Reserve a transaction's spans until the client's event pipeline reaches a terminal decision. Rejected
+ * segments are tracked independently so pending markers and child closures can always be released.
+ */
+function captureDeferredTransaction(
+  client: Client,
+  segmentSpan: Span,
+  transactionEvent: TransactionEvent,
+  spansInTransaction: Span[],
+): void {
+  spansInTransaction.forEach(span => PENDING_CAPTURED_SPANS.add(span));
+  ensurePendingChildCaptures(segmentSpan, client);
+
+  const hint = {};
+  setEventCaptureDecisionCallback(hint, decision => {
+    if (decision === 'accepted') {
+      spansInTransaction.forEach(span => {
+        PENDING_CAPTURED_SPANS.delete(span);
+        markSpanCaptured(span);
+      });
+      drainPendingChildCaptures([...spansInTransaction, segmentSpan]);
+      return;
+    }
+
+    rejectDeferredSegment(segmentSpan, spansInTransaction);
+  });
+  client.captureEvent(transactionEvent, hint);
+}
+
+function drainPendingChildCaptures(spans: Span[]): void {
+  const captures = new Set<PendingChildCapture>();
+  spans.forEach(span => {
+    PENDING_CHILD_CAPTURES.get(span)?.forEach(capture => captures.add(capture));
+    PENDING_CHILD_CAPTURES.delete(span);
+    PENDING_CAPTURE_CLIENTS.delete(span);
+  });
+  captures.forEach(({ span, capture }) => {
+    const pendingParentCapture = PENDING_PARENT_CAPTURES.get(span);
+    if (pendingParentCapture && !PENDING_CHILD_CAPTURES.has(pendingParentCapture)) {
+      PENDING_PARENT_CAPTURES.delete(span);
+    }
+    capture();
+  });
+}
+
+function ensurePendingChildCaptures(segmentSpan: Span, client?: Client): void {
+  if (!PENDING_CHILD_CAPTURES.has(segmentSpan)) {
+    PENDING_CHILD_CAPTURES.set(segmentSpan, new Set());
+  }
+  if (client) {
+    PENDING_CAPTURE_CLIENTS.set(segmentSpan, client);
+  }
+}
+
+function rejectDeferredSegment(segmentSpan: Span, spansInTransaction: Span[]): void {
+  spansInTransaction.forEach(span => {
+    PENDING_CAPTURED_SPANS.delete(span);
+    REJECTED_SEGMENT_SPANS.add(span);
+  });
+  REJECTED_SEGMENT_SPANS.add(segmentSpan);
+  discardPendingChildCaptures([...spansInTransaction, segmentSpan]);
+}
+
+function discardPendingChildCaptures(spans: Span[]): void {
+  const pendingSpans = [...spans];
+  const visited = new Set<Span>();
+  for (const pendingSpan of pendingSpans) {
+    if (visited.has(pendingSpan)) {
+      continue;
+    }
+
+    visited.add(pendingSpan);
+    PENDING_CHILD_CAPTURES.get(pendingSpan)?.forEach(({ span }) => {
+      PENDING_PARENT_CAPTURES.delete(span);
+      pendingSpans.push(span);
+    });
+    PENDING_CHILD_CAPTURES.delete(pendingSpan);
+    PENDING_PARENT_CAPTURES.delete(pendingSpan);
+    PENDING_CAPTURE_CLIENTS.delete(pendingSpan);
+  }
+}

--- a/packages/core/src/tracing/deferSegmentSpanCapture.ts
+++ b/packages/core/src/tracing/deferSegmentSpanCapture.ts
@@ -1,4 +1,5 @@
 import type { Client } from '../client';
+import { withIsolationScope, withScope } from '../currentScopes';
 import type { Scope } from '../scope';
 import type { TransactionEvent } from '../types/event';
 import type { Span } from '../types/span';
@@ -286,7 +287,25 @@ function captureDeferredTransaction(
 
     rejectDeferredSegment(segmentSpan, spansInTransaction);
   });
-  client.captureEvent(transactionEvent, hint);
+  // A shared client can drain deferred work from several invocations in one callback. Re-entering
+  // the span's scopes keeps processors and runtime-specific invocation state attributed to its owner.
+  const { capturedSpanScope, capturedSpanIsolationScope } = transactionEvent.sdkProcessingMetadata ?? {};
+  const capture = (): void => {
+    client.captureEvent(transactionEvent, hint);
+  };
+  const captureOnSpanScope = (): void => {
+    if (capturedSpanScope) {
+      withScope(capturedSpanScope, capture);
+    } else {
+      capture();
+    }
+  };
+
+  if (capturedSpanIsolationScope) {
+    withIsolationScope(capturedSpanIsolationScope, captureOnSpanScope);
+  } else {
+    captureOnSpanScope();
+  }
 }
 
 function drainPendingChildCaptures(spans: Span[]): void {

--- a/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
+++ b/packages/core/src/tracing/segmentSpanCaptureStrategy.ts
@@ -23,7 +23,7 @@ export type SegmentSpanConverter = (options?: SegmentSpanCaptureConvertOptions) 
  */
 export interface SegmentSpanCaptureStrategy {
   /** Assemble and capture a segment (root or standalone-root) span's transaction through its captured scope. */
-  onSegmentSpanEnded(convert: SegmentSpanConverter, scope: Scope): void;
+  onSegmentSpanEnded(segmentSpan: Span, convert: SegmentSpanConverter, scope: Scope): void;
   /** Consider a child that ended after its segment for emission as its own orphan transaction. */
   onChildSpanEnded(span: Span, rootSpan: Span, convert: SegmentSpanConverter, scope: Scope): void;
 }

--- a/packages/core/src/tracing/sentrySpan.ts
+++ b/packages/core/src/tracing/sentrySpan.ts
@@ -391,7 +391,7 @@ export class SentrySpan implements Span {
     const scope = getCapturedScopesOnSpan(this).scope || getCurrentScope();
     const strategy = getSegmentSpanCaptureStrategy();
     if (strategy) {
-      strategy.onSegmentSpanEnded(options => this._convertSpanToTransaction(options), scope);
+      strategy.onSegmentSpanEnded(this, options => this._convertSpanToTransaction(options), scope);
     } else {
       const transactionEvent = this._convertSpanToTransaction();
       if (transactionEvent) {

--- a/packages/core/src/utils/eventCaptureDecision.ts
+++ b/packages/core/src/utils/eventCaptureDecision.ts
@@ -1,0 +1,48 @@
+import type { EventHint } from '../types/event';
+
+export type EventCaptureDecision = 'accepted' | 'rejected';
+
+interface EventCaptureDecisionState {
+  callback?: (decision: EventCaptureDecision) => void;
+  resolved: boolean;
+}
+
+const EVENT_CAPTURE_DECISIONS = new WeakMap<EventHint, EventCaptureDecisionState>();
+
+/** Attach an internal callback which resolves when the event pipeline makes its terminal capture decision. */
+export function setEventCaptureDecisionCallback(
+  hint: EventHint,
+  callback: (decision: EventCaptureDecision) => void,
+): void {
+  EVENT_CAPTURE_DECISIONS.set(hint, { callback, resolved: false });
+}
+
+/** Preserve internal capture-decision state when the client adds an event ID to a hint. */
+export function copyEventCaptureDecision(source: EventHint | undefined, target: EventHint): void {
+  if (!source) {
+    return;
+  }
+
+  const state = EVENT_CAPTURE_DECISIONS.get(source);
+  if (state) {
+    EVENT_CAPTURE_DECISIONS.set(target, state);
+  }
+}
+
+/** Resolve an internal capture decision once without allowing telemetry bookkeeping to affect event processing. */
+export function notifyEventCaptureDecision(hint: EventHint, decision: EventCaptureDecision): void {
+  const state = EVENT_CAPTURE_DECISIONS.get(hint);
+  EVENT_CAPTURE_DECISIONS.delete(hint);
+  if (!state || state.resolved || !state.callback) {
+    return;
+  }
+
+  state.resolved = true;
+  const callback = state.callback;
+  state.callback = undefined;
+  try {
+    callback(decision);
+  } catch {
+    // Capture-decision observers only coordinate internal telemetry and must never alter application behavior.
+  }
+}

--- a/packages/core/src/utils/spanUtils.ts
+++ b/packages/core/src/utils/spanUtils.ts
@@ -363,10 +363,12 @@ export function addStatusMessageAttribute(
 
 const CHILD_SPANS_FIELD = '_sentryChildSpans';
 const ROOT_SPAN_FIELD = '_sentryRootSpan';
+const PARENT_SPAN_FIELD = '_sentryParentSpan';
 
 type SpanWithPotentialChildren = Span & {
   [CHILD_SPANS_FIELD]?: Set<Span>;
   [ROOT_SPAN_FIELD]?: Span;
+  [PARENT_SPAN_FIELD]?: Span;
 };
 
 /**
@@ -377,6 +379,7 @@ export function addChildSpanToSpan(span: SpanWithPotentialChildren, childSpan: S
   // We need this for `getRootSpan()` to work
   const rootSpan = span[ROOT_SPAN_FIELD] || span;
   addNonEnumerableProperty(childSpan, ROOT_SPAN_FIELD, rootSpan);
+  addNonEnumerableProperty(childSpan, PARENT_SPAN_FIELD, span);
 
   // `_sentryChildSpans` exists only so `getSpanDescendants()` can walk the tree when the segment span
   // is sent, and that walk stops at an unsampled span without ever visiting its children. So a child
@@ -440,6 +443,11 @@ export function getSpanDescendants(span: SpanWithPotentialChildren): Span[] {
  * Returns the root span of a given span.
  */
 export const getRootSpan = INTERNAL_getSegmentSpan;
+
+/** Returns the exact local parent span when the span was created by the Sentry SDK. */
+export function INTERNAL_getParentSpan(span: SpanWithPotentialChildren): Span | undefined {
+  return span[PARENT_SPAN_FIELD];
+}
 
 /**
  * Returns the segment span of a given span.

--- a/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
+++ b/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
@@ -1,15 +1,39 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getCurrentScope, setCurrentClient, startInactiveSpan, withActiveSpan, withScope } from '../../../src';
+import {
+  getCurrentScope,
+  setCurrentClient,
+  spanStreamingIntegration,
+  startInactiveSpan,
+  withActiveSpan,
+  withScope,
+} from '../../../src';
 import { _INTERNAL_setDeferSegmentSpanCapture } from '../../../src/tracing/deferSegmentSpanCapture';
 import {
   getSegmentSpanCaptureStrategy,
   setSegmentSpanCaptureStrategy,
 } from '../../../src/tracing/segmentSpanCaptureStrategy';
-import type { Event } from '../../../src/types/event';
-import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
+import type { Event, TransactionEvent } from '../../../src/types/event';
+import { getDefaultTestClientOptions, TestClient, type TestClientOptions } from '../../mocks/client';
 import { resetGlobals } from '../../testutils';
 
 const dsn = 'https://123@sentry.io/42';
+
+function createDeferredClient(capturedTransactions: Event[], options: Partial<TestClientOptions> = {}): TestClient {
+  const client = new TestClient(
+    getDefaultTestClientOptions({
+      dsn,
+      tracesSampleRate: 1,
+      enableSend: true,
+      ...options,
+    }),
+  );
+  client.init();
+  _INTERNAL_setDeferSegmentSpanCapture(client);
+  client.on('beforeSendEvent', event => {
+    capturedTransactions.push(event);
+  });
+  return client;
+}
 
 describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
   afterEach(() => {
@@ -24,7 +48,7 @@ describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
     expect(getSegmentSpanCaptureStrategy()).toBeDefined();
   });
 
-  it('registers the flush listener once and is idempotent on repeated enable', () => {
+  it('registers the client flush listener once and is idempotent on repeated enable', () => {
     const client = new TestClient(getDefaultTestClientOptions());
     const onSpy = vi.spyOn(client, 'on');
 
@@ -32,6 +56,7 @@ describe('_INTERNAL_setDeferSegmentSpanCapture', () => {
     _INTERNAL_setDeferSegmentSpanCapture(client);
 
     expect(onSpy.mock.calls.filter(([hook]) => hook === 'flush')).toHaveLength(1);
+    expect(onSpy.mock.calls.filter(([hook]) => hook === 'beforeSendEvent')).toHaveLength(0);
   });
 });
 
@@ -45,18 +70,8 @@ describe('deferred segment-span capture', () => {
     resetGlobals();
 
     transactions = [];
-    const options = getDefaultTestClientOptions({
-      dsn,
-      tracesSampleRate: 1,
-      beforeSendTransaction: event => {
-        transactions.push(event);
-        return null;
-      },
-    });
-    client = new TestClient(options);
+    client = createDeferredClient(transactions);
     setCurrentClient(client);
-    client.init();
-    _INTERNAL_setDeferSegmentSpanCapture(client);
   });
 
   afterEach(() => {
@@ -81,6 +96,47 @@ describe('deferred segment-span capture', () => {
     expect(transactions[0]!.spans).toEqual([expect.objectContaining({ description: 'child' })]);
   });
 
+  it('captures once a child created and ended after its segment but before the queued snapshot', () => {
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'child']);
+    expect(transactions[0]?.spans).toEqual([]);
+    expect(transactions[1]?.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
+  });
+
+  it('suppresses a child created after a queued segment which is rejected', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'root' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(0);
+  });
+
+  it('passes the exact segment span through the capture strategy seam', () => {
+    const onSegmentSpanEnded = vi.fn();
+    setSegmentSpanCaptureStrategy({
+      onSegmentSpanEnded,
+      onChildSpanEnded: vi.fn(),
+    });
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+
+    expect(onSegmentSpanEnded).toHaveBeenCalledWith(root, expect.any(Function), expect.any(Object));
+  });
+
   it('emits a child that ends after the snapshot as its own orphan transaction', () => {
     const root = startInactiveSpan({ name: 'root' });
     const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
@@ -100,6 +156,603 @@ describe('deferred segment-span capture', () => {
     expect(transactions[1]!.contexts?.trace?.data?.['sentry.parent_span_already_sent']).toBe(true);
   });
 
+  it('does not emit a grandchild already captured by its late parent', () => {
+    const root = startInactiveSpan({ name: 'root' });
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    parent.end();
+    grandchild.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(2);
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent']);
+    expect(transactions[1]?.spans).toEqual([expect.objectContaining({ description: 'grandchild' })]);
+  });
+
+  it('coalesces a grandchild that ends before its queued late parent', () => {
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+    grandchild.end();
+    parent.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent']);
+    expect(transactions[1]?.spans).toEqual([expect.objectContaining({ description: 'grandchild' })]);
+  });
+
+  it('suppresses a grandchild that ends after its late parent orphan is rejected', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'parent' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    parent.end();
+    vi.advanceTimersByTime(100);
+    grandchild.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+  });
+
+  it('does not retroactively discard a grandchild accepted before its open parent is rejected', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'parent' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+    grandchild.end();
+    vi.advanceTimersByTime(100);
+    parent.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'grandchild']);
+  });
+
+  it('does not include an unfinished descendant of a rejected orphan in a later ancestor event', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'child' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const child = withActiveSpan(parent, () => startInactiveSpan({ name: 'child' }));
+    const grandchild = withActiveSpan(child, () => startInactiveSpan({ name: 'grandchild' }));
+    child.end();
+    vi.advanceTimersByTime(100);
+    grandchild.end();
+    parent.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent']);
+    expect(transactions[1]?.spans).toEqual([]);
+  });
+
+  it('suppresses a grandchild queued before its late parent orphan is rejected', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'parent' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    parent.end();
+    grandchild.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+  });
+
+  it('suppresses a grandchild that ends before its queued late parent orphan is rejected', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'parent' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+    grandchild.end();
+    parent.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+  });
+
+  it('waits to suppress a grandchild that ends while its late parent orphan decision is pending', async () => {
+    let rejectParent!: () => void;
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => {
+        if (event.transaction !== 'parent') {
+          return event;
+        }
+
+        return new Promise<null>(resolve => {
+          rejectParent = () => resolve(null);
+        });
+      },
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    parent.end();
+    vi.advanceTimersByTime(100);
+    grandchild.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+
+    rejectParent();
+    await vi.runAllTimersAsync();
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+  });
+
+  it('reparents a queued grandchild when its late parent decision becomes pending first', async () => {
+    let rejectParent!: () => void;
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => {
+        if (event.transaction !== 'parent') {
+          return event;
+        }
+
+        return new Promise<null>(resolve => {
+          rejectParent = () => resolve(null);
+        });
+      },
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    parent.end();
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+    grandchild.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+
+    rejectParent();
+    await vi.runAllTimersAsync();
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+  });
+
+  it('captures an untracked descendant exactly once after its queued ancestor is accepted', () => {
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    parent.end();
+    const child = withActiveSpan(parent, () => startInactiveSpan({ name: 'child' }));
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent', 'child']);
+  });
+
+  it('drains an untracked descendant of a queued span subsumed by an accepted ancestor', () => {
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const child = withActiveSpan(parent, () => startInactiveSpan({ name: 'child' }));
+    child.end();
+    const descendant = withActiveSpan(child, () => startInactiveSpan({ name: 'descendant' }));
+    descendant.end();
+    parent.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent', 'descendant']);
+    expect(transactions[1]?.spans).toEqual([expect.objectContaining({ description: 'child' })]);
+  });
+
+  it('discards an untracked descendant of a queued span subsumed by a rejected ancestor', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'parent' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const child = withActiveSpan(parent, () => startInactiveSpan({ name: 'child' }));
+    child.end();
+    const descendant = withActiveSpan(child, () => startInactiveSpan({ name: 'descendant' }));
+    descendant.end();
+    parent.end();
+    vi.advanceTimersByTime(100);
+
+    const futureDescendant = withActiveSpan(child, () => startInactiveSpan({ name: 'future descendant' }));
+    futureDescendant.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root']);
+  });
+
+  it('lets a child client close without waiting for a queued parent owned by another client', async () => {
+    const childTransactions: Event[] = [];
+    const childClient = createDeferredClient(childTransactions);
+    const childSendEnvelope = vi.spyOn(childClient, 'sendEnvelope');
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    parent.end();
+    const child = withScope(scope => {
+      scope.setClient(childClient);
+      return withActiveSpan(parent, () => startInactiveSpan({ name: 'child' }));
+    });
+    child.end();
+
+    const childClose = childClient.close();
+    await vi.runAllTimersAsync();
+    expect(await childClose).toBe(true);
+    expect(childTransactions.map(transaction => transaction.transaction)).toEqual(['child']);
+    expect(childSendEnvelope).toHaveBeenCalledOnce();
+
+    const parentFlush = client.flush();
+    await vi.runAllTimersAsync();
+    expect(await parentFlush).toBe(true);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent']);
+    expect(childTransactions.map(transaction => transaction.transaction)).toEqual(['child']);
+    expect(childSendEnvelope).toHaveBeenCalledOnce();
+  });
+
+  it('does not leave a no-client child pending under another client', () => {
+    const descendantTransactions: Event[] = [];
+    const descendantClient = createDeferredClient(descendantTransactions);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    parent.end();
+    let childScope!: ReturnType<typeof getCurrentScope>;
+    const child = withScope(scope => {
+      childScope = scope;
+      return withActiveSpan(parent, () => startInactiveSpan({ name: 'child' }));
+    });
+    childScope.setClient(undefined);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    const descendant = withScope(scope => {
+      scope.setClient(descendantClient);
+      return withActiveSpan(child, () => startInactiveSpan({ name: 'descendant' }));
+    });
+    descendant.end();
+    descendantClient.emit('flush');
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent', 'child']);
+    expect(descendantTransactions.map(transaction => transaction.transaction)).toEqual(['descendant']);
+  });
+
+  it('still captures a late sibling after another orphan subtree is rejected', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'parent' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+    const sibling = withActiveSpan(root, () => startInactiveSpan({ name: 'sibling' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    parent.end();
+    vi.advanceTimersByTime(100);
+    grandchild.end();
+    sibling.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'sibling']);
+  });
+
+  it('leaves a late child on a stream client to the streaming lifecycle', () => {
+    const streamTransactions: Event[] = [];
+    const streamClient = createDeferredClient(streamTransactions, {
+      integrations: [spanStreamingIntegration()],
+      traceLifecycle: 'stream',
+    });
+    const sendEnvelopeSpy = vi.spyOn(streamClient, 'sendEnvelope');
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withScope(scope => {
+      scope.setClient(streamClient);
+      return withActiveSpan(root, () => startInactiveSpan({ name: 'streamed child' }));
+    });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    withScope(scope => {
+      scope.setClient(streamClient);
+      child.end();
+    });
+    streamClient.emit('flush');
+
+    expect(transactions).toHaveLength(1);
+    expect(streamTransactions).toHaveLength(0);
+    expect(sendEnvelopeSpy).toHaveBeenCalledTimes(1);
+    expect(sendEnvelopeSpy).toHaveBeenCalledWith([
+      expect.any(Object),
+      [
+        [
+          {
+            type: 'span',
+            item_count: 1,
+            content_type: 'application/vnd.sentry.items.span.v2+json',
+          },
+          {
+            version: 2,
+            items: [expect.objectContaining({ name: 'streamed child' })],
+          },
+        ],
+      ],
+    ]);
+  });
+
+  it('does not emit a late child when beforeSendTransaction drops its segment', () => {
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => (event.transaction === 'root' ? null : event),
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(0);
+  });
+
+  it('rejects the segment when a later beforeSendEvent listener throws', () => {
+    const observedTransactions: Event[] = [];
+    client = new TestClient(getDefaultTestClientOptions({ dsn, tracesSampleRate: 1, enableSend: true }));
+    client.init();
+    _INTERNAL_setDeferSegmentSpanCapture(client);
+    const failingBeforeSendEvent = vi.fn((event: Event) => {
+      if (event.type === 'transaction') {
+        throw new Error('later listener failed');
+      }
+    });
+    client.on('beforeSendEvent', failingBeforeSendEvent);
+    client.on('beforeSendEvent', event => {
+      if (event.type === 'transaction') {
+        observedTransactions.push(event);
+      }
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(failingBeforeSendEvent.mock.calls.filter(([event]) => event.type === 'transaction')).toHaveLength(1);
+    expect(observedTransactions).toHaveLength(0);
+  });
+
+  it('does not emit a late child when an event processor drops its segment', () => {
+    client.addEventProcessor(event => (event.transaction === 'root' ? null : event));
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(0);
+  });
+
+  it('waits for an asynchronous beforeSendTransaction decision before emitting a late child', async () => {
+    let resolveSegment!: (event: TransactionEvent) => void;
+    let segmentEvent!: TransactionEvent;
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => {
+        if (event.transaction !== 'root') {
+          return event;
+        }
+
+        segmentEvent = event;
+        return new Promise(resolve => {
+          resolveSegment = resolve;
+        });
+      },
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(0);
+
+    resolveSegment(segmentEvent);
+    await vi.runAllTimersAsync();
+
+    expect(transactions).toHaveLength(2);
+    expect(transactions.map(transaction => transaction.transaction).sort()).toEqual(['child', 'root']);
+  });
+
+  it('captures a queued late child after an asynchronous segment decision frees a full promise buffer', async () => {
+    let resolveSegment!: (event: TransactionEvent) => void;
+    let segmentEvent!: TransactionEvent;
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => {
+        if (event.transaction !== 'root') {
+          return event;
+        }
+
+        segmentEvent = event;
+        return new Promise(resolve => {
+          resolveSegment = resolve;
+        });
+      },
+      transportOptions: { bufferSize: 1 },
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    const flushPromise = client.flush();
+    resolveSegment(segmentEvent);
+    await vi.runAllTimersAsync();
+
+    expect(await flushPromise).toBe(true);
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'child']);
+    expect(client._clearOutcomes()).toEqual([]);
+  });
+
+  it('coalesces reverse-ended descendants waiting on an asynchronous segment decision', async () => {
+    let resolveSegment!: (event: TransactionEvent) => void;
+    let segmentEvent!: TransactionEvent;
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => {
+        if (event.transaction !== 'root') {
+          return event;
+        }
+
+        segmentEvent = event;
+        return new Promise(resolve => {
+          resolveSegment = resolve;
+        });
+      },
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    const parent = withActiveSpan(root, () => startInactiveSpan({ name: 'parent' }));
+    const grandchild = withActiveSpan(parent, () => startInactiveSpan({ name: 'grandchild' }));
+    grandchild.end();
+    parent.end();
+    vi.advanceTimersByTime(100);
+
+    resolveSegment(segmentEvent);
+    await vi.runAllTimersAsync();
+
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['root', 'parent']);
+    expect(transactions[1]?.spans).toEqual([expect.objectContaining({ description: 'grandchild' })]);
+  });
+
+  it('suppresses a late child when an asynchronous beforeSendTransaction drops its segment', async () => {
+    let resolveSegment!: () => void;
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => {
+        if (event.transaction !== 'root') {
+          return event;
+        }
+
+        return new Promise<null>(resolve => {
+          resolveSegment = () => resolve(null);
+        });
+      },
+    });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    vi.advanceTimersByTime(100);
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    resolveSegment();
+    await vi.runAllTimersAsync();
+
+    const futureChild = withActiveSpan(root, () => startInactiveSpan({ name: 'future child' }));
+    futureChild.end();
+    await vi.runAllTimersAsync();
+
+    expect(transactions).toHaveLength(0);
+  });
+
+  it('does not emit transactions for a negatively sampled segment', () => {
+    client = createDeferredClient(transactions, { tracesSampleRate: 0 });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    root.end();
+    child.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(0);
+  });
+
+  it('does not emit transactions when spans use the streaming lifecycle', () => {
+    client = createDeferredClient(transactions, { traceLifecycle: 'stream' });
+    setCurrentClient(client);
+    const root = startInactiveSpan({ name: 'root' });
+    const child = withActiveSpan(root, () => startInactiveSpan({ name: 'child' }));
+
+    child.end();
+    root.end();
+    vi.advanceTimersByTime(100);
+
+    expect(transactions).toHaveLength(0);
+  });
+
   it('drains pending captures synchronously on flush', () => {
     const root = startInactiveSpan({ name: 'root' });
     root.end();
@@ -114,18 +767,7 @@ describe('deferred segment-span capture', () => {
 
   it("routes a deferred segment to the span's own client, not whichever client is current at end", () => {
     const otherTransactions: Event[] = [];
-    const otherClient = new TestClient(
-      getDefaultTestClientOptions({
-        dsn,
-        tracesSampleRate: 1,
-        beforeSendTransaction: event => {
-          otherTransactions.push(event);
-          return null;
-        },
-      }),
-    );
-    otherClient.init();
-    _INTERNAL_setDeferSegmentSpanCapture(otherClient);
+    const otherClient = createDeferredClient(otherTransactions);
 
     // Created while `client` is current, so its captured scope belongs to `client`.
     const root = startInactiveSpan({ name: 'root' });
@@ -144,17 +786,11 @@ describe('deferred segment-span capture', () => {
 
   it('emits a late orphan synchronously when its client has no defer queue', () => {
     const orphanTransactions: Event[] = [];
-    const noQueueClient = new TestClient(
-      getDefaultTestClientOptions({
-        dsn,
-        tracesSampleRate: 1,
-        beforeSendTransaction: event => {
-          orphanTransactions.push(event);
-          return null;
-        },
-      }),
-    );
+    const noQueueClient = new TestClient(getDefaultTestClientOptions({ dsn, tracesSampleRate: 1, enableSend: true }));
     noQueueClient.init();
+    noQueueClient.on('beforeSendEvent', event => {
+      orphanTransactions.push(event);
+    });
     // Deliberately not enabling deferral on `noQueueClient`, so it has no queue.
 
     // Root is captured via `client` (which defers), so it lands in `CAPTURED_SPANS`.
@@ -180,18 +816,7 @@ describe('deferred segment-span capture', () => {
 
   it('binds the capturing client at span end, ignoring later reassignment of the scope client', () => {
     const laterTransactions: Event[] = [];
-    const laterClient = new TestClient(
-      getDefaultTestClientOptions({
-        dsn,
-        tracesSampleRate: 1,
-        beforeSendTransaction: event => {
-          laterTransactions.push(event);
-          return null;
-        },
-      }),
-    );
-    laterClient.init();
-    _INTERNAL_setDeferSegmentSpanCapture(laterClient);
+    const laterClient = createDeferredClient(laterTransactions);
 
     const root = startInactiveSpan({ name: 'root' });
     root.end(); // enqueued and bound to `client` (the captured scope's client at span end)

--- a/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
+++ b/packages/core/test/lib/tracing/deferSegmentSpanCapture.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getCurrentScope,
+  getIsolationScope,
+  Scope,
   setCurrentClient,
   spanStreamingIntegration,
   startInactiveSpan,
   withActiveSpan,
+  withIsolationScope,
   withScope,
 } from '../../../src';
+import { getAsyncContextStrategy, setAsyncContextStrategy } from '../../../src/asyncContext';
+import { getMainCarrier } from '../../../src/carrier';
 import { _INTERNAL_setDeferSegmentSpanCapture } from '../../../src/tracing/deferSegmentSpanCapture';
 import {
   getSegmentSpanCaptureStrategy,
@@ -76,6 +81,7 @@ describe('deferred segment-span capture', () => {
 
   afterEach(() => {
     setSegmentSpanCaptureStrategy(undefined);
+    setAsyncContextStrategy(undefined);
     vi.clearAllMocks();
     vi.useRealTimers();
   });
@@ -782,6 +788,59 @@ describe('deferred segment-span capture', () => {
 
     expect(transactions).toHaveLength(1);
     expect(otherTransactions).toHaveLength(0);
+  });
+
+  it("processes each deferred transaction on its span's captured scope", () => {
+    const baseStrategy = getAsyncContextStrategy(getMainCarrier());
+    let activeIsolationScope = baseStrategy.getIsolationScope();
+    setAsyncContextStrategy({
+      ...baseStrategy,
+      getIsolationScope: () => activeIsolationScope,
+      withSetIsolationScope: (isolationScope, callback) => {
+        const previousIsolationScope = activeIsolationScope;
+        activeIsolationScope = isolationScope;
+        try {
+          return callback(isolationScope);
+        } finally {
+          activeIsolationScope = previousIsolationScope;
+        }
+      },
+    });
+    const observedScopes: Array<{ current: string | undefined; isolation: string | undefined }> = [];
+    client = createDeferredClient(transactions, {
+      beforeSendTransaction: event => {
+        observedScopes.push({
+          current: getCurrentScope().getScopeData().tags['invocation'],
+          isolation: getIsolationScope().getScopeData().tags['invocation'],
+        });
+        return event;
+      },
+    });
+    setCurrentClient(client);
+    const isolationScopeA = new Scope();
+    const isolationScopeB = new Scope();
+    isolationScopeA.setTag('invocation', 'A');
+    isolationScopeB.setTag('invocation', 'B');
+
+    withIsolationScope(isolationScopeA, () => {
+      withScope(scope => {
+        scope.setTag('invocation', 'A');
+        startInactiveSpan({ name: 'request A' }).end();
+      });
+    });
+    withIsolationScope(isolationScopeB, () => {
+      withScope(scope => {
+        scope.setTag('invocation', 'B');
+        startInactiveSpan({ name: 'request B' }).end();
+      });
+    });
+    vi.advanceTimersByTime(100);
+
+    expect(observedScopes).toEqual([
+      { current: 'A', isolation: 'A' },
+      { current: 'B', isolation: 'B' },
+    ]);
+    expect(transactions.map(transaction => transaction.transaction)).toEqual(['request A', 'request B']);
   });
 
   it('emits a late orphan synchronously when its client has no defer queue', () => {

--- a/packages/core/test/lib/utils/eventCaptureDecision.test.ts
+++ b/packages/core/test/lib/utils/eventCaptureDecision.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Event, EventHint, TransactionEvent } from '../../../src/types/event';
+import {
+  copyEventCaptureDecision,
+  notifyEventCaptureDecision,
+  setEventCaptureDecisionCallback,
+} from '../../../src/utils/eventCaptureDecision';
+import { rejectedSyncPromise } from '../../../src/utils/syncpromise';
+import { getDefaultTestClientOptions, TestClient } from '../../mocks/client';
+
+describe('eventCaptureDecision', () => {
+  it('resolves a capture decision only once across internal hint copies', () => {
+    const hint: EventHint = {};
+    const callback = vi.fn();
+    setEventCaptureDecisionCallback(hint, callback);
+    const copiedHint = { ...hint };
+    copyEventCaptureDecision(hint, copiedHint);
+
+    notifyEventCaptureDecision(copiedHint, 'accepted');
+    notifyEventCaptureDecision(hint, 'rejected');
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith('accepted');
+  });
+
+  it('does not expose capture-decision state on event hints', () => {
+    const hint: EventHint = {};
+    setEventCaptureDecisionCallback(hint, vi.fn());
+
+    expect(Reflect.ownKeys(hint)).toEqual([]);
+    expect(Reflect.ownKeys({ ...hint })).toEqual([]);
+  });
+
+  it('does not expose capture-decision state to before-send hooks', async () => {
+    const beforeSendTransaction = vi.fn((event: TransactionEvent) => event);
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://123@sentry.io/42',
+        enableSend: true,
+        beforeSendTransaction,
+      }),
+    );
+    client.init();
+    const hint: EventHint = {};
+    const callback = vi.fn();
+    setEventCaptureDecisionCallback(hint, callback);
+
+    client.captureEvent({ type: 'transaction', transaction: 'root' }, hint);
+
+    expect(await client.flush()).toBe(true);
+    expect(beforeSendTransaction).toHaveBeenCalledWith(expect.any(Object), { event_id: expect.any(String) });
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith('accepted');
+  });
+
+  it('does not let a decision callback throw into event processing', () => {
+    const hint: EventHint = {};
+    setEventCaptureDecisionCallback(hint, () => {
+      throw new Error('observer failed');
+    });
+
+    expect(() => notifyEventCaptureDecision(hint, 'accepted')).not.toThrow();
+  });
+
+  it('rejects the capture decision when the client promise buffer is full', () => {
+    const client = new TestClient(getDefaultTestClientOptions({ transportOptions: { bufferSize: 1 } }));
+    client.addEventProcessor(event => {
+      return event.message === 'blocking' ? new Promise<never>(() => undefined) : event;
+    });
+    client.captureEvent({ message: 'blocking' });
+    const hint: EventHint = {};
+    const callback = vi.fn();
+    setEventCaptureDecisionCallback(hint, callback);
+
+    client.captureEvent({ type: 'transaction', transaction: 'overflow' }, hint);
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith('rejected');
+    expect(client._clearOutcomes()).toEqual([{ reason: 'queue_overflow', category: 'transaction', quantity: 1 }]);
+  });
+
+  it('rejects the capture decision when event capture throws before processing', () => {
+    class FailingTestClient extends TestClient {
+      public captureFailedEvent(hint: EventHint): void {
+        this._process(() => rejectedSyncPromise(new Error('capture failed')), 'transaction', hint);
+      }
+    }
+    const client = new FailingTestClient(getDefaultTestClientOptions());
+    const hint: EventHint = {};
+    const callback = vi.fn();
+    setEventCaptureDecisionCallback(hint, callback);
+
+    client.captureFailedEvent(hint);
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith('rejected');
+  });
+
+  it('rejects the capture decision when an event is deduplicated before processing', () => {
+    const client = new TestClient(getDefaultTestClientOptions());
+    const originalException = new Error('already captured');
+    client.captureEvent({ message: 'first' }, { originalException });
+    const hint: EventHint = { originalException };
+    const callback = vi.fn();
+    setEventCaptureDecisionCallback(hint, callback);
+
+    client.captureEvent({ type: 'transaction', transaction: 'duplicate' }, hint);
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith('rejected');
+  });
+
+  it('accepts a reentrant capture after releasing the current promise-buffer slot', async () => {
+    const capturedEvents: Event[] = [];
+    let resolveRoot!: (event: TransactionEvent) => void;
+    let rootEvent!: TransactionEvent;
+    const client = new TestClient(
+      getDefaultTestClientOptions({
+        dsn: 'https://123@sentry.io/42',
+        enableSend: true,
+        transportOptions: { bufferSize: 1 },
+        beforeSendTransaction: event => {
+          if (event.transaction !== 'root') {
+            return event;
+          }
+
+          rootEvent = event;
+          return new Promise(resolve => {
+            resolveRoot = resolve;
+          });
+        },
+      }),
+    );
+    client.init();
+    client.on('beforeSendEvent', event => capturedEvents.push(event));
+    const childDecision = vi.fn();
+    const rootHint: EventHint = {};
+    setEventCaptureDecisionCallback(rootHint, decision => {
+      expect(decision).toBe('accepted');
+      const childHint: EventHint = {};
+      setEventCaptureDecisionCallback(childHint, childDecision);
+      client.captureEvent({ type: 'transaction', transaction: 'child' }, childHint);
+    });
+
+    client.captureEvent({ type: 'transaction', transaction: 'root' }, rootHint);
+    resolveRoot(rootEvent);
+
+    expect(await client.flush()).toBe(true);
+    expect(capturedEvents.map(event => event.transaction)).toEqual(['root', 'child']);
+    expect(childDecision).toHaveBeenCalledOnce();
+    expect(childDecision).toHaveBeenCalledWith('accepted');
+    expect(client._clearOutcomes()).toEqual([]);
+  });
+});

--- a/packages/core/test/lib/utils/spanUtils.test.ts
+++ b/packages/core/test/lib/utils/spanUtils.test.ts
@@ -29,6 +29,7 @@ import type { OpenTelemetrySdkTraceBaseSpan } from '../../../src/utils/spanUtils
 import {
   addChildSpanToSpan,
   getActiveSpan,
+  INTERNAL_getParentSpan,
   getRootSpan,
   getSpanDescendants,
   spanIsSampled,
@@ -875,6 +876,19 @@ describe('getActiveSpan', () => {
 });
 
 describe('addChildSpanToSpan', () => {
+  it('retains the exact local parent separately from the segment root', () => {
+    const segment = new SentrySpan({ name: 'segment', sampled: true });
+    const parent = new SentrySpan({ name: 'parent', sampled: true });
+    const child = new SentrySpan({ name: 'child', sampled: true });
+
+    addChildSpanToSpan(segment, parent);
+    addChildSpanToSpan(parent, child);
+
+    expect(INTERNAL_getParentSpan(parent)).toBe(segment);
+    expect(INTERNAL_getParentSpan(child)).toBe(parent);
+    expect(getRootSpan(child)).toBe(segment);
+  });
+
   it('does not track children on an unsampled span', () => {
     const parent = new SentrySpan({ name: 'parent', sampled: false });
     const child = new SentrySpan({ name: 'child', sampled: false });


### PR DESCRIPTION
Preserves child spans which end after a Cloudflare static request transaction has already been sent. These spans are emitted exactly once on the same trace with their original parent instead of disappearing.

## Root cause

Cloudflare did not enable the deferred segment-capture strategy already used by the Node SDK. Static transactions were therefore assembled as soon as the request segment ended, with no path for a child ending later in `waitUntil()`.

Enabling the existing strategy directly was not sufficient. It treated spans as captured before the client event pipeline had accepted their transaction. If processing, a before-send hook, or queue admission rejected that event, pending descendants could still be emitted as ghost orphan transactions.

## Design

Core now exposes an internal, one-shot terminal capture decision. Deferred segment capture reserves spans while that decision is pending:

* acceptance marks included spans as captured and releases pending late descendants;
* rejection clears pending state and suppresses descendants which have not already been accepted.

Rejection is deliberately not retroactive: telemetry which has already passed its own pipeline remains accepted. The acceptance callback runs after the client processing-buffer slot has been released, so a follow-up capture does not incorrectly encounter a full buffer.

Cloudflare clients enable this strategy for static capture. A child ending after an accepted segment becomes a standalone transaction with the same trace ID, its exact original parent, and `sentry.parent_span_already_sent=true`. Span streaming remains unchanged. There is no public API or MCP protocol change.

Node already enables deferred segment capture, so the Core state-machine hardening also applies to its existing use of this machinery.

## Relation to #23151

#23151 and its prerequisite #23136 solve a different part of the Cloudflare lifecycle: they reuse one client across invocations and eagerly drain envelopes and streamed-span trace buckets. This PR handles static transaction aggregation, where a late child cannot be added to a transaction which has already been sent. The two approaches are complementary.

A shared client can drain deferred static transactions from several invocations in one callback. Deferred capture therefore re-enters each span's captured current and isolation scopes before event processing, keeping processors, `InvocationState`, `sendEnvelope`, and `waitUntil` attached to the owning invocation. A combined checkout of both PRs reproduced both events under invocation B before this guard and A/B ownership after it. The committed Core regression protects current and isolation scope ownership without making this PR depend on #23151.

When #23151 rebases after this PR, its `CloudflareClient` constructor must retain `_INTERNAL_setDeferSegmentSpanCapture(this)`. The strategy remains inert for its default streamed lifecycle.

## Evidence

The bug was reproduced using baseline and patched SDK tarballs built from the same source SHA, with one pinned Worker fixture and a protocol-independent control:

<!-- linear:table-colwidths:266,266,266 -->
| Scenario | Baseline | Patched |
| -- | -- | -- |
| Standard MCP control | HTTP → MCP → child, exactly three | Unchanged, exactly three |
| Generic late child | HTTP root only; child missing | HTTP root plus one correctly parented orphan |
| MCP `2026-07-28` late child | HTTP → MCP; child missing | HTTP → MCP plus one orphan parented to MCP |

The exact patched local run emitted seven expected transaction envelopes with no duplicates. A personal Cloudflare deployment with byte-identical Cloudflare/Core artifacts reproduced the same topology in Sentry; the final artifact set also passed the protected remote smoke. A modern MCP request is only the workload which exposed the generic lifecycle failure.

The repository regression uses a real Wrangler/workerd Worker and strict envelope cardinality. The final causal source state passes the complete Core (`3361` passed, `14` skipped), Node (`352` passed, `3` skipped), and Cloudflare (`818` passed) package suites. The modern Cloudflare MCP and legacy `McpAgent` E2Es also pass in development and production modes; the Node MCP v2 control passed during the finalization cycle.

The Cloudflare bundle remains below both size limits: `217731 B` minified and `541040 B` unminified (limits `215 KiB` and `529 KiB`).

## Compatibility and risk

Only static segment capture changes. Static traces can gain one transaction event where a late child was previously dropped. Accepted children are not emitted twice, children pending beneath a rejected segment remain suppressed, and the state is weakly keyed and released at terminal decisions.

The branch is arranged as five dependent review commits: terminal event decisions, the Core state machine, Cloudflare activation, the real Worker regression, and shared-client scope ownership.

Fixes getsentry/sentry-javascript#23427