### PR TITLE
docs: Fix v11 migration guide for removed `enableLogs` and `enableMetrics`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -477,18 +477,20 @@ const spanJson = Sentry.spanToStreamedSpanJSON(span);
 const spanJson = Sentry.spanToJSON(span);
 ```
 
-### Logs are enabled by default
+### The `enableLogs` option was removed
 
 Affected SDKs: All SDKs.
 
-Logging follows an opt-in-by-usage model similar to metrics: you are opted in when you call `Sentry.logger.*` or explicitly enable a logging integration. The default value of `enableLogs` is now `true`, and logging integrations do not emit logs unless explicitly enabled.
-
-To opt out of logging entirely, set `enableLogs` to `false`:
+The `enableLogs` option was removed. Logging now follows an opt-in-by-usage model similar to metrics: logs are captured whenever you call `Sentry.logger.*` or add a logging integration (such as `consoleLoggingIntegration()` or the Pino integration). There is no longer an option to disable logging once you use a logging API or integration.
 
 ```js
+// before
 Sentry.init({
-  enableLogs: false,
+  enableLogs: true,
 });
+
+// after: no option needed, logs are captured when you use a logging API or integration
+Sentry.init({});
 ```
 
 ### Browser sessions use `unhandled` instead of `crashed`
@@ -783,7 +785,28 @@ export default instrumentRoutePerformance(PostsRoute);
 - The `createSpanEnvelope` function and the `SpanEnvelope` / `SpanItem` types were removed. They existed only to send standalone (v1) spans as their own segment envelope, which the SDK no longer does. Standalone spans are gone; spans are sent either on their transaction or, with span streaming, as streamed spans (`StreamedSpanEnvelope`).
 - The `disableInstrumentationWarnings` option and the `MissingInstrumentationContext` type were removed. Now that instrumentation is channel-based, the SDK can no longer detect the "you imported a framework before `Sentry.init()`" case, so the warning it gated and the context it attached no longer exist.
 - The deprecated `sendDefaultPii` option was removed. Use [`dataCollection`](#senddefaultpii-is-replaced-by-datacollection) instead.
-- The `_experiments.enableLogs` option was removed. Logs are now enabled by default, so if you were opting in via `_experiments.enableLogs: true` you can simply omit the option. Use the top-level `enableLogs: false` to opt out.
+- The `_experiments.enableMetrics` and top-level `enableMetrics` options were removed. Metrics are now captured whenever you use a metric API (`Sentry.metrics.*`), so you can simply omit the option. The `_experiments.beforeSendMetric` callback moved to the top-level `beforeSendMetric` option.
+
+```js
+// before
+Sentry.init({
+  _experiments: {
+    enableMetrics: true,
+    beforeSendMetric: metric => {
+      return metric;
+    },
+  },
+});
+
+// after
+Sentry.init({
+  beforeSendMetric: metric => {
+    return metric;
+  },
+});
+```
+
+- The `_experiments.enableLogs` and top-level `enableLogs` options were removed. Logs are now captured whenever you use a logging API (`Sentry.logger.*`) or add a logging integration, so you can simply omit the option.
 
 ```js
 // before
@@ -793,13 +816,8 @@ Sentry.init({
   },
 });
 
-// after: logs are enabled by default, no option needed
+// after: no option needed
 Sentry.init({});
-
-// or, to opt out
-Sentry.init({
-  enableLogs: false,
-});
 ```
 
 ### `@sentry/browser`


### PR DESCRIPTION
## What

The v11 migration guide still told users that `enableLogs` defaults to `true` and that they can set `enableLogs: false` to opt out, but both options were removed in v11. It also never mentioned the `enableMetrics` removal at all. This aligns MIGRATION.md with `docs/migration/v11-end-state.md`.

## Why

Following the old guide leads users to set an option that no longer exists, and anyone migrating off `enableMetrics` had no entry to follow.