### PR TITLE
fix(server-utils): Keep orchestrion registration out of tree-shaking

### DIFF
--- a/packages/server-utils/src/orchestrion/bundler/moduleInjectedTransform.ts
+++ b/packages/server-utils/src/orchestrion/bundler/moduleInjectedTransform.ts
@@ -20,6 +20,13 @@ interface ProgramNode {
 const DEFAULT_IMPORT_SPECIFIER = '@sentry/server-utils';
 
 /**
+ * Assignment target that keeps the injected call from being tree-shaken. See
+ * {@link moduleInjectedSnippet}. The value written is always `undefined`; only
+ * the assignment matters.
+ */
+const MODULE_INJECTED_SINK = 'globalThis.__SENTRY_ORCHESTRION_INJECT__';
+
+/**
  * Entry-chunk banner that marks "the bundler plugin ran" for
  * `detectOrchestrionSetup()`. Merge-only (`g.bundler = g.bundler || []`) so it
  * can never clobber module names already recorded by an injected snippet that
@@ -50,6 +57,13 @@ export const ORCHESTRION_BUNDLER_MARKER_BANNER =
  * inside a transformed `node_modules` file can't resolve (Turbopack under
  * isolated installs); it's embedded via `JSON.stringify` so absolute Windows
  * paths survive.
+ *
+ * The call result is assigned to a global rather than discarded. The helper
+ * returns `void` and `@sentry/server-utils` is `sideEffects: false`, so a bare
+ * call statement is something a bundler can prove droppable: rollup >= 4.63.0
+ * does exactly that and removes the whole registration, leaving the module
+ * instrumented but unsubscribed. Writing to a property of `globalThis` is a
+ * side effect no bundler can shake out, so the call survives.
  */
 function moduleInjectedSnippet(
   moduleName: string,
@@ -63,7 +77,7 @@ function moduleInjectedSnippet(
     : `const { ${bindings} } = require(${JSON.stringify(importSpecifier)});`;
 
   const args = exportName ? `${JSON.stringify(moduleName)}, ${exportName}` : JSON.stringify(moduleName);
-  return `${importStmt}\norchestrionModuleInjected(${args});`;
+  return `${importStmt}\n${MODULE_INJECTED_SINK} = orchestrionModuleInjected(${args});`;
 }
 
 /**

--- a/packages/server-utils/test/orchestrion/moduleInjectedTransform.test.ts
+++ b/packages/server-utils/test/orchestrion/moduleInjectedTransform.test.ts
@@ -83,6 +83,10 @@ describe('module-injected transform', () => {
     // needed at runtime and the lazy-subscription event matches what channel
     // integrations wait for.
     expect(result!.code).toContain('orchestrionModuleInjected("mysql", mysqlIntegration)');
+    // The result is assigned to a global. `@sentry/server-utils` is `sideEffects: false` and the
+    // helper returns `void`, so a bare call statement is one a bundler can prove droppable.
+    // rollup >= 4.63.0 removes it, leaving the module instrumented but unsubscribed.
+    expect(result!.code).toContain('globalThis.__SENTRY_ORCHESTRION_INJECT__ = orchestrionModuleInjected(');
     // No separate @sentry/core import at the injection site — the helper owns that.
     expect(result!.code).not.toContain('@sentry/core');
     // It imports ONLY the mysql factory — no central dispatch pulling in others.


### PR DESCRIPTION
## What

Keep the orchestrion registration that the bundler transform injects from being tree-shaken away.

- Assign the injected `orchestrionModuleInjected(...)` result to a `globalThis` property instead of discarding it.

## Why

The helper returns `void` and `@sentry/server-utils` sets `sideEffects: false`, so a bare call statement is one a bundler can prove droppable. rollup 4.63.0 (released 2026-08-25) does, and drops the registration. Instrumented modules then publish on their diagnostics channel with nothing subscribed, so no spans are recorded. This currently breaks every Cloudflare E2E app that instruments through the vite transform, and it silently disables DB instrumentation for users on vite or rollup 4.63.0 and later.
