### PR TITLE
fix(server-utils): Instrument LangGraph stream executions

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/index.ts
@@ -61,6 +61,13 @@ export default Sentry.withSentry(
         messages: [{ role: 'user', content: 'What is the weather in SF?' }],
       });
 
+      const stream = await compiled.stream({
+        messages: [{ role: 'user', content: 'Stream the weather in SF' }],
+      });
+      for await (const _chunk of stream) {
+        // Consuming the iterator is what runs the graph and completes the agent span.
+      }
+
       return new Response(JSON.stringify({ success: true }));
     },
   },

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/test.ts
@@ -6,6 +6,7 @@ import {
   GEN_AI_OPERATION_NAME,
   GEN_AI_PIPELINE_NAME,
   GEN_AI_RESPONSE_MODEL,
+  GEN_AI_RESPONSE_STREAMING,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -17,7 +18,7 @@ import { createRunner } from '../../../runner';
 // want to test that the instrumentation does not break in our
 // cloudflare SDK.
 
-it('traces langgraph compile and invoke operations', async ({ signal }) => {
+it('traces langgraph invoke and stream operations', async ({ signal }) => {
   const runner = createRunner(__dirname)
     .ignore('event')
     .expect(envelope => {
@@ -29,13 +30,14 @@ it('traces langgraph compile and invoke operations', async ({ signal }) => {
       const container = envelope[1]?.[1]?.[1] as any;
       expect(container).toBeDefined();
 
-      expect(container.items).toHaveLength(1);
+      expect(container.items).toHaveLength(2);
       expect(container.items.map((span: SerializedStreamedSpan) => span.name).sort()).toEqual([
+        'invoke_agent weather_assistant',
         'invoke_agent weather_assistant',
       ]);
 
       const invokeAgentSpan = container.items.find(
-        (span: SerializedStreamedSpan) => span.name === 'invoke_agent weather_assistant',
+        (span: SerializedStreamedSpan) => span.attributes[GEN_AI_RESPONSE_STREAMING] === undefined,
       );
       expect(invokeAgentSpan).toBeDefined();
       expect(invokeAgentSpan!.status).toBe('ok');
@@ -72,6 +74,16 @@ it('traces langgraph compile and invoke operations', async ({ signal }) => {
       expect(invokeAgentSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS]).toEqual({
         type: 'integer',
         value: 30,
+      });
+
+      const streamSpan = container.items.find(
+        (span: SerializedStreamedSpan) => span.attributes[GEN_AI_RESPONSE_STREAMING]?.value === true,
+      );
+      expect(streamSpan).toBeDefined();
+      expect(streamSpan!.status).toBe('ok');
+      expect(streamSpan!.attributes[GEN_AI_INPUT_MESSAGES]).toEqual({
+        type: 'string',
+        value: '[{"role":"user","content":"Stream the weather in SF"}]',
       });
     })
     .start(signal);

--- a/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/langgraph/test.ts
@@ -5,8 +5,10 @@ import {
   GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
   GEN_AI_PIPELINE_NAME,
+  GEN_AI_RESPONSE_FINISH_REASONS,
   GEN_AI_RESPONSE_MODEL,
   GEN_AI_RESPONSE_STREAMING,
+  GEN_AI_RESPONSE_TEXT,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
@@ -84,6 +86,30 @@ it('traces langgraph invoke and stream operations', async ({ signal }) => {
       expect(streamSpan!.attributes[GEN_AI_INPUT_MESSAGES]).toEqual({
         type: 'string',
         value: '[{"role":"user","content":"Stream the weather in SF"}]',
+      });
+      expect(streamSpan!.attributes[GEN_AI_RESPONSE_TEXT]).toEqual({
+        type: 'string',
+        value: '[{"role":"assistant","content":"Mock response from LangGraph agent"}]',
+      });
+      expect(streamSpan!.attributes[GEN_AI_RESPONSE_MODEL]).toEqual({
+        type: 'string',
+        value: 'mock-model',
+      });
+      expect(streamSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS]).toEqual({
+        type: 'array',
+        value: ['stop'],
+      });
+      expect(streamSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS]).toEqual({
+        type: 'integer',
+        value: 20,
+      });
+      expect(streamSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS]).toEqual({
+        type: 'integer',
+        value: 10,
+      });
+      expect(streamSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS]).toEqual({
+        type: 'integer',
+        value: 30,
       });
     })
     .start(signal);

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/scenario.mjs
@@ -48,9 +48,12 @@ async function run() {
     const stream = await graph.stream({
       messages: [{ role: 'user', content: 'Stream the weather forecast' }],
     });
-    for await (const _chunk of stream) {
-      // Consuming the iterator is what runs the graph and completes the agent span.
-    }
+    await stream.pipeTo(new WritableStream());
+
+    const canceledStream = await graph.stream({
+      messages: [{ role: 'user', content: 'Cancel the weather forecast' }],
+    });
+    await canceledStream.cancel('no longer needed');
   });
 
   await Sentry.flush(2000);

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/scenario.mjs
@@ -44,6 +44,13 @@ async function run() {
         { role: 'user', content: 'Tell me about the weather' },
       ],
     });
+
+    const stream = await graph.stream({
+      messages: [{ role: 'user', content: 'Stream the weather forecast' }],
+    });
+    for await (const _chunk of stream) {
+      // Consuming the iterator is what runs the graph and completes the agent span.
+    }
   });
 
   await Sentry.flush(2000);

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
@@ -6,6 +6,7 @@ import {
   GEN_AI_INPUT_MESSAGES,
   GEN_AI_OPERATION_NAME,
   GEN_AI_PIPELINE_NAME,
+  GEN_AI_RESPONSE_FINISH_REASONS,
   GEN_AI_RESPONSE_MODEL,
   GEN_AI_RESPONSE_STREAMING,
   GEN_AI_RESPONSE_TEXT,
@@ -31,15 +32,16 @@ describe('LangGraph integration', () => {
         .expect({ transaction: { transaction: 'langgraph-test' } })
         .expect({
           span: container => {
-            expect(container.items).toHaveLength(3);
+            expect(container.items).toHaveLength(4);
             expect(container.items.map(span => span.name).sort()).toEqual([
+              'invoke_agent weather_assistant',
               'invoke_agent weather_assistant',
               'invoke_agent weather_assistant',
               'invoke_agent weather_assistant',
             ]);
 
             const invokeAgentSpans = container.items.filter(span => span.name === 'invoke_agent weather_assistant');
-            expect(invokeAgentSpans).toHaveLength(3);
+            expect(invokeAgentSpans).toHaveLength(4);
             for (const span of invokeAgentSpans) {
               expect(span.status).toBe('ok');
               expect(span.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
@@ -49,10 +51,10 @@ describe('LangGraph integration', () => {
               expect(span.attributes[GEN_AI_PIPELINE_NAME].value).toBe('weather_assistant');
             }
 
-            const streamSpan = invokeAgentSpans.find(
+            const streamSpans = invokeAgentSpans.filter(
               span => span.attributes[GEN_AI_RESPONSE_STREAMING]?.value === true,
             );
-            expect(streamSpan).toBeDefined();
+            expect(streamSpans).toHaveLength(2);
           },
         })
         .start()
@@ -66,7 +68,7 @@ describe('LangGraph integration', () => {
         .expect({ transaction: { transaction: 'langgraph-test' } })
         .expect({
           span: container => {
-            expect(container.items).toHaveLength(3);
+            expect(container.items).toHaveLength(4);
 
             const weatherTodaySpan = container.items.find(span =>
               getStringAttributeValue(span.attributes[GEN_AI_INPUT_MESSAGES]?.value)?.includes(
@@ -96,6 +98,22 @@ describe('LangGraph integration', () => {
             );
             expect(weatherStreamSpan).toBeDefined();
             expect(weatherStreamSpan!.attributes[GEN_AI_RESPONSE_STREAMING].value).toBe(true);
+            expect(weatherStreamSpan!.attributes[GEN_AI_RESPONSE_TEXT].value).toBe(
+              '[{"role":"assistant","content":"Mock LLM response"}]',
+            );
+            expect(weatherStreamSpan!.attributes[GEN_AI_RESPONSE_MODEL].value).toBe('mock-model');
+            expect(weatherStreamSpan!.attributes[GEN_AI_RESPONSE_FINISH_REASONS].value).toEqual(['stop']);
+            expect(weatherStreamSpan!.attributes[GEN_AI_USAGE_INPUT_TOKENS].value).toBe(20);
+            expect(weatherStreamSpan!.attributes[GEN_AI_USAGE_OUTPUT_TOKENS].value).toBe(10);
+            expect(weatherStreamSpan!.attributes[GEN_AI_USAGE_TOTAL_TOKENS].value).toBe(30);
+
+            const canceledStreamSpan = container.items.find(span =>
+              getStringAttributeValue(span.attributes[GEN_AI_INPUT_MESSAGES]?.value)?.includes(
+                'Cancel the weather forecast',
+              ),
+            );
+            expect(canceledStreamSpan).toBeDefined();
+            expect(canceledStreamSpan!.attributes[GEN_AI_RESPONSE_STREAMING].value).toBe(true);
           },
         })
         .start()

--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
@@ -7,6 +7,7 @@ import {
   GEN_AI_OPERATION_NAME,
   GEN_AI_PIPELINE_NAME,
   GEN_AI_RESPONSE_MODEL,
+  GEN_AI_RESPONSE_STREAMING,
   GEN_AI_RESPONSE_TEXT,
   GEN_AI_RESPONSE_TOOL_CALLS,
   GEN_AI_SYSTEM_INSTRUCTIONS,
@@ -30,14 +31,15 @@ describe('LangGraph integration', () => {
         .expect({ transaction: { transaction: 'langgraph-test' } })
         .expect({
           span: container => {
-            expect(container.items).toHaveLength(2);
+            expect(container.items).toHaveLength(3);
             expect(container.items.map(span => span.name).sort()).toEqual([
+              'invoke_agent weather_assistant',
               'invoke_agent weather_assistant',
               'invoke_agent weather_assistant',
             ]);
 
             const invokeAgentSpans = container.items.filter(span => span.name === 'invoke_agent weather_assistant');
-            expect(invokeAgentSpans).toHaveLength(2);
+            expect(invokeAgentSpans).toHaveLength(3);
             for (const span of invokeAgentSpans) {
               expect(span.status).toBe('ok');
               expect(span.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
@@ -46,6 +48,11 @@ describe('LangGraph integration', () => {
               expect(span.attributes[GEN_AI_AGENT_NAME].value).toBe('weather_assistant');
               expect(span.attributes[GEN_AI_PIPELINE_NAME].value).toBe('weather_assistant');
             }
+
+            const streamSpan = invokeAgentSpans.find(
+              span => span.attributes[GEN_AI_RESPONSE_STREAMING]?.value === true,
+            );
+            expect(streamSpan).toBeDefined();
           },
         })
         .start()
@@ -59,7 +66,7 @@ describe('LangGraph integration', () => {
         .expect({ transaction: { transaction: 'langgraph-test' } })
         .expect({
           span: container => {
-            expect(container.items).toHaveLength(2);
+            expect(container.items).toHaveLength(3);
 
             const weatherTodaySpan = container.items.find(span =>
               getStringAttributeValue(span.attributes[GEN_AI_INPUT_MESSAGES]?.value)?.includes(
@@ -81,6 +88,14 @@ describe('LangGraph integration', () => {
             expect(weatherDetailsSpan!.name).toBe('invoke_agent weather_assistant');
             expect(weatherDetailsSpan!.status).toBe('ok');
             expect(weatherDetailsSpan!.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+
+            const weatherStreamSpan = container.items.find(span =>
+              getStringAttributeValue(span.attributes[GEN_AI_INPUT_MESSAGES]?.value)?.includes(
+                'Stream the weather forecast',
+              ),
+            );
+            expect(weatherStreamSpan).toBeDefined();
+            expect(weatherStreamSpan!.attributes[GEN_AI_RESPONSE_STREAMING].value).toBe(true);
           },
         })
         .start()

--- a/packages/server-utils/src/ai/langgraph/index.ts
+++ b/packages/server-utils/src/ai/langgraph/index.ts
@@ -249,7 +249,7 @@ function instrumentCompiledGraphOperation(
           if (streaming) {
             if (isAsyncIterable(result)) {
               span.setAttribute(GEN_AI_RESPONSE_STREAMING, true);
-              return instrumentStreamResult(result, span);
+              return instrumentStreamResult(result, span, inputMessages ?? null, recordOutputs);
             }
 
             span.end();

--- a/packages/server-utils/src/ai/langgraph/index.ts
+++ b/packages/server-utils/src/ai/langgraph/index.ts
@@ -1,5 +1,13 @@
 /* eslint-disable typescript-eslint/no-deprecated */
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SPAN_STATUS_ERROR, startSpan, stringify } from '@sentry/core';
+import {
+  getCurrentScope,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SPAN_STATUS_ERROR,
+  startSpan,
+  startSpanManual,
+  stringify,
+} from '@sentry/core';
+import type { Span } from '@sentry/core';
 import {
   GEN_AI_AGENT_NAME,
   GEN_AI_CONVERSATION_ID,
@@ -7,6 +15,7 @@ import {
   GEN_AI_OPERATION_NAME,
   GEN_AI_PIPELINE_NAME,
   GEN_AI_REQUEST_MODEL,
+  GEN_AI_RESPONSE_STREAMING,
   GEN_AI_SYSTEM_INSTRUCTIONS,
   GEN_AI_TOOL_DEFINITIONS,
   SENTRY_OP,
@@ -15,8 +24,9 @@ import { GEN_AI_INVOKE_AGENT } from '@sentry/conventions/op';
 import { extractSystemInstructions, resolveAIRecordingOptions } from '../core/utils';
 import { createLangChainCallbackHandler } from '../langchain';
 import type { BaseChatModel, LangChainMessage } from '../langchain/types';
-import { normalizeLangChainMessages } from '../langchain/utils';
+import { _INTERNAL_mergeLangChainCallbackHandler, normalizeLangChainMessages } from '../langchain/utils';
 import { LANGGRAPH_ORIGIN } from './constants';
+import { getGraphInstrumentationId, instrumentStreamResult, isAsyncIterable } from './streaming';
 import type { CompiledGraph, LangGraphOptions } from './types';
 import {
   extractAgentNameFromParams,
@@ -25,15 +35,15 @@ import {
   setResponseAttributes,
   wrapToolsWithSpans,
 } from './utils';
-import { _INTERNAL_mergeLangChainCallbackHandler } from '../langchain/utils';
 
 let _insideCreateReactAgent = false;
 
 const SENTRY_PATCHED = '__sentry_patched__';
+const LANGGRAPH_INVOKE_ACTIVE = 'sentry_langgraph_invoke_active';
 
 /**
- * Instruments StateGraph's compile method to wrap the returned compiled graph's invoke() with a
- * `gen_ai.invoke_agent` span.
+ * Instruments StateGraph's compile method to wrap the returned compiled graph's invoke() and stream()
+ * methods with a `gen_ai.invoke_agent` span.
  */
 export function instrumentStateGraphCompile(
   originalCompile: (...args: unknown[]) => CompiledGraph,
@@ -55,11 +65,23 @@ export function instrumentStateGraphCompile(
       const compiledGraph = Reflect.apply(target, thisArg, args);
       const compileOptions = args.length > 0 ? (args[0] as Record<string, unknown>) : {};
 
-      // Instrument agent invoke method on the compiled graph
+      // Instrument agent methods on the compiled graph
       const originalInvoke = compiledGraph.invoke;
       if (originalInvoke && typeof originalInvoke === 'function') {
         compiledGraph.invoke = instrumentCompiledGraphInvoke(
           originalInvoke.bind(compiledGraph) as (...args: unknown[]) => Promise<unknown>,
+          compiledGraph,
+          compileOptions,
+          options,
+          undefined,
+          sentryHandler,
+        );
+      }
+
+      const originalStream = compiledGraph.stream;
+      if (originalStream && typeof originalStream === 'function') {
+        compiledGraph.stream = instrumentCompiledGraphStream(
+          originalStream.bind(compiledGraph),
           compiledGraph,
           compileOptions,
           options,
@@ -89,100 +111,167 @@ export function instrumentCompiledGraphInvoke(
   llm?: BaseChatModel | null,
   sentryCallbackHandler?: unknown,
 ): (...args: unknown[]) => Promise<unknown> {
-  return new Proxy(originalInvoke, {
+  return instrumentCompiledGraphOperation(
+    originalInvoke,
+    graphInstance,
+    compileOptions,
+    options,
+    llm,
+    sentryCallbackHandler,
+    false,
+  );
+}
+
+export function instrumentCompiledGraphStream(
+  originalStream: (...args: unknown[]) => Promise<AsyncIterable<unknown>>,
+  graphInstance: CompiledGraph,
+  compileOptions: Record<string, unknown>,
+  options: LangGraphOptions,
+  llm?: BaseChatModel | null,
+  sentryCallbackHandler?: unknown,
+): (...args: unknown[]) => Promise<AsyncIterable<unknown>> {
+  return instrumentCompiledGraphOperation(
+    originalStream,
+    graphInstance,
+    compileOptions,
+    options,
+    llm,
+    sentryCallbackHandler,
+    true,
+  ) as (...args: unknown[]) => Promise<AsyncIterable<unknown>>;
+}
+
+function instrumentCompiledGraphOperation(
+  originalOperation: (...args: unknown[]) => Promise<unknown>,
+  graphInstance: CompiledGraph,
+  compileOptions: Record<string, unknown>,
+  options: LangGraphOptions,
+  llm: BaseChatModel | null | undefined,
+  sentryCallbackHandler: unknown,
+  streaming: boolean,
+): (...args: unknown[]) => Promise<unknown> {
+  const graphInstrumentationId = getGraphInstrumentationId(graphInstance);
+
+  return new Proxy(originalOperation, {
     apply(target, thisArg, args: unknown[]): Promise<unknown> {
+      if (
+        streaming &&
+        getCurrentScope().getScopeData().sdkProcessingMetadata[LANGGRAPH_INVOKE_ACTIVE] === graphInstrumentationId
+      ) {
+        return Reflect.apply(target, thisArg, args);
+      }
+
       const modelName = llm?.modelName ?? llm?.model;
-      return startSpan(
-        {
-          name: 'invoke_agent',
-          attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: LANGGRAPH_ORIGIN,
-            [SENTRY_OP]: GEN_AI_INVOKE_AGENT,
-            [GEN_AI_OPERATION_NAME]: 'invoke_agent',
-          },
+      const spanOptions = {
+        name: 'invoke_agent',
+        attributes: {
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: LANGGRAPH_ORIGIN,
+          [SENTRY_OP]: GEN_AI_INVOKE_AGENT,
+          [GEN_AI_OPERATION_NAME]: 'invoke_agent',
         },
-        async span => {
-          try {
-            const graphName = compileOptions?.name;
+      };
+      const run = async (span: Span): Promise<unknown> => {
+        try {
+          const graphName = compileOptions?.name;
 
-            if (graphName && typeof graphName === 'string') {
-              span.setAttribute(GEN_AI_PIPELINE_NAME, graphName);
-              span.setAttribute(GEN_AI_AGENT_NAME, graphName);
-              span.updateName(`invoke_agent ${graphName}`);
-            }
-
-            if (modelName) {
-              span.setAttribute(GEN_AI_REQUEST_MODEL, modelName);
-            }
-
-            // Extract thread_id from the config (second argument)
-            // LangGraph uses config.configurable.thread_id for conversation/session linking
-            const config = args.length > 1 ? (args[1] as Record<string, unknown> | undefined) : undefined;
-            const configurable = config?.configurable as Record<string, unknown> | undefined;
-            const threadId = configurable?.thread_id;
-            if (threadId && typeof threadId === 'string') {
-              span.setAttribute(GEN_AI_CONVERSATION_ID, threadId);
-            }
-
-            // Inject callback handler and agent name into invoke config
-            if (sentryCallbackHandler) {
-              const invokeConfig = (args[1] ?? {}) as Record<string, unknown>;
-              args[1] = invokeConfig;
-
-              const existingMetadata = (invokeConfig.metadata ?? {}) as Record<string, unknown>;
-              invokeConfig.metadata = {
-                ...existingMetadata,
-                __sentry_langgraph__: true,
-                ...(typeof graphName === 'string' ? { lc_agent_name: graphName } : {}),
-              };
-
-              invokeConfig.callbacks = _INTERNAL_mergeLangChainCallbackHandler(
-                invokeConfig.callbacks,
-                sentryCallbackHandler,
-              );
-            }
-
-            // Extract available tools from the graph instance
-            const tools = extractToolsFromCompiledGraph(graphInstance);
-            if (tools) {
-              span.setAttribute(GEN_AI_TOOL_DEFINITIONS, JSON.stringify(tools));
-            }
-
-            // Parse input messages
-            const recordInputs = options.recordInputs;
-            const recordOutputs = options.recordOutputs;
-            const inputMessages =
-              args.length > 0 ? ((args[0] as { messages?: LangChainMessage[] } | null)?.messages ?? []) : [];
-
-            if (inputMessages && recordInputs) {
-              const normalizedMessages = normalizeLangChainMessages(inputMessages);
-              const { systemInstructions, filteredMessages } = extractSystemInstructions(normalizedMessages);
-
-              if (systemInstructions) {
-                span.setAttribute(GEN_AI_SYSTEM_INSTRUCTIONS, systemInstructions);
-              }
-
-              span.setAttributes({
-                [GEN_AI_INPUT_MESSAGES]: stringify(filteredMessages),
-              });
-            }
-
-            // Call original invoke
-            const result = await Reflect.apply(target, thisArg, args);
-
-            if (recordOutputs) {
-              setResponseAttributes(span, inputMessages ?? null, result);
-            }
-
-            return result;
-          } catch (error) {
-            // The error is rethrown to the caller (invoke() rejects), so we only mark the span failed
-            // and do not record it.
-            span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-            throw error;
+          if (graphName && typeof graphName === 'string') {
+            span.setAttribute(GEN_AI_PIPELINE_NAME, graphName);
+            span.setAttribute(GEN_AI_AGENT_NAME, graphName);
+            span.updateName(`invoke_agent ${graphName}`);
           }
-        },
-      );
+
+          if (modelName) {
+            span.setAttribute(GEN_AI_REQUEST_MODEL, modelName);
+          }
+
+          // Extract thread_id from the config (second argument)
+          // LangGraph uses config.configurable.thread_id for conversation/session linking
+          const config = args.length > 1 ? (args[1] as Record<string, unknown> | undefined) : undefined;
+          const configurable = config?.configurable as Record<string, unknown> | undefined;
+          const threadId = configurable?.thread_id;
+          if (threadId && typeof threadId === 'string') {
+            span.setAttribute(GEN_AI_CONVERSATION_ID, threadId);
+          }
+
+          // Inject callback handler and agent name into invoke config
+          if (sentryCallbackHandler) {
+            const invokeConfig = (args[1] ?? {}) as Record<string, unknown>;
+            args[1] = invokeConfig;
+
+            const existingMetadata = (invokeConfig.metadata ?? {}) as Record<string, unknown>;
+            invokeConfig.metadata = {
+              ...existingMetadata,
+              __sentry_langgraph__: true,
+              ...(typeof graphName === 'string' ? { lc_agent_name: graphName } : {}),
+            };
+
+            invokeConfig.callbacks = _INTERNAL_mergeLangChainCallbackHandler(
+              invokeConfig.callbacks,
+              sentryCallbackHandler,
+            );
+          }
+
+          // Extract available tools from the graph instance
+          const tools = extractToolsFromCompiledGraph(graphInstance);
+          if (tools) {
+            span.setAttribute(GEN_AI_TOOL_DEFINITIONS, JSON.stringify(tools));
+          }
+
+          // Parse input messages
+          const recordInputs = options.recordInputs;
+          const recordOutputs = options.recordOutputs;
+          const inputMessages =
+            args.length > 0 ? ((args[0] as { messages?: LangChainMessage[] } | null)?.messages ?? []) : [];
+
+          if (inputMessages && recordInputs) {
+            const normalizedMessages = normalizeLangChainMessages(inputMessages);
+            const { systemInstructions, filteredMessages } = extractSystemInstructions(normalizedMessages);
+
+            if (systemInstructions) {
+              span.setAttribute(GEN_AI_SYSTEM_INSTRUCTIONS, systemInstructions);
+            }
+
+            span.setAttributes({
+              [GEN_AI_INPUT_MESSAGES]: stringify(filteredMessages),
+            });
+          }
+
+          if (!streaming) {
+            // LangGraph implements invoke() by consuming stream(); the shared async scope keeps that internal
+            // call from producing a nested duplicate while leaving direct concurrent stream() calls unaffected.
+            getCurrentScope().setSDKProcessingMetadata({
+              [LANGGRAPH_INVOKE_ACTIVE]: graphInstrumentationId,
+            });
+          }
+
+          const result = await Reflect.apply(target, thisArg, args);
+
+          if (streaming) {
+            if (isAsyncIterable(result)) {
+              span.setAttribute(GEN_AI_RESPONSE_STREAMING, true);
+              return instrumentStreamResult(result, span);
+            }
+
+            span.end();
+            return result;
+          }
+
+          if (recordOutputs) {
+            setResponseAttributes(span, inputMessages ?? null, result);
+          }
+
+          return result;
+        } catch (error) {
+          // The error is rethrown to the caller, so we only mark the span failed and do not record it.
+          span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+          if (streaming) {
+            span.end();
+          }
+          throw error;
+        }
+      };
+
+      return streaming ? startSpanManual(spanOptions, run) : startSpan(spanOptions, run);
     },
   });
 }
@@ -221,7 +310,7 @@ export function instrumentCreateReactAgent(
         _insideCreateReactAgent = false;
       }
 
-      // Wrap invoke() on the returned compiled graph
+      // Wrap agent methods on the returned compiled graph
       const originalInvoke = compiledGraph.invoke;
       if (originalInvoke && typeof originalInvoke === 'function') {
         const compileOptions: Record<string, unknown> = {};
@@ -231,6 +320,23 @@ export function instrumentCreateReactAgent(
 
         compiledGraph.invoke = instrumentCompiledGraphInvoke(
           originalInvoke.bind(compiledGraph) as (...args: unknown[]) => Promise<unknown>,
+          compiledGraph,
+          compileOptions,
+          resolvedOptions,
+          llm,
+          sentryHandler,
+        );
+      }
+
+      const originalStream = compiledGraph.stream;
+      if (originalStream && typeof originalStream === 'function') {
+        const compileOptions: Record<string, unknown> = {};
+        if (agentName) {
+          compileOptions.name = agentName;
+        }
+
+        compiledGraph.stream = instrumentCompiledGraphStream(
+          originalStream.bind(compiledGraph),
           compiledGraph,
           compileOptions,
           resolvedOptions,

--- a/packages/server-utils/src/ai/langgraph/streaming.ts
+++ b/packages/server-utils/src/ai/langgraph/streaming.ts
@@ -1,0 +1,58 @@
+import { SPAN_STATUS_ERROR, withActiveSpan } from '@sentry/core';
+import type { Span } from '@sentry/core';
+import type { CompiledGraph } from './types';
+
+const graphInstrumentationIds = new WeakMap<CompiledGraph, number>();
+let nextGraphInstrumentationId = 0;
+
+export function getGraphInstrumentationId(graph: CompiledGraph): number {
+  const existingId = graphInstrumentationIds.get(graph);
+  if (existingId !== undefined) {
+    return existingId;
+  }
+
+  const id = nextGraphInstrumentationId++;
+  graphInstrumentationIds.set(graph, id);
+  return id;
+}
+
+export function isAsyncIterable(value: unknown): value is AsyncIterable<unknown> {
+  return !!value && typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] === 'function';
+}
+
+export function instrumentStreamResult<T extends AsyncIterable<unknown>>(stream: T, span: Span): T {
+  const iterate = stream[Symbol.asyncIterator].bind(stream);
+  const instrumented = instrumentStreamIterator({ [Symbol.asyncIterator]: iterate }, span);
+  stream[Symbol.asyncIterator] = () => instrumented;
+  return stream;
+}
+
+async function* instrumentStreamIterator(
+  stream: AsyncIterable<unknown>,
+  span: Span,
+): AsyncGenerator<unknown, void, unknown> {
+  const iterator = stream[Symbol.asyncIterator]();
+  let completed = false;
+
+  try {
+    while (true) {
+      const result = await withActiveSpan(span, () => iterator.next());
+      if (result.done) {
+        completed = true;
+        return;
+      }
+      yield result.value;
+    }
+  } catch (error) {
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+    throw error;
+  } finally {
+    try {
+      if (!completed) {
+        await withActiveSpan(span, () => iterator.return?.());
+      }
+    } finally {
+      span.end();
+    }
+  }
+}

--- a/packages/server-utils/src/ai/langgraph/streaming.ts
+++ b/packages/server-utils/src/ai/langgraph/streaming.ts
@@ -172,31 +172,54 @@ function instrumentReadableStream(stream: InstrumentableReadableStream, span: Sp
 
   if (stream.pipeTo) {
     const originalPipeTo = stream.pipeTo.bind(stream);
-    const originalPipeThrough = stream.pipeThrough?.bind(stream);
-    stream.pipeTo = (destination: WritableStream<unknown>, options?: StreamPipeOptions): Promise<void> => {
-      let pipePromise: Promise<void>;
+    const instrumentedPipeTo = (destination: WritableStream<unknown>, options?: StreamPipeOptions): Promise<void> => {
+      let destinationWriter: WritableStreamDefaultWriter<unknown>;
       try {
-        pipePromise = withActiveSpan(span, () => {
-          if (!originalPipeThrough) {
-            return originalPipeTo(destination, options);
-          }
-
-          const passthrough = new TransformStream<unknown, unknown>({
-            transform(chunk, controller) {
-              lifecycle.recordChunk(chunk);
-              controller.enqueue(chunk);
-            },
-          });
-          const outputStream: ReadableStream<unknown> = originalPipeThrough(passthrough);
-          return outputStream.pipeTo(destination, options);
-        });
+        destinationWriter = destination.getWriter();
       } catch (error) {
         lifecycle.fail();
-        throw error;
+        return Promise.reject(error);
       }
 
-      return completeWithLifecycle(pipePromise, lifecycle);
+      const recordingDestination = new WritableStream<unknown>({
+        write(chunk) {
+          lifecycle.recordChunk(chunk);
+          return destinationWriter.write(chunk);
+        },
+        close() {
+          return destinationWriter.close();
+        },
+        abort(reason) {
+          return destinationWriter.abort(reason);
+        },
+      });
+
+      let pipePromise: Promise<void>;
+      try {
+        pipePromise = withActiveSpan(span, () => originalPipeTo(recordingDestination, options));
+      } catch (error) {
+        destinationWriter.releaseLock();
+        lifecycle.fail();
+        return Promise.reject(error);
+      }
+
+      return completeWithLifecycle(pipePromise, lifecycle).finally(() => {
+        destinationWriter.releaseLock();
+      });
     };
+
+    stream.pipeTo = instrumentedPipeTo;
+
+    if (stream.pipeThrough) {
+      stream.pipeThrough = (
+        transform: ReadableWritablePair<unknown, unknown>,
+        options?: StreamPipeOptions,
+      ): ReadableStream<unknown> => {
+        // pipeThrough exposes pipeline failures through the returned readable instead of its internal promise.
+        void instrumentedPipeTo(transform.writable, options).catch(() => {});
+        return transform.readable;
+      };
+    }
   }
 }
 

--- a/packages/server-utils/src/ai/langgraph/streaming.ts
+++ b/packages/server-utils/src/ai/langgraph/streaming.ts
@@ -217,7 +217,6 @@ function instrumentReadableStream(stream: InstrumentableReadableStream, span: Sp
         options?: StreamPipeOptions,
       ): ReadableStream<unknown> => {
         if (stream.locked || transform.writable.locked) {
-          lifecycle.fail();
           throw new TypeError('Cannot pipe through a locked stream.');
         }
 

--- a/packages/server-utils/src/ai/langgraph/streaming.ts
+++ b/packages/server-utils/src/ai/langgraph/streaming.ts
@@ -65,6 +65,7 @@ interface ReadableStreamReaderLike {
 }
 
 interface InstrumentableReadableStream extends AsyncIterable<unknown> {
+  locked: boolean;
   getReader: (...args: unknown[]) => ReadableStreamReaderLike;
   cancel?: (reason?: unknown) => Promise<void>;
   pipeThrough?: (
@@ -215,8 +216,16 @@ function instrumentReadableStream(stream: InstrumentableReadableStream, span: Sp
         transform: ReadableWritablePair<unknown, unknown>,
         options?: StreamPipeOptions,
       ): ReadableStream<unknown> => {
-        // pipeThrough exposes pipeline failures through the returned readable instead of its internal promise.
-        void instrumentedPipeTo(transform.writable, options).catch(() => {});
+        if (stream.locked || transform.writable.locked) {
+          lifecycle.fail();
+          throw new TypeError('Cannot pipe through a locked stream.');
+        }
+
+        void instrumentedPipeTo(transform.writable, options).catch(error => {
+          void transform.writable.abort(error).catch(() => {
+            // The pipe may already have propagated the failure through the transform.
+          });
+        });
         return transform.readable;
       };
     }

--- a/packages/server-utils/src/ai/langgraph/streaming.ts
+++ b/packages/server-utils/src/ai/langgraph/streaming.ts
@@ -1,6 +1,8 @@
 import { SPAN_STATUS_ERROR, withActiveSpan } from '@sentry/core';
 import type { Span } from '@sentry/core';
+import type { LangChainMessage } from '../langchain/types';
 import type { CompiledGraph } from './types';
+import { setResponseAttributes } from './utils';
 
 const graphInstrumentationIds = new WeakMap<CompiledGraph, number>();
 let nextGraphInstrumentationId = 0;
@@ -20,16 +22,237 @@ export function isAsyncIterable(value: unknown): value is AsyncIterable<unknown>
   return !!value && typeof (value as AsyncIterable<unknown>)[Symbol.asyncIterator] === 'function';
 }
 
-export function instrumentStreamResult<T extends AsyncIterable<unknown>>(stream: T, span: Span): T {
+export function instrumentStreamResult<T extends AsyncIterable<unknown>>(
+  stream: T,
+  span: Span,
+  inputMessages: LangChainMessage[] | null,
+  recordOutputs: boolean | undefined,
+): T {
+  const responseState: StreamResponseState = { updateMessages: [] };
+  const lifecycle = createStreamLifecycle(
+    span,
+    recordOutputs ? chunk => accumulateStreamResponse(responseState, chunk) : undefined,
+    recordOutputs
+      ? () => setResponseAttributes(span, inputMessages, getStreamResponseResult(responseState, inputMessages))
+      : undefined,
+  );
+
+  if (isReadableStream(stream)) {
+    instrumentReadableStream(stream, span, lifecycle);
+    return stream;
+  }
+
   const iterate = stream[Symbol.asyncIterator].bind(stream);
-  const instrumented = instrumentStreamIterator({ [Symbol.asyncIterator]: iterate }, span);
+  const instrumented = instrumentStreamIterator({ [Symbol.asyncIterator]: iterate }, span, lifecycle);
   stream[Symbol.asyncIterator] = () => instrumented;
   return stream;
+}
+
+interface StreamLifecycle {
+  recordChunk: (chunk: unknown) => void;
+  complete: () => void;
+  fail: () => void;
+}
+
+interface StreamResponseState {
+  finalState?: { messages: LangChainMessage[] };
+  updateMessages: LangChainMessage[];
+}
+
+interface ReadableStreamReaderLike {
+  read: (...args: unknown[]) => Promise<ReadableStreamReadResult<unknown>>;
+  cancel?: (reason?: unknown) => Promise<void>;
+}
+
+interface InstrumentableReadableStream extends AsyncIterable<unknown> {
+  getReader: (...args: unknown[]) => ReadableStreamReaderLike;
+  cancel?: (reason?: unknown) => Promise<void>;
+  pipeThrough?: (
+    transform: ReadableWritablePair<unknown, unknown>,
+    options?: StreamPipeOptions,
+  ) => ReadableStream<unknown>;
+  pipeTo?: (destination: WritableStream<unknown>, options?: StreamPipeOptions) => Promise<void>;
+}
+
+function createStreamLifecycle(
+  span: Span,
+  recordChunk?: (chunk: unknown) => void,
+  completeResponse?: () => void,
+): StreamLifecycle {
+  let completed = false;
+
+  const complete = (): void => {
+    if (completed) {
+      return;
+    }
+
+    completed = true;
+    try {
+      completeResponse?.();
+    } finally {
+      span.end();
+    }
+  };
+
+  return {
+    recordChunk(chunk: unknown): void {
+      recordChunk?.(chunk);
+    },
+    complete,
+    fail(): void {
+      span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+      complete();
+    },
+  };
+}
+
+function accumulateStreamResponse(state: StreamResponseState, chunk: unknown): void {
+  const payload =
+    Array.isArray(chunk) && chunk.length === 2 && typeof chunk[0] === 'string' ? (chunk[1] as unknown) : chunk;
+  const directState = getMessageState(payload);
+  if (directState) {
+    state.finalState = directState;
+    return;
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return;
+  }
+
+  for (const update of Object.values(payload)) {
+    const updateState = getMessageState(update);
+    if (updateState) {
+      state.updateMessages.push(...updateState.messages);
+    }
+  }
+}
+
+function getMessageState(value: unknown): { messages: LangChainMessage[] } | undefined {
+  if (!value || typeof value !== 'object' || !('messages' in value) || !Array.isArray(value.messages)) {
+    return undefined;
+  }
+
+  return { messages: value.messages as LangChainMessage[] };
+}
+
+function getStreamResponseResult(
+  state: StreamResponseState,
+  inputMessages: LangChainMessage[] | null,
+): { messages: LangChainMessage[] } | undefined {
+  if (state.finalState) {
+    return state.finalState;
+  }
+
+  if (state.updateMessages.length === 0) {
+    return undefined;
+  }
+
+  return { messages: [...(inputMessages ?? []), ...state.updateMessages] };
+}
+
+function isReadableStream(stream: AsyncIterable<unknown>): stream is InstrumentableReadableStream {
+  return typeof (stream as Partial<InstrumentableReadableStream>).getReader === 'function';
+}
+
+function instrumentReadableStream(stream: InstrumentableReadableStream, span: Span, lifecycle: StreamLifecycle): void {
+  const originalGetReader = stream.getReader.bind(stream);
+  stream.getReader = (...args: unknown[]): ReadableStreamReaderLike => {
+    const reader = withActiveSpan(span, () => originalGetReader(...args));
+    return instrumentReader(reader, span, lifecycle);
+  };
+
+  if (stream.cancel) {
+    const originalCancel = stream.cancel.bind(stream);
+    stream.cancel = (reason?: unknown): Promise<void> =>
+      completeWithLifecycle(
+        withActiveSpan(span, () => originalCancel(reason)),
+        lifecycle,
+      );
+  }
+
+  if (stream.pipeTo) {
+    const originalPipeTo = stream.pipeTo.bind(stream);
+    const originalPipeThrough = stream.pipeThrough?.bind(stream);
+    stream.pipeTo = (destination: WritableStream<unknown>, options?: StreamPipeOptions): Promise<void> => {
+      let pipePromise: Promise<void>;
+      try {
+        pipePromise = withActiveSpan(span, () => {
+          if (!originalPipeThrough) {
+            return originalPipeTo(destination, options);
+          }
+
+          const passthrough = new TransformStream<unknown, unknown>({
+            transform(chunk, controller) {
+              lifecycle.recordChunk(chunk);
+              controller.enqueue(chunk);
+            },
+          });
+          const outputStream: ReadableStream<unknown> = originalPipeThrough(passthrough);
+          return outputStream.pipeTo(destination, options);
+        });
+      } catch (error) {
+        lifecycle.fail();
+        throw error;
+      }
+
+      return completeWithLifecycle(pipePromise, lifecycle);
+    };
+  }
+}
+
+function instrumentReader(
+  reader: ReadableStreamReaderLike,
+  span: Span,
+  lifecycle: StreamLifecycle,
+): ReadableStreamReaderLike {
+  const originalRead = reader.read.bind(reader);
+  reader.read = (...args: unknown[]): Promise<ReadableStreamReadResult<unknown>> => {
+    const readPromise: Promise<ReadableStreamReadResult<unknown>> = withActiveSpan(span, () => originalRead(...args));
+    return readPromise.then(
+      result => {
+        if (result.done) {
+          lifecycle.complete();
+        } else {
+          lifecycle.recordChunk(result.value);
+        }
+        return result;
+      },
+      error => {
+        lifecycle.fail();
+        throw error;
+      },
+    );
+  };
+
+  if (reader.cancel) {
+    const originalCancel = reader.cancel.bind(reader);
+    reader.cancel = (reason?: unknown): Promise<void> =>
+      completeWithLifecycle(
+        withActiveSpan(span, () => originalCancel(reason)),
+        lifecycle,
+      );
+  }
+
+  return reader;
+}
+
+function completeWithLifecycle<T>(promise: Promise<T>, lifecycle: StreamLifecycle): Promise<T> {
+  return promise.then(
+    result => {
+      lifecycle.complete();
+      return result;
+    },
+    error => {
+      lifecycle.fail();
+      throw error;
+    },
+  );
 }
 
 async function* instrumentStreamIterator(
   stream: AsyncIterable<unknown>,
   span: Span,
+  lifecycle: StreamLifecycle,
 ): AsyncGenerator<unknown, void, unknown> {
   const iterator = stream[Symbol.asyncIterator]();
   let completed = false;
@@ -39,12 +262,14 @@ async function* instrumentStreamIterator(
       const result = await withActiveSpan(span, () => iterator.next());
       if (result.done) {
         completed = true;
+        lifecycle.complete();
         return;
       }
+      lifecycle.recordChunk(result.value);
       yield result.value;
     }
   } catch (error) {
-    span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+    lifecycle.fail();
     throw error;
   } finally {
     try {
@@ -52,7 +277,7 @@ async function* instrumentStreamIterator(
         await withActiveSpan(span, () => iterator.return?.());
       }
     } finally {
-      span.end();
+      lifecycle.complete();
     }
   }
 }

--- a/packages/server-utils/src/ai/langgraph/types.ts
+++ b/packages/server-utils/src/ai/langgraph/types.ts
@@ -61,6 +61,7 @@ export interface StateGraphBuilder {
 export interface CompiledGraph {
   [key: string]: unknown;
   invoke?: (...args: unknown[]) => Promise<unknown>;
+  stream?: (...args: unknown[]) => Promise<AsyncIterable<unknown>>;
   name?: string;
   graph_name?: string;
   lc_kwargs?: {

--- a/packages/server-utils/src/integrations/langgraph.ts
+++ b/packages/server-utils/src/integrations/langgraph.ts
@@ -3,7 +3,7 @@ import type { IntegrationFn } from '@sentry/core';
 import { debug, defineIntegration } from '@sentry/core';
 import { resolveAIRecordingOptions } from '../ai/core/utils';
 import { createLangChainCallbackHandler } from '../ai/langchain';
-import { instrumentCompiledGraphInvoke } from '../ai/langgraph';
+import { instrumentCompiledGraphInvoke, instrumentCompiledGraphStream } from '../ai/langgraph';
 import { LANGGRAPH_INTEGRATION_NAME } from '../ai/langgraph/constants';
 import type { CompiledGraph, LangGraphOptions } from '../ai/langgraph/types';
 import { extractAgentNameFromParams, extractLLMFromParams, wrapToolsWithSpans } from '../ai/langgraph/utils';
@@ -47,7 +47,7 @@ function instrumentLanggraph(options: LangGraphOptions): void {
   const resolvedOptions = resolveAIRecordingOptions(options);
   const sentryHandler = createLangChainCallbackHandler(resolvedOptions);
 
-  // StateGraph.compile returns synchronously; wrap the returned graph's `invoke` at `end`.
+  // StateGraph.compile returns synchronously; wrap the returned graph's agent methods at `end`.
   diagnosticsChannel
     .tracingChannel<CompileChannelContext>(CHANNELS.LANGGRAPH_STATE_GRAPH_COMPILE)
     .end.subscribe(message => {
@@ -55,11 +55,11 @@ function instrumentLanggraph(options: LangGraphOptions): void {
         return;
       }
       const { arguments: args, result } = message as CompileChannelContext;
-      wrapCompiledGraphInvoke(result, getFirstArgObject(args) ?? {}, resolvedOptions, null, sentryHandler);
+      wrapCompiledGraphMethods(result, getFirstArgObject(args) ?? {}, resolvedOptions, null, sentryHandler);
     });
 
-  // createReactAgent only wraps tools and the returned graph's `invoke`. Tools are wrapped at
-  // `start` (before the agent runs), invoke at `end`.
+  // createReactAgent only wraps tools and the returned graph's agent methods. Tools are wrapped at
+  // `start` (before the agent runs), agent methods at `end`.
   const reactAgentChannel = diagnosticsChannel.tracingChannel<CreateReactAgentChannelContext>(
     CHANNELS.LANGGRAPH_CREATE_REACT_AGENT,
   );
@@ -84,7 +84,7 @@ function instrumentLanggraph(options: LangGraphOptions): void {
     const { arguments: args, result } = message as CreateReactAgentChannelContext;
     const agentName = extractAgentNameFromParams(args) ?? undefined;
     const compileOptions = agentName ? { name: agentName } : {};
-    wrapCompiledGraphInvoke(result, compileOptions, resolvedOptions, extractLLMFromParams(args), sentryHandler);
+    wrapCompiledGraphMethods(result, compileOptions, resolvedOptions, extractLLMFromParams(args), sentryHandler);
   });
   // Make sure a thrown `createReactAgent` doesn't leave the suppression flag stuck on.
   reactAgentChannel.error.subscribe(() => {
@@ -99,10 +99,10 @@ function getFirstArgObject(args: unknown[] | undefined): Record<string, unknown>
 }
 
 /**
- * Wrap the compiled graph's `invoke` with the shared `invoke_agent` instrumentation, exactly as the
- * OTel path does on the returned graph.
+ * Wrap the compiled graph's agent methods with the shared `invoke_agent` instrumentation, exactly as
+ * the OTel path does on the returned graph.
  */
-function wrapCompiledGraphInvoke(
+function wrapCompiledGraphMethods(
   graph: unknown,
   compileOptions: Record<string, unknown>,
   options: LangGraphOptions,
@@ -118,6 +118,18 @@ function wrapCompiledGraphInvoke(
   if (typeof originalInvoke === 'function') {
     compiledGraph.invoke = instrumentCompiledGraphInvoke(
       originalInvoke.bind(compiledGraph),
+      compiledGraph,
+      compileOptions,
+      options,
+      llm,
+      sentryHandler,
+    );
+  }
+
+  const originalStream = compiledGraph.stream;
+  if (typeof originalStream === 'function') {
+    compiledGraph.stream = instrumentCompiledGraphStream(
+      originalStream.bind(compiledGraph),
       compiledGraph,
       compileOptions,
       options,

--- a/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as SentryCore from '@sentry/core';
+import { SPAN_STATUS_ERROR } from '@sentry/core';
+import type { Span } from '@sentry/core';
+import { GEN_AI_RESPONSE_STREAMING } from '@sentry/conventions/attributes';
+import { instrumentStateGraphCompile } from '../../../../src/ai/langgraph';
+
+const spanEnd = vi.fn();
+const spanSetAttribute = vi.fn();
+const spanSetStatus = vi.fn();
+const startSpanManual = vi.fn();
+
+vi.mock('@sentry/core', async importOriginal => {
+  const actual = (await importOriginal()) as typeof SentryCore;
+  return {
+    ...actual,
+    startSpanManual: (
+      options: SentryCore.StartSpanOptions,
+      callback: (span: Span, finish: () => void) => unknown,
+    ): unknown => {
+      const span = {
+        end: spanEnd,
+        isRecording: () => true,
+        setAttribute: spanSetAttribute,
+        setAttributes: vi.fn(),
+        setStatus: spanSetStatus,
+        updateName: vi.fn(),
+      } as unknown as Span;
+
+      startSpanManual(options, callback);
+      return callback(span, spanEnd);
+    },
+  };
+});
+
+describe('instrumentStateGraphCompile stream instrumentation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps the span open until the stream is fully consumed', async () => {
+    const stream = {
+      async *[Symbol.asyncIterator]() {
+        yield { agent: { messages: ['first update'] } };
+        yield { agent: { messages: ['final update'] } };
+      },
+    };
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+
+    const graph = compile({ name: 'weather_assistant' }) as {
+      stream: (input: unknown) => Promise<AsyncIterable<unknown>>;
+    };
+    const instrumentedStream = await graph.stream({ messages: ['What is the weather?'] });
+
+    expect(instrumentedStream).toBe(stream);
+    expect(spanEnd).not.toHaveBeenCalled();
+
+    const chunks = [];
+    for await (const chunk of instrumentedStream) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([{ agent: { messages: ['first update'] } }, { agent: { messages: ['final update'] } }]);
+    expect(startSpanManual).toHaveBeenCalledTimes(1);
+    expect(spanSetAttribute).toHaveBeenCalledWith(GEN_AI_RESPONSE_STREAMING, true);
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the span and the underlying iterator when consumption stops early', async () => {
+    const streamCleanup = vi.fn();
+    const stream = {
+      async *[Symbol.asyncIterator]() {
+        try {
+          yield 'first update';
+          yield 'final update';
+        } finally {
+          streamCleanup();
+        }
+      },
+    };
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<AsyncIterable<unknown>> };
+
+    for await (const _chunk of await graph.stream()) {
+      break;
+    }
+
+    expect(streamCleanup).toHaveBeenCalledTimes(1);
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the span as failed when stream iteration throws', async () => {
+    const error = new Error('stream failed');
+    const stream = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: vi.fn().mockRejectedValue(error),
+        };
+      },
+    };
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<AsyncIterable<unknown>> };
+
+    await expect(async () => {
+      for await (const _chunk of await graph.stream()) {
+        // The iterator throws before yielding.
+      }
+    }).rejects.toThrow(error);
+
+    expect(spanSetStatus).toHaveBeenCalledWith({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
@@ -2,13 +2,60 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as SentryCore from '@sentry/core';
 import { SPAN_STATUS_ERROR } from '@sentry/core';
 import type { Span } from '@sentry/core';
-import { GEN_AI_RESPONSE_STREAMING } from '@sentry/conventions/attributes';
+import {
+  GEN_AI_RESPONSE_FINISH_REASONS,
+  GEN_AI_RESPONSE_MODEL,
+  GEN_AI_RESPONSE_STREAMING,
+  GEN_AI_RESPONSE_TEXT,
+  GEN_AI_USAGE_INPUT_TOKENS,
+  GEN_AI_USAGE_OUTPUT_TOKENS,
+  GEN_AI_USAGE_TOTAL_TOKENS,
+} from '@sentry/conventions/attributes';
 import { instrumentStateGraphCompile } from '../../../../src/ai/langgraph';
 
 const spanEnd = vi.fn();
 const spanSetAttribute = vi.fn();
 const spanSetStatus = vi.fn();
 const startSpanManual = vi.fn();
+
+class TestLangGraphStream<T> extends ReadableStream<T> implements AsyncIterableIterator<T> {
+  private iteratorReader: ReadableStreamDefaultReader<T> | undefined;
+
+  public constructor(chunks: T[]) {
+    const queuedChunks = [...chunks];
+    super({
+      pull(controller) {
+        const chunk = queuedChunks.shift();
+        if (chunk === undefined) {
+          controller.close();
+        } else {
+          controller.enqueue(chunk);
+        }
+      },
+    });
+  }
+
+  public async next(): Promise<IteratorResult<T>> {
+    this.iteratorReader ??= this.getReader();
+    const result = await this.iteratorReader.read();
+    if (result.done) {
+      this.iteratorReader.releaseLock();
+    }
+    return result;
+  }
+
+  public async return(): Promise<IteratorResult<T>> {
+    if (this.iteratorReader) {
+      await this.iteratorReader.cancel();
+      this.iteratorReader.releaseLock();
+    }
+    return { done: true, value: undefined };
+  }
+
+  public [Symbol.asyncIterator](): this {
+    return this;
+  }
+}
 
 vi.mock('@sentry/core', async importOriginal => {
   const actual = (await importOriginal()) as typeof SentryCore;
@@ -111,6 +158,118 @@ describe('instrumentStateGraphCompile stream instrumentation', () => {
     }).rejects.toThrow(error);
 
     expect(spanSetStatus).toHaveBeenCalledWith({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the span when a reader consumes the stream', async () => {
+    const stream = new TestLangGraphStream(['first update', 'final update']);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+
+    const reader = (await graph.stream()).getReader();
+    expect(await reader.read()).toEqual({ done: false, value: 'first update' });
+    expect(await reader.read()).toEqual({ done: false, value: 'final update' });
+    expect(spanEnd).not.toHaveBeenCalled();
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
+
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the span when pipeTo consumes the stream', async () => {
+    const chunks: string[] = [];
+    const stream = new TestLangGraphStream(['first update', 'final update']);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+
+    await (
+      await graph.stream()
+    ).pipeTo(
+      new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+      }),
+    );
+
+    expect(chunks).toEqual(['first update', 'final update']);
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the span when direct next calls consume the stream', async () => {
+    const stream = new TestLangGraphStream(['first update']);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+
+    const instrumentedStream = await graph.stream();
+    expect(await instrumentedStream.next()).toEqual({ done: false, value: 'first update' });
+    expect(spanEnd).not.toHaveBeenCalled();
+    expect(await instrumentedStream.next()).toEqual({ done: true, value: undefined });
+
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the span when the stream is canceled directly', async () => {
+    const stream = new TestLangGraphStream(['first update']);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+
+    await (await graph.stream()).cancel('no longer needed');
+
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('records response attributes from the final streamed state', async () => {
+    const inputMessages = [{ role: 'user', content: 'What is the weather in Paris?' }];
+    const intermediateMessage = {
+      role: 'assistant',
+      content: 'Checking the forecast',
+      response_metadata: {
+        model_name: 'weather-model-v2',
+        tokenUsage: {
+          promptTokens: 8,
+          completionTokens: 2,
+          totalTokens: 10,
+        },
+      },
+    };
+    const outputMessage = {
+      role: 'assistant',
+      content: 'Clear skies',
+      response_metadata: {
+        model_name: 'weather-model-v2',
+        finish_reason: 'stop',
+        tokenUsage: {
+          promptTokens: 12,
+          completionTokens: 3,
+          totalTokens: 15,
+        },
+      },
+    };
+    const stream = new TestLangGraphStream([
+      { planner: { messages: [intermediateMessage] } },
+      { agent: { messages: [outputMessage] } },
+    ]);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, { recordInputs: true, recordOutputs: true });
+    const graph = compile() as { stream: (input: unknown) => Promise<TestLangGraphStream<unknown>> };
+
+    for await (const _chunk of await graph.stream({ messages: inputMessages })) {
+      // The final state is applied when iteration completes.
+    }
+
+    expect(spanSetAttribute).toHaveBeenCalledWith(
+      GEN_AI_RESPONSE_TEXT,
+      '[{"role":"assistant","content":"Checking the forecast"},{"role":"assistant","content":"Clear skies"}]',
+    );
+    expect(spanSetAttribute).toHaveBeenCalledWith(GEN_AI_RESPONSE_MODEL, 'weather-model-v2');
+    expect(spanSetAttribute).toHaveBeenCalledWith(GEN_AI_RESPONSE_FINISH_REASONS, ['stop']);
+    expect(spanSetAttribute).toHaveBeenCalledWith(GEN_AI_USAGE_INPUT_TOKENS, 20);
+    expect(spanSetAttribute).toHaveBeenCalledWith(GEN_AI_USAGE_OUTPUT_TOKENS, 5);
+    expect(spanSetAttribute).toHaveBeenCalledWith(GEN_AI_USAGE_TOTAL_TOKENS, 25);
     expect(spanEnd).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
@@ -294,6 +294,8 @@ describe('instrumentStateGraphCompile stream instrumentation', () => {
     const reader = instrumentedStream.getReader();
 
     expect(() => instrumentedStream.pipeThrough(new TransformStream())).toThrow(TypeError);
+    expect(spanSetStatus).not.toHaveBeenCalled();
+    expect(spanEnd).not.toHaveBeenCalled();
 
     reader.releaseLock();
   });
@@ -308,6 +310,8 @@ describe('instrumentStateGraphCompile stream instrumentation', () => {
     const instrumentedStream = await graph.stream();
 
     expect(() => instrumentedStream.pipeThrough(transform)).toThrow(TypeError);
+    expect(spanSetStatus).not.toHaveBeenCalled();
+    expect(spanEnd).not.toHaveBeenCalled();
 
     writer.releaseLock();
   });

--- a/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
@@ -197,6 +197,94 @@ describe('instrumentStateGraphCompile stream instrumentation', () => {
     expect(spanEnd).toHaveBeenCalledTimes(1);
   });
 
+  it('records response attributes when pipeThrough is unavailable', async () => {
+    const responseMessage = { role: 'assistant', content: 'Clear skies' };
+    const stream = new TestLangGraphStream([{ agent: { messages: [responseMessage] } }]);
+    Object.defineProperty(stream, 'pipeThrough', { value: undefined });
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, { recordOutputs: true });
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<unknown>> };
+
+    await (await graph.stream()).pipeTo(new WritableStream());
+
+    expect(spanSetAttribute).toHaveBeenCalledWith(
+      GEN_AI_RESPONSE_TEXT,
+      '[{"role":"assistant","content":"Clear skies"}]',
+    );
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-enter custom pipeThrough implementations from pipeTo', async () => {
+    const chunks: string[] = [];
+    const stream = new TestLangGraphStream(['first update', 'final update']);
+    Object.defineProperty(stream, 'pipeThrough', {
+      configurable: true,
+      value(
+        this: TestLangGraphStream<string>,
+        transform: ReadableWritablePair<unknown, string>,
+        options?: StreamPipeOptions,
+      ): ReadableStream<unknown> {
+        void this.pipeTo(transform.writable, options).catch(() => {});
+        return transform.readable;
+      },
+      writable: true,
+    });
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+
+    await (
+      await graph.stream()
+    ).pipeTo(
+      new WritableStream({
+        write(chunk) {
+          chunks.push(chunk);
+        },
+      }),
+    );
+
+    expect(chunks).toEqual(['first update', 'final update']);
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards pipe options to the source pipeTo operation', async () => {
+    const stream = new TestLangGraphStream(['first update']);
+    const originalPipeTo = stream.pipeTo.bind(stream);
+    const sourcePipeTo = vi.fn((destination: WritableStream<string>, options?: StreamPipeOptions) =>
+      originalPipeTo(destination, options),
+    );
+    Object.defineProperty(stream, 'pipeTo', { configurable: true, value: sourcePipeTo, writable: true });
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+    const destination = new WritableStream<string>();
+    const options = { preventClose: true, signal: new AbortController().signal };
+
+    await (await graph.stream()).pipeTo(destination, options);
+
+    expect(sourcePipeTo).toHaveBeenCalledWith(expect.any(WritableStream), options);
+    expect(destination.locked).toBe(false);
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('ends the span when pipeThrough output is consumed', async () => {
+    const responseMessage = { role: 'assistant', content: 'Clear skies' };
+    const stream = new TestLangGraphStream([{ agent: { messages: [responseMessage] } }]);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, { recordOutputs: true });
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<unknown>> };
+
+    const transformed = (await graph.stream()).pipeThrough(new TransformStream());
+    await transformed.pipeTo(new WritableStream());
+    await Promise.resolve();
+
+    expect(spanSetAttribute).toHaveBeenCalledWith(
+      GEN_AI_RESPONSE_TEXT,
+      '[{"role":"assistant","content":"Clear skies"}]',
+    );
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
   it('ends the span when direct next calls consume the stream', async () => {
     const stream = new TestLangGraphStream(['first update']);
     const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };

--- a/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langgraph-stream.test.ts
@@ -285,6 +285,52 @@ describe('instrumentStateGraphCompile stream instrumentation', () => {
     expect(spanEnd).toHaveBeenCalledTimes(1);
   });
 
+  it('throws when pipeThrough is called with a locked source', async () => {
+    const stream = new TestLangGraphStream(['first update']);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+    const instrumentedStream = await graph.stream();
+    const reader = instrumentedStream.getReader();
+
+    expect(() => instrumentedStream.pipeThrough(new TransformStream())).toThrow(TypeError);
+
+    reader.releaseLock();
+  });
+
+  it('throws when pipeThrough is called with a locked writable', async () => {
+    const stream = new TestLangGraphStream(['first update']);
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+    const transform = new TransformStream();
+    const writer = transform.writable.getWriter();
+    const instrumentedStream = await graph.stream();
+
+    expect(() => instrumentedStream.pipeThrough(transform)).toThrow(TypeError);
+
+    writer.releaseLock();
+  });
+
+  it('errors the pipeThrough readable when the source pipe rejects', async () => {
+    const error = new Error('pipe failed');
+    const stream = new TestLangGraphStream(['first update']);
+    Object.defineProperty(stream, 'pipeTo', {
+      configurable: true,
+      value: vi.fn().mockRejectedValue(error),
+      writable: true,
+    });
+    const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };
+    const compile = instrumentStateGraphCompile(() => compiledGraph, {});
+    const graph = compile() as { stream: () => Promise<TestLangGraphStream<string>> };
+
+    const reader = (await graph.stream()).pipeThrough(new TransformStream()).getReader();
+
+    await expect(reader.read()).rejects.toThrow(error);
+    expect(spanSetStatus).toHaveBeenCalledWith({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
+    expect(spanEnd).toHaveBeenCalledTimes(1);
+  });
+
   it('ends the span when direct next calls consume the stream', async () => {
     const stream = new TestLangGraphStream(['first update']);
     const compiledGraph = { stream: vi.fn().mockResolvedValue(stream) };


### PR DESCRIPTION
LangGraph `CompiledGraph.stream()` now creates the same `gen_ai.invoke_agent` parent span as `invoke()` and keeps it active until stream consumption finishes. The shared wrapper is used by manual server-runtime instrumentation and diagnostics-channel auto-instrumentation.

## Root cause

The compile and create-agent wrappers only patched `invoke()`. `stream()` returned an async iterable without an agent span, so callback-created child spans became roots. Ending a span when `stream()` resolves would also be too early because graph work continues while the stream is consumed.

The implementation preserves the original stream object, observes async-iterator and ReadableStream consumption paths, forwards chunks unchanged, records accumulated response attributes when enabled, and ends the span on completion, cancellation, or error. It also suppresses LangGraph's internal `invoke()` to `stream()` call per compiled graph so existing invoke instrumentation does not emit duplicate agent spans.

[JS-1858](https://linear.app/getsentry/issue/JS-1858/instrumentlanggraph-does-not-instrument-stream-only-invoke)

Fixes #19626
