### PR TITLE
ref(node): Fix flaky ANR stop-and-restart test with deterministic worker-ready signal

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -52,7 +52,11 @@ setTimeout(() => {
     setTimeout(() => {
       anr.startWorker();
 
-      setTimeout(() => {
+      // Wait for the restarted worker to reconnect its debugger session before blocking the event
+      // loop. The main-thread inspector stays open across restarts, so there is no main-thread signal
+      // that the new worker is ready; without this, on slow CI `longWork` can run before the worker
+      // is sampling and the ANR is missed entirely.
+      anr.waitUntilWorkerReady().then(() => {
         longWork();
       });
     }, 2000);

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -1,5 +1,4 @@
 const Sentry = require('@sentry/node');
-const { waitForDebuggerReady } = require('@sentry-internal/test-utils');
 
 setTimeout(() => {
   process.exit();

--- a/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
+++ b/dev-packages/node-integration-tests/suites/anr/stop-and-start.js
@@ -53,9 +53,11 @@ setTimeout(() => {
     setTimeout(() => {
       anr.startWorker();
 
-      // Wait for the restarted worker's debugger session to reconnect before blocking the event
-      // loop, otherwise on slow CI the worker isn't ready to sample and the ANR is missed entirely.
-      waitForDebuggerReady(() => {
+      // Wait for the restarted worker to reconnect its debugger session before blocking the event
+      // loop. The main-thread inspector stays open across restarts, so there is no main-thread signal
+      // that the new worker is ready; without this, on slow CI `longWork` can run before the worker
+      // is sampling and the ANR is missed entirely.
+      anr.waitUntilWorkerReady().then(() => {
         longWork();
       });
     }, 2000);

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -60,12 +60,17 @@ async function getContexts(client: NodeClient): Promise<Contexts> {
 
 const INTEGRATION_NAME = 'Anr' as const;
 
-type AnrInternal = { startWorker: () => void; stopWorker: () => void };
+type AnrInternal = {
+  startWorker: () => void;
+  stopWorker: () => void;
+  waitUntilWorkerReady: () => Promise<void>;
+};
 
 // eslint-disable-next-line typescript/no-deprecated
 const _anrIntegration = ((options: Partial<AnrIntegrationOptions> = {}) => {
   let worker: Promise<() => void> | undefined;
   let client: NodeClient | undefined;
+  let workerReady: Promise<void> | undefined;
 
   // Hookup the scope fetch function to the global object so that it can be called from the worker thread via the
   // debugger when it pauses
@@ -79,12 +84,16 @@ const _anrIntegration = ((options: Partial<AnrIntegrationOptions> = {}) => {
         return;
       }
 
-      if (client) {
-        worker = _startWorker(client, options);
+      const initializedClient = client;
+      if (initializedClient) {
+        workerReady = new Promise<void>(resolve => {
+          worker = _startWorker(initializedClient, options, resolve);
+        });
       }
     },
     stopWorker: () => {
       if (worker) {
+        workerReady = undefined;
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         worker.then(stop => {
           stop();
@@ -92,6 +101,7 @@ const _anrIntegration = ((options: Partial<AnrIntegrationOptions> = {}) => {
         });
       }
     },
+    waitUntilWorkerReady: () => workerReady ?? Promise.resolve(),
     async setup(initClient: NodeClient) {
       client = initClient;
 
@@ -157,6 +167,7 @@ async function _startWorker(
   client: NodeClient,
   // eslint-disable-next-line typescript/no-deprecated
   integrationOptions: Partial<AnrIntegrationOptions>,
+  onReady?: () => void,
 ): Promise<() => void> {
   const dsn = client.getDsn();
 
@@ -234,6 +245,8 @@ async function _startWorker(
     if (msg === 'session-ended') {
       log('ANR event sent from ANR worker. Clearing session in this thread.');
       getIsolationScope().setSession(undefined);
+    } else if (msg === 'worker-ready') {
+      onReady?.();
     }
   });
 

--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -328,3 +328,9 @@ parentPort?.on('message', (msg: { session: Session | undefined; debugImages?: Re
 
   poll();
 });
+
+// Signal that the worker is fully set up: the inspector session (when capturing stack traces) is
+// connected to the main thread and the watchdog is armed. Consumers that restart the worker can wait
+// for this before blocking the event loop, since the main-thread inspector stays open across restarts
+// and gives no signal that the new worker has reconnected.
+parentPort?.postMessage('worker-ready');

--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -325,3 +325,9 @@ parentPort?.on('message', (msg: { session: Session | undefined; debugImages?: Re
 
   poll();
 });
+
+// Signal that the worker is fully set up: the inspector session (when capturing stack traces) is
+// connected to the main thread and the watchdog is armed. Consumers that restart the worker can wait
+// for this before blocking the event loop, since the main-thread inspector stays open across restarts
+// and gives no signal that the new worker has reconnected.
+parentPort?.postMessage('worker-ready');


### PR DESCRIPTION
The `anr/stop-and-start` integration test restarts the ANR worker and then blocks the event loop, expecting the restarted worker to sample and report the ANR. The gate before `longWork` was ineffective, so on slow CI the event loop could block before the new worker had reconnected — and the ANR was missed, making the test flaky.

### Root cause

`waitForDebuggerReady` polls `inspector.url()`. That works for the *initial* worker start (where `inspector.open(0)` flips `inspector.url()` from unset to set), but it cannot gate a *restart*:

- The ANR integration opens the main-thread inspector once and never calls `inspector.close()`, so `inspector.url()` stays truthy across `stopWorker()`/`startWorker()`. The poll returns immediately and only a fixed ~200ms delay remains.
- `_startWorker` is `async` (it awaits `getContexts`), so when the poll passes the new worker may not even be spawned yet.

The main thread has no observable signal that the *new* worker's `InspectorSession` has reconnected, so any main-thread poll or fixed delay is a race.

### Change

The worker now posts a `worker-ready` message once it is fully set up (inspector session connected when capturing stack traces, watchdog armed, message handler registered). The integration tracks this and exposes an internal `waitUntilWorkerReady()`, which the restart path awaits instead of relying on a fixed delay. This makes readiness deterministic rather than timing-dependent.

The flake exists on `develop` too (the restart path there blocks after a bare `setTimeout(..., 0)`), which is why this is a standalone fix rather than part of any feature branch.