### PR TITLE
feat(astro)!: Remove deprecated `sourceMapsUploadOptions` build option

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1291,7 +1291,7 @@ moved under the `webpack` option in v10; use the replacement listed below instea
 
 ### Meta-framework build options
 
-The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin options were removed from `@sentry/nuxt` and `@sentry/sveltekit`. Use the top-level equivalents (e.g. `sourcemaps`, `release`, `authToken`, `org`, `project`, `telemetry`) instead.
+The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin options were removed from `@sentry/astro`, `@sentry/nuxt` and `@sentry/sveltekit`. Use the top-level equivalents (e.g. `sourcemaps`, `release`, `authToken`, `org`, `project`, `telemetry`) instead.
 
 ### Removed `unstable_` bundler plugin options
 
@@ -1299,14 +1299,14 @@ The `unstable_sentry*PluginOptions` escape hatch was removed from every SDK. It 
 bundler plugins shipped on a separate release cadence from the SDK; they now live in the SDK monorepo and
 move in lockstep, so every supported plugin option is reachable as a first-class build option.
 
-| SDK                    | Removed option                                                                      |
-| ---------------------- | ----------------------------------------------------------------------------------- |
-| `@sentry/astro`        | `unstable_sentryVitePluginOptions` (top-level and inside `sourceMapsUploadOptions`) |
-| `@sentry/nextjs`       | `unstable_sentryWebpackPluginOptions` (top-level and inside `webpack`)              |
-| `@sentry/nuxt`         | `unstable_sentryBundlerPluginOptions`                                               |
-| `@sentry/react-router` | `unstable_sentryVitePluginOptions`                                                  |
-| `@sentry/solidstart`   | `unstable_sentryVitePluginOptions`                                                  |
-| `@sentry/sveltekit`    | `unstable_sentryVitePluginOptions`                                                  |
+| SDK                    | Removed option                                                         |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `@sentry/astro`        | `unstable_sentryVitePluginOptions`                                     |
+| `@sentry/nextjs`       | `unstable_sentryWebpackPluginOptions` (top-level and inside `webpack`) |
+| `@sentry/nuxt`         | `unstable_sentryBundlerPluginOptions`                                  |
+| `@sentry/react-router` | `unstable_sentryVitePluginOptions`                                     |
+| `@sentry/solidstart`   | `unstable_sentryVitePluginOptions`                                     |
+| `@sentry/sveltekit`    | `unstable_sentryVitePluginOptions`                                     |
 
 Set the option you need directly on the Sentry build options instead. Most real-world usage of this escape
 hatch was to set `applicationKey`, which has a top-level equivalent in every SDK:
