### PR TITLE
test(nextjs): Expect `route` span source in nextjs-orpc e2e tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/tests/orpc-tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/tests/orpc-tracing.test.ts
@@ -21,7 +21,7 @@ test('should trace orpc server component', async ({ page }) => {
     data: {
       'sentry.origin': 'auto.pageload.nextjs.app_router_instrumentation',
       'sentry.op': 'pageload',
-      'sentry.source': 'url',
+      'sentry.source': 'route',
     },
     op: 'pageload',
     origin: 'auto.pageload.nextjs.app_router_instrumentation',
@@ -77,7 +77,7 @@ test('should trace orpc client component', async ({ page }) => {
     data: {
       'sentry.op': 'navigation',
       'sentry.origin': 'auto.navigation.nextjs.app_router_instrumentation',
-      'sentry.source': 'url',
+      'sentry.source': 'route',
       'sentry.previous_trace': expect.any(String),
     },
     op: 'navigation',


### PR DESCRIPTION
Aligns the `nextjs-orpc` pageload and navigation expectations with #23503, which started annotating static routes as low-cardinality (`source: 'route'`) but missed this app.