### PR TITLE
ref(ember)!: Change `'ui.ember.component.render'` to `ui.render`

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -219,7 +219,7 @@ import { AppModule } from './app/app.module';
 startSpan(
   {
     name: 'platform-browser-dynamic',
-    op: 'ui.angular.bootstrap',
+    op: 'ui.mount',
   },
   async () => {
     await platformBrowserDynamic().bootstrapModule(AppModule);

--- a/packages/ember/tests/unit/instrument-ember-globals-test.ts
+++ b/packages/ember/tests/unit/instrument-ember-globals-test.ts
@@ -1,3 +1,4 @@
+import { UI_RENDER } from '@sentry/conventions/op';
 import type { RenderEntries } from '@sentry/ember/utils/instrumentEmberGlobals';
 import {
   _processComponentRenderAfter,
@@ -19,7 +20,7 @@ module('Unit | Utility | instrument-ember-globals', function (hooks) {
     _processComponentRenderBefore(payload, beforeEntries);
     assert.true(beforeEntries.has(payload), 'Entry is recorded when the render starts');
 
-    _processComponentRenderAfter(payload, beforeEntries, 'ui.ember.component.render', 1_000);
+    _processComponentRenderAfter(payload, beforeEntries, UI_RENDER, 1_000);
     assert.false(
       beforeEntries.has(payload),
       'Entry is removed when the render finishes, so the payload (and the component instance it references) is not retained',
@@ -31,7 +32,7 @@ module('Unit | Utility | instrument-ember-globals', function (hooks) {
     const payload = { containerKey: 'component:test-component', initialRender: true as const, object: '<ember124>' };
 
     _processComponentRenderBefore(payload, beforeEntries);
-    _processComponentRenderAfter(payload, beforeEntries, 'ui.ember.component.render', 0);
+    _processComponentRenderAfter(payload, beforeEntries, UI_RENDER, 0);
 
     assert.false(beforeEntries.has(payload), 'Entry is removed after the span is created');
   });
@@ -42,7 +43,7 @@ module('Unit | Utility | instrument-ember-globals', function (hooks) {
     const unknownPayload = { containerKey: 'component:unknown', initialRender: true as const, object: '<ember126>' };
 
     _processComponentRenderBefore(trackedPayload, beforeEntries);
-    _processComponentRenderAfter(unknownPayload, beforeEntries, 'ui.ember.component.render', 1_000);
+    _processComponentRenderAfter(unknownPayload, beforeEntries, UI_RENDER, 1_000);
 
     assert.true(beforeEntries.has(trackedPayload), 'The in-flight entry is still tracked');
     assert.false(beforeEntries.has(unknownPayload), 'The unknown payload was not added');

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,7 +1,7 @@
 import { startInactiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, spanToJSON, timestampInSeconds, withActiveSpan } from '@sentry/core';
-import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { SENTRY_OP, UI_COMPONENT_NAME } from '@sentry/conventions/attributes';
 import { UI_MOUNT, UI_RENDER, UI_UPDATE } from '@sentry/conventions/op';
 import * as React from 'react';
 import { hoistNonReactStatics } from './hoist-non-react-statics';
@@ -53,7 +53,7 @@ class Profiler extends React.Component<ProfilerProps> {
       attributes: {
         [SENTRY_OP]: UI_MOUNT,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
-        'ui.component_name': name,
+        [UI_COMPONENT_NAME]: name,
       },
     });
   }
@@ -83,7 +83,7 @@ class Profiler extends React.Component<ProfilerProps> {
             attributes: {
               [SENTRY_OP]: UI_UPDATE,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
-              'ui.component_name': this.props.name,
+              [UI_COMPONENT_NAME]: this.props.name,
               'ui.react.changed_props': changedProps,
             },
           });
@@ -117,7 +117,7 @@ class Profiler extends React.Component<ProfilerProps> {
           attributes: {
             [SENTRY_OP]: UI_RENDER,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
-            'ui.component_name': name,
+            [UI_COMPONENT_NAME]: name,
           },
         });
         if (renderSpan) {
@@ -198,7 +198,7 @@ function useProfiler(
       attributes: {
         [SENTRY_OP]: UI_MOUNT,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
-        'ui.component_name': name,
+        [UI_COMPONENT_NAME]: name,
       },
     });
   });
@@ -220,7 +220,7 @@ function useProfiler(
           attributes: {
             [SENTRY_OP]: UI_RENDER,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.react.profiler',
-            'ui.component_name': name,
+            [UI_COMPONENT_NAME]: name,
           },
         });
         if (renderSpan) {


### PR DESCRIPTION
That was already done in this PR: https://github.com/getsentry/sentry-javascript/pull/23085
This just adds the missing span name from ember.

And also a mini readme change (angular), plus usage of the semantic conventions import in react.

Closes  https://github.com/getsentry/sentry-javascript/issues/23566
