### PR TITLE
ref(react)!: Remove redundant `url.path.params.<key>` attribute

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -523,6 +523,7 @@ Two consequences to be aware of when upgrading:
 Affected SDKs: All SDKs.
 
 - The `http.query` and `http.fragment` span attributes were renamed to `url.query` and `url.fragment`.
+- The `url.path.params.<key>` attribute was removed from the TanStack Router (library) integration. The replacement is `url.path.parameter.<key>` and holds the same values.
 - The gen_ai cache token attributes `gen_ai.usage.cache_creation_input_tokens` and `gen_ai.usage.cache_read_input_tokens` were renamed to `gen_ai.usage.cache_creation.input_tokens` and `gen_ai.usage.cache_read.input_tokens`.
 - The `gen_ai.system` span attribute was renamed to `gen_ai.provider.name` across all AI integrations.
 - The `gen_ai.request.available_tools` span attribute was renamed to `gen_ai.tool.definitions` across all AI integrations.

--- a/dev-packages/e2e-tests/test-applications/tanstack-router/tests/basepath.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstack-router/tests/basepath.test.ts
@@ -24,10 +24,10 @@ test.describe('router basepath', () => {
     // match already set, so the stale `a`/`b`/`c` params survive on the span. Keys are passed as
     // arrays because `toHaveProperty` would otherwise read the dots as a nested lookup.
     const traceData = rootSpan.contexts?.trace?.data;
-    expect(traceData).not.toHaveProperty(['url.path.params.a']);
-    expect(traceData).not.toHaveProperty(['url.path.params.b']);
-    expect(traceData).not.toHaveProperty(['url.path.params.c']);
-    expect(traceData).toHaveProperty(['url.path.params.postId'], '456');
+    expect(traceData).not.toHaveProperty(['url.path.parameter.a']);
+    expect(traceData).not.toHaveProperty(['url.path.parameter.b']);
+    expect(traceData).not.toHaveProperty(['url.path.parameter.c']);
+    expect(traceData).toHaveProperty(['url.path.parameter.postId'], '456');
     expect(traceData).toHaveProperty(['url.template'], '/posts/$postId');
   });
 

--- a/dev-packages/e2e-tests/test-applications/tanstack-router/tests/routing-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstack-router/tests/routing-instrumentation.test.ts
@@ -19,7 +19,7 @@ test('sends a pageload transaction with a parameterized URL', async ({ page }) =
           'sentry.source': 'route',
           'sentry.origin': 'auto.pageload.react.tanstack_router',
           'sentry.op': 'pageload',
-          'url.path.params.postId': '456',
+          'url.path.parameter.postId': '456',
           'url.template': '/posts/$postId',
           'url.path': '/posts/456',
           'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/456$/),
@@ -111,7 +111,7 @@ test('sends a navigation transaction with a parameterized URL', async ({ page })
           'sentry.source': 'route',
           'sentry.origin': 'auto.navigation.react.tanstack_router',
           'sentry.op': 'navigation',
-          'url.path.params.postId': '2',
+          'url.path.parameter.postId': '2',
           'url.template': '/posts/$postId',
           'url.path': '/posts/2',
           'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/2$/),
@@ -151,7 +151,7 @@ test('sends a pageload transaction with resolved URL attrs after same-route redi
           'sentry.source': 'route',
           'sentry.origin': 'auto.pageload.react.tanstack_router',
           'sentry.op': 'pageload',
-          'url.path.params.postId': '2',
+          'url.path.parameter.postId': '2',
           'url.template': '/posts/$postId',
           'url.path': '/posts/2',
           'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/2$/),
@@ -187,7 +187,7 @@ test('sends a pageload transaction named after the resolved route when a redirec
           'sentry.source': 'route',
           'sentry.origin': 'auto.pageload.react.tanstack_router',
           'sentry.op': 'pageload',
-          'url.path.params.postId': '1',
+          'url.path.parameter.postId': '1',
           'url.template': '/posts/$postId',
           'url.path': '/posts/1',
           'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/1$/),
@@ -228,7 +228,7 @@ test('sends a navigation transaction when a redirect is thrown in beforeLoad', a
           'sentry.source': 'route',
           'sentry.origin': 'auto.navigation.react.tanstack_router',
           'sentry.op': 'navigation',
-          'url.path.params.postId': '1',
+          'url.path.parameter.postId': '1',
           'url.template': '/posts/$postId',
           'url.path': '/posts/1',
           'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/1$/),
@@ -265,7 +265,7 @@ test('sends a navigation transaction for a normal navigation that happens after 
   const navigationTxnPromise = waitForTransaction('tanstack-router', async transactionEvent => {
     return (
       transactionEvent.contexts?.trace?.op === 'navigation' &&
-      transactionEvent.contexts?.trace?.data?.['url.path.params.postId'] === '2'
+      transactionEvent.contexts?.trace?.data?.['url.path.parameter.postId'] === '2'
     );
   });
 
@@ -280,7 +280,7 @@ test('sends a navigation transaction for a normal navigation that happens after 
           'sentry.source': 'route',
           'sentry.origin': 'auto.navigation.react.tanstack_router',
           'sentry.op': 'navigation',
-          'url.path.params.postId': '2',
+          'url.path.parameter.postId': '2',
           'url.template': '/posts/$postId',
           'url.path': '/posts/2',
           'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/2$/),

--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -197,7 +197,6 @@ function routeMatchToParamSpanAttributes(match: VendoredTanstackRouterRouteMatch
 
   const paramAttributes: Record<string, string> = {};
   Object.entries(match.params).forEach(([key, value]) => {
-    paramAttributes[`url.path.params.${key}`] = value; // TODO(v11): remove attribute which does not adhere to Sentry's semantic convention
     paramAttributes[`${URL_PATH_PARAMETER_KEY_BASE}.${key}`] = value;
     paramAttributes[`${PARAMS_KEY_BASE}.${key}`] = value; // params.[key] is an alias
   });

--- a/packages/react/test/tanstackrouter.test.ts
+++ b/packages/react/test/tanstackrouter.test.ts
@@ -87,7 +87,7 @@ describe('tanstackRouterBrowserTracingIntegration', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.tanstack_router',
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
         [URL_TEMPLATE]: '/posts/$postId',
-        'url.path.params.postId': '999',
+        'url.path.parameter.postId': '999',
       }),
     });
   });
@@ -156,7 +156,6 @@ describe('tanstackRouterBrowserTracingIntegration', () => {
         [URL_TEMPLATE]: '/posts/$postId',
         'url.path': '/posts/2',
         'url.full': expect.any(String),
-        'url.path.params.postId': '2',
         'url.path.parameter.postId': '2',
         'params.postId': '2',
       }),


### PR DESCRIPTION
This PR removes the undocumented `url.path.params.<key>` in favour of the already set and [documented](https://getsentry.github.io/sentry-conventions/attributes/url/#url-path-parameter-key) `url.path.parameter.<key>` attribute. 