### PR TITLE
fix(v10/bundler-plugins): Preserve full file path in component annotation source maps

### DIFF
--- a/packages/bundler-plugins/src/core/index.ts
+++ b/packages/bundler-plugins/src/core/index.ts
@@ -117,6 +117,7 @@ export function createComponentNameAnnotateHooks(ignoredComponents: string[], in
         const result = await transformAsync(code, {
           plugins: [[plugin, { ignoredComponents }]],
           filename: id,
+          sourceFileName: idWithoutQueryAndHash,
           parserOpts: {
             sourceType: 'module',
             allowAwaitOutsideFunction: true,

--- a/packages/bundler-plugins/test/core/index.test.ts
+++ b/packages/bundler-plugins/test/core/index.test.ts
@@ -1,6 +1,20 @@
-import { getDebugIdSnippet } from '../../src/core';
+import { createComponentNameAnnotateHooks, getDebugIdSnippet } from '../../src/core';
 import { containsOnlyImports } from '../../src/core/utils';
 import { describe, it, expect } from 'vitest';
+
+describe('createComponentNameAnnotateHooks', () => {
+  it.each([
+    ['.tsx', '/project/src/shared/providers/AppProviders.tsx'],
+    ['.jsx', '/project/src/shared/providers/AppProviders.jsx'],
+  ])('preserves the full file path in the emitted source map (%s)', async (_ext, id) => {
+    const { transform } = createComponentNameAnnotateHooks([], false);
+    const code = 'export function AppProviders() {\n  return <div>hello</div>;\n}\n';
+
+    const result = await transform(code, id);
+
+    expect(result?.map?.sources).toEqual([id]);
+  });
+});
 
 describe('getDebugIdSnippet', () => {
   it('returns the debugId injection snippet for a passed debugId', () => {


### PR DESCRIPTION
Backport of: #23572