### PR TITLE
chore(bugbot): Add rule to prefer eagerly set span attributes

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -54,6 +54,7 @@ Unless explicitly noted (e.g. in the `Testing Conventions` section), only flag t
 - Flag usage of the following APIs: `getCurrentScope()`, `getIsolationScope()`, `getClient()` if they are avoidable. Flag it with severity Low and acknowledge from the start that this is more a "is this necessary" check, rather than a rule violation.
   - Reason for flagging: Usage of these APIs is problematic for multi-client setups where either there is no "current" client/scope, or the wrong client might be used. Calling these APIs would create a current scope, thereby misleading any future calls to these APIs.
   - What to do instead: Use an existing reference to the scope or client. For example, this is possible in most `Integration` hooks.
+- Flag unnecessary `span.setAttribute(s)` calls: If data is already available at span start, it must be set via the `attributes` option of `startSpan`, `startSpanManual`, `startInactiveSpan` or `startIdleSpan` calls. This ensures that as much context as possible is available when `tracesSampler` or `ignoreSpans` SDK options are applied. If a `span.setAttribute(s)` call happens at a later time than right after span start and the attribute value can only be computed at that time, do not flag it.
 
 ### Code quality
 


### PR DESCRIPTION
Adds a `BUGBOT.md` rule to flag usage of `span.setAttribute(s)` when the value can already be set directly in `attributes` options of our span starting APIs. This ensures the attribute is available at `ignoreSpans` and `tracesSampler` application time.