### PR TITLE
test(nextjs): Drop nextjs-16-cf-workers canary variant

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -45,12 +45,6 @@
         "build-command": "pnpm test:build-latest",
         "label": "nextjs-16-cf-workers (latest)"
       }
-    ],
-    "optionalVariants": [
-      {
-        "build-command": "pnpm test:build-canary",
-        "label": "nextjs-16-cf-workers (canary)"
-      }
     ]
   }
 }


### PR DESCRIPTION
Removes the `nextjs-16-cf-workers (canary)` E2E variant while the upstream fix is pending.


Refs #23541 for restoring the variant.