### PR TITLE
fix(tanstackstart-react): avoid double-injecting trace meta tags across stream chunks

### DIFF
--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -77,11 +77,24 @@ function injectMetaTagsInResponse(originalResponse: Response): Response {
           }
         }
 
+        // Once we've injected, pass later chunks through untouched so a <head> inside a
+        // quoted attribute in a later chunk isn't matched again.
+        let injected = false;
+
         let errored = false;
         try {
           for await (const chunk of bodyReporter()) {
             const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
+
+            if (injected) {
+              controller.enqueue(new TextEncoder().encode(html));
+              continue;
+            }
+
             const modifiedHtml = addMetaTagToHead(html, metaTagsStr);
+            if (modifiedHtml !== html) {
+              injected = true;
+            }
             controller.enqueue(new TextEncoder().encode(modifiedHtml));
           }
         } catch (e) {

--- a/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
+++ b/packages/tanstackstart-react/test/server/wrapFetchWithSentry.test.ts
@@ -165,6 +165,31 @@ describe('wrapFetchWithSentry', () => {
     expect(html).toContain('data-content="<head>ignore"');
   });
 
+  it('injects meta tags only once when a later chunk has <head> inside a quoted attribute', async () => {
+    const encoder = new TextEncoder();
+    const chunks = ['<head></head><body><div data-content="junk', '<head>junk"></div></body>'];
+    const body = new ReadableStream({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(encoder.encode(c));
+        controller.close();
+      },
+    });
+    const mockResponse = new Response(body, {
+      headers: new Headers({ 'content-type': 'text/html' }),
+    });
+    const fetchFn = vi.fn().mockResolvedValue(mockResponse);
+
+    const serverEntry = wrapFetchWithSentry({ fetch: fetchFn });
+    const request = new Request('http://localhost:3000/');
+
+    const response = await serverEntry.fetch(request);
+    const html = await response.text();
+
+    expect(html.match(/name="sentry-trace"/g)).toHaveLength(1);
+    expect(html).toContain('<head><meta name="sentry-trace"');
+    expect(html).toContain('data-content="junk<head>junk"');
+  });
+
   it('captures exception when HTML response body stream errors', async () => {
     const streamError = new Error('stream read error');
     const body = new ReadableStream({


### PR DESCRIPTION
`wrapFetchWithSentry` rewrites the SSR HTML stream chunk-by-chunk to inject trace meta tags into `<head>`. Each chunk is scanned independently, so a `<head>` that appears inside a quoted attribute value in a *later* chunk gets injected into a second time.

Example — a document split so the real `<head>` and a second heat tag in an attribute land in different chunks:

```
chunk 1: <head></head><body><div data-content="junk
chunk 2: <head>junk"></div></body>

result:  <head>[meta]</head>...<div data-content="junk<head>[meta]junk">...
                                                        ^ injected into an attribute value
```

This breaks because the per-chunk scan has no memory that injection already happened in an earlier chunk. This fix injects at the first `<head>` and then passes later chunks through untouched.

Note: This should fix a bug in the injection logic but not entirely sure this is the root cause of the attached issue (hard to reproduce since this depends on how the chunks get split up).

Fixes #23468