@@ -1407,6 +1407,33 @@ export default defineConfig({
   - Types: `PrismaInstrumentationConfig`, `PrismaOptions`, `RedisDiagnosticChannelsOptions`, `SentryTracingChannel`, `TracingChannelLifeCycleOptions`, `TracingChannelBindingHandle`.
 
 ### `@sentry/astro`
+
+The deprecated `sourceMapsUploadOptions` option was removed from `sentryAstro()`. Move its fields to the top level of the `sentryAstro()` options. Note that `assets` and `filesToDeleteAfterUpload` moved into `sourcemaps`, and `enabled` was replaced by `sourcemaps.disable` (inverted: `enabled: false` becomes `sourcemaps: { disable: true }`).
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  integrations: [
+    sentry({
+      // before
+      sourceMapsUploadOptions: {
+        org: 'my-org',
+        project: 'my-project',
+        authToken: process.env.SENTRY_AUTH_TOKEN,
+        assets: ['./dist/**/*'],
+      },
+
+      // after
+      org: 'my-org',
+      project: 'my-project',
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+      sourcemaps: {
+        assets: ['./dist/**/*'],
+      },
+    }),
+  ],
+});
+```
 
 Runtime SDK options (`dsn`, `environment`, `release` as a string, `sampleRate`, `tracesSampleRate`, `replaysSessionSampleRate`, `replaysOnErrorSampleRate`) can no longer be passed to `sentryAstro()`. Configure them in `sentry.client.config.ts` / `sentry.server.config.ts` instead. `release` and `debug` on `sentryAstro()` are now build-time options (`release` for source map uploads, `debug` for build-time logging). If no config files exist, the generated default init snippets still pick them up (`release.name` as the runtime `release`, `debug` for SDK debug logging). The generated client snippet now always includes the `Replay` integration with default sample rates — to customize or remove it (previously done by setting both replay sample rates to `0`), create a `sentry.client.config.ts`.
 

--- a/dev-packages/e2e-tests/test-applications/astro-4/astro.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-4/astro.config.mjs
@@ -10,8 +10,8 @@ export default defineConfig({
   integrations: [
     sentry({
       debug: true,
-      sourceMapsUploadOptions: {
-        enabled: false,
+      sourcemaps: {
+        disable: true,
       },
     }),
     spotlightjs(),

--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/astro.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/astro.config.mjs
@@ -8,8 +8,8 @@ export default defineConfig({
   integrations: [
     sentry({
       debug: true,
-      sourceMapsUploadOptions: {
-        enabled: false,
+      sourcemaps: {
+        disable: true,
       },
     }),
   ],

--- a/dev-packages/e2e-tests/test-applications/astro-5/astro.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-5/astro.config.mjs
@@ -9,8 +9,8 @@ export default defineConfig({
   integrations: [
     sentry({
       debug: true,
-      sourceMapsUploadOptions: {
-        enabled: false,
+      sourcemaps: {
+        disable: true,
       },
     }),
   ],

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/astro.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/astro.config.mjs
@@ -8,8 +8,8 @@ export default defineConfig({
   integrations: [
     sentry({
       debug: true,
-      sourceMapsUploadOptions: {
-        enabled: false,
+      sourcemaps: {
+        disable: true,
       },
     }),
   ],

--- a/dev-packages/e2e-tests/test-applications/astro-6/astro.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-6/astro.config.mjs
@@ -9,8 +9,8 @@ export default defineConfig({
   integrations: [
     sentry({
       debug: true,
-      sourceMapsUploadOptions: {
-        enabled: false,
+      sourcemaps: {
+        disable: true,
       },
     }),
   ],

--- a/dev-packages/e2e-tests/test-applications/astro-7/astro.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-7/astro.config.mjs
@@ -9,8 +9,8 @@ export default defineConfig({
   integrations: [
     sentry({
       debug: true,
-      sourceMapsUploadOptions: {
-        enabled: false,
+      sourcemaps: {
+        disable: true,
       },
     }),
   ],

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -32,8 +32,6 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           clientInitPath,
           serverInitPath,
           autoInstrumentation,
-          // eslint-disable-next-line typescript/no-deprecated
-          sourceMapsUploadOptions,
           sourcemaps,
           release,
           buildTimeInstrumentation,
@@ -51,10 +49,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           errorHandler,
         } = options;
 
-        warnOnRemovedBuildOptions(options, ['unstable_sentryVitePluginOptions'], message => logger.warn(message));
-        // The nested spelling is not covered by the check above.
-        // eslint-disable-next-line typescript/no-deprecated
-        warnOnRemovedBuildOptions(options.sourceMapsUploadOptions, ['unstable_sentryVitePluginOptions'], message =>
+        warnOnRemovedBuildOptions(options, ['unstable_sentryVitePluginOptions', 'sourceMapsUploadOptions'], message =>
           logger.warn(message),
         );
 
@@ -64,14 +59,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
         };
 
         const sourceMapsNeeded = sdkEnabled.client || sdkEnabled.server;
-        const uploadOptions = sourceMapsUploadOptions || {};
-
-        const shouldUploadSourcemaps =
-          (sourceMapsNeeded &&
-            sourcemaps?.disable !== true &&
-            // eslint-disable-next-line typescript/no-deprecated
-            uploadOptions?.enabled) ??
-          true;
+        const shouldUploadSourcemaps = sourceMapsNeeded && sourcemaps?.disable !== true;
 
         // We don't need to check for AUTH_TOKEN here, because the plugin will pick it up from the env
         if (shouldUploadSourcemaps && command !== 'dev') {
@@ -80,8 +68,6 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           let updatedFilesToDeleteAfterUpload: string[] | undefined = undefined;
 
           if (
-            // eslint-disable-next-line typescript/no-deprecated
-            typeof uploadOptions?.filesToDeleteAfterUpload === 'undefined' &&
             typeof sourcemaps?.filesToDeleteAfterUpload === 'undefined' &&
             computedSourceMapSettings.previousUserSourceMapSetting === 'unset'
           ) {
@@ -90,7 +76,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
 
             debug &&
               logger.info(
-                `Automatically setting \`sourceMapsUploadOptions.filesToDeleteAfterUpload: ${JSON.stringify(
+                `Automatically setting \`sourcemaps.filesToDeleteAfterUpload: ${JSON.stringify(
                   updatedFilesToDeleteAfterUpload,
                 )}\` to delete generated source maps after they were uploaded to Sentry.`,
               );
