### PR TITLE
feat(tanstack): Register a route provider from the TanStack router matcher

### DIFF
--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -7,10 +7,12 @@ import {
 } from '@sentry/browser';
 import type { Integration } from '@sentry/core/browser';
 import {
+  createUrlRouteProvider,
   filterCollectedUrl,
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
+  setRouteProvider,
 } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core/browser';
 import type { VendoredTanstackRouter, VendoredTanstackRouterRouteMatch } from './vendor/tanstackrouter-types';
@@ -54,21 +56,33 @@ export function tanstackRouterBrowserTracingIntegration(
 
   const { instrumentPageLoad = true, instrumentNavigation = true } = options;
 
+  const resolveRouteMatch = (pathname: string, search: unknown): VendoredTanstackRouterRouteMatch | undefined => {
+    const matchedRoutes = castRouterInstance.matchRoutes(pathname, search as {}, {
+      preload: false,
+      throwOnError: false,
+    });
+    const lastMatch = matchedRoutes[matchedRoutes.length - 1];
+    // If we only match __root__, we ended up not matching any route at all, so
+    // we fall back to the pathname.
+    return lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
+  };
+
   return {
     ...browserTracingIntegrationInstance,
+    setup(client) {
+      // Registered before `afterAllSetup` so the provider is in place by the time the pageload span
+      // is named.
+      setRouteProvider(
+        createUrlRouteProvider(
+          url => resolveRouteMatch(url.pathname, castRouterInstance.options.parseSearch(url.search))?.routeId,
+        ),
+        client,
+      );
+
+      browserTracingIntegrationInstance.setup?.(client);
+    },
     afterAllSetup(client) {
       browserTracingIntegrationInstance.afterAllSetup(client);
-
-      const resolveRouteMatch = (pathname: string, search: unknown): VendoredTanstackRouterRouteMatch | undefined => {
-        const matchedRoutes = castRouterInstance.matchRoutes(pathname, search as {}, {
-          preload: false,
-          throwOnError: false,
-        });
-        const lastMatch = matchedRoutes[matchedRoutes.length - 1];
-        // If we only match __root__, we ended up not matching any route at all, so
-        // we fall back to the pathname.
-        return lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
-      };
 
       const applyRouteMatch = (
         span: NonNullable<ReturnType<typeof startBrowserTracingPageLoadSpan>>,

--- a/packages/solid/src/tanstackrouter.ts
+++ b/packages/solid/src/tanstackrouter.ts
@@ -17,9 +17,11 @@ import {
 import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 import type { Integration } from '@sentry/core';
 import {
+  createUrlRouteProvider,
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
+  setRouteProvider,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   filterCollectedUrl,
 } from '@sentry/core';
@@ -53,18 +55,28 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
 
   const { instrumentPageLoad = true, instrumentNavigation = true } = options;
 
+  const resolveRouteMatch = (pathname: string, search: Record<string, unknown>): RouteMatch | undefined => {
+    const matchedRoutes = router.matchRoutes(pathname, search, { preload: false, throwOnError: false });
+    const lastMatch = matchedRoutes[matchedRoutes.length - 1];
+    // If we only match __root__, we ended up not matching any route at all, so
+    // we fall back to the pathname.
+    return lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
+  };
+
   return {
     ...browserTracingIntegrationInstance,
+    setup(client) {
+      // Registered before `afterAllSetup` so the provider is in place by the time the pageload span
+      // is named.
+      setRouteProvider(
+        createUrlRouteProvider(url => resolveRouteMatch(url.pathname, router.options.parseSearch(url.search))?.routeId),
+        client,
+      );
+
+      browserTracingIntegrationInstance.setup?.(client);
+    },
     afterAllSetup(client) {
       browserTracingIntegrationInstance.afterAllSetup(client);
-
-      const resolveRouteMatch = (pathname: string, search: Record<string, unknown>): RouteMatch | undefined => {
-        const matchedRoutes = router.matchRoutes(pathname, search, { preload: false, throwOnError: false });
-        const lastMatch = matchedRoutes[matchedRoutes.length - 1];
-        // If we only match __root__, we ended up not matching any route at all, so
-        // we fall back to the pathname.
-        return lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
-      };
 
       const applyRouteMatch = (
         span: NonNullable<ReturnType<typeof startBrowserTracingPageLoadSpan>>,

--- a/packages/vue/src/tanstackrouter.ts
+++ b/packages/vue/src/tanstackrouter.ts
@@ -17,9 +17,11 @@ import {
 import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 import type { Integration } from '@sentry/core';
 import {
+  createUrlRouteProvider,
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
+  setRouteProvider,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   filterCollectedUrl,
 } from '@sentry/core';
@@ -58,19 +60,29 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
 
   const { instrumentPageLoad = true, instrumentNavigation = true } = options;
 
+  const resolveRouteMatch = (pathname: string, search: unknown): RouteMatch | undefined => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const matchedRoutes = router.matchRoutes(pathname, search as any, { preload: false, throwOnError: false });
+    const lastMatch = matchedRoutes[matchedRoutes.length - 1];
+    // If we only match __root__, we ended up not matching any route at all, so
+    // we fall back to the pathname.
+    return lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
+  };
+
   return {
     ...browserTracingIntegrationInstance,
+    setup(client) {
+      // Registered before `afterAllSetup` so the provider is in place by the time the pageload span
+      // is named.
+      setRouteProvider(
+        createUrlRouteProvider(url => resolveRouteMatch(url.pathname, router.options.parseSearch(url.search))?.routeId),
+        client,
+      );
+
+      browserTracingIntegrationInstance.setup?.(client);
+    },
     afterAllSetup(client) {
       browserTracingIntegrationInstance.afterAllSetup(client);
-
-      const resolveRouteMatch = (pathname: string, search: unknown): RouteMatch | undefined => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const matchedRoutes = router.matchRoutes(pathname, search as any, { preload: false, throwOnError: false });
-        const lastMatch = matchedRoutes[matchedRoutes.length - 1];
-        // If we only match __root__, we ended up not matching any route at all, so
-        // we fall back to the pathname.
-        return lastMatch?.routeId !== '__root__' ? lastMatch : undefined;
-      };
 
       const applyRouteMatch = (
         span: NonNullable<ReturnType<typeof startBrowserTracingPageLoadSpan>>,


### PR DESCRIPTION
Registers a route provider from the TanStack Router matcher in the react, solid and vue packages.

`resolveRouteMatch` already existed in all three, just scoped inside `afterAllSetup`. Hoisting it lets the provider reuse it rather than restating the match rules.

Worth flagging: these three files are ~60% identical and have drifted. #23299 taught only the react copy to prefer `router.state.location` for the initial pageload match. Left alone here since it is a behavior fix that deserves its own PR.

Part of #23556
