### PR TITLE
chore(solidstart): Refresh SolidStart test versions

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solidstart-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-2/package.json
@@ -21,7 +21,7 @@
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^1.0.0",
-    "@solidjs/start": "2.0.0",
+    "@solidjs/start": "2.0.2",
     "@solidjs/testing-library": "^0.8.10",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -90,7 +90,7 @@
   },
   "devDependencies": {
     "@solidjs/router": "^1.0.0",
-    "@solidjs/start": "^1.2.1",
+    "@solidjs/start": "^1.3.2",
     "@solidjs/testing-library": "0.8.5",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/user-event": "^14.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8592,10 +8592,10 @@
   resolved "https://registry.yarnpkg.com/@solidjs/router/-/router-1.0.0.tgz#9e4e5d6dbdeb725e8e4a9b5a3c7158c39fff096f"
   integrity sha512-cCSk1hvgCowiMa9bzzYWHiLu1U4E22+DfJe6/rOwAyECKrxc3jrd5QnoW3sDDJtW+e077cz/M67bPl3DqOBw1Q==
 
-"@solidjs/start@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@solidjs/start/-/start-1.2.1.tgz#ef37d57fddaf0d8d81b099c444faac468d63be92"
-  integrity sha512-O5E7rcCwm2f8GlXKgS2xnU37Ld5vMVXJgo/qR7UI5iR5uFo9V2Ac+SSVNXkM98CeHKHt55h1UjbpxxTANEsHmA==
+"@solidjs/start@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@solidjs/start/-/start-1.3.2.tgz#438cf350fde2d4aa03c179fea224f7231c3d8489"
+  integrity sha512-tasDl3utVbtP0rr4InB3ntBIFV2upvEiFrOOCkRrAA3yBfjx9elpxnc94sJQXo65PNYdAAAkPIC6h93vLrtwHg==
   dependencies:
     "@tanstack/server-functions-plugin" "1.121.21"
     "@vinxi/plugin-directives" "^0.5.0"
@@ -8605,13 +8605,13 @@
     error-stack-parser "^2.1.4"
     html-to-image "^1.11.11"
     radix3 "^1.1.0"
-    seroval "^1.4.1"
-    seroval-plugins "^1.4.0"
+    seroval "^1.5.0"
+    seroval-plugins "^1.5.0"
     shiki "^1.26.1"
     source-map-js "^1.0.2"
     terracotta "^1.0.4"
     tinyglobby "^0.2.2"
-    vite-plugin-solid "^2.11.1"
+    vite-plugin-solid "^2.11.10"
 
 "@solidjs/testing-library@0.8.5":
   version "0.8.5"
@@ -24756,12 +24756,17 @@ serialize-javascript@^7.0.3:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz#c798cc0552ffbb08981914a42a8756e339d0d5b1"
   integrity sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==
 
-seroval-plugins@^1.4.0, seroval-plugins@^1.5.4, seroval-plugins@~1.5.0:
+seroval-plugins@^1.4.0, seroval-plugins@^1.5.0, seroval-plugins@^1.5.4:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/seroval-plugins/-/seroval-plugins-1.6.2.tgz#8e49b47fd585c2025f74f84f78272ea1753a8daa"
+  integrity sha512-TfxuUjlbBESzUOWdTkTKqvSmav0ABym+itetDXLK6mDz8SmrpdI30aF8RTXE8Bvq+tH/1yIDkvy3W0lfQb1ipQ==
+
+seroval-plugins@~1.5.0:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/seroval-plugins/-/seroval-plugins-1.5.4.tgz#3e7d1910b5a516684046770d201b993c81b1b95a"
   integrity sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==
 
-seroval@^1.4.0, seroval@^1.4.1, seroval@^1.5.4, seroval@^1.6.2:
+seroval@^1.4.0, seroval@^1.5.0, seroval@^1.5.4, seroval@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/seroval/-/seroval-1.6.2.tgz#93ecff62ca1312a565e37146b2a332b9d625194d"
   integrity sha512-mPT+SD2TrlB6wvte1KkYOYUkubaTbd6pZ/6Kk3C9nxzrHmCZyhxOO7XGAeL7f+yLKZglzGtM9odUVvg/EhO+vQ==
@@ -27368,10 +27373,10 @@ vite-plugin-inspect@^11.4.1:
     unplugin-utils "^0.3.1"
     vite-dev-rpc "^2.0.0"
 
-vite-plugin-solid@^2.11.1, vite-plugin-solid@^2.11.6:
-  version "2.11.10"
-  resolved "https://registry.yarnpkg.com/vite-plugin-solid/-/vite-plugin-solid-2.11.10.tgz#5646d1aa20162837959957cc4b47ed8b925d3604"
-  integrity sha512-Yr1dQybmtDtDAHkii6hXuc1oVH9CPcS/Zb2jN/P36qqcrkNnVPsMTzQ06jyzFPFjj3U1IYKMVt/9ZqcwGCEbjw==
+vite-plugin-solid@^2.11.10, vite-plugin-solid@^2.11.6:
+  version "2.11.14"
+  resolved "https://registry.yarnpkg.com/vite-plugin-solid/-/vite-plugin-solid-2.11.14.tgz#acf7e61c3b052de7c178ad5a3109750cb5063691"
+  integrity sha512-7ZVBt8rpoyqmlwin2kRIUveaHoF6/kulY7gsnD+qFh4nS29V4OPAnw+ojoAspXIjObiL9o1xh9a/nTuYHm02Rw==
   dependencies:
     "@babel/core" "^7.23.3"
     "@types/babel__core" "^7.20.4"


### PR DESCRIPTION
Refresh the SolidStart versions exercised by the SDK while preserving legacy v1 coverage:

- move the retained package development target and root lockfile from SolidStart 1.2.1 to the final v1 release, 1.3.2
- move the existing Node 24 SolidStart 2 E2E fixture from 2.0.0 to 2.0.2

SolidStart 1 is deprecated and is retained here only for legacy compatibility testing, but it's really not wise to stay on that version. SolidStart 2 is the supported and recommended version and has dedicated Vite/Nitro integration and E2E coverage in `@sentry/solidstart` from #23090.