### PR TITLE
ref(react-router)!: Move Vite plugin exports to subpath `@sentry/react-router/vite`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/react-router.config.ts
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/react-router.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from '@react-router/dev/config';
-import { sentryOnBuildEnd } from '@sentry/react-router';
+import { sentryOnBuildEnd } from '@sentry/react-router/vite';
 
 export default {
   appDirectory: 'app',

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/vite.config.ts
@@ -3,7 +3,7 @@ import { hydrogen } from '@shopify/hydrogen/vite';
 import { oxygen } from '@shopify/mini-oxygen/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
+import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router/vite';
 
 const sentryConfig: SentryReactRouterBuildOptions = {
   org: 'example-org',

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/vite.config.ts
@@ -1,5 +1,5 @@
 import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter } from '@sentry/react-router';
+import { sentryReactRouter } from '@sentry/react-router/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig(async config => ({

--- a/dev-packages/e2e-tests/test-applications/react-router-8-cloudflare/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-cloudflare/vite.config.ts
@@ -1,6 +1,6 @@
 import { cloudflare } from '@cloudflare/vite-plugin';
 import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter } from '@sentry/react-router';
+import { sentryReactRouter } from '@sentry/react-router/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig(async config => ({

--- a/dev-packages/e2e-tests/test-applications/react-router-8-framework/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-framework/vite.config.ts
@@ -1,5 +1,5 @@
 import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter } from '@sentry/react-router';
+import { sentryReactRouter } from '@sentry/react-router/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig(config => {

--- a/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/react-router.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/react-router.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from '@react-router/dev/config';
-import { sentryOnBuildEnd } from '@sentry/react-router';
+import { sentryOnBuildEnd } from '@sentry/react-router/vite';
 
 export default {
   ssr: true,

--- a/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/vite.config.ts
@@ -1,5 +1,5 @@
 import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router';
+import { sentryReactRouter, type SentryReactRouterBuildOptions } from '@sentry/react-router/vite';
 import { defineConfig } from 'vite';
 
 // Guards against debug IDs being injected twice - once by the Vite plugin and once by

--- a/docs/migration/v11-end-state.md
+++ b/docs/migration/v11-end-state.md
@@ -745,6 +745,24 @@ Affected SDKs: `@sentry/cloudflare`.
 + import { wrapRequestHandler } from '@sentry/cloudflare/request';
 ```
 
+### React Router: Vite plugin moved to `@sentry/react-router/vite`
+
+Affected SDKs: `@sentry/react-router`.
+
+`sentryReactRouter`, `sentryOnBuildEnd`, `makeConfigInjectorPlugin` and the `SentryReactRouterBuildOptions` type are no longer available from the main `@sentry/react-router` entry point. Import them from the dedicated subpath instead:
+
+```diff
+// vite.config.ts
+- import { sentryReactRouter } from '@sentry/react-router';
++ import { sentryReactRouter } from '@sentry/react-router/vite';
+```
+
+```diff
+// react-router.config.ts
+- import { sentryOnBuildEnd } from '@sentry/react-router';
++ import { sentryOnBuildEnd } from '@sentry/react-router/vite';
+```
+
 ## 3. Removed APIs
 
 ### `@sentry/core` / All SDKs

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -155,7 +155,7 @@ Update your vite.config.ts file to include the `sentryReactRouter` plugin and al
 
 ```ts
 import { reactRouter } from '@react-router/dev/vite';
-import { sentryReactRouter } from '@sentry/react-router';
+import { sentryReactRouter } from '@sentry/react-router/vite';
 import { defineConfig } from 'vite';
 
 const sentryConfig = {
@@ -177,7 +177,7 @@ Next, in your `react-router.config.ts` file, include the `sentryOnBuildEnd` hook
 
 ```ts
 import type { Config } from '@react-router/dev/config';
-import { sentryOnBuildEnd } from '@sentry/react-router';
+import { sentryOnBuildEnd } from '@sentry/react-router/vite';
 
 export default {
   ssr: true,

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -39,6 +39,11 @@
       "require": "./build/cjs/cloudflare/index.js",
       "types": "./build/types/cloudflare/index.d.ts",
       "default": "./build/esm/cloudflare/index.js"
+    },
+    "./vite": {
+      "types": "./build/types/vite/index.d.ts",
+      "import": "./build/esm/vite/index.js",
+      "require": "./build/cjs/vite/index.js"
     }
   },
   "publishConfig": {

--- a/packages/react-router/rollup.npm.config.mjs
+++ b/packages/react-router/rollup.npm.config.mjs
@@ -7,7 +7,7 @@ import { makeBaseNPMConfig, makeNPMConfigVariants } from '@sentry-internal/rollu
 export default [
   ...makeNPMConfigVariants(
     makeBaseNPMConfig({
-      entrypoints: ['src/index.server.ts', 'src/index.client.ts', 'src/cloudflare/index.ts'],
+      entrypoints: ['src/index.server.ts', 'src/index.client.ts', 'src/cloudflare/index.ts', 'src/vite/index.ts'],
       packageSpecificConfig: {
         external: ['react-router', 'react-router-dom', 'react', 'react/jsx-runtime', 'vite'],
         output: {

--- a/packages/react-router/src/index.server.ts
+++ b/packages/react-router/src/index.server.ts
@@ -1,2 +1,1 @@
 export * from './server';
-export * from './vite';

--- a/packages/react-router/src/index.types.ts
+++ b/packages/react-router/src/index.types.ts
@@ -9,7 +9,6 @@ import type * as serverSdk from './server';
 // re-define colliding type exports below
 export * from './client';
 export * from './server';
-export * from './vite';
 
 /** Initializes Sentry React Router SDK */
 export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;


### PR DESCRIPTION
`sentryReactRouter`, `sentryOnBuildEnd`, `makeConfigInjectorPlugin` and `SentryReactRouterBuildOptions` are no longer re-exported from the main entry point. They now live on a dedicated `./vite` subpath.

These are build-time only APIs, but the static re-export meant a server-side `import * as Sentry from '@sentry/react-router'` eagerly pulled `@sentry/bundler-plugins`, `@sentry/cli` and `glob` into the running server's module graph. Since the root entry had no narrower subpath to fall back on, consumers had no way to opt out.

Brings the package in line with `@sentry/sveltekit`, `@sentry/solidstart` and `@sentry/tanstackstart-react`, which all already ship a `./vite` subpath and keep the plugin out of their server entry.

Fixes #23495