### PR TITLE
ref: Remove orchestrion references from customer-facing surfaces

### DIFF
--- a/packages/bun/src/plugin.ts
+++ b/packages/bun/src/plugin.ts
@@ -1,5 +1,5 @@
 /**
- * orchestrion code-transform plugin for Bun's bundler (`bun build`).
+ * Sentry code-transform plugin for Bun's bundler (`bun build`).
  *
  * Usage:
  *
@@ -17,7 +17,7 @@
  *
  * When https://github.com/oven-sh/bun/pull/31770 lands, we can revisit.
  *
- * Until then, Bun apps must bundle to get orchestrion instrumentation. In dev
+ * Until then, Bun apps must bundle to get build-time instrumentation. In dev
  * (ie, `bun run`) there is simply no instrumentation, which is clearer than
  * partial/inconsistent coverage.
  *
@@ -52,7 +52,7 @@ interface BunPluginBuilder {
 }
 
 /**
- * Returns the orchestrion code-transform plugin for Bun's bundler, configured
+ * Returns the Sentry code-transform plugin for Bun's bundler, configured
  * with the central `SENTRY_INSTRUMENTATIONS`. The plugin injects
  * `diagnostics_channel.tracingChannel` calls into the instrumented libraries as
  * `bun build` bundles them — plus, via the module-injected transform, the

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -974,7 +974,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public on(hook: 'stopUIProfiler', callback: () => void): () => void;
 
   /**
-   * A hook that is called when an orchestrion-instrumented module is injected —
+   * A hook that is called when an instrumented module is injected —
    * at runtime by the module hook, or at load of a bundler-transformed module.
    * Channel-based integrations use it to subscribe their diagnostics-channel
    * listeners lazily, only once the module they instrument is actually loaded.
@@ -1262,7 +1262,7 @@ export abstract class Client<O extends ClientOptions = ClientOptions> {
   public emit(hook: 'stopUIProfiler'): void;
 
   /**
-   * Emit a hook when an orchestrion-instrumented module is injected (runtime
+   * Emit a hook when an instrumented module is injected (runtime
    * module hook or bundler-transformed module load).
    */
   public emit(hook: 'orchestrion.module-injected', moduleName: string): void;

