### PR TITLE
chore(deps): Bump `@sentry/conventions` to 0.20.0

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -63,7 +63,7 @@
     "@sentry/browser": "10.67.0",
     "@sentry/replay": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",
-    "@sentry/conventions": "0.19.0",
+    "@sentry/conventions": "0.20.0",
     "@supabase/supabase-js": "2.109.0",
     "axios": "1.18.0",
     "babel-loader": "^10.1.1",

--- a/dev-packages/cloudflare-integration-tests/package.json
+++ b/dev-packages/cloudflare-integration-tests/package.json
@@ -33,7 +33,7 @@
     "@cloudflare/workers-types": "^4.20260426.0",
     "@cloudflare/workers-types-v5": "npm:@cloudflare/workers-types@5.20260710.1",
     "@sentry-internal/test-utils": "10.67.0",
-    "@sentry/conventions": "0.19.0",
+    "@sentry/conventions": "0.20.0",
     "eslint-plugin-regexp": "^3.1.0",
     "prisma": "6.15.0",
     "vite": "7.3.5",

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -103,7 +103,7 @@
   },
   "devDependencies": {
     "@opentelemetry/instrumentation-http": "0.220.0",
-    "@sentry/conventions": "0.19.0",
+    "@sentry/conventions": "0.20.0",
     "@sentry-internal/test-utils": "10.67.0",
     "@types/amqplib": "^0.10.5",
     "@types/node-cron": "^3.0.11",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -22,7 +22,7 @@ import {
   getAbsoluteUrl,
 } from '@sentry/browser';
 import { CODE_FUNCTION_NAME, SENTRY_OP, URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import type { Integration, Span } from '@sentry/core';
 import {
   debug,
@@ -399,7 +399,7 @@ export function TraceMethod(options?: TraceMethodOptions): MethodDecorator {
           name: `<${options?.name ? options.name : 'unnamed'}>`,
           startTime: now,
           attributes: {
-            [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+            [SENTRY_OP]: FUNCTION,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular.trace_method_decorator',
             [CODE_FUNCTION_NAME]: String(propertyKey),
           },

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0"

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0",

--- a/packages/aws-serverless/src/requestSpanOptions.ts
+++ b/packages/aws-serverless/src/requestSpanOptions.ts
@@ -26,7 +26,7 @@ import {
   SENTRY_OP,
   URL_FULL,
 } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_AWS_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_AWS } from '@sentry/conventions/op';
 import type { SpanAttributes, StartSpanOptions } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, filterCollectedUrl } from '@sentry/core';
 import type { Context } from 'aws-lambda';
@@ -48,7 +48,7 @@ export function getRequestSpanOptions(event: unknown, context: Context, requestI
     name: context.functionName,
     forceTransaction: true,
     attributes: {
-      [SENTRY_OP]: FAAS_FUNCTION_AWS_SPAN_OP,
+      [SENTRY_OP]: FUNCTION_AWS,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.otel.aws_lambda',
       [SENTRY_KIND]: 'server',
       [ATTR_FAAS_EXECUTION]: context.awsRequestId,

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "web-vitals": "^6.0.1"
   },
   "scripts": {

--- a/packages/browser-utils/src/performance/entries.ts
+++ b/packages/browser-utils/src/performance/entries.ts
@@ -10,7 +10,7 @@ import {
   filterCollectedUrl,
 } from '@sentry/core';
 import { CODE_FILE_PATH, CODE_FUNCTION_NAME, SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
-import { BROWSER_BROWSER_PAINT_SPAN_OP } from '@sentry/conventions/op';
+import { BROWSER_PAINT } from '@sentry/conventions/op';
 import {
   addPerformanceInstrumentationHandler,
   type PerformanceLongAnimationFrameTiming,
@@ -250,7 +250,7 @@ function _addPaintSpan(
   startAndEndSpan(span, startTimestamp, startTimestamp + duration, {
     name: entry.name,
     attributes: {
-      [SENTRY_OP]: BROWSER_BROWSER_PAINT_SPAN_OP,
+      [SENTRY_OP]: BROWSER_PAINT,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.resource.browser.metrics',
     },
   });

--- a/packages/browser-utils/src/performance/interactions.ts
+++ b/packages/browser-utils/src/performance/interactions.ts
@@ -6,7 +6,7 @@ import {
   SENTRY_SOURCE,
   SENTRY_SEGMENT_NAME_SOURCE,
 } from '@sentry/conventions/attributes';
-import { BROWSER_UI_INTERACTION_CLICK_SPAN_OP, BROWSER_UI_ACTION_CLICK_SPAN_OP } from '@sentry/conventions/op';
+import { UI_INTERACTION_CLICK, UI_ACTION_CLICK } from '@sentry/conventions/op';
 import type { IntegrationFn, Span, StartSpanOptions, TransactionSource } from '@sentry/core';
 import {
   browserPerformanceTimeOrigin,
@@ -155,7 +155,7 @@ function registerInteractionListener(
       if (getInflightRouteSpan()) {
         DEBUG_BUILD &&
           debug.warn(
-            `[Tracing] Did not create ${BROWSER_UI_ACTION_CLICK_SPAN_OP} span because a pageload or navigation span is in progress.`,
+            `[Tracing] Did not create ${UI_ACTION_CLICK} span because a pageload or navigation span is in progress.`,
           );
         return;
       }
@@ -168,9 +168,7 @@ function registerInteractionListener(
 
       if (!latestRoute.name) {
         DEBUG_BUILD &&
-          debug.warn(
-            `[Tracing] Did not create ${BROWSER_UI_ACTION_CLICK_SPAN_OP} span because the latest route name is missing.`,
-          );
+          debug.warn(`[Tracing] Did not create ${UI_ACTION_CLICK} span because the latest route name is missing.`);
         return;
       }
 
@@ -178,7 +176,7 @@ function registerInteractionListener(
         {
           name: latestRoute.name,
           attributes: {
-            [SENTRY_OP]: BROWSER_UI_ACTION_CLICK_SPAN_OP,
+            [SENTRY_OP]: UI_ACTION_CLICK,
             [SENTRY_SEGMENT_NAME_SOURCE]: latestRoute.source || 'url',
             [SENTRY_ORIGIN]: 'auto.browser.interactions',
           },
@@ -208,7 +206,7 @@ function trackInteractionsAsSpans(): void {
           name: htmlTreeAsString(entry.target),
           startTime: startTime,
           attributes: {
-            [SENTRY_OP]: BROWSER_UI_INTERACTION_CLICK_SPAN_OP,
+            [SENTRY_OP]: UI_INTERACTION_CLICK,
             [SENTRY_ORIGIN]: 'auto.browser.interactions',
           },
         };

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@sentry/browser-utils": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/feedback": "10.67.0",
     "@sentry/replay": "10.67.0",
     "@sentry/replay-canvas": "10.67.0",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.4",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"
   },

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "magic-string": "~0.30.21"

--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { WEB_SERVER_WEBSOCKET_SPAN_OP } from '@sentry/conventions/op';
+import { WEBSOCKET } from '@sentry/conventions/op';
 import { captureException, isObjectLike } from '@sentry/core';
 import type { DurableObject } from 'cloudflare:workers';
 import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';
@@ -200,7 +200,7 @@ function instrumentDurableObjectHandlers<E, T extends DurableObject<E>>(
         options,
         context,
         spanName: 'webSocketMessage',
-        spanOp: WEB_SERVER_WEBSOCKET_SPAN_OP,
+        spanOp: WEBSOCKET,
         origin: 'auto.faas.cloudflare.durable_object',
       },
       obj.webSocketMessage.bind(obj),
@@ -213,7 +213,7 @@ function instrumentDurableObjectHandlers<E, T extends DurableObject<E>>(
         options,
         context,
         spanName: 'webSocketClose',
-        spanOp: WEB_SERVER_WEBSOCKET_SPAN_OP,
+        spanOp: WEBSOCKET,
         origin: 'auto.faas.cloudflare.durable_object',
       },
       obj.webSocketClose.bind(obj),
@@ -226,7 +226,7 @@ function instrumentDurableObjectHandlers<E, T extends DurableObject<E>>(
         options,
         context,
         spanName: 'webSocketError',
-        spanOp: WEB_SERVER_WEBSOCKET_SPAN_OP,
+        spanOp: WEBSOCKET,
         origin: 'auto.faas.cloudflare.durable_object',
       },
       obj.webSocketError.bind(obj),

--- a/packages/cloudflare/src/instrumentations/worker/instrumentEmail.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentEmail.ts
@@ -2,7 +2,7 @@ import type { EmailMessage } from '@cloudflare/workers-types';
 import type { AnyExportedHandler } from '../../types';
 import type { env as cloudflareEnv } from 'cloudflare:workers';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import {
   captureException,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -40,7 +40,7 @@ function wrapEmailHandler(
       {
         name: `Handle Email ${emailMessage.to}`,
         attributes: {
-          [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+          [SENTRY_OP]: FUNCTION,
           'faas.trigger': 'email',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.faas.cloudflare.email',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'task',

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueue.ts
@@ -2,7 +2,7 @@ import type { MessageBatch } from '@cloudflare/workers-types';
 import type { AnyExportedHandler } from '../../types';
 import type { env as cloudflareEnv, WorkerEntrypoint } from 'cloudflare:workers';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { MESSAGING_QUEUE_PROCESS_SPAN_OP } from '@sentry/conventions/op';
+import { QUEUE_PROCESS } from '@sentry/conventions/op';
 import {
   captureException,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -40,7 +40,7 @@ function wrapQueueHandler(
       {
         name: `process ${batch.queue}`,
         attributes: {
-          [SENTRY_OP]: MESSAGING_QUEUE_PROCESS_SPAN_OP,
+          [SENTRY_OP]: QUEUE_PROCESS,
           'faas.trigger': 'pubsub',
           'messaging.destination.name': batch.queue,
           'messaging.system': 'cloudflare',

--- a/packages/cloudflare/src/instrumentations/worker/instrumentRateLimit.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentRateLimit.ts
@@ -1,6 +1,6 @@
 import type { RateLimit, RateLimitOptions, RateLimitOutcome } from '@cloudflare/workers-types';
 import { RPC_SERVICE, SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_RPC_SPAN_OP } from '@sentry/conventions/op';
+import { RPC } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 
 const ORIGIN = 'auto.faas.cloudflare.rate_limit';
@@ -23,7 +23,7 @@ export function instrumentRateLimit<T extends RateLimit>(rateLimit: T, bindingNa
           {
             name: `rate_limit ${bindingName}`,
             attributes: {
-              [SENTRY_OP]: WEB_SERVER_RPC_SPAN_OP,
+              [SENTRY_OP]: RPC,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
               [RPC_SERVICE]: RATE_LIMIT_SERVICE,
             },

--- a/packages/cloudflare/src/instrumentations/worker/instrumentScheduled.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentScheduled.ts
@@ -2,7 +2,7 @@ import type { ScheduledController } from '@cloudflare/workers-types';
 import type { AnyExportedHandler } from '../../types';
 import type { env as cloudflareEnv, WorkerEntrypoint } from 'cloudflare:workers';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import {
   captureException,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -37,7 +37,7 @@ function wrapScheduledHandler(
       {
         name: `Scheduled Cron ${controller.cron}`,
         attributes: {
-          [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+          [SENTRY_OP]: FUNCTION,
           'faas.cron': controller.cron,
           'faas.time': new Date(controller.scheduledTime).toISOString(),
           'faas.trigger': 'timer',

--- a/packages/cloudflare/src/workflows.ts
+++ b/packages/cloudflare/src/workflows.ts
@@ -1,5 +1,5 @@
 import { CODE_FUNCTION_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import type { PropagationContext } from '@sentry/core';
 import {
   captureException,
@@ -123,7 +123,7 @@ class WrappedWorkflowStep implements WorkflowStep {
           name,
           scope: scopeForStep,
           attributes: {
-            [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+            [SENTRY_OP]: FUNCTION,
             [CODE_FUNCTION_NAME]: name,
             'workflow.step.name': name,
             'cloudflare.workflow.timeout': config?.timeout,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,6 +93,6 @@
     "zod": "^3.24.1"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.19.0"
+    "@sentry/conventions": "^0.20.0"
   }
 }

--- a/packages/core/src/integrations/express/patch-layer.ts
+++ b/packages/core/src/integrations/express/patch-layer.ts
@@ -28,7 +28,7 @@
  */
 
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../../debug-build';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR, withActiveSpan } from '../../tracing';
@@ -63,7 +63,7 @@ import { setSDKProcessingMetadata } from './set-sdk-processing-metadata';
 
 // TODO(conventions): Replace `'handler'` and `'router'` with their span op constants once they are released in `@sentry/conventions`.
 const EXPRESS_TYPE_TO_SPAN_OP: Record<string, string> = {
-  [ExpressLayerType_MIDDLEWARE]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+  [ExpressLayerType_MIDDLEWARE]: MIDDLEWARE,
   [ExpressLayerType_REQUEST_HANDLER]: 'handler',
   [ExpressLayerType_ROUTER]: 'router',
 };

--- a/packages/core/src/trpc.ts
+++ b/packages/core/src/trpc.ts
@@ -5,7 +5,7 @@ import {
   TRPC_PROCEDURE_PATH,
   TRPC_PROCEDURE_TYPE,
 } from '@sentry/conventions/attributes';
-import { WEB_SERVER_RPC_SPAN_OP } from '@sentry/conventions/op';
+import { RPC } from '@sentry/conventions/op';
 import { getClient, withIsolationScope } from './currentScopes';
 import { captureException } from './exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from './semanticAttributes';
@@ -94,7 +94,7 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
         {
           name: `trpc/${path}`,
           attributes: {
-            [SENTRY_OP]: WEB_SERVER_RPC_SPAN_OP,
+            [SENTRY_OP]: RPC,
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.rpc.trpc',
             [RPC_SYSTEM_NAME]: 'trpc',

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/server-utils": "10.67.0"
   },

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0"
   },

--- a/packages/effect/src/tracer.ts
+++ b/packages/effect/src/tracer.ts
@@ -1,9 +1,5 @@
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import {
-  GENERAL_FUNCTION_SPAN_OP,
-  WEB_SERVER_HTTP_CLIENT_SPAN_OP,
-  WEB_SERVER_HTTP_SERVER_SPAN_OP,
-} from '@sentry/conventions/op';
+import { FUNCTION, HTTP_CLIENT, HTTP_SERVER } from '@sentry/conventions/op';
 import type { Span, StartSpanOptions } from '@sentry/core';
 import { isObjectLike, getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, withActiveSpan } from '@sentry/core';
 import type * as Context from 'effect/Context';
@@ -26,14 +22,14 @@ function deriveOrigin(name: string): string {
  */
 function deriveOp(name: string): string {
   if (name.startsWith('http.server')) {
-    return WEB_SERVER_HTTP_SERVER_SPAN_OP;
+    return HTTP_SERVER;
   }
 
   if (name.startsWith('http.client')) {
-    return WEB_SERVER_HTTP_CLIENT_SPAN_OP;
+    return HTTP_CLIENT;
   }
 
-  return GENERAL_FUNCTION_SPAN_OP;
+  return FUNCTION;
 }
 
 type HrTime = [number, number];

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@sentry/bun": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0"
+    "@sentry/conventions": "^0.20.0"
   },
   "peerDependencies": {
     "elysia": "^1.4.0"

--- a/packages/elysia/src/withElysia.ts
+++ b/packages/elysia/src/withElysia.ts
@@ -1,5 +1,5 @@
 import { HTTP_ROUTE, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   captureException,
@@ -31,16 +31,16 @@ const ELYSIA_ORIGIN = 'auto.http.elysia';
  * Map Elysia lifecycle phase names to Sentry span ops.
  */
 const ELYSIA_LIFECYCLE_OP_MAP: Record<string, string> = {
-  Request: WEB_SERVER_MIDDLEWARE_SPAN_OP,
-  Parse: WEB_SERVER_MIDDLEWARE_SPAN_OP,
-  Transform: WEB_SERVER_MIDDLEWARE_SPAN_OP,
-  BeforeHandle: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+  Request: MIDDLEWARE,
+  Parse: MIDDLEWARE,
+  Transform: MIDDLEWARE,
+  BeforeHandle: MIDDLEWARE,
   // TODO(conventions): Replace with the `handler` span op constant once it is released in `@sentry/conventions`.
   Handle: 'handler',
-  AfterHandle: WEB_SERVER_MIDDLEWARE_SPAN_OP,
-  MapResponse: WEB_SERVER_MIDDLEWARE_SPAN_OP,
-  AfterResponse: WEB_SERVER_MIDDLEWARE_SPAN_OP,
-  Error: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+  AfterHandle: MIDDLEWARE,
+  MapResponse: MIDDLEWARE,
+  AfterResponse: MIDDLEWARE,
+  Error: MIDDLEWARE,
 };
 
 function isBun(): boolean {

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -44,7 +44,7 @@
     "@embroider/addon-shim": "^1.10.2",
     "@embroider/macros": "^1.20.2",
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "decorator-transforms": "^2.3.2"
   },

--- a/packages/ember/src/utils/instrumentEmberGlobals.ts
+++ b/packages/ember/src/utils/instrumentEmberGlobals.ts
@@ -1,7 +1,7 @@
 import { subscribe } from '@ember/instrumentation';
 import { scheduleOnce } from '@ember/runloop';
 import { SENTRY_OP, UI_COMPONENT_NAME } from '@sentry/conventions/attributes';
-import { BROWSER_UI_RENDER_SPAN_OP, BROWSER_UI_TASK_SPAN_OP, GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { UI_RENDER, UI_TASK, FUNCTION } from '@sentry/conventions/op';
 import { getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { browserPerformanceTimeOrigin, timestampInSeconds } from '@sentry/core';
@@ -90,7 +90,7 @@ function _instrumentEmberRunloop(config: { minimumRunloopQueueDuration?: number 
         if ((now - currentQueueStart) * 1000 >= minQueueDuration) {
           startInactiveSpan({
             attributes: {
-              [SENTRY_OP]: BROWSER_UI_TASK_SPAN_OP,
+              [SENTRY_OP]: UI_TASK,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.ember',
               'ember.runloop.queue': queue,
             },
@@ -183,12 +183,7 @@ function _instrumentComponents(config: {
       },
 
       after(_name: string, _timestamp: number, payload: object) {
-        _processComponentRenderAfter(
-          payload as Payload,
-          beforeEntries,
-          BROWSER_UI_RENDER_SPAN_OP,
-          minComponentDuration,
-        );
+        _processComponentRenderAfter(payload as Payload, beforeEntries, UI_RENDER, minComponentDuration);
       },
     });
     if (enableComponentDefinitions) {
@@ -198,12 +193,7 @@ function _instrumentComponents(config: {
         },
 
         after(_name: string, _timestamp: number, payload: object) {
-          _processComponentRenderAfter(
-            payload as Payload,
-            beforeComponentDefinitionEntries,
-            GENERAL_FUNCTION_SPAN_OP,
-            0,
-          );
+          _processComponentRenderAfter(payload as Payload, beforeComponentDefinitionEntries, FUNCTION, 0);
         },
       });
     }

--- a/packages/ember/src/utils/instrumentRoutePerformance.ts
+++ b/packages/ember/src/utils/instrumentRoutePerformance.ts
@@ -1,6 +1,6 @@
 import { startSpan } from '@sentry/browser';
 import { CODE_FUNCTION_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 
 import type Route from '@ember/routing/route';
@@ -45,7 +45,7 @@ export function instrumentRoutePerformance<T extends RouteConstructor>(BaseRoute
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.ember',
-          [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+          [SENTRY_OP]: FUNCTION,
           [CODE_FUNCTION_NAME]: hookName,
         },
         name,

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/cloud_events.ts
@@ -1,5 +1,5 @@
 import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_GCP } from '@sentry/conventions/op';
 import {
   debug,
   handleCallbackErrors,
@@ -40,7 +40,7 @@ function _wrapCloudEventFunction(
       {
         name: context.type || '<unknown>',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',

--- a/packages/google-cloud-serverless/src/gcpfunction/events.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/events.ts
@@ -1,5 +1,5 @@
 import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_GCP } from '@sentry/conventions/op';
 import {
   debug,
   handleCallbackErrors,
@@ -43,7 +43,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
       {
         name: context.eventType,
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',

--- a/packages/google-cloud-serverless/src/gcpfunction/http.ts
+++ b/packages/google-cloud-serverless/src/gcpfunction/http.ts
@@ -1,5 +1,5 @@
 import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_GCP } from '@sentry/conventions/op';
 import {
   debug,
   handleCallbackErrors,
@@ -54,7 +54,7 @@ function _wrapHttpFunction(fn: HttpFunction, options: Partial<WrapperOptions>): 
         {
           name: `${reqMethod} ${reqUrl}`,
           attributes: {
-            [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+            [SENTRY_OP]: FUNCTION_GCP,
             [FAAS_TRIGGER]: 'http',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_http',

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-grpc.ts
@@ -1,5 +1,5 @@
 import { RPC_METHOD, RPC_SERVICE, RPC_SYSTEM_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_GRPC_SPAN_OP } from '@sentry/conventions/op';
+import { GRPC } from '@sentry/conventions/op';
 import type { Client, IntegrationFn } from '@sentry/core';
 import { defineIntegration, fill, getClient, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { startInactiveSpan } from '@sentry/node';
@@ -105,7 +105,7 @@ export function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodNa
       name: `${callType} ${methodName}`,
       onlyIfParent: true,
       attributes: {
-        [SENTRY_OP]: FAAS_GRPC_SPAN_OP,
+        [SENTRY_OP]: GRPC,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.grpc.serverless',
         [RPC_SYSTEM_NAME]: 'grpc',
         [RPC_SERVICE]: serviceIdentifier,

--- a/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
+++ b/packages/google-cloud-serverless/src/integrations/google-cloud-http.ts
@@ -1,6 +1,6 @@
 import type * as common from '@google-cloud/common';
 import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS, URL_FULL } from '@sentry/conventions/attributes';
-import { WEB_SERVER_HTTP_CLIENT_SPAN_OP } from '@sentry/conventions/op';
+import { HTTP_CLIENT } from '@sentry/conventions/op';
 import type { Client, IntegrationFn } from '@sentry/core';
 import {
   defineIntegration,
@@ -62,7 +62,7 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
           name: `${httpMethod} ${stripUrlQueryAndFragment(reqOpts.uri)}`,
           onlyIfParent: true,
           attributes: {
-            [SENTRY_OP]: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
+            [SENTRY_OP]: HTTP_CLIENT,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
             [HTTP_REQUEST_METHOD]: httpMethod,
             [SERVER_ADDRESS]: getServerAddress(this.apiEndpoint),

--- a/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/cloud_event.test.ts
@@ -1,5 +1,5 @@
 import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_GCP } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { wrapCloudEventFunction } from '../../src/gcpfunction/cloud_events';
@@ -76,7 +76,7 @@ describe('wrapCloudEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
@@ -102,7 +102,7 @@ describe('wrapCloudEventFunction', () => {
         const fakeTransactionContext = {
           name: 'event.type',
           attributes: {
-            [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+            [SENTRY_OP]: FUNCTION_GCP,
             [FAAS_TRIGGER]: 'cloud_event',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
@@ -129,7 +129,7 @@ describe('wrapCloudEventFunction', () => {
         const fakeTransactionContext = {
           name: 'event.type',
           attributes: {
-            [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+            [SENTRY_OP]: FUNCTION_GCP,
             [FAAS_TRIGGER]: 'cloud_event',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
@@ -167,7 +167,7 @@ describe('wrapCloudEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
@@ -205,7 +205,7 @@ describe('wrapCloudEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
@@ -228,7 +228,7 @@ describe('wrapCloudEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',
@@ -265,7 +265,7 @@ describe('wrapCloudEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'cloud_event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_cloud_event',

--- a/packages/google-cloud-serverless/test/gcpfunction/events.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/events.test.ts
@@ -1,5 +1,5 @@
 import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_GCP } from '@sentry/conventions/op';
 import type { Event } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
@@ -72,7 +72,7 @@ describe('wrapEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
@@ -95,7 +95,7 @@ describe('wrapEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
@@ -123,7 +123,7 @@ describe('wrapEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
@@ -150,7 +150,7 @@ describe('wrapEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
@@ -175,7 +175,7 @@ describe('wrapEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
@@ -198,7 +198,7 @@ describe('wrapEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',
@@ -222,7 +222,7 @@ describe('wrapEventFunction', () => {
       const fakeTransactionContext = {
         name: 'event.type',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'event',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_event',

--- a/packages/google-cloud-serverless/test/gcpfunction/http.test.ts
+++ b/packages/google-cloud-serverless/test/gcpfunction/http.test.ts
@@ -1,5 +1,5 @@
 import { FAAS_TRIGGER, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_GCP } from '@sentry/conventions/op';
 import type { Integration } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { beforeEach, describe, expect, type MockInstance, test, vi } from 'vitest';
@@ -95,7 +95,7 @@ describe('GCPFunction', () => {
       const fakeTransactionContext = {
         name: 'POST /path',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'http',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_http',
@@ -119,7 +119,7 @@ describe('GCPFunction', () => {
       const fakeTransactionContext = {
         name: 'POST /path',
         attributes: {
-          [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+          [SENTRY_OP]: FUNCTION_GCP,
           [FAAS_TRIGGER]: 'http',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.serverless.gcp_http',

--- a/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
+++ b/packages/google-cloud-serverless/test/integrations/google-cloud-http.test.ts
@@ -1,6 +1,6 @@
 import { BigQuery } from '@google-cloud/bigquery';
 import { HTTP_REQUEST_METHOD, SENTRY_OP, SERVER_ADDRESS, URL_FULL } from '@sentry/conventions/attributes';
-import { WEB_SERVER_HTTP_CLIENT_SPAN_OP } from '@sentry/conventions/op';
+import { HTTP_CLIENT } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { createTransport, NodeClient, setCurrentClient } from '@sentry/node';
 import * as fs from 'fs';
@@ -81,7 +81,7 @@ describe('GoogleCloudHttp tracing', () => {
         name: 'POST /jobs',
         onlyIfParent: true,
         attributes: {
-          [SENTRY_OP]: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
+          [SENTRY_OP]: HTTP_CLIENT,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
           [HTTP_REQUEST_METHOD]: 'POST',
           [SERVER_ADDRESS]: 'bigquery.googleapis.com',
@@ -92,7 +92,7 @@ describe('GoogleCloudHttp tracing', () => {
         name: expect.stringMatching(/^GET \/queries\/.+/),
         onlyIfParent: true,
         attributes: {
-          [SENTRY_OP]: WEB_SERVER_HTTP_CLIENT_SPAN_OP,
+          [SENTRY_OP]: HTTP_CLIENT,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
           [HTTP_REQUEST_METHOD]: 'GET',
           [SERVER_ADDRESS]: 'bigquery.googleapis.com',

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0"
+    "@sentry/conventions": "^0.20.0"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.x",

--- a/packages/hono/src/shared/patchAppRequest.ts
+++ b/packages/hono/src/shared/patchAppRequest.ts
@@ -1,5 +1,5 @@
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_HTTP_SERVER_SPAN_OP } from '@sentry/conventions/op';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 import {
   debug,
   getActiveSpan,
@@ -11,7 +11,7 @@ import {
 import type { Env, Hono } from 'hono';
 import { DEBUG_BUILD } from '../debug-build';
 
-const INTERNAL_REQUEST_OP = WEB_SERVER_HTTP_SERVER_SPAN_OP;
+const INTERNAL_REQUEST_OP = HTTP_SERVER;
 const INTERNAL_REQUEST_ORIGIN = 'auto.http.hono.internal_request';
 
 function extractPathname(input: string | Request | URL): string {

--- a/packages/hono/src/shared/wrapMiddlewareSpan.ts
+++ b/packages/hono/src/shared/wrapMiddlewareSpan.ts
@@ -1,5 +1,5 @@
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import {
   getActiveSpan,
   getOriginalFunction,
@@ -35,7 +35,7 @@ export function wrapMiddlewareWithSpan(handler: MiddlewareHandler): MiddlewareHa
         onlyIfParent: true,
         parentSpan: rootSpan,
         attributes: {
-          [SENTRY_OP]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+          [SENTRY_OP]: MIDDLEWARE,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: MIDDLEWARE_ORIGIN,
         },
       });

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/nestjs/src/integrations/helpers.ts
+++ b/packages/nestjs/src/integrations/helpers.ts
@@ -1,5 +1,5 @@
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP, WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION, MIDDLEWARE } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   addNonEnumerableProperty,
@@ -91,7 +91,7 @@ export function getMiddlewareSpanOptions(
   return {
     name: name ?? target.name ?? 'unknown',
     attributes: {
-      [SENTRY_OP]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+      [SENTRY_OP]: MIDDLEWARE,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: middlewareOrigin(componentType),
     },
   };
@@ -108,7 +108,7 @@ export function getEventSpanOptions(event: string): {
   return {
     name: `event ${event}`,
     attributes: {
-      [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+      [SENTRY_OP]: FUNCTION,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.event.nestjs',
     },
     forceTransaction: true,

--- a/packages/nestjs/src/integrations/wrap-route.ts
+++ b/packages/nestjs/src/integrations/wrap-route.ts
@@ -1,5 +1,5 @@
 import { HTTP_METHOD, HTTP_ROUTE, SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import type { SpanAttributes } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan, filterCollectedUrl } from '@sentry/core';
 import type { AnyFn } from './helpers';
@@ -33,7 +33,7 @@ export function getAppCreationSpanOptions(
     name: 'Create Nest App',
     attributes: {
       component: NESTJS_COMPONENT,
-      [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+      [SENTRY_OP]: FUNCTION,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: HTTP_ORIGIN,
       [AttributeNames.TYPE]: NestType.APP_CREATION,
       [AttributeNames.VERSION]: moduleVersion || undefined,
@@ -90,7 +90,7 @@ export function wrapRequestContextHandler(
     const attributes: SpanAttributes = {
       component: NESTJS_COMPONENT,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: HTTP_ORIGIN,
-      [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+      [SENTRY_OP]: FUNCTION,
       [AttributeNames.TYPE]: NestType.REQUEST_CONTEXT,
       [AttributeNames.CONTROLLER]: instanceName,
       [AttributeNames.CALLBACK]: callbackName,

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -72,7 +72,7 @@
     "@rollup/plugin-commonjs": "28.0.1",
     "@sentry/browser-utils": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",

--- a/packages/nextjs/src/common/enhanceMiddlewareRootSpan.ts
+++ b/packages/nextjs/src/common/enhanceMiddlewareRootSpan.ts
@@ -1,4 +1,4 @@
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, stripUrlQueryAndFragment } from '@sentry/core';
 import { ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from './nextSpanAttributes';
 
@@ -27,7 +27,7 @@ export function enhanceMiddlewareRootSpan(span: MutableMiddlewareRootSpan): void
     return;
   }
 
-  span.setOp(WEB_SERVER_MIDDLEWARE_SPAN_OP);
+  span.setOp(MIDDLEWARE);
 
   const spanName = attributes[ATTR_NEXT_SPAN_NAME];
   if (typeof spanName !== 'string' || !spanName || !span.getName()) {

--- a/packages/nextjs/src/common/utils/tracingUtils.ts
+++ b/packages/nextjs/src/common/utils/tracingUtils.ts
@@ -1,5 +1,5 @@
 import { HTTP_ROUTE, SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import type { PropagationContext, RawAttributes, Span } from '@sentry/core';
 import { isObjectLike, Scope, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import { ATTR_NEXT_SEGMENT, ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../nextSpanAttributes';
@@ -110,7 +110,7 @@ export function maybeEnhanceServerComponentSpanName(
   activeSpan.setAttributes({
     'sentry.nextjs.ssr.function.type': segment === PAGE_SEGMENT ? 'Page' : 'Layout',
     'sentry.nextjs.ssr.function.route': route as string | undefined,
-    [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+    [SENTRY_OP]: FUNCTION,
     [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
   });
 }

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -18,7 +18,7 @@ import { flushSafelyWithTimeout, waitUntil } from '../common/utils/responseEnd';
 import { DEBUG_BUILD } from './debug-build';
 import { isNotFoundNavigationError, isRedirectNavigationError } from './nextNavigationErrorUtils';
 import { SENTRY_KIND, SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 
 interface Options {
   formData?: FormData;
@@ -118,7 +118,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
               forceTransaction: true,
               attributes: {
                 [SENTRY_KIND]: 'server',
-                [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.nextjs.server_action',
               },

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -35,7 +35,7 @@ import { distDirRewriteFramesIntegration } from './distDirRewriteFramesIntegrati
 import { enhanceMiddlewareRootSpan } from '../common/enhanceMiddlewareRootSpan';
 import { enhanceRunHandlerRootSpan } from './enhanceRunHandlerRootSpan';
 import { SENTRY_KIND } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 
 export * from '@sentry/vercel-edge';
 export * from '../common';
@@ -143,7 +143,7 @@ export function init(options: VercelEdgeOptions = {}): void {
 
     // Make sure middleware spans get the right op
     if (spanAttributes?.[ATTR_NEXT_SPAN_TYPE] === 'Middleware.execute') {
-      span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, WEB_SERVER_MIDDLEWARE_SPAN_OP);
+      span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, MIDDLEWARE);
       span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, 'url');
     }
 

--- a/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
+++ b/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
@@ -1,5 +1,5 @@
 import { HTTP_METHOD, HTTP_REQUEST_METHOD, HTTP_ROUTE, HTTP_TARGET } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, stripUrlQueryAndFragment } from '@sentry/core';
 import { ATTR_NEXT_ROUTE, ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../common/nextSpanAttributes';
 import { TRANSACTION_ATTR_SENTRY_ROUTE_BACKFILL } from '../common/span-attributes-with-logic-attached';
@@ -69,7 +69,7 @@ export function enhanceHandleRequestRootSpan(span: MutableRootSpan): void {
 
   if (middlewareMatch) {
     span.setName(`middleware ${middlewareMatch[1]}`);
-    span.setOp(WEB_SERVER_MIDDLEWARE_SPAN_OP);
+    span.setOp(MIDDLEWARE);
     attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] = 'route';
   }
 

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@sentry/bundler-plugins": "^10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureStorageEvents.ts
@@ -1,10 +1,6 @@
 import * as dc from 'node:diagnostics_channel';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import {
-  DATABASE_CACHE_GET_SPAN_OP,
-  DATABASE_CACHE_PUT_SPAN_OP,
-  DATABASE_CACHE_REMOVE_SPAN_OP,
-} from '@sentry/conventions/op';
+import { CACHE_GET, CACHE_PUT, CACHE_REMOVE } from '@sentry/conventions/op';
 import {
   flushIfServerless,
   GLOBAL_OBJ,
@@ -46,16 +42,16 @@ const CACHE_HIT_OPERATIONS = new Set<TracedOperation>(['hasItem', 'getItem', 'ge
  * The precise operation stays available on `db.operation.name`.
  */
 const OPERATION_SPAN_OPS = {
-  hasItem: DATABASE_CACHE_GET_SPAN_OP,
-  getItem: DATABASE_CACHE_GET_SPAN_OP,
-  getItemRaw: DATABASE_CACHE_GET_SPAN_OP,
-  getItems: DATABASE_CACHE_GET_SPAN_OP,
-  getKeys: DATABASE_CACHE_GET_SPAN_OP,
-  setItem: DATABASE_CACHE_PUT_SPAN_OP,
-  setItemRaw: DATABASE_CACHE_PUT_SPAN_OP,
-  setItems: DATABASE_CACHE_PUT_SPAN_OP,
-  removeItem: DATABASE_CACHE_REMOVE_SPAN_OP,
-  clear: DATABASE_CACHE_REMOVE_SPAN_OP,
+  hasItem: CACHE_GET,
+  getItem: CACHE_GET,
+  getItemRaw: CACHE_GET,
+  getItems: CACHE_GET,
+  getKeys: CACHE_GET,
+  setItem: CACHE_PUT,
+  setItemRaw: CACHE_PUT,
+  setItems: CACHE_PUT,
+  removeItem: CACHE_REMOVE,
+  clear: CACHE_REMOVE,
 } as const satisfies Record<TracedOperation, string>;
 
 const CACHED_FN_HANDLERS_RE = /^nitro:(functions|handlers):/i;

--- a/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
+++ b/packages/nitro/src/runtime/hooks/captureTracingEvents.ts
@@ -1,6 +1,6 @@
 import * as dc from 'node:diagnostics_channel';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_HTTP_SERVER_SPAN_OP, WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { HTTP_SERVER, MIDDLEWARE } from '@sentry/conventions/op';
 import {
   isObjectLike,
   getActiveSpan,
@@ -108,7 +108,7 @@ function setupH3TracingChannels(): void {
         attributes: {
           ...urlAttributes,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.nitro.h3',
-          [SENTRY_OP]: data?.type === 'middleware' ? WEB_SERVER_MIDDLEWARE_SPAN_OP : WEB_SERVER_HTTP_SERVER_SPAN_OP,
+          [SENTRY_OP]: data?.type === 'middleware' ? MIDDLEWARE : HTTP_SERVER,
         },
       });
 
@@ -181,7 +181,7 @@ function setupSrvxTracingChannels(): void {
           ...urlAttributes,
           ...headerAttributes,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.nitro.srvx',
-          [SENTRY_OP]: data.middleware ? WEB_SERVER_MIDDLEWARE_SPAN_OP : WEB_SERVER_HTTP_SERVER_SPAN_OP,
+          [SENTRY_OP]: data.middleware ? MIDDLEWARE : HTTP_SERVER,
           'server.port': data.server.options.port,
         },
         // Use the same parent span as middleware to make them siblings
@@ -220,7 +220,7 @@ function setupSrvxTracingChannels(): void {
         attributes: {
           ...urlAttributes,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.nitro.srvx',
-          [SENTRY_OP]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+          [SENTRY_OP]: MIDDLEWARE,
         },
         parentSpan: requestParentSpans.get(data.request) || undefined,
       });

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",
     "@sentry/server-utils": "10.67.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -56,7 +56,7 @@
     "@nuxt/kit": "^4.5.2",
     "@sentry/browser": "10.67.0",
     "@sentry/cloudflare": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",

--- a/packages/nuxt/src/runtime/hooks/wrapMiddlewareHandler.ts
+++ b/packages/nuxt/src/runtime/hooks/wrapMiddlewareHandler.ts
@@ -1,5 +1,5 @@
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import {
   captureException,
   debug,
@@ -165,7 +165,7 @@ function getSpanAttributes(
   index?: number,
 ): SpanAttributes {
   const attributes: SpanAttributes = {
-    [SENTRY_OP]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+    [SENTRY_OP]: MIDDLEWARE,
     [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'custom',
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.middleware.nuxt',
     'nuxt.middleware.name': middlewareName,

--- a/packages/nuxt/src/runtime/utils/instrumentStorage.ts
+++ b/packages/nuxt/src/runtime/utils/instrumentStorage.ts
@@ -1,9 +1,5 @@
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import {
-  DATABASE_CACHE_GET_SPAN_OP,
-  DATABASE_CACHE_PUT_SPAN_OP,
-  DATABASE_CACHE_REMOVE_SPAN_OP,
-} from '@sentry/conventions/op';
+import { CACHE_GET, CACHE_PUT, CACHE_REMOVE } from '@sentry/conventions/op';
 import {
   isObjectLike,
   captureException,
@@ -66,16 +62,16 @@ const CACHE_HIT_METHODS = new Set<DriverMethod>(['hasItem', 'getItem', 'getItemR
  * The precise method stays available on `db.operation.name`.
  */
 const METHOD_SPAN_OPS = {
-  hasItem: DATABASE_CACHE_GET_SPAN_OP,
-  getItem: DATABASE_CACHE_GET_SPAN_OP,
-  getItemRaw: DATABASE_CACHE_GET_SPAN_OP,
-  getItems: DATABASE_CACHE_GET_SPAN_OP,
-  getKeys: DATABASE_CACHE_GET_SPAN_OP,
-  setItem: DATABASE_CACHE_PUT_SPAN_OP,
-  setItemRaw: DATABASE_CACHE_PUT_SPAN_OP,
-  setItems: DATABASE_CACHE_PUT_SPAN_OP,
-  removeItem: DATABASE_CACHE_REMOVE_SPAN_OP,
-  clear: DATABASE_CACHE_REMOVE_SPAN_OP,
+  hasItem: CACHE_GET,
+  getItem: CACHE_GET,
+  getItemRaw: CACHE_GET,
+  getItems: CACHE_GET,
+  getKeys: CACHE_GET,
+  setItem: CACHE_PUT,
+  setItemRaw: CACHE_PUT,
+  setItems: CACHE_PUT,
+  removeItem: CACHE_REMOVE,
+  clear: CACHE_REMOVE,
 } as const satisfies Partial<Record<DriverMethod, string>>;
 
 /**

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0"
   },
   "peerDependencies": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -53,7 +53,7 @@
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser": "10.67.0",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/react-router/src/client/createClientInstrumentation.ts
+++ b/packages/react-router/src/client/createClientInstrumentation.ts
@@ -26,7 +26,7 @@ import {
   updateNavigationSpanUrlFromLocation,
 } from './utils';
 import { CODE_FUNCTION_NAME, SENTRY_OP, URL_FULL, URL_TEMPLATE } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP, WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION, MIDDLEWARE } from '@sentry/conventions/op';
 
 const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
@@ -223,7 +223,7 @@ export function createSentryClientInstrumentation(
             {
               name: `Fetcher ${info.fetcherKey}`,
               attributes: {
-                [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [CODE_FUNCTION_NAME]: 'fetcher',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
               },
@@ -258,7 +258,7 @@ export function createSentryClientInstrumentation(
             {
               name: routePattern,
               attributes: {
-                [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [CODE_FUNCTION_NAME]: 'clientLoader',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
               },
@@ -285,7 +285,7 @@ export function createSentryClientInstrumentation(
             {
               name: routePattern,
               attributes: {
-                [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [CODE_FUNCTION_NAME]: 'clientAction',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
               },
@@ -319,7 +319,7 @@ export function createSentryClientInstrumentation(
             {
               name: `middleware ${routeId}`,
               attributes: {
-                [SENTRY_OP]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+                [SENTRY_OP]: MIDDLEWARE,
                 [CODE_FUNCTION_NAME]: 'clientMiddleware',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
                 'react_router.route.id': routeId,
@@ -344,7 +344,7 @@ export function createSentryClientInstrumentation(
             {
               name: 'Lazy Route Load',
               attributes: {
-                [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [CODE_FUNCTION_NAME]: 'lazy',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
               },

--- a/packages/react-router/src/server/createServerInstrumentation.ts
+++ b/packages/react-router/src/server/createServerInstrumentation.ts
@@ -6,7 +6,7 @@ import {
   URL_FULL,
   URL_PATH,
 } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP, WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION, MIDDLEWARE } from '@sentry/conventions/op';
 import {
   debug,
   flushIfServerless,
@@ -139,7 +139,7 @@ export function createSentryServerInstrumentation(
             {
               name: routePattern,
               attributes: {
-                [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [CODE_FUNCTION_NAME]: 'loader',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
               },
@@ -167,7 +167,7 @@ export function createSentryServerInstrumentation(
             {
               name: routePattern,
               attributes: {
-                [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [CODE_FUNCTION_NAME]: 'action',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
               },
@@ -211,7 +211,7 @@ export function createSentryServerInstrumentation(
             {
               name: `middleware ${middlewareName || routeId}`,
               attributes: {
-                [SENTRY_OP]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+                [SENTRY_OP]: MIDDLEWARE,
                 [CODE_FUNCTION_NAME]: 'middleware',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
                 'react_router.route.id': routeId,
@@ -238,7 +238,7 @@ export function createSentryServerInstrumentation(
             {
               name: 'Lazy Route Load',
               attributes: {
-                [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+                [SENTRY_OP]: FUNCTION,
                 [CODE_FUNCTION_NAME]: 'lazy',
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.react_router.instrumentation_api',
               },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0"
+    "@sentry/conventions": "^0.20.0"
   },
   "peerDependencies": {
     "react": "17.x || 18.x || 19.x"

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -2,7 +2,7 @@ import { startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON, timestampInSeconds, withActiveSpan } from '@sentry/core';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { BROWSER_UI_RENDER_SPAN_OP } from '@sentry/conventions/op';
+import { UI_RENDER } from '@sentry/conventions/op';
 import * as React from 'react';
 import { hoistNonReactStatics } from './hoist-non-react-statics';
 
@@ -117,7 +117,7 @@ class Profiler extends React.Component<ProfilerProps> {
           name: `<${name}>`,
           startTime,
           attributes: {
-            [SENTRY_OP]: BROWSER_UI_RENDER_SPAN_OP,
+            [SENTRY_OP]: UI_RENDER,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
             'ui.component_name': name,
           },
@@ -221,7 +221,7 @@ function useProfiler(
           onlyIfParent: true,
           startTime,
           attributes: {
-            [SENTRY_OP]: BROWSER_UI_RENDER_SPAN_OP,
+            [SENTRY_OP]: UI_RENDER,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
             'ui.component_name': name,
           },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "@remix-run/router": "^1.23.3",
     "@sentry/cli": "^2.58.6",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -42,7 +42,7 @@ import { extractData, isResponse, json } from '../utils/vendor/response';
 import { captureRemixServerException, errorHandleDataFunction } from './errors';
 import { generateSentryServerTimingHeader, injectServerTimingHeaderValue } from './serverTimingTracePropagation';
 import { CODE_FUNCTION_NAME, HTTP_ROUTE, SENTRY_OP, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 
 type AppData = unknown;
 type RemixRequest = Parameters<RequestHandler>[0];
@@ -137,7 +137,7 @@ function makeWrappedDocumentRequestFunction(instrumentTracing?: boolean) {
               method: request.method,
               [URL_FULL]: filterCollectedUrl(request.url),
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.remix',
-              [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+              [SENTRY_OP]: FUNCTION,
             },
           },
           () => {
@@ -211,7 +211,7 @@ function makeWrappedDataFunction(
           name: id,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.remix',
-            [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+            [SENTRY_OP]: FUNCTION,
             [CODE_FUNCTION_NAME]: name,
             name,
           },

--- a/packages/remix/src/server/integrations/tracing-channel.ts
+++ b/packages/remix/src/server/integrations/tracing-channel.ts
@@ -26,7 +26,7 @@ import {
   SENTRY_OP,
   HTTP_RESPONSE_STATUS_CODE,
 } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import { remixChannels } from '@sentry/server-utils/orchestrion/config';
 import type { FormDataCapture } from '../../utils/formData';
 import { applyFormDataAttributes } from '../../utils/formData';
@@ -190,7 +190,7 @@ function subscribeCallRouteLoader(): void {
         name: `LOADER ${params.routeId}`,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+          [SENTRY_OP]: FUNCTION,
           [CODE_FUNCTION_NAME]: 'loader',
           ...getRequestAttributes(params.request),
           ...getMatchAttributes(params),
@@ -224,7 +224,7 @@ function subscribeCallRouteAction(formDataCapture: FormDataCapture | undefined):
         name: `ACTION ${params.routeId}`,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+          [SENTRY_OP]: FUNCTION,
           [CODE_FUNCTION_NAME]: 'action',
           ...getRequestAttributes(params.request),
           ...getMatchAttributes(params),

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -95,7 +95,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0"
   },
   "devDependencies": {

--- a/packages/server-utils/src/ai/core/utils.ts
+++ b/packages/server-utils/src/ai/core/utils.ts
@@ -15,7 +15,7 @@ import {
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 
 export interface GenAiOptions {
   /**
@@ -61,7 +61,7 @@ const NON_INFERENCE_OPERATIONS = new Set(['unknown']);
  * non-inference operations (`unknown`) become the generic `function` op.
  */
 export function getGenAiSpanOp(operationName: string): string {
-  return NON_INFERENCE_OPERATIONS.has(operationName) ? GENERAL_FUNCTION_SPAN_OP : `gen_ai.${operationName}`;
+  return NON_INFERENCE_OPERATIONS.has(operationName) ? FUNCTION : `gen_ai.${operationName}`;
 }
 
 /**

--- a/packages/server-utils/src/integrations/amqplib.ts
+++ b/packages/server-utils/src/integrations/amqplib.ts
@@ -24,7 +24,7 @@ import {
   SERVER_PORT,
   URL_FULL,
 } from '@sentry/conventions/attributes';
-import { MESSAGING_QUEUE_PROCESS_SPAN_OP, MESSAGING_QUEUE_PUBLISH_SPAN_OP } from '@sentry/conventions/op';
+import { QUEUE_PROCESS, QUEUE_PUBLISH } from '@sentry/conventions/op';
 import { amqplibModuleNames } from '../orchestrion/config/amqplib';
 import { invokeOrchestrionInstrumentation } from '../orchestrion/instrumentation';
 import { CHANNELS } from '../orchestrion/channels';
@@ -462,7 +462,7 @@ function startPublishSpan(data: AmqpChannelContext): Span {
   const span = startInactiveSpan({
     name: `publish ${normalizeExchange(exchange)}`,
     attributes: {
-      [SENTRY_OP]: MESSAGING_QUEUE_PUBLISH_SPAN_OP,
+      [SENTRY_OP]: QUEUE_PUBLISH,
       [SENTRY_KIND]: 'producer',
       ...getStoredConnectionAttributes(data.self),
       [ATTR_MESSAGING_DESTINATION]: exchange, // TODO(v11) remove this attribute
@@ -500,7 +500,7 @@ function startConsumeSpan(queue: string, msg: ConsumeMessage, channel: ChannelLi
   return startInactiveSpan({
     name: `${queue} process`,
     attributes: {
-      [SENTRY_OP]: MESSAGING_QUEUE_PROCESS_SPAN_OP,
+      [SENTRY_OP]: QUEUE_PROCESS,
       [SENTRY_KIND]: 'consumer',
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
       ...getStoredConnectionAttributes(channel),

--- a/packages/server-utils/src/integrations/dataloader.ts
+++ b/packages/server-utils/src/integrations/dataloader.ts
@@ -1,10 +1,6 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import { CACHE_KEY, DB_OPERATION_NAME, SENTRY_KIND, SENTRY_OP } from '@sentry/conventions/attributes';
-import {
-  DATABASE_CACHE_GET_SPAN_OP,
-  DATABASE_CACHE_PUT_SPAN_OP,
-  DATABASE_CACHE_REMOVE_SPAN_OP,
-} from '@sentry/conventions/op';
+import { CACHE_GET, CACHE_PUT, CACHE_REMOVE } from '@sentry/conventions/op';
 import type { IntegrationFn, Span, StartSpanOptions } from '@sentry/core';
 import {
   debug,
@@ -35,12 +31,12 @@ type Operation = 'load' | 'loadMany' | 'batch' | 'prime' | 'clear' | 'clearAll';
  * available on `db.operation.name`.
  */
 const OPERATION_SPAN_OPS = {
-  load: DATABASE_CACHE_GET_SPAN_OP,
-  loadMany: DATABASE_CACHE_GET_SPAN_OP,
-  batch: DATABASE_CACHE_GET_SPAN_OP,
-  prime: DATABASE_CACHE_PUT_SPAN_OP,
-  clear: DATABASE_CACHE_REMOVE_SPAN_OP,
-  clearAll: DATABASE_CACHE_REMOVE_SPAN_OP,
+  load: CACHE_GET,
+  loadMany: CACHE_GET,
+  batch: CACHE_GET,
+  prime: CACHE_PUT,
+  clear: CACHE_REMOVE,
+  clearAll: CACHE_REMOVE,
 } as const satisfies Record<Operation, string>;
 
 // The link shape shared between a `load` span and the `batch` span it triggers.

--- a/packages/server-utils/src/integrations/express/instrumentation.ts
+++ b/packages/server-utils/src/integrations/express/instrumentation.ts
@@ -1,6 +1,6 @@
 import type * as diagnosticsChannel from 'node:diagnostics_channel';
 import { HTTP_ROUTE, SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   debug,
@@ -44,7 +44,7 @@ const ATTR_EXPRESS_TYPE = 'express.type';
 
 // TODO(conventions): Replace `'handler'` and `'router'` with their span op constants once they are released in `@sentry/conventions`.
 const EXPRESS_TYPE_TO_SPAN_OP: Record<string, string> = {
-  middleware: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+  middleware: MIDDLEWARE,
   request_handler: 'handler',
   router: 'router',
 };

--- a/packages/server-utils/src/integrations/fastify/instrumentation.ts
+++ b/packages/server-utils/src/integrations/fastify/instrumentation.ts
@@ -22,7 +22,7 @@ import {
   SENTRY_OP,
   URL_PATH,
 } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   isObjectLike,
@@ -42,7 +42,7 @@ const PACKAGE_NAME = '@sentry/instrumentation-fastify';
 const SUPPORTED_VERSIONS = '>=3.21.0 <6';
 
 const ORIGIN = 'auto.http.otel.fastify';
-const HOOK_OP = WEB_SERVER_MIDDLEWARE_SPAN_OP;
+const HOOK_OP = MIDDLEWARE;
 // TODO(conventions): Replace with the `handler` span op constant once it is released in `@sentry/conventions`.
 const REQUEST_HANDLER_OP = 'handler';
 

--- a/packages/server-utils/src/integrations/firebase/functions.ts
+++ b/packages/server-utils/src/integrations/firebase/functions.ts
@@ -1,5 +1,5 @@
 import { FAAS_NAME, FAAS_TRIGGER, SENTRY_KIND, SENTRY_OP } from '@sentry/conventions/attributes';
-import { FAAS_FUNCTION_GCP_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION_GCP } from '@sentry/conventions/op';
 import type { SpanAttributes } from '@sentry/core';
 import {
   captureException,
@@ -59,7 +59,7 @@ function wrapHandler(handler: Handler, triggerType: string): Handler {
       [FAAS_TRIGGER]: triggerType,
       'faas.provider': 'firebase',
       [SENTRY_KIND]: 'server',
-      [SENTRY_OP]: FAAS_FUNCTION_GCP_SPAN_OP,
+      [SENTRY_OP]: FUNCTION_GCP,
       [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
     };
 

--- a/packages/server-utils/src/integrations/generic-pool.ts
+++ b/packages/server-utils/src/integrations/generic-pool.ts
@@ -1,6 +1,6 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { DATABASE_DB_SPAN_OP } from '@sentry/conventions/op';
+import { DB } from '@sentry/conventions/op';
 import type { IntegrationFn } from '@sentry/core';
 import { defineIntegration, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 import { CHANNELS } from '../orchestrion/channels';
@@ -40,7 +40,7 @@ function instrumentGenericPool(): void {
       startInactiveSpan({
         name: 'generic-pool.acquire',
         attributes: {
-          [SENTRY_OP]: DATABASE_DB_SPAN_OP,
+          [SENTRY_OP]: DB,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.generic_pool',
         },
       }),

--- a/packages/server-utils/src/integrations/graphql/graphql-dc-subscriber.ts
+++ b/packages/server-utils/src/integrations/graphql/graphql-dc-subscriber.ts
@@ -1,6 +1,6 @@
 import type { TracingChannel } from 'node:diagnostics_channel';
 import { GRAPHQL_DOCUMENT, GRAPHQL_OPERATION_NAME, GRAPHQL_OPERATION_TYPE } from '@sentry/conventions/attributes';
-import { WEB_SERVER_GRAPHQL_SPAN_OP } from '@sentry/conventions/op';
+import { GRAPHQL } from '@sentry/conventions/op';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
@@ -150,7 +150,7 @@ function setupParseChannel(tracingChannel: GraphqlTracingChannelFactory): void {
       name: SPAN_NAME_PARSE,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: WEB_SERVER_GRAPHQL_SPAN_OP,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GRAPHQL,
       },
     }),
   );
@@ -164,7 +164,7 @@ function setupValidateChannel(tracingChannel: GraphqlTracingChannelFactory): voi
         name: SPAN_NAME_VALIDATE,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: WEB_SERVER_GRAPHQL_SPAN_OP,
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GRAPHQL,
           [GRAPHQL_DOCUMENT]: collectGraphqlDocument(data.document),
         },
       });
@@ -193,7 +193,7 @@ function setupOperationChannel(
         name: getOperationSpanName(data.operationType, data.operationName, fallbackName),
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: WEB_SERVER_GRAPHQL_SPAN_OP,
+          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GRAPHQL,
           [GRAPHQL_OPERATION_TYPE]: data.operationType,
           [GRAPHQL_OPERATION_NAME]: data.operationName || undefined,
           [GRAPHQL_DOCUMENT]: collectGraphqlDocument(data.document),
@@ -229,7 +229,7 @@ function setupResolveChannel(tracingChannel: GraphqlTracingChannelFactory, ignor
       name: `${SPAN_NAME_RESOLVE} ${data.fieldPath}`,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: WEB_SERVER_GRAPHQL_SPAN_OP,
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GRAPHQL,
         [GRAPHQL_FIELD_NAME]: data.fieldName,
         [GRAPHQL_FIELD_PATH]: data.fieldPath,
         [GRAPHQL_FIELD_TYPE]: data.fieldType,

--- a/packages/server-utils/src/integrations/graphql/resolvers.ts
+++ b/packages/server-utils/src/integrations/graphql/resolvers.ts
@@ -6,7 +6,7 @@
  * call runs). Resolver spans use the same origin/op/field attributes as the native subscriber.
  */
 
-import { WEB_SERVER_GRAPHQL_SPAN_OP } from '@sentry/conventions/op';
+import { GRAPHQL } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   isObjectLike,
@@ -179,7 +179,7 @@ function createFieldIfNotExists(
 function createResolverSpan(info: GraphQLResolveInfo, path: string[], parentSpan?: Span): Span {
   const attributes: SpanAttributes = {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: WEB_SERVER_GRAPHQL_SPAN_OP,
+    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GRAPHQL,
     [GRAPHQL_FIELD_NAME]: info.fieldName,
     [GRAPHQL_FIELD_PATH]: path.join('.'),
     [GRAPHQL_FIELD_TYPE]: info.returnType.toString(),

--- a/packages/server-utils/src/integrations/graphql/spans.ts
+++ b/packages/server-utils/src/integrations/graphql/spans.ts
@@ -6,7 +6,7 @@
  */
 
 import { GRAPHQL_DOCUMENT, GRAPHQL_OPERATION_NAME, GRAPHQL_OPERATION_TYPE } from '@sentry/conventions/attributes';
-import { WEB_SERVER_GRAPHQL_SPAN_OP } from '@sentry/conventions/op';
+import { GRAPHQL } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -29,7 +29,7 @@ import type {
 
 const BASE_ATTRIBUTES = {
   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: WEB_SERVER_GRAPHQL_SPAN_OP,
+  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GRAPHQL,
 } as const;
 
 export function startParseSpan(): Span {

--- a/packages/server-utils/src/integrations/hapi-utils.ts
+++ b/packages/server-utils/src/integrations/hapi-utils.ts
@@ -11,7 +11,7 @@
 
 import { getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import type {
   LifecycleMethod,
   PatchableExtMethod,
@@ -111,7 +111,7 @@ export const getExtMetadata = (
 const HAPI_TYPE_TO_SPAN_OP: Record<string, string> = {
   [HapiLayerType.PLUGIN]: 'handler',
   [HapiLayerType.ROUTER]: 'router',
-  [HapiLayerType.EXT]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+  [HapiLayerType.EXT]: MIDDLEWARE,
 };
 
 function startMetadataSpan(metadata: SpanMetadata, original: () => unknown): unknown {

--- a/packages/server-utils/src/integrations/kafkajs/spans.ts
+++ b/packages/server-utils/src/integrations/kafkajs/spans.ts
@@ -18,11 +18,7 @@ import {
   SENTRY_KIND,
   SENTRY_OP,
 } from '@sentry/conventions/attributes';
-import {
-  MESSAGING_QUEUE_PROCESS_SPAN_OP,
-  MESSAGING_QUEUE_PUBLISH_SPAN_OP,
-  MESSAGING_QUEUE_RECEIVE_SPAN_OP,
-} from '@sentry/conventions/op';
+import { QUEUE_PROCESS, QUEUE_PUBLISH, QUEUE_RECEIVE } from '@sentry/conventions/op';
 import type { Span, SpanAttributes, SpanLink } from '@sentry/core';
 import {
   getTraceData,
@@ -111,7 +107,7 @@ export function startConsumerSpan({ topic, message, operationType, links, attrib
     name: `${operationName} ${topic}`,
     links,
     attributes: {
-      [SENTRY_OP]: isBatchReceive ? MESSAGING_QUEUE_RECEIVE_SPAN_OP : MESSAGING_QUEUE_PROCESS_SPAN_OP,
+      [SENTRY_OP]: isBatchReceive ? QUEUE_RECEIVE : QUEUE_PROCESS,
       [SENTRY_KIND]: isBatchReceive ? 'client' : 'consumer',
       ...attributes,
       [MESSAGING_SYSTEM]: MESSAGING_SYSTEM_VALUE_KAFKA,
@@ -133,7 +129,7 @@ export function startProducerSpan(topic: string, message: Message): Span {
   const span = startInactiveSpan({
     name: `send ${topic}`,
     attributes: {
-      [SENTRY_OP]: MESSAGING_QUEUE_PUBLISH_SPAN_OP,
+      [SENTRY_OP]: QUEUE_PUBLISH,
       [SENTRY_KIND]: 'producer',
       [MESSAGING_SYSTEM]: MESSAGING_SYSTEM_VALUE_KAFKA,
       [MESSAGING_DESTINATION_NAME]: topic,

--- a/packages/server-utils/src/integrations/koa.ts
+++ b/packages/server-utils/src/integrations/koa.ts
@@ -11,7 +11,7 @@ import {
 } from '@sentry/core';
 // oxlint-disable-next-line typescript/no-deprecated
 import { CODE_FUNCTION_NAME, HTTP_ROUTE, KOA_NAME, KOA_TYPE, SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../debug-build';
 import { CHANNELS } from '../orchestrion/channels';
 import { koaModuleNames } from '../orchestrion/config/koa';
@@ -181,7 +181,7 @@ function patchLayer(
         attributes: {
           ...metadata.attributes,
           // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
-          [SENTRY_OP]: layerType === LAYER_TYPE.MIDDLEWARE ? WEB_SERVER_MIDDLEWARE_SPAN_OP : 'router',
+          [SENTRY_OP]: layerType === LAYER_TYPE.MIDDLEWARE ? MIDDLEWARE : 'router',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
         },
       },

--- a/packages/server-utils/src/integrations/redis/index.ts
+++ b/packages/server-utils/src/integrations/redis/index.ts
@@ -8,7 +8,7 @@ import {
   SERVER_PORT,
   SENTRY_OP,
 } from '@sentry/conventions/attributes';
-import { DATABASE_DB_QUERY_SPAN_OP, DATABASE_DB_SPAN_OP } from '@sentry/conventions/op';
+import { DB_QUERY, DB } from '@sentry/conventions/op';
 import type { IntegrationFn, Span, SpanAttributes } from '@sentry/core';
 import {
   isObjectLike,
@@ -123,7 +123,7 @@ function startCommandSpan(commandName: string, commandArgs: Array<string | Buffe
     attributes: {
       [SENTRY_KIND]: 'client',
       ...attributes,
-      [SENTRY_OP]: DATABASE_DB_QUERY_SPAN_OP,
+      [SENTRY_OP]: DB_QUERY,
       [DB_QUERY_TEXT]: dbStatement,
     },
   });
@@ -250,7 +250,7 @@ function bindNodeRedisConnectChannel(): void {
       attributes: {
         [SENTRY_KIND]: 'client',
         ...nodeRedisAttributes(options),
-        [SENTRY_OP]: DATABASE_DB_SPAN_OP,
+        [SENTRY_OP]: DB,
       },
     });
   });
@@ -270,7 +270,7 @@ function bindNodeRedisBatchChannel(channelName: string, getOperation: (data: Com
       attributes: {
         [SENTRY_KIND]: 'client',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-        [SENTRY_OP]: DATABASE_DB_QUERY_SPAN_OP,
+        [SENTRY_OP]: DB_QUERY,
         [DB_SYSTEM_NAME]: DB_SYSTEM_VALUE_REDIS,
         ...(size && size > 1 ? { [DB_OPERATION_BATCH_SIZE]: size } : {}),
         ...(socket?.host != null ? { [SERVER_ADDRESS]: socket.host } : {}),

--- a/packages/server-utils/src/integrations/redis/redis-cache.ts
+++ b/packages/server-utils/src/integrations/redis/redis-cache.ts
@@ -6,11 +6,7 @@ import {
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
-import {
-  DATABASE_CACHE_GET_SPAN_OP,
-  DATABASE_CACHE_PUT_SPAN_OP,
-  DATABASE_CACHE_REMOVE_SPAN_OP,
-} from '@sentry/conventions/op';
+import { CACHE_GET, CACHE_PUT, CACHE_REMOVE } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_CACHE_HIT,
@@ -62,11 +58,11 @@ export function isInCommands(redisCommands: string[], command: string): boolean 
 /** Determine cache operation based on redis statement */
 export function getCacheOperation(command: string): 'cache.get' | 'cache.put' | 'cache.remove' | undefined {
   if (isInCommands(GET_COMMANDS, command)) {
-    return DATABASE_CACHE_GET_SPAN_OP;
+    return CACHE_GET;
   } else if (isInCommands(SET_COMMANDS, command)) {
-    return DATABASE_CACHE_PUT_SPAN_OP;
+    return CACHE_PUT;
   } else if (isInCommands(REMOVE_COMMANDS, command)) {
-    return DATABASE_CACHE_REMOVE_SPAN_OP;
+    return CACHE_REMOVE;
   } else {
     return undefined;
   }

--- a/packages/server-utils/src/integrations/redis/redis-dc-subscriber.ts
+++ b/packages/server-utils/src/integrations/redis/redis-dc-subscriber.ts
@@ -8,7 +8,7 @@ import {
   SERVER_PORT,
   SENTRY_OP,
 } from '@sentry/conventions/attributes';
-import { DATABASE_DB_QUERY_SPAN_OP, DATABASE_DB_SPAN_OP } from '@sentry/conventions/op';
+import { DB_QUERY, DB } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 import { bindTracingChannelToSpan } from '../../tracing-channel';
 import type { RedisCacheOptions } from './redis-cache';
@@ -145,7 +145,7 @@ function setupCommandChannel<T extends RedisCommandData | IORedisCommandData>(
         name: `redis-${data.command}`,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SENTRY_OP]: DATABASE_DB_QUERY_SPAN_OP,
+          [SENTRY_OP]: DB_QUERY,
           [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
           [DB_OPERATION_NAME]: data.command,
           [DB_QUERY_TEXT]: statement,
@@ -173,7 +173,7 @@ function setupBatchChannel(
       name: getOperationName(data),
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-        [SENTRY_OP]: DATABASE_DB_QUERY_SPAN_OP,
+        [SENTRY_OP]: DB_QUERY,
         [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
         // should only include batch size greater than 1,
         // or else it isn't properly considered a "batch"
@@ -191,7 +191,7 @@ function setupConnectChannel(tracingChannel: RedisTracingChannelFactory, channel
       name: 'redis-connect',
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-        [SENTRY_OP]: DATABASE_DB_SPAN_OP,
+        [SENTRY_OP]: DB,
         [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_REDIS,
         ...(data.serverAddress != null ? { [SERVER_ADDRESS]: data.serverAddress } : {}),
         ...(data.serverPort != null ? { [SERVER_PORT]: data.serverPort } : {}),

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0"
+    "@sentry/conventions": "^0.20.0"
   },
   "peerDependencies": {
     "@solidjs/router": ">=0.13.4 <2.0.0-0",

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -86,7 +86,7 @@
     "@sentry/server-utils": "10.67.0",
     "@sentry/solid": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",
-    "@sentry/conventions": "0.19.0"
+    "@sentry/conventions": "0.20.0"
   },
   "devDependencies": {
     "@solidjs/router": "^1.0.0",

--- a/packages/solidstart/src/server/withServerActionInstrumentation.ts
+++ b/packages/solidstart/src/server/withServerActionInstrumentation.ts
@@ -7,7 +7,7 @@ import {
 import { captureException, getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, spanToJSON, startSpan } from '@sentry/node';
 import { isRedirect } from './utils';
 import { HTTP_ROUTE, HTTP_TARGET, SENTRY_OP, URL_PATH } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import { setHttpServerSpanRouteAttribute } from '@sentry/server-utils';
 
 /**
@@ -43,7 +43,7 @@ export async function withServerActionInstrumentation<A extends (...args: unknow
       {
         name: serverActionName,
         attributes: {
-          [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+          [SENTRY_OP]: FUNCTION,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.solidstart',
           [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'component',
         },

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "magic-string": "~0.30.0"
   },

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@sentry/cloudflare": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0",
     "@sentry/svelte": "10.67.0",

--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -7,7 +7,7 @@ import {
 } from '@sentry/core';
 import { startSpan } from '@sentry/core/browser';
 import { CODE_FUNCTION_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
-import { GENERAL_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import { captureException } from '@sentry/svelte';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { SentryWrappedFlag } from '../common/utils';
@@ -79,7 +79,7 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
       return startSpan(
         {
           attributes: {
-            [SENTRY_OP]: GENERAL_FUNCTION_SPAN_OP,
+            [SENTRY_OP]: FUNCTION,
             [CODE_FUNCTION_NAME]: 'load',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.sveltekit',
             [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeId ? 'route' : 'url',

--- a/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
+++ b/packages/sveltekit/src/server-common/integrations/svelteKitSpans.ts
@@ -1,7 +1,7 @@
 import type { Integration, SpanJSON, SpanOrigin, StreamedSpanJSON } from '@sentry/core';
 import { safeSetSpanJSONAttributes, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 
 /**
  * A small integration that preprocesses spans so that SvelteKit-generated spans
@@ -42,8 +42,8 @@ export function _enhanceKitSpan(span: SpanJSON): void {
   const previousOrigin = span.origin || span.data[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN];
 
   if (!previousOp) {
-    span.op = WEB_SERVER_FUNCTION_SPAN_OP;
-    span.data[SENTRY_OP] = WEB_SERVER_FUNCTION_SPAN_OP;
+    span.op = FUNCTION;
+    span.data[SENTRY_OP] = FUNCTION;
   }
 
   if (!previousOrigin || previousOrigin === 'manual') {
@@ -64,7 +64,7 @@ export function _enhanceKitSpanStreamed(span: StreamedSpanJSON): void {
 
   const previousOrigin = span.attributes[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] as SpanOrigin | undefined;
 
-  safeSetSpanJSONAttributes(span, { [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP });
+  safeSetSpanJSONAttributes(span, { [SENTRY_OP]: FUNCTION });
 
   if (previousOrigin === 'manual') {
     // `safeSetSpanJSONAttributes` skips existing keys, so overwrite the 'manual' sentinel directly.

--- a/packages/sveltekit/src/server-common/load.ts
+++ b/packages/sveltekit/src/server-common/load.ts
@@ -6,7 +6,7 @@ import {
   startSpan,
 } from '@sentry/core';
 import { CODE_FUNCTION_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import type { LoadEvent, ServerLoadEvent } from '@sveltejs/kit';
 import type { SentryWrappedFlag } from '../common/utils';
 import { getRouteId } from '../common/utils';
@@ -43,7 +43,7 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
         return await startSpan(
           {
             attributes: {
-              [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+              [SENTRY_OP]: FUNCTION,
               [CODE_FUNCTION_NAME]: 'load',
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.sveltekit',
               [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeId ? 'route' : 'url',
@@ -107,7 +107,7 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
         return await startSpan(
           {
             attributes: {
-              [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+              [SENTRY_OP]: FUNCTION,
               [CODE_FUNCTION_NAME]: 'load',
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.sveltekit.server',
               [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: routeId ? 'route' : 'url',

--- a/packages/sveltekit/src/server-common/serverRoute.ts
+++ b/packages/sveltekit/src/server-common/serverRoute.ts
@@ -6,7 +6,7 @@ import {
   startSpan,
 } from '@sentry/core';
 import { CODE_FUNCTION_NAME, HTTP_REQUEST_METHOD, SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import type { RequestEvent } from '@sveltejs/kit';
 import { sendErrorToSentry } from './utils';
 
@@ -55,7 +55,7 @@ export function wrapServerRouteWithSentry<T extends RequestEvent>(
           {
             name: `${httpMethod} ${routeId || 'Server Route'}`,
             attributes: {
-              [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+              [SENTRY_OP]: FUNCTION,
               [CODE_FUNCTION_NAME]: httpMethod,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.sveltekit',
               [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser-utils": "10.67.0",
-    "@sentry/conventions": "^0.19.0",
+    "@sentry/conventions": "^0.20.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/tanstackstart-react/src/server/utils.ts
+++ b/packages/tanstackstart-react/src/server/utils.ts
@@ -1,5 +1,5 @@
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_MIDDLEWARE_SPAN_OP } from '@sentry/conventions/op';
+import { MIDDLEWARE } from '@sentry/conventions/op';
 import type { StartSpanOptions } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/node';
 
@@ -11,7 +11,7 @@ export function getMiddlewareSpanOptions(name: string): StartSpanOptions {
     name,
     attributes: {
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.middleware.tanstackstart',
-      [SENTRY_OP]: WEB_SERVER_MIDDLEWARE_SPAN_OP,
+      [SENTRY_OP]: MIDDLEWARE,
     },
   };
 }

--- a/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
+++ b/packages/tanstackstart-react/src/server/wrapFetchWithSentry.ts
@@ -1,7 +1,7 @@
 import { flushIfServerless, getTraceMetaTags } from '@sentry/core';
 import { captureException, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/node';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { WEB_SERVER_FUNCTION_SPAN_OP } from '@sentry/conventions/op';
+import { FUNCTION } from '@sentry/conventions/op';
 import { updateSpanWithRouteParametrization } from './routeParametrization';
 
 declare const __SENTRY_ROUTE_PATTERNS__: string[] | undefined;
@@ -148,7 +148,7 @@ export function wrapFetchWithSentry(serverEntry: ServerEntry): ServerEntry {
                 name: `${method} ${url.pathname}`,
                 attributes: {
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.tanstackstart.server',
-                  [SENTRY_OP]: WEB_SERVER_FUNCTION_SPAN_OP,
+                  [SENTRY_OP]: FUNCTION,
                 },
               },
               async () => {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.19.0"
+    "@sentry/conventions": "^0.20.0"
   },
   "peerDependencies": {
     "@tanstack/vue-router": "^1.64.0",

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -2,7 +2,7 @@ import { getActiveSpan, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } fr
 import type { Span } from '@sentry/core';
 import { debug, timestampInSeconds, uniq } from '@sentry/core';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { BROWSER_UI_RENDER_SPAN_OP } from '@sentry/conventions/op';
+import { UI_RENDER } from '@sentry/conventions/op';
 import { DEFAULT_HOOKS } from './constants';
 import { DEBUG_BUILD } from './debug-build';
 import type { Hook, Operation, TracingOptions, ViewModel, Vue } from './types';
@@ -96,7 +96,7 @@ export const createTracingMixins = (options: Partial<TracingOptions> = {}): Mixi
             startInactiveSpan({
               name: 'Application Render',
               attributes: {
-                [SENTRY_OP]: BROWSER_UI_RENDER_SPAN_OP,
+                [SENTRY_OP]: UI_RENDER,
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.vue',
               },
               onlyIfParent: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7922,10 +7922,10 @@
     "@sentry/cli-win32-i686" "2.58.6"
     "@sentry/cli-win32-x64" "2.58.6"
 
-"@sentry/conventions@0.19.0", "@sentry/conventions@^0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.19.0.tgz#da81dd1b8c4f2f42aca2d74251a07ff9f8718e42"
-  integrity sha512-nYciB7Pt/Ujf6pJSt1FnHeJBp908P5Ibod4FMlTzASJcqU1RvixI5EFzkbe8gvUxP3XAMoWDgeWeG8agCjKYVA==
+"@sentry/conventions@0.20.0", "@sentry/conventions@^0.20.0":
+  version "0.20.0"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.20.0.tgz#f73f6f46934d754dacef447755b5adf1bf7f3245"
+  integrity sha512-nAL3tL+xgom6Dbuxq0NCEZZfBNIrUspjDJRcMMRl3WLiBCSeZzNCa7an48IpnrZoVMpAi2NQ2v9rFU+EQziKuQ==
 
 "@sentry/node-cpu-profiler@^2.4.3":
   version "2.4.3"


### PR DESCRIPTION
This PR:
- bumps `@sentry/conventions` to 0.20.0
- fixes the renamed op constants (an intentional breaking change in 0.20.0)