### PR TITLE
chore(v10): Add external contributor to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+Work in this release was contributed by @ryanrho-mercor. Thank you for your contribution!
+
 ## 10.71.0
 
 ### Important Changes


### PR DESCRIPTION
This PR adds the external contributor to the CHANGELOG.md file, so that they are credited for their contribution.

@ryanrho-mercor reported the source-map path regression and suggested the exact fix in #23561. The fix shipped on v10 via the backport #23595 (original: #23572), so they should be credited in the next v10 release.