### PR TITLE
feat(server-utils): Emit low cardinality knex, tedious and prisma db span names

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument-span-streaming.mjs
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  integrations: [Sentry.knexIntegration()],
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/test.ts
@@ -66,5 +66,41 @@ describeWithDockerCompose('knex auto instrumentation', { workingDirectory: [__di
         await createRunner().expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
       });
     });
+
+    createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-span-streaming.mjs', (createRunner, test) => {
+      test('should name spans after the query summary with span streaming', { timeout: 60_000 }, async () => {
+        await createRunner()
+          .expect({
+            span: container => {
+              // The `mysql2` driver spans underneath the knex spans come from a different integration and
+              // are named after the full statement, so they are filtered out here.
+              const knexSpans = container.items.filter(item => item.attributes['sentry.origin']?.value === ORIGIN);
+
+              expect(
+                knexSpans.map(span => ({
+                  name: span.name,
+                  summary: span.attributes['db.query.summary']?.value,
+                  text: span.attributes['db.query.text']?.value,
+                })),
+              ).toEqual([
+                {
+                  name: 'create table `User`',
+                  summary: 'create table `User`',
+                  text: 'create table `User` (`id` int unsigned not null auto_increment primary key, `createdAt` timestamp(3) not null default CURRENT_TIMESTAMP(3), `email` text not null, `name` text not null)',
+                },
+                {
+                  name: 'insert `User`',
+                  summary: 'insert `User`',
+                  text: 'insert into `User` (`email`, `name`) values (?, ?)',
+                },
+                { name: 'select `User`', summary: 'select `User`', text: 'select * from `User`' },
+                { name: 'drop table `User`', summary: 'drop table `User`', text: 'drop table `User`' },
+              ]);
+            },
+          })
+          .start()
+          .completed();
+      });
+    });
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument-span-streaming.mjs
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  integrations: [Sentry.knexIntegration()],
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/test.ts
@@ -80,5 +80,46 @@ describe('knex auto instrumentation', () => {
         await createRunner().expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
       });
     });