@@ -105,17 +91,13 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                 sentryVitePlugin({
                   applicationKey,
                   moduleMetadata,
-                  // Priority: top-level options > deprecated options > env vars
-                  // eslint-disable-next-line typescript/no-deprecated
-                  org: org ?? uploadOptions.org ?? env.SENTRY_ORG,
-                  // eslint-disable-next-line typescript/no-deprecated
-                  project: project ?? uploadOptions.project ?? env.SENTRY_PROJECT,
-                  // eslint-disable-next-line typescript/no-deprecated
-                  authToken: authToken ?? uploadOptions.authToken ?? env.SENTRY_AUTH_TOKEN,
+                  // Priority: top-level options > env vars
+                  org: org ?? env.SENTRY_ORG,
+                  project: project ?? env.SENTRY_PROJECT,
+                  authToken: authToken ?? env.SENTRY_AUTH_TOKEN,
                   url: sentryUrl ?? env.SENTRY_URL,
                   headers,
-                  // eslint-disable-next-line typescript/no-deprecated
-                  telemetry: telemetry ?? uploadOptions.telemetry ?? true,
+                  telemetry: telemetry ?? true,
                   silent: silent ?? false,
                   errorHandler,
                   _metaOptions: {
@@ -127,13 +109,8 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                   release,
                   sourcemaps: {
                     ...sourcemaps,
-                    // eslint-disable-next-line typescript/no-deprecated
-                    assets: sourcemaps?.assets ?? uploadOptions.assets ?? [getSourcemapsAssetsGlob(config)],
-                    filesToDeleteAfterUpload:
-                      sourcemaps?.filesToDeleteAfterUpload ??
-                      // eslint-disable-next-line typescript/no-deprecated
-                      uploadOptions?.filesToDeleteAfterUpload ??
-                      updatedFilesToDeleteAfterUpload,
+                    assets: sourcemaps?.assets ?? [getSourcemapsAssetsGlob(config)],
+                    filesToDeleteAfterUpload: sourcemaps?.filesToDeleteAfterUpload ?? updatedFilesToDeleteAfterUpload,
                   },
                   bundleSizeOptimizations: {
                     ...bundleSizeOptimizations,

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -21,83 +21,6 @@ type SdkInitPaths = {
   serverInitPath?: string;
 };
 
-/**
- * @deprecated Move these options to the top-level of your Sentry configuration.
- */
-type SourceMapsOptions = {
-  /**
-   * If this flag is `true`, and an auth token is detected, the Sentry integration will
-   * automatically generate and upload source maps to Sentry during a production build.
-   *
-   * @default true
-   * @deprecated Use `sourcemaps.disable` instead (with inverted logic)
-   */
-  enabled?: boolean;
-
-  /**
-   * The auth token to use when uploading source maps to Sentry.
-   *
-   * Instead of specifying this option, you can also set the `SENTRY_AUTH_TOKEN` environment variable.
-   *
-   * To create an auth token, follow this guide:
-   * @see https://docs.sentry.io/product/accounts/auth-tokens/#organization-auth-tokens
-   *
-   * @deprecated Use top-level `authToken` option instead
-   */
-  authToken?: string;
-
-  /**
-   * The organization slug of your Sentry organization.
-   * Instead of specifying this option, you can also set the `SENTRY_ORG` environment variable.
-   *
-   * @deprecated Use top-level `org` option instead
-   */
-  org?: string;
-
-  /**
-   * The project slug of your Sentry project.
-   * Instead of specifying this option, you can also set the `SENTRY_PROJECT` environment variable.
-   *
-   * @deprecated Use top-level `project` option instead
-   */
-  project?: string;
-
-  /**
-   * If this flag is `true`, the Sentry plugin will collect some telemetry data and send it to Sentry.
-   * It will not collect any sensitive or user-specific data.
-   *
-   * @default true
-   * @deprecated Use top-level `telemetry` option instead
-   */
-  telemetry?: boolean;
-
-  /**
-   * A glob or an array of globs that specify the build artifacts and source maps that will be uploaded to Sentry.
-   *
-   * If this option is not specified, sensible defaults based on your `outDir`, `rootDir` and `adapter`
-   * config will be used. Use this option to override these defaults, for instance if you have a
-   * customized build setup that diverges from Astro's defaults.
-   *
-   * The globbing patterns must follow the implementation of the `glob` package.
-   * @see https://www.npmjs.com/package/glob#glob-primer
-   *
-   * @deprecated Use `sourcemaps.assets` instead
-   */
-  assets?: string | Array<string>;
-
-  /**
-   * A glob or an array of globs that specifies the build artifacts that should be deleted after the artifact
-   * upload to Sentry has been completed.
-   *
-   * @default [] - By default no files are deleted.
-   *
-   * The globbing patterns follow the implementation of the glob package. (https://www.npmjs.com/package/glob)
-   *
-   * @deprecated Use `sourcemaps.filesToDeleteAfterUpload` instead
-   */
-  filesToDeleteAfterUpload?: string | Array<string>;
-};
-
 type InstrumentationOptions = {
   /**
    * Options for automatic instrumentation of your application.
@@ -146,22 +69,7 @@ type SdkEnabledOptions = {
  *
  * If you specify a dedicated init file, the SDK options passed to `sentryAstro` will be ignored for init.
  */
-export type SentryOptions = BuildTimeOptionsBase &
-  SdkInitPaths &
-  InstrumentationOptions &
-  SdkEnabledOptions & {
-    /**
-     * Options for the Sentry Vite plugin to customize the source maps upload process.
-     *
-     * These options are always read from the `sentryAstro` integration.
-     * Do not define them in the `sentry.client.config.(js|ts)` or `sentry.server.config.(js|ts)` files.
-     *
-     * @deprecated This option was deprecated. Please move the options to the top-level configuration.
-     * See the migration guide in the SourceMapsOptions type documentation.
-     */
-    // eslint-disable-next-line typescript/no-deprecated
-    sourceMapsUploadOptions?: SourceMapsOptions;
-  };
+export type SentryOptions = BuildTimeOptionsBase & SdkInitPaths & InstrumentationOptions & SdkEnabledOptions;
 
 /**
  * Routes inside 'astro:routes:resolved' hook (Astro v5+)

--- a/packages/astro/test/buildOptions.test-d.ts
+++ b/packages/astro/test/buildOptions.test-d.ts
@@ -64,31 +64,6 @@ describe('Sentry Astro build-time options type', () => {
     expectTypeOf(completeOptions).toEqualTypeOf<SentryOptions>();
   });
 
-  it('includes all deprecated options', () => {
-    const completeOptions: SentryOptions = {
-      // SentryOptions specific options
-      enabled: true,
-      debug: true,
-      clientInitPath: './src/sentry.client.config.ts',
-      serverInitPath: './src/sentry.server.config.ts',
-      autoInstrumentation: {
-        requestHandler: true,
-      },
-      // Deprecated sourceMapsUploadOptions
-      sourceMapsUploadOptions: {
-        enabled: true,
-        authToken: 'deprecated-token',
-        org: 'deprecated-org',
-        project: 'deprecated-project',
-        telemetry: false,
-        assets: './build/**/*',
-        filesToDeleteAfterUpload: ['./build/*.map'],
-      },
-    };
-
-    expectTypeOf(completeOptions).toEqualTypeOf<SentryOptions>();
-  });
-
   it('allows partial configuration', () => {
     const minimalOptions: SentryOptions = { enabled: true };
 
@@ -140,6 +115,18 @@ describe('Sentry Astro build-time options type', () => {
       // @ts-expect-error - removed in v11, use the top-level build options instead
       unstable_sentryVitePluginOptions: {
         sourcemaps: { assets: './dist/**/*' },
+      },
+    };
+
+    expectTypeOf(options).toEqualTypeOf<SentryOptions>();
+  });
+
+  it('rejects the removed `sourceMapsUploadOptions`', () => {
+    const options: SentryOptions = {
+      // @ts-expect-error - removed in v11, use the top-level build options instead
+      sourceMapsUploadOptions: {
+        org: 'my-org',
+        project: 'my-project',
       },
     };
 

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -76,7 +76,9 @@ describe('sentryAstro integration', () => {
 
   it('enables "hidden" source maps, adds filesToDeleteAfterUpload and adds the sentry vite plugin if an auth token is detected', async () => {
     const integration = sentryAstro({
-      sourceMapsUploadOptions: { enabled: true, org: 'my-org', project: 'my-project', telemetry: false },
+      org: 'my-org',
+      project: 'my-project',
+      telemetry: false,
     });
 
     expect(integration.hooks['astro:config:setup']).toBeDefined();
@@ -123,7 +125,9 @@ describe('sentryAstro integration', () => {
 
   it('falls back to default output dir, if out and root dir are not available', async () => {
     const integration = sentryAstro({
-      sourceMapsUploadOptions: { enabled: true, org: 'my-org', project: 'my-project', telemetry: false },
+      org: 'my-org',
+      project: 'my-project',
+      telemetry: false,
     });
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config: {} });
@@ -152,7 +156,9 @@ describe('sentryAstro integration', () => {
 
   it('sets the correct assets glob for vercel if the Vercel adapter is used', async () => {
     const integration = sentryAstro({
-      sourceMapsUploadOptions: { enabled: true, org: 'my-org', project: 'my-project', telemetry: false },
+      org: 'my-org',
+      project: 'my-project',
+      telemetry: false,
     });
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({
@@ -189,12 +195,9 @@ describe('sentryAstro integration', () => {
 
   it('prefers user-specified assets-globs over the default values', async () => {
     const integration = sentryAstro({
-      sourceMapsUploadOptions: {
-        enabled: true,
-        org: 'my-org',
-        project: 'my-project',
-        assets: ['dist/server/**/*, dist/client/**/*'],
-      },
+      org: 'my-org',
+      project: 'my-project',
+      sourcemaps: { assets: ['dist/server/**/*, dist/client/**/*'] },
     });
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({
@@ -231,12 +234,9 @@ describe('sentryAstro integration', () => {
 
   it('prefers user-specified filesToDeleteAfterUpload over the default values', async () => {
     const integration = sentryAstro({
-      sourceMapsUploadOptions: {
-        enabled: true,
-        org: 'my-org',
-        project: 'my-project',
-        filesToDeleteAfterUpload: ['./custom/path/**/*'],
-      },
+      org: 'my-org',
+      project: 'my-project',
+      sourcemaps: { filesToDeleteAfterUpload: ['./custom/path/**/*'] },
     });
     // @ts-expect-error - the hook exists, and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({
@@ -259,19 +259,17 @@ describe('sentryAstro integration', () => {
     );
   });
 
-  // No `@ts-expect-error` here on purpose: `SentryOptions` intersects `Record<string, unknown>`, so
-  // TypeScript accepts any key and this runtime warning is the only signal an Astro user ever gets.
-  it('warns for the removed option nested inside `sourceMapsUploadOptions`', async () => {
+  it('ignores the removed `sourceMapsUploadOptions` when computing the vite plugin options', async () => {
     const integration = sentryAstro({
+      org: 'my-org',
       // @ts-expect-error - removed in v11
-      sourceMapsUploadOptions: { unstable_sentryVitePluginOptions: { org: 'my-other-org' } },
+      sourceMapsUploadOptions: { org: 'my-other-org', enabled: false },
     });
     // @ts-expect-error - the hook exists, and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
 
-    expect(baseConfigHookObject.logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('unstable_sentryVitePluginOptions'),
-    );
+    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith(expect.objectContaining({ org: 'my-org' }));
   });
 
   it('forwards moduleMetadata to the vite plugin', async () => {
@@ -284,23 +282,22 @@ describe('sentryAstro integration', () => {
 
   // TypeScript rejects the key (see `buildOptions.test-d.ts`); this covers JS configs, which get no
   // type checking.
-  it('warns via the Astro logger when the removed `unstable_sentryVitePluginOptions` is still set', async () => {
-    const integration = sentryAstro({
-      // @ts-expect-error - removed in v11
-      unstable_sentryVitePluginOptions: { org: 'my-other-org' },
-    });
-    // @ts-expect-error - the hook exists, and we only need to pass what we actually use
-    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
+  it.each(['unstable_sentryVitePluginOptions', 'sourceMapsUploadOptions'])(
+    'warns via the Astro logger when the removed `%s` is still set',
+    async removedOption => {
+      const integration = sentryAstro({ [removedOption]: { org: 'my-other-org' } });
+      // @ts-expect-error - the hook exists, and we only need to pass what we actually use
+      await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
 
-    expect(baseConfigHookObject.logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('unstable_sentryVitePluginOptions'),
-    );
-  });
+      expect(baseConfigHookObject.logger.warn).toHaveBeenCalledWith(expect.stringContaining(removedOption));
+    },
+  );
 
   it('passes top-level applicationKey to the vite plugin', async () => {
     const integration = sentryAstro({
       applicationKey: 'my-app-key',
-      sourceMapsUploadOptions: { enabled: true, org: 'my-org', project: 'my-project' },
+      org: 'my-org',
+      project: 'my-project',
     });
     // @ts-expect-error - the hook exists and we only need to pass what we actually use
     await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
@@ -310,25 +307,6 @@ describe('sentryAstro integration', () => {
         applicationKey: 'my-app-key',
       }),
     );
-  });
-
-  it("doesn't enable source maps if `sourceMapsUploadOptions.enabled` is `false`", async () => {
-    const integration = sentryAstro({
-      sourceMapsUploadOptions: { enabled: false },
-    });
-
-    expect(integration.hooks['astro:config:setup']).toBeDefined();
-    // @ts-expect-error - the hook exists and we only need to pass what we actually use
-    await integration.hooks['astro:config:setup']({ ...baseConfigHookObject, updateConfig, injectScript, config });
-
-    // only the orchestrion plugin is wired, no sourcemaps plugin
-    expect(updateConfig).toHaveBeenCalledTimes(1);
-    expect(updateConfig).toHaveBeenCalledWith({
-      vite: {
-        plugins: [{ name: 'sentry-orchestrion-vite' }],
-      },
-    });
-    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(0);
   });
 
   it("doesn't enable source maps if `sourcemaps.disable` is `true`", async () => {
@@ -363,9 +341,7 @@ describe('sentryAstro integration', () => {
   });
 
   it("doesn't add the sourcemaps Vite plugin in dev mode", async () => {
-    const integration = sentryAstro({
-      sourceMapsUploadOptions: { enabled: true },
-    });
+    const integration = sentryAstro({});
 
     expect(integration.hooks['astro:config:setup']).toBeDefined();
     // @ts-expect-error - the hook exists and we only need to pass what we actually use


### PR DESCRIPTION
## What

Removes the deprecated `sourceMapsUploadOptions` option from `sentryAstro()`. Its fields move to the top level, where `assets` and `filesToDeleteAfterUpload` go under `sourcemaps`, and `enabled: false` becomes `sourcemaps: { disable: true }`. Passing the removed option logs a build-time warning, because Astro configs are usually plain JavaScript where TypeScript cannot catch it.

## Why

Astro was the last meta-framework SDK still carrying this option after the v11 removal sweep covered sveltekit and nuxt.

Closes: #23624