### PR TITLE
test(bun): Fix integration test on Bun 1.4.0

### DIFF
--- a/packages/bun/test/integrations/bunHttpServer.test.ts
+++ b/packages/bun/test/integrations/bunHttpServer.test.ts
@@ -60,13 +60,15 @@ describe('Bun HTTP Server Integration', () => {
     let span: ReturnType<typeof spanToJSON> | undefined;
 
     const { port, close } = await startServer((req, res) => {
+      // Read the span synchronously: once a request body is streamed, the 'data'/'end' events fire
+      // outside the handler's async context, so `getActiveSpan()` is empty there. This is how Node
+      // behaves too; Bun < 1.4 was more lenient, which is why reading it in 'end' used to work.
+      const activeSpan = getActiveSpan();
+      span = activeSpan ? spanToJSON(activeSpan) : undefined;
+
       const chunks: Buffer[] = [];
       req.on('data', chunk => chunks.push(chunk));
-      req.on('end', () => {
-        const activeSpan = getActiveSpan();
-        span = activeSpan ? spanToJSON(activeSpan) : undefined;
-        res.end(Buffer.concat(chunks));
-      });
+      req.on('end', () => res.end(Buffer.concat(chunks)));
     });
 
     const response = await fetch(`http://localhost:${port}/search`, {


### PR DESCRIPTION
Read the active span before the request body is consumed.

The CI uses another Bun version (`1.3.14`). Locally, I use 1.4.0 and this test kept failing because of how this version behaves. Bun now behaves more like Node and it looses request context in `end`. 

I fixed the test assertion so the test works again for Bun 1.4.0.