+
+    createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-span-streaming.mjs', (createRunner, test) => {
+      test('should name spans after the query summary with span streaming', { timeout: 60_000 }, async () => {
+        await createRunner()
+          .expect({
+            span: container => {
+              // The `pg` driver spans underneath the knex spans come from a different integration and
+              // are named after the full statement, so they are filtered out here.
+              const knexSpans = container.items.filter(item => item.attributes['sentry.origin']?.value === ORIGIN);
+
+              expect(
+                knexSpans.map(span => ({
+                  name: span.name,
+                  summary: span.attributes['db.query.summary']?.value,
+                  text: span.attributes['db.query.text']?.value,
+                })),
+              ).toEqual([
+                {
+                  name: 'create table "User"',
+                  summary: 'create table "User"',
+                  text: 'create table "User" ("id" serial primary key, "createdAt" timestamptz(3) not null default CURRENT_TIMESTAMP(3), "email" text not null, "name" text not null)',
+                },
+                {
+                  name: 'insert "User"',
+                  summary: 'insert "User"',
+                  text: 'insert into "User" ("email", "name") values (?, ?)',
+                },
+                { name: 'select "User"', summary: 'select "User"', text: 'select * from "User"' },
+                {
+                  name: 'select "DoesNotExist"',
+                  summary: 'select "DoesNotExist"',
+                  text: 'select * from "DoesNotExist"',
+                },
+                { name: 'drop table "User"', summary: 'drop table "User"', text: 'drop table "User"' },
+              ]);
+            },
+          })
+          .start()
+          .completed();
+      });
+    });
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/instrument-span-streaming.mjs
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -72,6 +72,7 @@ function expectPrismaV5Spans(transaction: TransactionEvent): void {
       expect.objectContaining({
         data: {
           'db.statement': expect.stringContaining('INSERT INTO'),
+          'db.query.summary': 'INSERT "public"."User"',
           'db.system': 'postgresql',
           'sentry.kind': 'client',
           'sentry.op': 'db',
@@ -84,6 +85,7 @@ function expectPrismaV5Spans(transaction: TransactionEvent): void {
       expect.objectContaining({
         data: {
           'db.statement': expect.stringContaining('SELECT'),
+          'db.query.summary': 'SELECT "public"',
           'db.system': 'postgresql',
           'sentry.kind': 'client',
           'sentry.op': 'db',
@@ -96,6 +98,7 @@ function expectPrismaV5Spans(transaction: TransactionEvent): void {
       expect.objectContaining({
         data: {
           'db.statement': expect.stringContaining('DELETE'),
+          'db.query.summary': 'DELETE "public"."User"',
           'db.system': 'postgresql',
           'sentry.kind': 'client',
           'sentry.op': 'db',
@@ -121,6 +124,52 @@ describeWithDockerCompose('Prisma ORM v5', { workingDirectory: [__dirname] }, ()
         test('should instrument PostgreSQL queries from Prisma ORM', { timeout: 75_000 }, async () => {
           await createRunner().expect({ transaction: expectPrismaV5Spans }).start().completed();
         });
+      },
+      {
+        additionalDependencies: ADDITIONAL_DEPENDENCIES,
+        afterSetupCommand: AFTER_SETUP_COMMAND,
+        copyPaths: ['prisma'],
+      },
+    );
+
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario.mjs',
+      'instrument-span-streaming.mjs',
+      (createRunner, test) => {
+        test(
+          'should name db query spans after the query summary with span streaming',
+          { timeout: 75_000 },
+          async () => {
+            await createRunner()
+              .expect({
+                span: container => {
+                  // v5 reports the SQL on the deprecated `db.statement` rather than `db.query.text`.
+                  const querySpans = container.items.filter(item => item.attributes['db.statement']);
+
+                  expect(
+                    querySpans.map(span => ({
+                      name: span.name,
+                      summary: span.attributes['db.query.summary']?.value,
+                    })),
+                  ).toEqual([
+                    { name: 'INSERT "public"."User"', summary: 'INSERT "public"."User"' },
+                    { name: 'SELECT "public"', summary: 'SELECT "public"' },
+                    { name: 'BEGIN', summary: 'BEGIN' },
+                    { name: 'INSERT "public"."User"', summary: 'INSERT "public"."User"' },
+                    { name: 'SELECT "public"', summary: 'SELECT "public"' },
+                    { name: 'COMMIT', summary: 'COMMIT' },
+                    { name: 'DELETE "public"."User"', summary: 'DELETE "public"."User"' },
+                  ]);
+
+                  // The raw engine span name must never leak through.
+                  expect(container.items.map(span => span.name)).not.toContain('prisma:engine:db_query');
+                },
+              })
+              .start()
+              .completed();
+          },
+        );
       },
       {
         additionalDependencies: ADDITIONAL_DEPENDENCIES,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v5/test.ts
@@ -142,6 +142,9 @@ describeWithDockerCompose('Prisma ORM v5', { workingDirectory: [__dirname] }, ()
           { timeout: 75_000 },
           async () => {
             await createRunner()
+              // Prisma's engine startup can outlast the span buffer's flush interval, so the query spans
+              // are not guaranteed to be in the first span envelope.
+              .unordered()
               .expect({
                 span: container => {
                   // v5 reports the SQL on the deprecated `db.statement` rather than `db.query.text`.

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/instrument-span-streaming.mjs
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -129,6 +129,9 @@ describeWithDockerCompose('Prisma ORM v6 Tests', { workingDirectory: [__dirname]
     (createRunner, test) => {
       test('should name db query spans after the query summary with span streaming', { timeout: 75_000 }, async () => {
         await createRunner()
+          // Prisma's engine startup can outlast the span buffer's flush interval, so the query spans
+          // are not guaranteed to be in the first span envelope.
+          .unordered()
           .expect({
             span: container => {
               const querySpans = container.items.filter(item => item.attributes['db.query.text']);

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v6/test.ts
@@ -88,6 +88,7 @@ describeWithDockerCompose('Prisma ORM v6 Tests', { workingDirectory: [__dirname]
                   'sentry.op': 'db',
                   'db.query.text':
                     'SELECT "public"."User"."id", "public"."User"."createdAt", "public"."User"."email", "public"."User"."name" FROM "public"."User" WHERE 1=1 OFFSET $1',
+                  'db.query.summary': 'SELECT "public"',
                   'db.system': 'postgresql',
                   'sentry.kind': 'client',
                 },
@@ -99,6 +100,7 @@ describeWithDockerCompose('Prisma ORM v6 Tests', { workingDirectory: [__dirname]
                 data: {
                   'sentry.op': 'db',
                   'db.query.text': 'DELETE FROM "public"."User" WHERE "public"."User"."email"::text LIKE $1',
+                  'db.query.summary': 'DELETE "public"."User"',
                   'db.system': 'postgresql',
                   'sentry.kind': 'client',
                 },
@@ -108,6 +110,47 @@ describeWithDockerCompose('Prisma ORM v6 Tests', { workingDirectory: [__dirname]
               // The db query span name must always be rewritten to the SQL text; the raw engine span
               // name should never leak through.
               expect(spans.find(span => span.description === 'prisma:engine:db_query')).toBeUndefined();
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    {
+      afterSetupCommand: 'prisma generate --schema prisma/schema.prisma',
+      copyPaths: ['prisma'],
+    },
+  );
+
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario.mjs',
+    'instrument-span-streaming.mjs',
+    (createRunner, test) => {
+      test('should name db query spans after the query summary with span streaming', { timeout: 75_000 }, async () => {
+        await createRunner()
+          .expect({
+            span: container => {
+              const querySpans = container.items.filter(item => item.attributes['db.query.text']);
+
+              // `SELECT "public"` is what the core query-summary helper derives from a schema-qualified,
+              // quoted table (it stops at the first quoted identifier).
+              expect(
+                querySpans.map(span => ({
+                  name: span.name,
+                  summary: span.attributes['db.query.summary']?.value,
+                })),
+              ).toEqual([
+                { name: 'INSERT "public"."User"', summary: 'INSERT "public"."User"' },
+                { name: 'SELECT "public"', summary: 'SELECT "public"' },
+                { name: 'DELETE "public"."User"', summary: 'DELETE "public"."User"' },
+              ]);
+
+              // Neither the raw engine span name nor the full statement may end up as a span name.
+              expect(container.items.map(span => span.name)).not.toContain('prisma:engine:db_query');
+              querySpans.forEach(span => {
+                expect(span.name).not.toBe(span.attributes['db.query.text']?.value);
+              });
             },
           })
           .start()

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/instrument-span-streaming.mjs
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -100,6 +100,9 @@ describe('Prisma ORM v7 Tests', () => {
           { timeout: 75_000 },
           async () => {
             await createRunner()
+              // Prisma's engine startup can outlast the span buffer's flush interval, so the query spans
+              // are not guaranteed to be in the first span envelope.
+              .unordered()
               .expect({
                 span: container => {
                   // v7 runs the queries through the `pg` adapter, whose own spans are named after the full

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -109,8 +109,7 @@ describe('Prisma ORM v7 Tests', () => {
                   // statement by a different integration, so they are filtered out here.
                   const querySpans = container.items.filter(
                     item =>
-                      item.attributes['sentry.origin']?.value === 'auto.db.otel.prisma' &&
-                      item.attributes['db.query.text'],
+                      item.attributes['sentry.origin']?.value === 'auto.db.prisma' && item.attributes['db.query.text'],
                   );
 
                   // `SELECT "public"` is what the core query-summary helper derives from a schema-qualified,

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm-v7/test.ts
@@ -89,5 +89,63 @@ describe('Prisma ORM v7 Tests', () => {
         copyPaths: ['prisma', 'prisma.config.ts'],
       },
     );
+
+    createEsmAndCjsTests(
+      __dirname,
+      'scenario.mjs',
+      'instrument-span-streaming.mjs',
+      (createRunner, test) => {
+        test(
+          'should name db query spans after the query summary with span streaming',
+          { timeout: 75_000 },
+          async () => {
+            await createRunner()
+              .expect({
+                span: container => {
+                  // v7 runs the queries through the `pg` adapter, whose own spans are named after the full
+                  // statement by a different integration, so they are filtered out here.
+                  const querySpans = container.items.filter(
+                    item =>
+                      item.attributes['sentry.origin']?.value === 'auto.db.otel.prisma' &&
+                      item.attributes['db.query.text'],
+                  );
+
+                  // `SELECT "public"` is what the core query-summary helper derives from a schema-qualified,
+                  // quoted table (it stops at the first quoted identifier).
+                  expect(
+                    querySpans.map(span => ({
+                      name: span.name,
+                      summary: span.attributes['db.query.summary']?.value,
+                    })),
+                  ).toEqual([
+                    { name: 'INSERT "public"."User"', summary: 'INSERT "public"."User"' },
+                    { name: 'SELECT "public"', summary: 'SELECT "public"' },
+                    { name: 'DELETE "public"."User"', summary: 'DELETE "public"."User"' },
+                  ]);
+
+                  // Neither the raw client span name nor the full statement may end up as a span name.
+                  expect(container.items.map(span => span.name)).not.toContain('prisma:client:db_query');
+                  querySpans.forEach(span => {
+                    expect(span.name).not.toBe(span.attributes['db.query.text']?.value);
+                  });
+                },
+              })
+              .start()
+              .completed();
+          },
+        );
+      },
+      {
+        additionalDependencies: {
+          '@prisma/adapter-pg': '7.2.0',
+          '@prisma/client': '7.2.0',
+          pg: '^8.11.0',
+          prisma: '7.2.0',
+          typescript: '^5.9.0',
+        },
+        afterSetupCommand: 'prisma generate --schema prisma/schema.prisma && tsc -p prisma/tsconfig.json',
+        copyPaths: ['prisma', 'prisma.config.ts'],
+      },
+    );
   });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/instrument-span-streaming.mjs
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/node';
+import { loggingTransport } from '@sentry-internal/node-integration-tests';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+  traceLifecycle: 'stream',
+});

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/scenario.mjs
@@ -46,6 +46,14 @@ function query(connection, sql, method = 'execSql') {
   });
 }
 
+function queryWithParameter(connection, sql, name, type, value) {
+  return new Promise((resolve, reject) => {
+    const request = new Request(sql, err => (err ? reject(err) : resolve()));
+    request.addParameter(name, type, value);
+    connection.execSql(request);
+  });
+}
+
 function callProcedure(connection) {
   return new Promise((resolve, reject) => {
     const request = new Request(PROCEDURE_NAME, err => (err ? reject(err) : resolve()));
@@ -118,6 +126,16 @@ async function run() {
       `if object_id('[dbo].[${BULK_TABLE}]') is null CREATE TABLE [dbo].[${BULK_TABLE}] (c1 int, c2 varchar(30))`,
     );
     await bulkLoad(connection);
+
+    // Reads against real tables: the single- and multi-table shapes a query summary has to resolve.
+    await query(connection, `SELECT c1, c2 FROM ${PREPARED_TABLE}`);
+    await query(connection, `SELECT p.c1 FROM ${PREPARED_TABLE} p INNER JOIN [dbo].[${BULK_TABLE}] b ON p.c1 = b.c1`);
+
+    // An inlined literal, the same filter parameterized, and a string literal containing `from` — the
+    // last one is why the statement is sanitized before it is summarized.
+    await query(connection, `SELECT c1, c2 FROM ${PREPARED_TABLE} WHERE c1 = 42`);
+    await queryWithParameter(connection, `SELECT c1, c2 FROM ${PREPARED_TABLE} WHERE c1 = @c1`, 'c1', TYPES.Int, 1);
+    await query(connection, `SELECT c1, c2 FROM [dbo].[${BULK_TABLE}] WHERE c2 = 'hello from acme'`);
   });
 
   connection.close();

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
@@ -44,42 +44,135 @@ describeWithDockerCompose('tedious auto instrumentation', { workingDirectory: [_
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createTestRunner, test) => {
     test('should auto-instrument `tedious` package', async () => {
-      await createTestRunner().expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
+      await createTestRunner()
+        .expect({
+          transaction: transaction => {
+            expect(transaction.transaction).toBe(EXPECTED_TRANSACTION.transaction);
+            expect(transaction.spans).toEqual(EXPECTED_TRANSACTION.spans);
+
+            const CREATE_PROCEDURE =
+              'CREATE OR ALTER PROCEDURE [dbo].[test_proced] @inputVal varchar(30), @outputCount int OUTPUT AS set @outputCount = LEN(@inputVal);';
+            const CREATE_PREPARED_TABLE =
+              "if object_id('[dbo].[test_prepared]') is null CREATE TABLE [dbo].[test_prepared] (c1 int, c2 int)";
+            const CREATE_BULK_TABLE =
+              "if object_id('[dbo].[test_bulk]') is null CREATE TABLE [dbo].[test_bulk] (c1 int, c2 varchar(30))";
+            const INSERT_PREPARED = 'INSERT INTO [dbo].[test_prepared] VALUES (@val1, @val2)';
+            const INSERT_BULK = 'insert bulk test_bulk([c1] int, [c2] nvarchar(50)) WITH (KEEP_NULLS)';
+            const SELECT_PREPARED = 'SELECT c1, c2 FROM [dbo].[test_prepared]';
+            const SELECT_JOIN =
+              'SELECT p.c1 FROM [dbo].[test_prepared] p INNER JOIN [dbo].[test_bulk] b ON p.c1 = b.c1';
+            const SELECT_INLINE_LITERAL = 'SELECT c1, c2 FROM [dbo].[test_prepared] WHERE c1 = 42';
+            const SELECT_PARAMETERIZED = 'SELECT c1, c2 FROM [dbo].[test_prepared] WHERE c1 = @c1';
+            const SELECT_STRING_LITERAL = "SELECT c1, c2 FROM [dbo].[test_bulk] WHERE c2 = 'hello from acme'";
+
+            expect(
+              (transaction.spans ?? [])
+                .filter(span => span.origin === ORIGIN)
+                .map(span => ({ name: span.description, text: span.data?.['db.query.text'] })),
+            ).toEqual([
+              { name: 'SELECT 1 + 1 AS solution', text: 'SELECT 1 + 1 AS solution' },
+              { name: 'SELECT 42; SELECT 42;', text: 'SELECT 42; SELECT 42;' },
+              { name: 'select !', text: 'select !' },
+              { name: CREATE_PROCEDURE, text: CREATE_PROCEDURE },
+              { name: '[dbo].[test_proced]', text: '[dbo].[test_proced]' },
+              { name: CREATE_PREPARED_TABLE, text: CREATE_PREPARED_TABLE },
+              { name: INSERT_PREPARED, text: INSERT_PREPARED },
+              { name: INSERT_PREPARED, text: INSERT_PREPARED },
+              { name: CREATE_BULK_TABLE, text: CREATE_BULK_TABLE },
+              { name: 'execBulkLoad test_bulk master', text: undefined },
+              { name: INSERT_BULK, text: INSERT_BULK },
+              { name: SELECT_PREPARED, text: SELECT_PREPARED },
+              { name: SELECT_JOIN, text: SELECT_JOIN },
+              { name: SELECT_INLINE_LITERAL, text: SELECT_INLINE_LITERAL },
+              { name: SELECT_PARAMETERIZED, text: SELECT_PARAMETERIZED },
+              { name: SELECT_STRING_LITERAL, text: SELECT_STRING_LITERAL },
+            ]);
+          },
+        })
+        .start()
+        .completed();
     });
   });
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-span-streaming.mjs', (createTestRunner, test) => {
-    test('should name spans after the operation with span streaming', async () => {
+    test('should name spans after the query summary with span streaming', async () => {
       await createTestRunner()
         .expect({
           span: container => {
             const dbSpans = container.items.filter(item => item.attributes['sentry.origin']?.value === ORIGIN);
 
-            // The SQL statement stays on `db.query.text`, but never reaches the span name.
-            expect(dbSpans.map(span => ({ name: span.name, text: span.attributes['db.query.text']?.value }))).toEqual([
-              { name: 'execSql master', text: 'SELECT 1 + 1 AS solution' },
-              { name: 'execSqlBatch master', text: 'SELECT 42; SELECT 42;' },
-              { name: 'execSql master', text: 'select !' },
+            expect(
+              dbSpans.map(span => ({
+                name: span.name,
+                summary: span.attributes['db.query.summary']?.value,
+                text: span.attributes['db.query.text']?.value,
+              })),
+            ).toEqual([
+              { name: 'SELECT', summary: 'SELECT', text: 'SELECT 1 + 1 AS solution' },
+              { name: 'SELECT', summary: 'SELECT', text: 'SELECT 42; SELECT 42;' },
+              { name: 'select', summary: 'select', text: 'select !' },
               {
-                name: 'execSql master',
+                name: 'CREATE',
+                summary: 'CREATE',
                 text: 'CREATE OR ALTER PROCEDURE [dbo].[test_proced] @inputVal varchar(30), @outputCount int OUTPUT AS set @outputCount = LEN(@inputVal);',
               },
-              { name: 'callProcedure [dbo].[test_proced] master', text: '[dbo].[test_proced]' },
+              { name: 'callProcedure [dbo].[test_proced]', summary: undefined, text: '[dbo].[test_proced]' },
               {
-                name: 'execSql master',
+                name: 'if',
+                summary: 'if',
                 text: "if object_id('[dbo].[test_prepared]') is null CREATE TABLE [dbo].[test_prepared] (c1 int, c2 int)",
               },
-              { name: 'prepare master', text: 'INSERT INTO [dbo].[test_prepared] VALUES (@val1, @val2)' },
-              { name: 'execute master', text: 'INSERT INTO [dbo].[test_prepared] VALUES (@val1, @val2)' },
               {
-                name: 'execSql master',
+                name: 'INSERT [dbo].[test_prepared]',
+                summary: 'INSERT [dbo].[test_prepared]',
+                text: 'INSERT INTO [dbo].[test_prepared] VALUES (@val1, @val2)',
+              },
+              {
+                name: 'INSERT [dbo].[test_prepared]',
+                summary: 'INSERT [dbo].[test_prepared]',
+                text: 'INSERT INTO [dbo].[test_prepared] VALUES (@val1, @val2)',
+              },
+              {
+                name: 'if',
+                summary: 'if',
                 text: "if object_id('[dbo].[test_bulk]') is null CREATE TABLE [dbo].[test_bulk] (c1 int, c2 varchar(30))",
               },
               {
-                name: 'execSqlBatch master',
+                name: 'insert',
+                summary: 'insert',
                 text: 'insert bulk test_bulk([c1] int, [c2] nvarchar(50)) WITH (KEEP_NULLS)',
               },
-              { name: 'execBulkLoad test_bulk master', text: undefined },
+              { name: 'execBulkLoad test_bulk', summary: undefined, text: undefined },
+              {
+                name: 'SELECT [dbo].[test_prepared]',
+                summary: 'SELECT [dbo].[test_prepared]',
+                text: 'SELECT c1, c2 FROM [dbo].[test_prepared]',
+              },
+              {
+                name: 'SELECT [dbo].[test_prepared]',
+                summary: 'SELECT [dbo].[test_prepared]',
+                text: 'SELECT c1, c2 FROM [dbo].[test_prepared] WHERE c1 = @c1',
+              },
+              {
+                // TODO: (check if correct) Both sides of the join survive into the summary.
+                name: 'SELECT [dbo].[test_prepared] [dbo].[test_bulk]',
+                summary: 'SELECT [dbo].[test_prepared] [dbo].[test_bulk]',
+                text: 'SELECT p.c1 FROM [dbo].[test_prepared] p INNER JOIN [dbo].[test_bulk] b ON p.c1 = b.c1',
+              },
+              {
+                // TODO: (fix) tedious reports the statement as the caller wrote it, so an inlined literal reaches
+                // `db.query.text` unsanitized. Only the summary is sanitized.
+                name: 'SELECT [dbo].[test_prepared]',
+                summary: 'SELECT [dbo].[test_prepared]',
+                text: 'SELECT c1, c2 FROM [dbo].[test_prepared] WHERE c1 = 42',
+              },
+              {
+                // TODO: (fix) The `from` inside the string literal must not be read as a table: the statement is
+                // sanitized before it is summarized, so the summary is just the real table.
+                name: 'SELECT [dbo].[test_bulk]',
+                summary: 'SELECT [dbo].[test_bulk]',
+                text: "SELECT c1, c2 FROM [dbo].[test_bulk] WHERE c2 = 'hello from acme'",
+              },
             ]);
           },
         })

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
@@ -149,11 +149,6 @@ describeWithDockerCompose('tedious auto instrumentation', { workingDirectory: [_
                 text: 'SELECT c1, c2 FROM [dbo].[test_prepared]',
               },
               {
-                name: 'SELECT [dbo].[test_prepared]',
-                summary: 'SELECT [dbo].[test_prepared]',
-                text: 'SELECT c1, c2 FROM [dbo].[test_prepared] WHERE c1 = @c1',
-              },
-              {
                 // TODO: (check if correct) Both sides of the join survive into the summary.
                 name: 'SELECT [dbo].[test_prepared] [dbo].[test_bulk]',
                 summary: 'SELECT [dbo].[test_prepared] [dbo].[test_bulk]',
@@ -165,6 +160,11 @@ describeWithDockerCompose('tedious auto instrumentation', { workingDirectory: [_
                 name: 'SELECT [dbo].[test_prepared]',
                 summary: 'SELECT [dbo].[test_prepared]',
                 text: 'SELECT c1, c2 FROM [dbo].[test_prepared] WHERE c1 = 42',
+              },
+              {
+                name: 'SELECT [dbo].[test_prepared]',
+                summary: 'SELECT [dbo].[test_prepared]',
+                text: 'SELECT c1, c2 FROM [dbo].[test_prepared] WHERE c1 = @c1',
               },
               {
                 // TODO: (fix) The `from` inside the string literal must not be read as a table: the statement is

--- a/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tedious/test.ts
@@ -47,4 +47,44 @@ describeWithDockerCompose('tedious auto instrumentation', { workingDirectory: [_
       await createTestRunner().expect({ transaction: EXPECTED_TRANSACTION }).start().completed();
     });
   });
+
+  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-span-streaming.mjs', (createTestRunner, test) => {
+    test('should name spans after the operation with span streaming', async () => {
+      await createTestRunner()
+        .expect({
+          span: container => {
+            const dbSpans = container.items.filter(item => item.attributes['sentry.origin']?.value === ORIGIN);
+
+            // The SQL statement stays on `db.query.text`, but never reaches the span name.
+            expect(dbSpans.map(span => ({ name: span.name, text: span.attributes['db.query.text']?.value }))).toEqual([
+              { name: 'execSql master', text: 'SELECT 1 + 1 AS solution' },
+              { name: 'execSqlBatch master', text: 'SELECT 42; SELECT 42;' },
+              { name: 'execSql master', text: 'select !' },
+              {
+                name: 'execSql master',
+                text: 'CREATE OR ALTER PROCEDURE [dbo].[test_proced] @inputVal varchar(30), @outputCount int OUTPUT AS set @outputCount = LEN(@inputVal);',
+              },
+              { name: 'callProcedure [dbo].[test_proced] master', text: '[dbo].[test_proced]' },
+              {
+                name: 'execSql master',
+                text: "if object_id('[dbo].[test_prepared]') is null CREATE TABLE [dbo].[test_prepared] (c1 int, c2 int)",
+              },
+              { name: 'prepare master', text: 'INSERT INTO [dbo].[test_prepared] VALUES (@val1, @val2)' },
+              { name: 'execute master', text: 'INSERT INTO [dbo].[test_prepared] VALUES (@val1, @val2)' },
+              {
+                name: 'execSql master',
+                text: "if object_id('[dbo].[test_bulk]') is null CREATE TABLE [dbo].[test_bulk] (c1 int, c2 varchar(30))",
+              },
+              {
+                name: 'execSqlBatch master',
+                text: 'insert bulk test_bulk([c1] int, [c2] nvarchar(50)) WITH (KEEP_NULLS)',
+              },
+              { name: 'execBulkLoad test_bulk master', text: undefined },
+            ]);
+          },
+        })
+        .start()
+        .completed();
+    });
+  });
 });

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -5,8 +5,6 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Span, SpanAttributes } from '@sentry/core';
 import {
-  _INTERNAL_getSqlQuerySummary,
-  _INTERNAL_sanitizeSqlQuery,
   debug,
   defineIntegration,
   getActiveSpan,
@@ -35,6 +33,7 @@ import { DB } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../debug-build';
 import { CHANNELS } from '../orchestrion/channels';
 import { bindTracingChannelToSpan } from '../tracing-channel';
+import { _INTERNAL_getSqlQuerySummary, _INTERNAL_sanitizeSqlQuery } from '@sentry/core/server';
 
 // NOTE: this uses the same name as the OTel integration by design. `@sentry/node`'s `knexIntegration`
 // picks this subscriber over the vendored OTel path when orchestrion injection is active.

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -7,7 +7,6 @@ import type { IntegrationFn, Span, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_getSqlQuerySummary,
   _INTERNAL_sanitizeSqlQuery,
-  DB_SPAN_NAME_FALLBACK,
   debug,
   defineIntegration,
   getActiveSpan,
@@ -173,6 +172,7 @@ function subscribeQuery(): void {
       const operation = query?.method;
       const dbNameSpace =
         connection?.filename || connection?.database || extractDatabaseFromConnectionString(connectionString);
+      const dbSystem = mapSystem(client?.driverName);
 
       const dbStatement = query?.sql != null ? truncate(query.sql, MAX_QUERY_LENGTH) : undefined;
       // The statement is sanitized before it is summarized, so that a string literal containing
@@ -185,7 +185,7 @@ function subscribeQuery(): void {
         [SENTRY_KIND]: 'client',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
         'knex.version': data.moduleVersion,
-        [DB_SYSTEM_NAME]: mapSystem(client?.driverName),
+        [DB_SYSTEM_NAME]: dbSystem,
         [ATTR_DB_SQL_TABLE]: table,
         [DB_OPERATION_NAME]: operation,
         [DB_USER]: connection?.user,
@@ -200,7 +200,7 @@ function subscribeQuery(): void {
       const sentryClient = getClient();
       const spanName =
         sentryClient && hasSpanStreamingEnabled(sentryClient)
-          ? querySummary || getSecondaryStreamName(dbNameSpace, operation, table)
+          ? querySummary || getSecondaryStreamName(dbSystem, dbNameSpace, operation, table)
           : (dbStatement ?? getName(dbNameSpace, operation, table) ?? 'knex.query');
 
       return startInactiveSpan({
@@ -282,7 +282,12 @@ function getName(db: string | undefined, operation?: string, table?: string): st
   return db;
 }
 
-function getSecondaryStreamName(dbNameSpace: string | undefined, operation?: string, table?: string): string {
+function getSecondaryStreamName(
+  dbSystem: string | undefined,
+  dbNameSpace: string | undefined,
+  operation?: string,
+  table?: string,
+): string {
   if (operation) {
     if (table) {
       return `${operation} ${table}`;
@@ -297,7 +302,9 @@ function getSecondaryStreamName(dbNameSpace: string | undefined, operation?: str
   if (dbNameSpace) {
     return dbNameSpace;
   }
-  return DB_SPAN_NAME_FALLBACK;
+  // Mirrors the postgres integration, which falls back to `{db.system.name}` rather than to a static
+  // name. `db.system.name` is only unset when the knex client reports no driver.
+  return dbSystem ?? 'knex.query';
 }
 
 function extractTableName(builder: KnexBuilder | undefined): string | undefined {

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -5,9 +5,14 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, Span, SpanAttributes } from '@sentry/core';
 import {
+  _INTERNAL_getSqlQuerySummary,
+  _INTERNAL_sanitizeSqlQuery,
+  DB_SPAN_NAME_FALLBACK,
   debug,
   defineIntegration,
   getActiveSpan,
+  getClient,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   startInactiveSpan,
@@ -17,6 +22,7 @@ import {
 import {
   DB_NAMESPACE,
   DB_OPERATION_NAME,
+  DB_QUERY_SUMMARY,
   DB_QUERY_TEXT,
   DB_SYSTEM_NAME,
   DB_USER,
@@ -169,6 +175,11 @@ function subscribeQuery(): void {
         connection?.filename || connection?.database || extractDatabaseFromConnectionString(connectionString);
 
       const dbStatement = query?.sql != null ? truncate(query.sql, MAX_QUERY_LENGTH) : undefined;
+      // The statement is sanitized before it is summarized, so that a string literal containing
+      // `from`/`join` can't leak a value into the summary.
+      const querySummary = dbStatement
+        ? _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(dbStatement))
+        : undefined;
       const attributes: SpanAttributes = {
         [SENTRY_OP]: DB,
         [SENTRY_KIND]: 'client',
@@ -183,10 +194,20 @@ function subscribeQuery(): void {
         [SERVER_PORT]: connection?.port ?? extractPortFromConnectionString(connectionString),
         [NETWORK_TRANSPORT]: connection?.filename === ':memory:' ? 'inproc' : undefined,
         [DB_QUERY_TEXT]: dbStatement,
+        [DB_QUERY_SUMMARY]: querySummary,
       };
 
+      const sentryClient = getClient();
+      // With span streaming, span names have to be low cardinality, so `{db.query.summary}` is used
+      // instead of the full statement, falling back to `getName`'s `{operation} {namespace}.{table}`
+      // when there is no statement to summarize.
+      const streamedName =
+        sentryClient && hasSpanStreamingEnabled(sentryClient)
+          ? querySummary || getName(name, operation, table) || DB_SPAN_NAME_FALLBACK
+          : undefined;
+
       return startInactiveSpan({
-        name: dbStatement ?? getName(name, operation, table) ?? 'knex.query',
+        name: streamedName ?? dbStatement ?? getName(name, operation, table) ?? 'knex.query',
         parentSpan,
         attributes,
       });

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -171,7 +171,7 @@ function subscribeQuery(): void {
       const connectionString = connection?.connectionString;
       const table = extractTableName(builder);
       const operation = query?.method;
-      const name =
+      const dbNameSpace =
         connection?.filename || connection?.database || extractDatabaseFromConnectionString(connectionString);
 
       const dbStatement = query?.sql != null ? truncate(query.sql, MAX_QUERY_LENGTH) : undefined;
@@ -189,7 +189,7 @@ function subscribeQuery(): void {
         [ATTR_DB_SQL_TABLE]: table,
         [DB_OPERATION_NAME]: operation,
         [DB_USER]: connection?.user,
-        [DB_NAMESPACE]: name,
+        [DB_NAMESPACE]: dbNameSpace,
         [SERVER_ADDRESS]: connection?.host ?? extractHostFromConnectionString(connectionString),
         [SERVER_PORT]: connection?.port ?? extractPortFromConnectionString(connectionString),
         [NETWORK_TRANSPORT]: connection?.filename === ':memory:' ? 'inproc' : undefined,
@@ -198,16 +198,13 @@ function subscribeQuery(): void {
       };
 
       const sentryClient = getClient();
-      // With span streaming, span names have to be low cardinality, so `{db.query.summary}` is used
-      // instead of the full statement, falling back to `getName`'s `{operation} {namespace}.{table}`
-      // when there is no statement to summarize.
-      const streamedName =
+      const spanName =
         sentryClient && hasSpanStreamingEnabled(sentryClient)
-          ? querySummary || getName(name, operation, table) || DB_SPAN_NAME_FALLBACK
-          : undefined;
+          ? querySummary || getSecondaryStreamName(dbNameSpace, operation, table)
+          : (dbStatement ?? getName(dbNameSpace, operation, table) ?? 'knex.query');
 
       return startInactiveSpan({
-        name: streamedName ?? dbStatement ?? getName(name, operation, table) ?? 'knex.query',
+        name: spanName,
         parentSpan,
         attributes,
       });
@@ -283,6 +280,24 @@ function getName(db: string | undefined, operation?: string, table?: string): st
     return table ? `${operation} ${db}.${table}` : `${operation} ${db}`;
   }
   return db;
+}
+
+function getSecondaryStreamName(dbNameSpace: string | undefined, operation?: string, table?: string): string {
+  if (operation) {
+    if (table) {
+      return `${operation} ${table}`;
+    }
+    if (dbNameSpace) {
+      return `${operation} ${dbNameSpace}`;
+    }
+  }
+  if (table) {
+    return table;
+  }
+  if (dbNameSpace) {
+    return dbNameSpace;
+  }
+  return DB_SPAN_NAME_FALLBACK;
 }
 
 function extractTableName(builder: KnexBuilder | undefined): string | undefined {

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -153,6 +153,7 @@ function subscribeBuilder(channelName: string): void {
 function subscribeQuery(): void {
   bindTracingChannelToSpan<KnexQueryChannelContext>(
     diagnosticsChannel.tracingChannel<KnexQueryChannelContext>(CHANNELS.KNEX_QUERY),
+    // oxlint-disable-next-line complexity
     data => {
       const runner = data.self;
       const builder = runner?.builder;
@@ -175,10 +176,9 @@ function subscribeQuery(): void {
       const dbSystem = mapSystem(client?.driverName);
 
       const dbStatement = query?.sql != null ? truncate(query.sql, MAX_QUERY_LENGTH) : undefined;
-      // The statement is sanitized before it is summarized, so that a string literal containing
-      // `from`/`join` can't leak a value into the summary.
+      const dialect = client?.driverName === 'mysql' || client?.driverName === 'mysql2' ? 'mysql' : undefined;
       const querySummary = dbStatement
-        ? _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(dbStatement))
+        ? _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(dbStatement, dialect))
         : undefined;
       const attributes: SpanAttributes = {
         [SENTRY_OP]: DB,

--- a/packages/server-utils/src/integrations/prisma/tracing-helper.ts
+++ b/packages/server-utils/src/integrations/prisma/tracing-helper.ts
@@ -15,8 +15,12 @@
 
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
+  _INTERNAL_getSqlQuerySummary,
+  _INTERNAL_sanitizeSqlQuery,
   debug,
   getActiveSpan,
+  getClient,
+  hasSpanStreamingEnabled,
   LRUMap,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startInactiveSpan,
@@ -24,7 +28,15 @@ import {
 } from '@sentry/core';
 import { DEBUG_BUILD } from '../../debug-build';
 import type { EngineSpan, ExtendedSpanOptions, SpanCallback, TracingHelper } from './types';
-import { DB_STATEMENT, DB_SYSTEM, DB_SYSTEM_NAME, SENTRY_KIND, SENTRY_OP } from '@sentry/conventions/attributes';
+import {
+  DB_QUERY_SUMMARY,
+  DB_QUERY_TEXT,
+  DB_STATEMENT,
+  DB_SYSTEM,
+  DB_SYSTEM_NAME,
+  SENTRY_KIND,
+  SENTRY_OP,
+} from '@sentry/conventions/attributes';
 
 // Reading `process.env` can throw in runtimes that gate env access (e.g. Deno without `--allow-env`)
 // and `process` may be absent altogether (edge runtimes), so this degrades to `false` in those cases.
@@ -102,7 +114,31 @@ function buildSpanAttributes(name: string, attributes: Record<string, unknown> |
     merged[SENTRY_OP] = 'db';
   }
 
+  const statement = getSqlStatement(name, merged);
+  if (statement) {
+    // Sanitized before summarizing, so that a string literal containing `from`/`join` can't leak a
+    // value into the summary.
+    merged[DB_QUERY_SUMMARY] = _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(statement));
+  }
+
   return merged;
+}
+
+/**
+ * The SQL a span reports, if any. Prisma emits it as the deprecated `db.statement` on older versions
+ * and as `db.query.text` on the `db_query` spans of newer ones.
+ */
+function getSqlStatement(name: string, attributes: SpanAttributes): string | undefined {
+  // oxlint-disable-next-line typescript/no-deprecated
+  const dbStatement = attributes[DB_STATEMENT];
+  if (typeof dbStatement === 'string' && dbStatement) {
+    return dbStatement;
+  }
+  const queryText = attributes[DB_QUERY_TEXT];
+  if ((name === 'prisma:engine:db_query' || name === 'prisma:client:db_query') && typeof queryText === 'string') {
+    return queryText;
+  }
+  return undefined;
 }
 
 /**
@@ -110,16 +146,15 @@ function buildSpanAttributes(name: string, attributes: Record<string, unknown> |
  * engine name. v5/v6 emit `prisma:engine:db_query`; v7 inlined the engine and emits `prisma:client:db_query`.
  */
 function buildSpanName(name: string, attributes: SpanAttributes): string {
-  // oxlint-disable-next-line typescript/no-deprecated
-  const dbStatement = attributes[DB_STATEMENT];
-  if (typeof dbStatement === 'string' && dbStatement) {
-    return dbStatement;
+  const client = getClient();
+
+  // With span streaming, span names have to be low cardinality, so `{db.query.summary}` is used
+  // instead of the full statement. Spans that report no SQL keep the engine span name.
+  if (client && hasSpanStreamingEnabled(client)) {
+    return (attributes[DB_QUERY_SUMMARY] as string | undefined) || name;
   }
-  const queryText = attributes['db.query.text'];
-  if ((name === 'prisma:engine:db_query' || name === 'prisma:client:db_query') && typeof queryText === 'string') {
-    return queryText;
-  }
-  return name;
+
+  return getSqlStatement(name, attributes) ?? name;
 }
 
 /**

--- a/packages/server-utils/src/integrations/prisma/tracing-helper.ts
+++ b/packages/server-utils/src/integrations/prisma/tracing-helper.ts
@@ -15,8 +15,6 @@
 
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
-  _INTERNAL_getSqlQuerySummary,
-  _INTERNAL_sanitizeSqlQuery,
   debug,
   getActiveSpan,
   getClient,
@@ -37,6 +35,7 @@ import {
   SENTRY_KIND,
   SENTRY_OP,
 } from '@sentry/conventions/attributes';
+import { _INTERNAL_getSqlQuerySummary, _INTERNAL_sanitizeSqlQuery } from '@sentry/core/server';
 
 // Reading `process.env` can throw in runtimes that gate env access (e.g. Deno without `--allow-env`)
 // and `process` may be absent altogether (edge runtimes), so this degrades to `false` in those cases.

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -7,6 +7,8 @@ import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, SpanAttributes } from '@sentry/core';
 import {
   defineIntegration,
+  getClient,
+  hasSpanStreamingEnabled,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   startInactiveSpan,
@@ -143,8 +145,14 @@ function subscribeQuery(channelName: string, operation: string): void {
       [SERVER_PORT]: connection.config?.options?.port,
     };
 
+    const client = getClient();
+    // `getSpanName` already builds `{db.operation.name}` paired with the bulk-load table, the stored
+    // procedure or `{db.namespace}`, so with span streaming — where span names have to be low
+    // cardinality — it is used instead of the SQL statement.
+    const spanName = getSpanName(operation, databaseName, sql, request.table);
+
     const span = startInactiveSpan({
-      name: sql || getSpanName(operation, databaseName, sql, request.table),
+      name: client && hasSpanStreamingEnabled(client) ? spanName : sql || spanName,
       attributes,
     });
 

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -6,6 +6,8 @@ import { EventEmitter } from 'node:events';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, SpanAttributes } from '@sentry/core';
 import {
+  _INTERNAL_getSqlQuerySummary,
+  _INTERNAL_sanitizeSqlQuery,
   defineIntegration,
   getClient,
   hasSpanStreamingEnabled,
@@ -15,6 +17,7 @@ import {
 } from '@sentry/core';
 import {
   DB_NAMESPACE,
+  DB_QUERY_SUMMARY,
   DB_QUERY_TEXT,
   DB_SYSTEM_NAME,
   DB_USER,
@@ -130,6 +133,8 @@ function subscribeQuery(channelName: string, operation: string): void {
 
     const databaseName = connection[currentDatabaseSymbol];
     const sql = extractSql(request);
+    const querySummary =
+      sql && operation !== 'callProcedure' ? _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(sql)) : undefined;
 
     const attributes: SpanAttributes = {
       [SENTRY_OP]: DB,
@@ -140,19 +145,19 @@ function subscribeQuery(channelName: string, operation: string): void {
       // `>=4` uses the `authentication` object; older versions expose `userName` directly.
       [DB_USER]: connection.config?.userName ?? connection.config?.authentication?.options?.userName,
       [DB_QUERY_TEXT]: sql,
+      [DB_QUERY_SUMMARY]: querySummary,
       [ATTR_DB_SQL_TABLE]: request.table,
       [SERVER_ADDRESS]: connection.config?.server,
       [SERVER_PORT]: connection.config?.options?.port,
     };
 
     const client = getClient();
-    // `getSpanName` already builds `{db.operation.name}` paired with the bulk-load table, the stored
-    // procedure or `{db.namespace}`, so with span streaming — where span names have to be low
-    // cardinality — it is used instead of the SQL statement.
-    const spanName = getSpanName(operation, databaseName, sql, request.table);
 
     const span = startInactiveSpan({
-      name: client && hasSpanStreamingEnabled(client) ? spanName : sql || spanName,
+      name:
+        client && hasSpanStreamingEnabled(client)
+          ? (querySummary ?? getLowCardinalitySecondarySpanName(operation, databaseName, sql, request.table))
+          : sql || getSecondarySpanName(operation, databaseName, sql, request.table),
       attributes,
     });
 
@@ -207,7 +212,7 @@ function extractSql(request: TediousRequest): string | undefined {
  * The span name is a low-cardinality label for the operation; the SDK's db-span inference later renames
  * the span description off `db.query.text` when present. Mirrors the vendored OTel `getSpanName`.
  */
-function getSpanName(
+function getSecondarySpanName(
   operation: string,
   db: string | undefined,
   sql: string | undefined,
@@ -221,6 +226,22 @@ function getSpanName(
     return db ? `${operation} ${sql} ${db}` : `${operation} ${sql}`;
   }
   // Avoid `sql` in the general case because of its high cardinality.
+  return db ? `${operation} ${db}` : operation;
+}
+
+function getLowCardinalitySecondarySpanName(
+  operation: string,
+  db: string | undefined,
+  sql: string | undefined,
+  bulkLoadTable: string | undefined,
+): string {
+  if (operation === 'execBulkLoad' && bulkLoadTable) {
+    return `${operation} ${bulkLoadTable}`;
+  }
+  if (operation === 'callProcedure') {
+    // `sql` refers to the procedure name for `callProcedure`, so it is low-cardinality in this case.
+    return `${operation} ${sql}`;
+  }
   return db ? `${operation} ${db}` : operation;
 }
 

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -221,7 +221,7 @@ function getSecondarySpanName(
   if (operation === 'execBulkLoad' && bulkLoadTable && db) {
     return `${operation} ${bulkLoadTable} ${db}`;
   }
-  if (operation === 'callProcedure') {
+  if (operation === 'callProcedure' && sql) {
     // `sql` refers to the procedure name for `callProcedure`.
     return db ? `${operation} ${sql} ${db}` : `${operation} ${sql}`;
   }

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -6,8 +6,6 @@ import { EventEmitter } from 'node:events';
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import type { IntegrationFn, SpanAttributes } from '@sentry/core';
 import {
-  _INTERNAL_getSqlQuerySummary,
-  _INTERNAL_sanitizeSqlQuery,
   defineIntegration,
   getClient,
   hasSpanStreamingEnabled,
@@ -30,6 +28,7 @@ import { DB } from '@sentry/conventions/op';
 import { CHANNELS } from '../orchestrion/channels';
 import { tediousModuleNames } from '../orchestrion/config/tedious';
 import { invokeOrchestrionInstrumentation } from '../orchestrion/instrumentation';
+import { _INTERNAL_getSqlQuerySummary, _INTERNAL_sanitizeSqlQuery } from '@sentry/core/server';
 
 // NOTE: this uses the same name as the OTel integration by design. When orchestrion injection is active,
 // `_init` swaps the OTel `Tedious` integration out of the defaults and appends this one (matched by name).

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -156,8 +156,8 @@ function subscribeQuery(channelName: string, operation: string): void {
     const span = startInactiveSpan({
       name:
         client && hasSpanStreamingEnabled(client)
-          ? (querySummary ?? getLowCardinalitySecondarySpanName(operation, databaseName, sql, request.table))
-          : sql || getSecondarySpanName(operation, databaseName, sql, request.table),
+          ? querySummary || getLowCardinalitySecondarySpanName(operation, databaseName, sql, request.table)
+          : sql || getSecondarySpanName(operation, databaseName, request.table),
       attributes,
     });
 
@@ -209,21 +209,11 @@ function extractSql(request: TediousRequest): string | undefined {
 }
 
 /**
- * The span name is a low-cardinality label for the operation; the SDK's db-span inference later renames
- * the span description off `db.query.text` when present. Mirrors the vendored OTel `getSpanName`.
+ * Get a secondary span name for static trace lifecycle (not strictly adhering to sentry-convention span names)
  */
-function getSecondarySpanName(
-  operation: string,
-  db: string | undefined,
-  sql: string | undefined,
-  bulkLoadTable: string | undefined,
-): string {
+function getSecondarySpanName(operation: string, db: string | undefined, bulkLoadTable: string | undefined): string {
   if (operation === 'execBulkLoad' && bulkLoadTable && db) {
     return `${operation} ${bulkLoadTable} ${db}`;
-  }
-  if (operation === 'callProcedure' && sql) {
-    // `sql` refers to the procedure name for `callProcedure`.
-    return db ? `${operation} ${sql} ${db}` : `${operation} ${sql}`;
   }
   // Avoid `sql` in the general case because of its high cardinality.
   return db ? `${operation} ${db}` : operation;

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -238,7 +238,7 @@ function getLowCardinalitySecondarySpanName(
   if (operation === 'execBulkLoad' && bulkLoadTable) {
     return `${operation} ${bulkLoadTable}`;
   }
-  if (operation === 'callProcedure') {
+  if (operation === 'callProcedure' && sql) {
     // `sql` refers to the procedure name for `callProcedure`, so it is low-cardinality in this case.
     return `${operation} ${sql}`;
   }


### PR DESCRIPTION
With span streaming enabled:

- knex, prisma and tedious spans are named after `db.query.summary`, with fallbacks according to lower prio sentry [convention name templates](https://getsentry.github.io/sentry-conventions/names/#db-queries)
- `traceLifecycle: 'static'` keeps the existing names

Also discovered some bugs along the way that should be addressed afterwards but don't belong into this PR:

- https://github.com/getsentry/sentry-javascript/issues/23684
- https://github.com/getsentry/sentry-javascript/issues/23676

Refs #23523