--- a/packages/core/src/integrations/postgresjs.ts
+++ b/packages/core/src/integrations/postgresjs.ts
@@ -401,7 +401,7 @@ export function _sanitizeSqlQuery(sqlQuery: string | undefined): string {
 /**
  * Sets connection context attributes on a span.
  *
- * @internal Exported for the orchestrion (diagnostics-channel) integration.
+ * @internal Exported for the diagnostics-channel integration.
  */
 export function _setConnectionAttributes(span: Span, connectionContext: PostgresConnectionContext | undefined): void {
   if (!connectionContext) {
@@ -426,7 +426,7 @@ export function _setConnectionAttributes(span: Span, connectionContext: Postgres
 /**
  * Extracts DB operation name from SQL query and sets it on the span.
  *
- * @internal Exported for the orchestrion (diagnostics-channel) integration.
+ * @internal Exported for the diagnostics-channel integration.
  */
 export function _setOperationName(span: Span, sanitizedQuery: string | undefined, command?: string): void {
   if (command) {
@@ -444,7 +444,7 @@ export function _setOperationName(span: Span, sanitizedQuery: string | undefined
  * Builds a {@link PostgresConnectionContext} from postgres.js' parsed options
  * (which store `host`/`port` as arrays). Defaults to 'localhost'/5432.
  *
- * @internal Exported for the orchestrion (diagnostics-channel) integration.
+ * @internal Exported for the diagnostics-channel integration.
  */
 export function _buildConnectionContext(options: {
   host?: string[];

--- a/packages/core/src/utils/worldwide.ts
+++ b/packages/core/src/utils/worldwide.ts
@@ -56,7 +56,7 @@ export type InternalGlobal = {
   _sentryModuleMetadata?: Record<string, any>;
   _sentryWrappedDepth?: number;
   /**
-   * Orchestrion bundler and runtime detection.
+   * Bundler and runtime instrumentation detection.
    */
   __SENTRY_ORCHESTRION__?: {
     /** Empty array signifies runtime hooked */

--- a/packages/deno/README.md
+++ b/packages/deno/README.md
@@ -60,10 +60,8 @@ Sentry.captureEvent({
 ## Auto-instrumentation (experimental)
 
 Some libraries (e.g. `mysql`) don't emit tracing signals on their
-own. To instrument them, Sentry uses
-[orchestrion](https://github.com/apm-js-collab/tracing-hooks) to
-transform them at load time so they publish to
-`node:diagnostics_channel`.
+own. To instrument them, Sentry transforms them at load time so they
+publish to `node:diagnostics_channel`.
 
 Use the `--import` or `--preload` argument to `deno run` to enable
 these instrumentations.

--- a/packages/nestjs/src/integrations/orchestrion-subscriber.ts
+++ b/packages/nestjs/src/integrations/orchestrion-subscriber.ts
@@ -121,7 +121,7 @@ export function subscribeToNestChannels(): void {
     return;
   }
 
-  DEBUG_BUILD && debug.log('[orchestrion:nestjs] subscribing to @nestjs channels');
+  DEBUG_BUILD && debug.log('[instrumentation:nestjs] subscribing to @nestjs channels');
 
   // App-creation span: `bindTracingChannelToSpan` opens the span on
   // `start`, makes it the active context for the bootstrap, and ends it

--- a/packages/node/src/bundler-plugin/esbuild.ts
+++ b/packages/node/src/bundler-plugin/esbuild.ts
@@ -2,7 +2,7 @@ import { sentryEsbuildPlugin as sentryEsbuildBundlerPlugin } from '@sentry/bundl
 import type { SentryEsbuildPluginOptions as SentryEsbuildPluginOptionsBase } from '@sentry/bundler-plugins/esbuild';
 import type { InstrumentationConfig } from '@sentry/server-utils';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/esbuild';
-import type { Plugin as EsbuildPlugin } from 'esbuild';
+import type { EsbuildPlugin } from '@sentry/server-utils/orchestrion/esbuild';
 
 export type SentryEsbuildPluginOptions = SentryEsbuildPluginOptionsBase & {
   /**

--- a/packages/node/src/bundler-plugin/esbuild.ts
+++ b/packages/node/src/bundler-plugin/esbuild.ts
@@ -1,12 +1,14 @@
 import { sentryEsbuildPlugin as sentryEsbuildBundlerPlugin } from '@sentry/bundler-plugins/esbuild';
 import type { SentryEsbuildPluginOptions as SentryEsbuildPluginOptionsBase } from '@sentry/bundler-plugins/esbuild';
+import type { InstrumentationConfig } from '@sentry/server-utils';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/esbuild';
+import type { Plugin as EsbuildPlugin } from 'esbuild';
 
 export type SentryEsbuildPluginOptions = SentryEsbuildPluginOptionsBase & {
   /**
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
-  instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
+  instrumentations?: InstrumentationConfig[];
 
   /**
    * Automatic instrumentation of server-side dependencies at build time.
@@ -17,8 +19,6 @@ export type SentryEsbuildPluginOptions = SentryEsbuildPluginOptionsBase & {
    */
   buildTimeInstrumentation?: boolean;
 };
-
-type EsbuildPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
 
 /**
  * esbuild plugin that bundles the Sentry esbuild bundler plugin (source maps,

--- a/packages/node/src/bundler-plugin/rollup.ts
+++ b/packages/node/src/bundler-plugin/rollup.ts
@@ -2,7 +2,7 @@ import { sentryRollupPlugin as sentryRollupBundlerPlugin } from '@sentry/bundler
 import type { SentryRollupPluginOptions as SentryRollupPluginOptionsBase } from '@sentry/bundler-plugins/rollup';
 import type { InstrumentationConfig } from '@sentry/server-utils';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/rollup';
-import type { Plugin as RollupPlugin } from 'rollup';
+import type { RollupPlugin } from '@sentry/server-utils/orchestrion/rollup';
 
 export type SentryRollupPluginOptions = SentryRollupPluginOptionsBase & {
   /**

--- a/packages/node/src/bundler-plugin/rollup.ts
+++ b/packages/node/src/bundler-plugin/rollup.ts
@@ -1,12 +1,14 @@
 import { sentryRollupPlugin as sentryRollupBundlerPlugin } from '@sentry/bundler-plugins/rollup';
 import type { SentryRollupPluginOptions as SentryRollupPluginOptionsBase } from '@sentry/bundler-plugins/rollup';
+import type { InstrumentationConfig } from '@sentry/server-utils';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/rollup';
+import type { Plugin as RollupPlugin } from 'rollup';
 
 export type SentryRollupPluginOptions = SentryRollupPluginOptionsBase & {
   /**
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
-  instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
+  instrumentations?: InstrumentationConfig[];
 
   /**
    * Automatic instrumentation of server-side dependencies at build time.
@@ -17,8 +19,6 @@ export type SentryRollupPluginOptions = SentryRollupPluginOptionsBase & {
    */
   buildTimeInstrumentation?: boolean;
 };
-
-type RollupPlugin = ReturnType<typeof sentryOrchestrionPlugin>;
 
 /**
  * Rollup plugin that bundles the Sentry Rollup bundler plugin (source maps,

--- a/packages/node/src/bundler-plugin/vite.ts
+++ b/packages/node/src/bundler-plugin/vite.ts
@@ -2,7 +2,7 @@ import { sentryVitePlugin as sentryViteBundlerPlugin } from '@sentry/bundler-plu
 import type { SentryVitePluginOptions as SentryVitePluginOptionsBase } from '@sentry/bundler-plugins/vite';
 import type { InstrumentationConfig } from '@sentry/server-utils';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
-import type { Plugin as VitePlugin } from 'vite';
+import type { VitePlugin } from '@sentry/server-utils/orchestrion/vite';
 
 export type SentryVitePluginOptions = SentryVitePluginOptionsBase & {
   /**

--- a/packages/node/src/bundler-plugin/vite.ts
+++ b/packages/node/src/bundler-plugin/vite.ts
@@ -1,12 +1,14 @@
 import { sentryVitePlugin as sentryViteBundlerPlugin } from '@sentry/bundler-plugins/vite';
 import type { SentryVitePluginOptions as SentryVitePluginOptionsBase } from '@sentry/bundler-plugins/vite';
+import type { InstrumentationConfig } from '@sentry/server-utils';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
+import type { Plugin as VitePlugin } from 'vite';
 
 export type SentryVitePluginOptions = SentryVitePluginOptionsBase & {
   /**
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
-  instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionPlugin>[0]>['instrumentations'];
+  instrumentations?: InstrumentationConfig[];
 
   /**
    * Automatic instrumentation of server-side dependencies at build time.
@@ -17,8 +19,6 @@ export type SentryVitePluginOptions = SentryVitePluginOptionsBase & {
    */
   buildTimeInstrumentation?: boolean;
 };
-
-type VitePlugin = ReturnType<typeof sentryOrchestrionPlugin>;
 
 /**
  * Vite plugin that bundles the Sentry Vite bundler plugin (source maps, release

--- a/packages/node/src/bundler-plugin/webpack.ts
+++ b/packages/node/src/bundler-plugin/webpack.ts
@@ -1,12 +1,13 @@
 import { sentryWebpackPlugin as sentryWebpackBundlerPlugin } from '@sentry/bundler-plugins/webpack';
 import type { SentryWebpackPluginOptions as SentryWebpackPluginOptionsBase } from '@sentry/bundler-plugins/webpack';
+import type { InstrumentationConfig } from '@sentry/server-utils';
 import { sentryOrchestrionWebpackPlugin } from '@sentry/server-utils/orchestrion/webpack';
 
 export type SentryWebpackPluginOptions = SentryWebpackPluginOptionsBase & {
   /**
    * @ignore This is for internal use only when this plugin is consumed by a framework SDK
    */
-  instrumentations?: NonNullable<Parameters<typeof sentryOrchestrionWebpackPlugin>[0]>['instrumentations'];
+  instrumentations?: InstrumentationConfig[];
 
   /**
    * Automatic instrumentation of server-side dependencies at build time.

--- a/packages/server-utils/src/integrations/amqplib.ts
+++ b/packages/server-utils/src/integrations/amqplib.ts
@@ -596,10 +596,10 @@ function getHeaderAsString(headers: Record<string, unknown> | undefined, key: st
 }
 
 /**
- * Orchestrion-driven `amqplib` integration.
+ * Diagnostics-channel-based `amqplib` integration.
  *
- * Subscribes to the `orchestrion:amqplib:*` diagnostics_channels that the orchestrion code transform
- * injects into `amqplib`'s channel/connection methods. Requires the orchestrion runtime hook or
+ * Subscribes to the `orchestrion:amqplib:*` diagnostics_channels that Sentry's code transform
+ * injects into `amqplib`'s channel/connection methods. Requires the Sentry runtime hook or
  * bundler plugin to be active.
  */
 export const amqplibIntegration = defineIntegration(_amqplibIntegration);

--- a/packages/server-utils/src/integrations/anthropic.ts
+++ b/packages/server-utils/src/integrations/anthropic.ts
@@ -157,8 +157,8 @@ function wrapStreamResult(
 }
 
 /**
- * Orchestrion-driven Anthropic integration. Subscribes to the `orchestrion:@anthropic-ai/sdk:*`
+ * Diagnostics-channel-based Anthropic integration. Subscribes to the `orchestrion:@anthropic-ai/sdk:*`
  * diagnostics_channels injected into the SDK's chat (`messages`/`completions`/beta `messages`) and
- * `messages.stream()` methods, so it requires the orchestrion runtime hook or bundler plugin.
+ * `messages.stream()` methods, so it requires the Sentry runtime hook or bundler plugin.
  */
 export const anthropicAIIntegration = defineIntegration(_anthropicAIIntegration);

--- a/packages/server-utils/src/integrations/aws-sdk/index.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/index.ts
@@ -237,11 +237,11 @@ function instrumentAwsSdk(servicesExtensions: ServicesExtensions): void {
 }
 
 /**
- * Orchestrion-driven aws-sdk (v3) integration.
+ * Diagnostics-channel-based aws-sdk (v3) integration.
  *
  * Subscribes to the `orchestrion:@smithy/smithy-client:send` (and equivalent) diagnostics_channel
- * the orchestrion code transform injects into the AWS SDK's smithy `Client.prototype.send`, emitting
+ * Sentry's code transform injects into the AWS SDK's smithy `Client.prototype.send`, emitting
  * spans identical to the OTel `@opentelemetry/instrumentation-aws-sdk` integration. Requires the
- * orchestrion runtime hook or bundler plugin.
+ * Sentry runtime hook or bundler plugin.
  */
 export const awsIntegration = defineIntegration(_awsIntegration);

--- a/packages/server-utils/src/integrations/aws-sdk/services/MessageAttributes.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/services/MessageAttributes.ts
@@ -43,7 +43,7 @@ export function injectPropagationContext(
   } else {
     DEBUG_BUILD &&
       debug.warn(
-        '[orchestrion:aws-sdk] cannot set trace propagation on SQS/SNS message due to maximum amount of MessageAttributes',
+        '[instrumentation:aws-sdk] cannot set trace propagation on SQS/SNS message due to maximum amount of MessageAttributes',
       );
   }
   return attributes;

--- a/packages/server-utils/src/integrations/aws-sdk/services/bedrock-runtime.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/services/bedrock-runtime.ts
@@ -419,7 +419,7 @@ function parseChunk(bytes?: Uint8Array): ParsedChunk {
     const str = Buffer.from(bytes).toString('utf-8');
     return JSON.parse(str);
   } catch (err) {
-    DEBUG_BUILD && debug.warn('[orchestrion:aws-sdk] failed to parse streamed bedrock chunk', err);
+    DEBUG_BUILD && debug.warn('[instrumentation:aws-sdk] failed to parse streamed bedrock chunk', err);
     return null;
   }
 }

--- a/packages/server-utils/src/integrations/aws-sdk/services/lambda.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/services/lambda.ts
@@ -71,14 +71,14 @@ function injectLambdaPropagationContext(clientContext: string | undefined, span:
     if (encodedClientContext.length > 3583) {
       DEBUG_BUILD &&
         debug.warn(
-          '[orchestrion:aws-sdk] cannot set trace propagation on lambda invoke parameters due to ClientContext length limitations.',
+          '[instrumentation:aws-sdk] cannot set trace propagation on lambda invoke parameters due to ClientContext length limitations.',
         );
       return clientContext;
     }
 
     return encodedClientContext;
   } catch (e) {
-    DEBUG_BUILD && debug.log('[orchestrion:aws-sdk] failed to set trace propagation on lambda ClientContext', e);
+    DEBUG_BUILD && debug.log('[instrumentation:aws-sdk] failed to set trace propagation on lambda ClientContext', e);
     return clientContext;
   }
 }

--- a/packages/server-utils/src/integrations/dataloader.ts
+++ b/packages/server-utils/src/integrations/dataloader.ts
@@ -113,7 +113,7 @@ const _dataloaderIntegration = (() => {
         return;
       }
 
-      DEBUG_BUILD && debug.log('[orchestrion:dataloader] subscribing to dataloader tracing channels');
+      DEBUG_BUILD && debug.log('[instrumentation:dataloader] subscribing to dataloader tracing channels');
 
       waitForTracingChannelBinding(() => {
         subscribeConstruct();
@@ -193,10 +193,10 @@ function startInactiveSpanFor(loader: DataLoaderInstance | undefined, operation:
 }
 
 /**
- * Orchestrion-driven `dataloader` integration.
+ * Diagnostics-channel-based `dataloader` integration.
  *
- * Subscribes to the `orchestrion:dataloader:*` diagnostics_channels that the orchestrion code
- * transform injects into `dataloader`'s constructor and prototype methods. Requires the orchestrion
+ * Subscribes to the `orchestrion:dataloader:*` diagnostics_channels that Sentry's code
+ * transform injects into `dataloader`'s constructor and prototype methods. Requires the Sentry
  * runtime hook or bundler plugin to be active.
  */
 export const dataloaderIntegration = defineIntegration(_dataloaderIntegration);

--- a/packages/server-utils/src/integrations/express/index.ts
+++ b/packages/server-utils/src/integrations/express/index.ts
@@ -23,15 +23,15 @@ const _expressIntegration = ((options: ExpressIntegrationOptions = {}) => {
 }) satisfies IntegrationFn;
 
 /**
- * Orchestrion-driven Express integration.
+ * Diagnostics-channel-based Express integration.
  *
  * Subscribes to the `orchestrion:express:handle` (Express v4) and
  * `orchestrion:router:handle` (Express v5, via the `router` package)
- * diagnostics_channels that the orchestrion code transform injects into the
+ * diagnostics_channels that Sentry's code transform injects into the
  * routing layer's request handler (`Layer.prototype.handle_request` /
  * `handleRequest`). One span is opened per layer invocation — producing the
  * same spans as the OTel Express instrumentation.
  *
- * Requires the orchestrion runtime hook or bundler plugin to be active.
+ * Requires the Sentry runtime hook or bundler plugin to be active.
  */
 export const expressIntegration = defineIntegration(_expressIntegration);

--- a/packages/server-utils/src/integrations/express/instrumentation.ts
+++ b/packages/server-utils/src/integrations/express/instrumentation.ts
@@ -210,7 +210,7 @@ function getSpanForLayer(data: HandleChannelContext, options: ExpressIntegration
     } else {
       DEBUG_BUILD &&
         debug.warn(
-          '[orchestrion:express] Isolation scope is still default isolation scope - skipping transaction name',
+          '[instrumentation:express] Isolation scope is still default isolation scope - skipping transaction name',
         );
     }
   }

--- a/packages/server-utils/src/integrations/firebase/index.ts
+++ b/packages/server-utils/src/integrations/firebase/index.ts
@@ -16,11 +16,11 @@ const _firebaseIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Orchestrion-driven firebase integration.
+ * Diagnostics-channel-based firebase integration.
  *
  * Subscribes to the `orchestrion:@firebase/firestore:*` and `orchestrion:firebase-functions:*`
- * diagnostics_channels the orchestrion code transform injects into firestore's `addDoc`/`getDocs`/
+ * diagnostics_channels Sentry's code transform injects into firestore's `addDoc`/`getDocs`/
  * `setDoc`/`deleteDoc` and firebase-functions' `onX` registration functions, emitting spans identical
- * to the OTel integration. Requires the orchestrion runtime hook or bundler plugin.
+ * to the OTel integration. Requires the Sentry runtime hook or bundler plugin.
  */
 export const firebaseIntegration = defineIntegration(_firebaseIntegration);

--- a/packages/server-utils/src/integrations/generic-pool.ts
+++ b/packages/server-utils/src/integrations/generic-pool.ts
@@ -26,10 +26,10 @@ const _genericPoolIntegration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Orchestrion-driven generic-pool integration. Subscribes to
+ * Diagnostics-channel-based generic-pool integration. Subscribes to
  * `orchestrion:generic-pool:acquire` (injected into `generic-pool/lib/Pool.js`'s
  * `Pool.prototype.acquire`). Creates a `generic-pool.acquire` span for each
- * acquisition. Requires the orchestrion runtime hook or bundler plugin.
+ * acquisition. Requires the Sentry runtime hook or bundler plugin.
  */
 export const genericPoolIntegration = defineIntegration(_genericPoolIntegration);
 

--- a/packages/server-utils/src/integrations/google-genai.ts
+++ b/packages/server-utils/src/integrations/google-genai.ts
@@ -148,10 +148,10 @@ function wrapStreamResult(span: Span, data: GoogleGenAIChannelContext, options: 
 }
 
 /**
- * Orchestrion-driven Google GenAI integration. Subscribes to the
+ * Diagnostics-channel-based Google GenAI integration. Subscribes to the
  * `orchestrion:@google/genai:*` diagnostics_channels injected into the SDK's `Models`
  * (`generateContent`/`generateContentStream`/`embedContent`) and `Chat`
- * (`sendMessage`/`sendMessageStream`) methods, so it requires the orchestrion runtime hook or
+ * (`sendMessage`/`sendMessageStream`) methods, so it requires the Sentry runtime hook or
  * bundler plugin.
  */
 export const googleGenAIIntegration = defineIntegration(_googleGenAIIntegration);

--- a/packages/server-utils/src/integrations/hapi.ts
+++ b/packages/server-utils/src/integrations/hapi.ts
@@ -63,8 +63,8 @@ function instrumentHapi(): void {
 }
 
 /**
- * Orchestrion-driven hapi integration. Subscribes to the
+ * Diagnostics-channel-based hapi integration. Subscribes to the
  * `orchestrion:@hapi/hapi:route` / `:ext` channels injected into `@hapi/hapi`'s
- * `lib/server.js`. Requires the orchestrion runtime hook or bundler plugin.
+ * `lib/server.js`. Requires the Sentry runtime hook or bundler plugin.
  */
 export const hapiIntegration = defineIntegration(_hapiIntegration);

--- a/packages/server-utils/src/integrations/kafkajs/index.ts
+++ b/packages/server-utils/src/integrations/kafkajs/index.ts
@@ -96,11 +96,11 @@ function instrumentKafkajs(): void {
 }
 
 /**
- * Orchestrion-driven kafkajs integration.
+ * Diagnostics-channel-based kafkajs integration.
  *
- * Subscribes to the `orchestrion:kafkajs:*` diagnostics_channels that the orchestrion code transform
+ * Subscribes to the `orchestrion:kafkajs:*` diagnostics_channels that Sentry's code transform
  * injects into `kafkajs`'s `producer/messageProducer.js` (`sendBatch`) and `consumer/index.js` (`run`).
- * Requires the orchestrion runtime hook or bundler plugin to be active.
+ * Requires the Sentry runtime hook or bundler plugin to be active.
  *
  * Known limitation vs. the OTel integration it replaces: the wrapping producer-`transaction` span is
  * not emitted (the transformer can't replace `transaction()`'s return value to patch commit/abort).

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -109,7 +109,7 @@ const _knexIntegration = (() => {
         return;
       }
 
-      DEBUG_BUILD && debug.log(`[orchestrion:knex] subscribing to channel "${CHANNELS.KNEX_QUERY}"`);
+      DEBUG_BUILD && debug.log(`[instrumentation:knex] subscribing to channel "${CHANNELS.KNEX_QUERY}"`);
 
       waitForTracingChannelBinding(() => {
         subscribeBuilder(CHANNELS.KNEX_QUERY_BUILDER);
@@ -306,10 +306,10 @@ function extractPortFromConnectionString(connectionString: string | undefined): 
 }
 
 /**
- * Orchestrion-driven knex integration.
+ * Diagnostics-channel-based knex integration.
  *
- * Subscribes to the `orchestrion:knex:*` diagnostics_channels that the orchestrion code transform
+ * Subscribes to the `orchestrion:knex:*` diagnostics_channels that Sentry's code transform
  * injects into knex's `Runner.query` (span) and `Client.queryBuilder`/`schemaBuilder`/`raw` (parent-span
- * bookkeeping). Requires the orchestrion runtime hook or bundler plugin to be active.
+ * bookkeeping). Requires the Sentry runtime hook or bundler plugin to be active.
  */
 export const knexIntegration = defineIntegration(_knexIntegration);

--- a/packages/server-utils/src/integrations/koa.ts
+++ b/packages/server-utils/src/integrations/koa.ts
@@ -236,9 +236,9 @@ function getMiddlewareMetadata(
 }
 
 /**
- * Orchestrion-driven koa integration. Subscribes to the
+ * Diagnostics-channel-based koa integration. Subscribes to the
  * `orchestrion:koa:use` channel injected into `Application.prototype.use` and
  * wraps each registered middleware/router layer in a span-creating proxy.
- * Requires the orchestrion runtime hook or bundler plugin.
+ * Requires the Sentry runtime hook or bundler plugin.
  */
 export const koaIntegration = defineIntegration(_koaIntegration);

--- a/packages/server-utils/src/integrations/langchain.ts
+++ b/packages/server-utils/src/integrations/langchain.ts
@@ -111,8 +111,8 @@ function createEmbeddingsSpan(data: EmbeddingsChannelContext, options: LangChain
 }
 
 /**
- * Orchestrion-driven LangChain integration. Subscribes to the diagnostics_channels
+ * Diagnostics-channel-based LangChain integration. Subscribes to the diagnostics_channels
  * injected into `@langchain/core`'s `BaseChatModel` (to inject the Sentry callback handler) and into
- * `@langchain/openai`'s embedding methods, so it requires the orchestrion runtime hook or bundler plugin.
+ * `@langchain/openai`'s embedding methods, so it requires the Sentry runtime hook or bundler plugin.
  */
 export const langChainIntegration = defineIntegration(_langChainIntegration);

--- a/packages/server-utils/src/integrations/langgraph.ts
+++ b/packages/server-utils/src/integrations/langgraph.ts
@@ -76,7 +76,7 @@ function instrumentLanggraph(options: LangGraphOptions): void {
         wrapToolsWithSpans(params.tools, resolvedOptions, extractAgentNameFromParams(args) ?? undefined);
       }
     } catch (error) {
-      DEBUG_BUILD && debug.error('[orchestrion:langgraph] failed to wrap createReactAgent tools', error);
+      DEBUG_BUILD && debug.error('[instrumentation:langgraph] failed to wrap createReactAgent tools', error);
     }
   });
   reactAgentChannel.end.subscribe(message => {
@@ -128,8 +128,8 @@ function wrapCompiledGraphInvoke(
 }
 
 /**
- * Orchestrion-driven LangGraph integration. Subscribes to the diagnostics_channels
+ * Diagnostics-channel-based LangGraph integration. Subscribes to the diagnostics_channels
  * injected into `@langchain/langgraph`'s `StateGraph.compile` and `createReactAgent`, so it requires
- * the orchestrion runtime hook or bundler plugin.
+ * the Sentry runtime hook or bundler plugin.
  */
 export const langGraphIntegration = defineIntegration(_langGraphIntegration);

--- a/packages/server-utils/src/integrations/lru-memoizer.ts
+++ b/packages/server-utils/src/integrations/lru-memoizer.ts
@@ -32,9 +32,9 @@ function instrumentLruMemoizer(): void {
 }
 
 /**
- * Orchestrion-driven lru-memoizer integration. Subscribes to
+ * Diagnostics-channel-based lru-memoizer integration. Subscribes to
  * `orchestrion:lru-memoizer:load` (injected into `lru-memoizer/lib/async.js`'s
  * `memoizedFunction`). Creates no spans; only re-runs the memoized callback with the
- * caller's scope. Requires the orchestrion runtime hook or bundler plugin.
+ * caller's scope. Requires the Sentry runtime hook or bundler plugin.
  */
 export const lruMemoizerIntegration = defineIntegration(_lruMemoizerIntegration);

--- a/packages/server-utils/src/integrations/mongodb/index.ts
+++ b/packages/server-utils/src/integrations/mongodb/index.ts
@@ -168,11 +168,11 @@ function bindV3(channelName: string, extract: (args: unknown[]) => V3CallInfo | 
 }
 
 /**
- * Orchestrion-driven mongodb integration.
+ * Diagnostics-channel-based mongodb integration.
  *
  * Reproduces the vendored `@opentelemetry/instrumentation-mongodb` span shape
  * (legacy db/net semantic conventions, `mongodb.<op>` names, scrubbed
  * `db.statement`) via the `orchestrion:mongodb:*` diagnostics_channels
- * injected by the orchestrion code transform.
+ * injected by Sentry's code transform.
  */
 export const mongoIntegration = defineIntegration(_mongoIntegration);

--- a/packages/server-utils/src/integrations/mongoose/index.ts
+++ b/packages/server-utils/src/integrations/mongoose/index.ts
@@ -181,12 +181,12 @@ function stashParentSpan(self: object | undefined): void {
 }
 
 /**
- * Orchestrion-driven mongoose integration.
+ * Diagnostics-channel-based mongoose integration.
  *
  * Reproduces the vendored `@opentelemetry/instrumentation-mongoose` span
  * shape (legacy db/net semantic conventions, `mongoose.<Model>.<op>` names,
  * build-time span parenting) via the `orchestrion:mongoose:*`
- * diagnostics_channels injected into mongoose `< 9.7` by the orchestrion
+ * diagnostics_channels injected into mongoose `< 9.7` by Sentry's
  * code transform. For mongoose `>= 9.7` it also drives the native
  * diagnostics_channel subscription, so this single integration covers every
  * supported version once it replaces the OTel one.

--- a/packages/server-utils/src/integrations/mysql.ts
+++ b/packages/server-utils/src/integrations/mysql.ts
@@ -164,11 +164,11 @@ function getJDBCString(host: string | undefined, port: number | undefined, datab
 }
 
 /**
- * Orchestrion-driven mysql integration.
+ * Diagnostics-channel-based mysql integration.
  *
- * Subscribes to the `orchestrion:mysql:query` diagnostics_channel that the
- * orchestrion code transform injects into `mysql/lib/Connection.js`'s
- * `Connection.prototype.query`. Requires the orchestrion runtime hook or
+ * Subscribes to the `orchestrion:mysql:query` diagnostics_channel that
+ * Sentry's code transform injects into `mysql/lib/Connection.js`'s
+ * `Connection.prototype.query`. Requires the Sentry runtime hook or
  * bundler plugin to be active.
  */
 export const mysqlIntegration = defineIntegration(_mysqlIntegration);

--- a/packages/server-utils/src/integrations/mysql2/index.ts
+++ b/packages/server-utils/src/integrations/mysql2/index.ts
@@ -57,7 +57,7 @@ interface Mysql2Connection {
 }
 
 /**
- * Orchestrion-driven mysql2 integration.
+ * Diagnostics-channel-based mysql2 integration.
  *
  * Subscribes to:
  *   - the `orchestrion:mysql2:query`/`:execute` channels the code transform
@@ -65,7 +65,7 @@ interface Mysql2Connection {
  *   - mysql2's native `node:diagnostics_channel` tracing channels
  *     (mysql2 `>= 3.20.0`), which the transform intentionally leaves alone.
  *
- * The two version ranges never overlap, so no query is double-counted. Requires the orchestrion
+ * The two version ranges never overlap, so no query is double-counted. Requires the Sentry
  * runtime hook or bundler plugin to be active.
  */
 function instrumentMysql2Orchestrion(): void {
@@ -151,7 +151,7 @@ const _mysql2Integration = (() => {
 }) satisfies IntegrationFn;
 
 /**
- * Orchestrion-driven mysql2 integration.
+ * Diagnostics-channel-based mysql2 integration.
  *
  * Adds Sentry tracing instrumentation for the
  * [mysql2](https://www.npmjs.com/package/mysql2) library via diagnostics-channel
@@ -160,7 +160,7 @@ const _mysql2Integration = (() => {
  *
  * Known limitation vs. older OTel integration it replaced: the callback-less
  * streaming form (`connection.query(sql).on('result', ...)`) is not traced.
- * See the `mysql2` orchestrion config for why. The callback and promise forms
+ * See the `mysql2` transform config for why. The callback and promise forms
  * (the common case) are fully instrumented.
  */
 export const mysql2Integration = defineIntegration(_mysql2Integration);

--- a/packages/server-utils/src/integrations/openai.ts
+++ b/packages/server-utils/src/integrations/openai.ts
@@ -126,8 +126,8 @@ function wrapStreamResult(span: Span, data: OpenAiChatChannelContext, options: O
 }
 
 /**
- * Orchestrion-driven OpenAI integration. Subscribes to the `orchestrion:openai:*`
+ * Diagnostics-channel-based OpenAI integration. Subscribes to the `orchestrion:openai:*`
  * diagnostics_channels injected into `openai`'s `create` methods (chat completions, responses, embeddings,
- * conversations), so it requires the orchestrion runtime hook or bundler plugin.
+ * conversations), so it requires the Sentry runtime hook or bundler plugin.
  */
 export const openAIIntegration = defineIntegration(_openAIIntegration);

--- a/packages/server-utils/src/integrations/postgres-js.ts
+++ b/packages/server-utils/src/integrations/postgres-js.ts
@@ -172,7 +172,7 @@ function wrapQuerySettlement(data: PostgresJsQueryContext, span: Span, sanitized
         _INTERNAL_setPostgresOperationName(span, sanitizedSqlQuery, command);
         span.end();
       } catch (e) {
-        DEBUG_BUILD && debug.error('[orchestrion:postgresjs] error ending span in resolve:', e);
+        DEBUG_BUILD && debug.error('[instrumentation:postgresjs] error ending span in resolve:', e);
       }
       return originalResolve.apply(this, resolveArgs);
     };
@@ -190,7 +190,7 @@ function wrapQuerySettlement(data: PostgresJsQueryContext, span: Span, sanitized
         _INTERNAL_setPostgresOperationName(span, sanitizedSqlQuery);
         span.end();
       } catch (e) {
-        DEBUG_BUILD && debug.error('[orchestrion:postgresjs] error ending span in reject:', e);
+        DEBUG_BUILD && debug.error('[instrumentation:postgresjs] error ending span in reject:', e);
       }
       return originalReject.apply(this, rejectArgs);
     };
@@ -289,7 +289,7 @@ function instrumentPostgresJs(options: PostgresJsIntegrationOptions): void {
           requestHook(span, sanitizedSqlQuery, context);
         } catch (e) {
           span.setAttribute('sentry.hook.error', 'requestHook failed');
-          DEBUG_BUILD && debug.error('[orchestrion:postgresjs] error in requestHook:', e);
+          DEBUG_BUILD && debug.error('[instrumentation:postgresjs] error in requestHook:', e);
         }
       }
 
@@ -318,12 +318,12 @@ function instrumentPostgresJs(options: PostgresJsIntegrationOptions): void {
 }
 
 /**
- * Orchestrion-driven postgres.js (`postgres` v3.x) integration.
+ * Diagnostics-channel-based postgres.js (`postgres` v3.x) integration.
  *
  * Subscribes to the `orchestrion:postgres:handle` / `:connection` / `:execute` /
  * `:connect` diagnostics channels injected into postgres.js' `Query.prototype.handle`
  * and `Connection`/`execute`/`connect` (in `src/*` and `cjs/src/*`) and creates db
- * spans matching the OTel `postgresJsIntegration`. Requires the orchestrion runtime
+ * spans matching the OTel `postgresJsIntegration`. Requires the Sentry runtime
  * hook or bundler plugin.
  */
 export const postgresJsIntegration = defineIntegration(_postgresJsIntegration);

--- a/packages/server-utils/src/integrations/postgres.ts
+++ b/packages/server-utils/src/integrations/postgres.ts
@@ -274,12 +274,12 @@ function getConnectionString(params: PgConnectionParams): string {
 }
 
 /**
- * Orchestrion-driven `pg` (node-postgres) integration.
+ * Diagnostics-channel-based `pg` (node-postgres) integration.
  *
  * Subscribes to the `orchestrion:pg:query`/`:connect` and
- * `orchestrion:pg-pool:connect` diagnostics_channels that the orchestrion code
+ * `orchestrion:pg-pool:connect` diagnostics_channels that Sentry's code
  * transform injects into `pg`'s `Client.prototype.query`/`connect`
- * and `pg-pool`'s `Pool.prototype.connect`. Requires the orchestrion runtime
+ * and `pg-pool`'s `Pool.prototype.connect`. Requires the Sentry runtime
  * hook or bundler plugin to be active.
  */
 export const postgresIntegration = defineIntegration(_postgresIntegration);

--- a/packages/server-utils/src/integrations/redis/index.ts
+++ b/packages/server-utils/src/integrations/redis/index.ts
@@ -312,7 +312,7 @@ function instrumentNodeRedis(options: RedisIntegrationOptions): void {
  * [ioredis](https://www.npmjs.com/package/ioredis) libraries.
  *
  * A single integration covers every client version: `redis` v2-v3, node-redis v4/v5 (`@redis/client`)
- * and ioredis `<5.11.0` via orchestrion channels, and node-redis `>=5.12.0` / ioredis `>=5.11.0` via
+ * and ioredis `<5.11.0` via injected channels, and node-redis `>=5.12.0` / ioredis `>=5.11.0` via
  * their native `diagnostics_channel`. Captures single commands, `connect`, and multi/pipeline batches,
  * plus cache spans for keys matching the configured `cachePrefixes`.
  *

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -248,10 +248,10 @@ function instrumentTedious(): void {
 }
 
 /**
- * Orchestrion-driven tedious integration.
+ * Diagnostics-channel-based tedious integration.
  *
- * Subscribes to the `orchestrion:tedious:*` diagnostics_channels that the orchestrion code transform
+ * Subscribes to the `orchestrion:tedious:*` diagnostics_channels that Sentry's code transform
  * injects into tedious's `Connection` request methods (each traced as one db span) and `Connection.connect`
- * (active-database bookkeeping). Requires the orchestrion runtime hook or bundler plugin to be active.
+ * (active-database bookkeeping). Requires the Sentry runtime hook or bundler plugin to be active.
  */
 export const tediousIntegration = defineIntegration(_tediousIntegration);

--- a/packages/server-utils/src/integrations/vercel-ai/index.ts
+++ b/packages/server-utils/src/integrations/vercel-ai/index.ts
@@ -33,7 +33,7 @@ const _vercelAIIntegration = ((options: VercelAiOptions = {}) => {
 /**
  * Auto-instrument the `ai` SDK. Supported are:
  * - v7 via native `ai:telemetry` tracing channel
- * - v4, v5 & v6 via orchestrion `orchestrion:ai:*` channels
+ * - v4, v5 & v6 via the injected `orchestrion:ai:*` channels
  */
 export const vercelAIIntegration = defineIntegration(_vercelAIIntegration);
 

--- a/packages/server-utils/src/integrations/vercel-ai/vercel-ai-orchestrion-subscriber.ts
+++ b/packages/server-utils/src/integrations/vercel-ai/vercel-ai-orchestrion-subscriber.ts
@@ -203,7 +203,7 @@ export function subscribeVercelAiOrchestrionChannels(
     );
     subscribeResolveLanguageModel(tracingChannel, CHANNELS.VERCEL_AI_RESOLVE_LANGUAGE_MODEL, options);
   } catch {
-    DEBUG_BUILD && debug.log('Vercel AI orchestrion channel subscription failed.');
+    DEBUG_BUILD && debug.log('Vercel AI channel subscription failed.');
   }
 }
 
@@ -578,7 +578,7 @@ function patchOperationTools(tools: Record<string, unknown>, options: VercelAiCh
       }
     }
   } catch {
-    DEBUG_BUILD && debug.log('Vercel AI orchestrion tool patching failed.');
+    DEBUG_BUILD && debug.log('Vercel AI tool patching failed.');
   }
 }
 

--- a/packages/server-utils/src/orchestrion/bundler/esbuild.ts
+++ b/packages/server-utils/src/orchestrion/bundler/esbuild.ts
@@ -1,5 +1,7 @@
 import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/esbuild';
 import type { Plugin } from 'esbuild';
+
+export type { Plugin as EsbuildPlugin } from 'esbuild';
 import { escapeStringForRegex } from '@sentry/core';
 import { instrumentedModuleNames } from '../config';
 import type { PluginOptions } from './options';

--- a/packages/server-utils/src/orchestrion/bundler/rollup.ts
+++ b/packages/server-utils/src/orchestrion/bundler/rollup.ts
@@ -1,5 +1,7 @@
 import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/rollup';
 import type { NormalizedInputOptions, Plugin, PluginContext } from 'rollup';
+
+export type { Plugin as RollupPlugin } from 'rollup';
 import { instrumentedModuleNames } from '../config';
 import type { PluginOptions } from './options';
 import { externalizedModulesWarning, orchestrionTransformOptions } from './options';

--- a/packages/server-utils/src/orchestrion/bundler/vite.ts
+++ b/packages/server-utils/src/orchestrion/bundler/vite.ts
@@ -1,5 +1,7 @@
 import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/vite';
 import type { Plugin, ResolvedConfig } from 'vite';
+
+export type { Plugin as VitePlugin } from 'vite';
 import { instrumentedModuleNames } from '../config';
 import type { PluginOptions } from './options';
 import { externalEntryMatchesModule, externalizedModulesWarning, orchestrionTransformOptions } from './options';

--- a/packages/server-utils/src/orchestrion/instrumentation.ts
+++ b/packages/server-utils/src/orchestrion/instrumentation.ts
@@ -59,12 +59,12 @@ export function invokeOrchestrionInstrumentation<Callback extends Instrumentatio
 
   // `tracingChannel` is unavailable before Node 18.19; nothing to subscribe to.
   if (!diagnosticsChannel.tracingChannel) {
-    DEBUG_BUILD && debug.log(`[orchestrion:${label}] no \`tracingChannel\` (Node < 18.19), not subscribing`);
+    DEBUG_BUILD && debug.log(`[instrumentation:${label}] no \`tracingChannel\` (Node < 18.19), not subscribing`);
     return;
   }
 
   if (hasBeenInstrumented(callback)) {
-    DEBUG_BUILD && debug.log(`[orchestrion:${label}] already subscribed, skipping`);
+    DEBUG_BUILD && debug.log(`[instrumentation:${label}] already subscribed, skipping`);
     return;
   }
 
@@ -77,7 +77,7 @@ export function invokeOrchestrionInstrumentation<Callback extends Instrumentatio
       }
       markInstrumented(callback);
       cleanup?.();
-      DEBUG_BUILD && debug.log(`[orchestrion:${label}] subscribing to channels`);
+      DEBUG_BUILD && debug.log(`[instrumentation:${label}] subscribing to channels`);
       callback(...args);
     };
 
@@ -95,12 +95,12 @@ export function invokeOrchestrionInstrumentation<Callback extends Instrumentatio
     // silently. Not being subscribed by now means we took that path, so say so:
     // without this, an integration that never subscribes leaves no trace at all.
     if (DEBUG_BUILD && !hasBeenInstrumented(callback)) {
-      debug.log(`[orchestrion:${label}] async-context binding not ready, retrying before subscribing`);
+      debug.log(`[instrumentation:${label}] async-context binding not ready, retrying before subscribing`);
     }
   };
 
   if (isBun || isDeno) {
-    DEBUG_BUILD && debug.log(`[orchestrion:${label}] Bun/Deno, subscribing eagerly`);
+    DEBUG_BUILD && debug.log(`[instrumentation:${label}] Bun/Deno, subscribing eagerly`);
     run();
     return;
   }
@@ -108,12 +108,12 @@ export function invokeOrchestrionInstrumentation<Callback extends Instrumentatio
   const injected = getOrchestrionInjectedModules();
   const injectedName = moduleNames.find(name => injected.includes(name));
   if (injectedName) {
-    DEBUG_BUILD && debug.log(`[orchestrion:${label}] "${injectedName}" already injected, subscribing now`);
+    DEBUG_BUILD && debug.log(`[instrumentation:${label}] "${injectedName}" already injected, subscribing now`);
     run();
     return;
   }
 
-  DEBUG_BUILD && debug.log(`[orchestrion:${label}] not injected yet, waiting for the module to load`);
+  DEBUG_BUILD && debug.log(`[instrumentation:${label}] not injected yet, waiting for the module to load`);
 
   const cleanup = client.on('orchestrion.module-injected', (moduleName: string) => {
     if (hasBeenInstrumented(callback)) {
@@ -121,7 +121,7 @@ export function invokeOrchestrionInstrumentation<Callback extends Instrumentatio
       return;
     }
     if (moduleNames.includes(moduleName)) {
-      DEBUG_BUILD && debug.log(`[orchestrion:${label}] "${moduleName}" injected at runtime, subscribing now`);
+      DEBUG_BUILD && debug.log(`[instrumentation:${label}] "${moduleName}" injected at runtime, subscribing now`);
       run(cleanup);
     }
   });

--- a/packages/server-utils/src/orchestrion/runtime/register.ts
+++ b/packages/server-utils/src/orchestrion/runtime/register.ts
@@ -49,7 +49,7 @@ export function registerDiagnosticsChannelInjection(): void {
 
   setDiagnosticsHook(({ moduleName, error }): void => {
     if (error) {
-      debug.warn(`[orchestrion] failed to inject diagnostics-channel into ${moduleName}:`, error);
+      debug.warn(`[instrumentation] failed to inject diagnostics-channel into ${moduleName}:`, error);
     } else {
       GLOBAL_OBJ.__SENTRY_ORCHESTRION__ = GLOBAL_OBJ.__SENTRY_ORCHESTRION__ || {};
       GLOBAL_OBJ.__SENTRY_ORCHESTRION__.runtime = GLOBAL_OBJ.__SENTRY_ORCHESTRION__.runtime || [];

--- a/packages/server-utils/src/tracing-channel.ts
+++ b/packages/server-utils/src/tracing-channel.ts
@@ -98,7 +98,7 @@ export function safeChannelCallback<T>(fn: () => T): T | undefined {
   try {
     return fn();
   } catch (error) {
-    DEBUG_BUILD && debug.warn('[orchestrion] error handling channel event', error);
+    DEBUG_BUILD && debug.warn('[instrumentation] error handling channel event', error);
     return undefined;
   }
 }


### PR DESCRIPTION
Orchestrion is internal tooling, so this rewords debug-log prefixes (`[orchestrion:express]` → `[instrumentation:express]`), JSDoc on publicly re-exported integrations, and the `@sentry/deno` README so the name no longer shows up in customer terminals, IDE hover text, or npm-rendered docs. The `@sentry/node` bundler plugin types are now derived explicitly so the emitted `.d.ts` stops referencing `@sentry/server-utils/orchestrion` symbols. No identifiers, export subpaths, client hook names, or diagnostics channel names change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8UfMdJmd1kxCRkT9XC9uf)_