### PR TITLE
test(node-integration-tests): Unflake LocalVariables out-of-app capture

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app-default.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app-default.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const { waitForLocalVariablesCapture } = require('./wait-for-local-variables');
 
 const externalFunctionFile = require.resolve('./node_modules/out-of-app-function.js');
 
@@ -17,11 +18,16 @@ Sentry.init({
   includeLocalVariables: true,
 });
 
-setTimeout(async () => {
+(async () => {
+  await waitForLocalVariablesCapture();
+
   try {
     in_app_function();
   } catch (e) {
     Sentry.captureException(e);
     await Sentry.flush();
   }
-}, 500);
+})().catch(error => {
+  process.stderr.write(`${error}\n`);
+  process.exit(1);
+});

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-out-of-app.js
@@ -1,5 +1,6 @@
 const Sentry = require('@sentry/node');
 const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const { waitForLocalVariablesCapture } = require('./wait-for-local-variables');
 
 const externalFunctionFile = require.resolve('./node_modules/out-of-app-function.js');
 
@@ -22,11 +23,16 @@ function in_app_function() {
   out_of_app_function(`${inAppVar} modified value`);
 }
 
-setTimeout(async () => {
+(async () => {
+  await waitForLocalVariablesCapture();
+
   try {
     in_app_function();
   } catch (e) {
     Sentry.captureException(e);
     await Sentry.flush();
   }
-}, 500);
+})().catch(error => {
+  process.stderr.write(`${error}\n`);
+  process.exit(1);
+});

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -7,6 +7,10 @@ import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 // So we increase the timeout here
 // vi.setTimeout(45_000);
 
+function findFrameByFunctionName(frames: Array<{ function?: string }>, functionName: string) {
+  return frames.find(frame => frame.function === functionName || frame.function === `Object.${functionName}`);
+}
+
 const EXPECTED_LOCAL_VARIABLES_EVENT = {
   exception: {
     values: [
@@ -187,12 +191,14 @@ module.exports = { out_of_app_function };`,
         event: event => {
           const frames = event.exception?.values?.[0]?.stacktrace?.frames || [];
 
-          const inAppFrame = frames.find(frame => frame.function === 'in_app_function');
-          const outOfAppFrame = frames.find(frame => frame.function === 'out_of_app_function');
+          const inAppFrame = findFrameByFunctionName(frames, 'in_app_function');
+          const outOfAppFrame = findFrameByFunctionName(frames, 'out_of_app_function');
 
+          expect(inAppFrame).toBeDefined();
           expect(inAppFrame?.vars).toEqual({ inAppVar: 'in app value' });
           expect(inAppFrame?.in_app).toEqual(true);
 
+          expect(outOfAppFrame).toBeDefined();
           expect(outOfAppFrame?.vars).toEqual({
             outOfAppVar: 'out of app value modified value',
             passedArg: 'in app value modified value',
@@ -210,12 +216,14 @@ module.exports = { out_of_app_function };`,
         event: event => {
           const frames = event.exception?.values?.[0]?.stacktrace?.frames || [];
 
-          const inAppFrame = frames.find(frame => frame.function === 'in_app_function');
-          const outOfAppFrame = frames.find(frame => frame.function === 'out_of_app_function');
+          const inAppFrame = findFrameByFunctionName(frames, 'in_app_function');
+          const outOfAppFrame = findFrameByFunctionName(frames, 'out_of_app_function');
 
+          expect(inAppFrame).toBeDefined();
           expect(inAppFrame?.vars).toEqual({ inAppVar: 'in app value' });
           expect(inAppFrame?.in_app).toEqual(true);
 
+          expect(outOfAppFrame).toBeDefined();
           expect(outOfAppFrame?.vars).toBeUndefined();
           expect(outOfAppFrame?.in_app).toEqual(false);
         },

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/wait-for-local-variables.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/wait-for-local-variables.js
@@ -1,0 +1,27 @@
+const inspector = require('node:inspector');
+
+function delay(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * LocalVariables captures vars on a worker that attaches after `inspector.open()`.
+ * Throwing before that worker has enabled pause-on-exceptions produces events without `vars`.
+ */
+async function waitForLocalVariablesCapture() {
+  const deadline = Date.now() + 8_000;
+
+  while (!inspector.url()) {
+    if (Date.now() >= deadline) {
+      throw new Error('Timed out waiting for the Node inspector used by LocalVariables');
+    }
+    await delay(25);
+  }
+
+  // Worker startup + Debugger.setPauseOnExceptions still happens after inspector.open().
+  await delay(1_000);
+}
+
+module.exports = { waitForLocalVariablesCapture };


### PR DESCRIPTION
The Node 20.19 integration job on #23573 failed with `expected undefined to deeply equal { inAppVar: 'in app value' }` in `adds local variables to out of app frames when includeOutOfAppFrames is true`. That PR does not touch LocalVariables, and the same suite passed on Node 22, 24, and 26 in the same run.

**Root cause:** LocalVariables captures vars on a worker that attaches after `inspector.open()`. The out-of-app scenarios threw after a fixed 500ms, which is short enough on a loaded runner for the throw to land before pause-on-exceptions is enabled — so the event is sent without `vars`. Other tests in this suite already wait 1000ms; these two did not.

Decision: wait until `inspector.url()` is actually set, then give the worker a beat to enable the debugger, instead of lengthening another blind timeout. Frame lookup also accepts `Object.<name>`, which this suite already treats as a valid Node function-name variant.

Unrelated to #23573.