### PR TITLE
fix(v10/core): Stop reporting caller-handled errors from the OpenAI, Anthropic & Google GenAI instrumentations

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-response-error.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/scenario-response-error.mjs
@@ -1,0 +1,45 @@
+import Anthropic from '@anthropic-ai/sdk';
+import * as Sentry from '@sentry/node';
+import express from 'express';
+
+function startMockAnthropicServer() {
+  const app = express();
+  app.use(express.json());
+
+  // Anthropic can hand back an error-shaped body on an otherwise successful (HTTP 200) response.
+  // The SDK resolves it as data, so the caller never sees a thrown error.
+  // @see https://docs.anthropic.com/en/api/errors#error-shapes
+  app.post('/anthropic/v1/messages', (_req, res) => {
+    res
+      .status(200)
+      .set('x-request-id', 'mock-response-error')
+      .json({ type: 'error', error: { type: 'overloaded_error', message: 'Overloaded' } });
+  });
+
+  return new Promise(resolve => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+async function run() {
+  const server = await startMockAnthropicServer();
+
+  await Sentry.startSpan({ op: 'function', name: 'main' }, async () => {
+    const client = new Anthropic({
+      apiKey: 'mock-api-key',
+      baseURL: `http://localhost:${server.address().port}/anthropic`,
+    });
+
+    // Resolves with the error-shaped body; no try/catch because nothing is thrown.
+    await client.messages.create({
+      model: 'claude-3-haiku-20240307',
+      messages: [{ role: 'user', content: 'What is the capital of France?' }],
+      max_tokens: 100,
+    });
+  });
+
+  await Sentry.flush(2000);
+  server.close();
+}
+
+run();

--- a/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/anthropic/test.ts
@@ -40,17 +40,6 @@ describe('Anthropic integration', () => {
     transaction: 'main',
   };
 
-  const EXPECTED_MODEL_ERROR = {
-    exception: {
-      values: [
-        {
-          type: 'Error',
-          value: '404 Model not found',
-        },
-      ],
-    },
-  };
-
   const EXPECTED_STREAM_EVENT_HANDLER_MESSAGE = {
     message: 'stream event from user-added event listener captured',
   };
@@ -58,7 +47,6 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-with-response.mjs', 'instrument.mjs', (createRunner, test) => {
     test('preserves .withResponse() and .asResponse() for non-streaming and streaming', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'main',
@@ -94,15 +82,7 @@ describe('Anthropic integration', () => {
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates anthropic related spans with genAI recording disabled', async () => {
-      const runner = createRunner();
-
-      // The orchestrion path only marks the errored span; unlike the OTel path it does not
-      // capture the handled `error-model` rejection as an event.
-      if (!isOrchestrionEnabled()) {
-        runner.expect({ event: EXPECTED_MODEL_ERROR });
-      }
-
-      await runner
+      await createRunner()
         .expect({ transaction: EXPECTED_TRANSACTION_DEFAULT_PII_FALSE })
         .expect({
           span: container => {
@@ -149,15 +129,7 @@ describe('Anthropic integration', () => {
 
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates anthropic related spans with genAI recording enabled', async () => {
-      const runner = createRunner();
-
-      // The orchestrion path only marks the errored span; unlike the OTel path it does not
-      // capture the handled `error-model` rejection as an event.
-      if (!isOrchestrionEnabled()) {
-        runner.expect({ event: EXPECTED_MODEL_ERROR });
-      }
-
-      await runner
+      await createRunner()
         .expect({ transaction: EXPECTED_TRANSACTION_DEFAULT_PII_TRUE })
         .expect({
           span: container => {
@@ -237,7 +209,6 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-options.mjs', (createRunner, test) => {
     test('creates anthropic related spans with custom options', async () => {
       await createRunner()
-        .expect({ event: EXPECTED_MODEL_ERROR })
         .expect({ transaction: EXPECTED_TRANSACTION_WITH_OPTIONS })
         .expect({
           span: container => {
@@ -302,7 +273,6 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-stream.mjs', 'instrument.mjs', (createRunner, test) => {
     test('streams produce spans with token usage and metadata (PII false)', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: EXPECTED_STREAM_SPANS_PII_FALSE })
         .expect({
           span: container => {
@@ -364,7 +334,6 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-stream.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('streams record response text when PII true', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: EXPECTED_STREAM_SPANS_PII_TRUE })
         .expect({
           span: container => {
@@ -415,7 +384,6 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-stream-nested-create.mjs', 'instrument.mjs', (createRunner, test) => {
     test('traces a create() invoked from a stream event handler (dedup does not over-suppress)', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -446,7 +414,6 @@ describe('Anthropic integration', () => {
       const EXPECTED_TOOL_CALLS_JSON =
         '[{"type":"tool_use","id":"tool_weather_1","name":"weather","input":{"city":"Paris"}}]';
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {},
         })
@@ -476,7 +443,6 @@ describe('Anthropic integration', () => {
       const EXPECTED_TOOL_CALLS_JSON =
         '[{"type":"tool_use","id":"tool_weather_2","name":"weather","input":{"city":"Paris"}}]';
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {},
         })
@@ -517,6 +483,9 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-stream-errors.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('handles streaming errors correctly', async () => {
       await createRunner()
+        // Stream errors surface via the MessageStream `error` event; attaching that listener stops it
+        // being raised as an unhandled rejection, so the instrumentation captures it. This test only
+        // asserts the spans.
         .ignore('event')
         .expect({ transaction: EXPECTED_STREAM_ERROR_SPANS })
         .expect({
@@ -574,7 +543,6 @@ describe('Anthropic integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-errors.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('handles tool errors and model retrieval errors correctly', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: EXPECTED_ERROR_SPANS })
         .expect({
           span: container => {
@@ -717,7 +685,6 @@ describe('Anthropic integration', () => {
       test('extracts system instructions from messages', async () => {
         const expectedInstructions = JSON.stringify([{ type: 'text', content: 'You are a helpful assistant' }]);
         await createRunner()
-          .ignore('event')
           .expect({
             transaction: {
               transaction: 'main',
@@ -833,4 +800,27 @@ describe('Anthropic integration', () => {
       });
     },
   );
+  createEsmAndCjsTests(__dirname, 'scenario-response-error.mjs', 'instrument.mjs', (createRunner, test) => {
+    test('captures error-shaped responses returned as data', async () => {
+      await createRunner()
+        // The API returns the error as data on a 200 response, never as a thrown error to the caller,
+        // so the instrumentation intentionally captures it as an event.
+        .unordered()
+        .expect({
+          event: {
+            exception: {
+              values: [
+                {
+                  value: 'Overloaded',
+                  mechanism: { type: 'auto.ai.anthropic.anthropic_error', handled: false },
+                },
+              ],
+            },
+          },
+        })
+        .expect({ transaction: { transaction: 'main' } })
+        .start()
+        .completed();
+    });
+  });
 });

--- a/dev-packages/node-integration-tests/suites/tracing/google-genai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/google-genai/test.ts
@@ -34,7 +34,6 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates google genai related spans with genAI recording disabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -88,7 +87,6 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates google genai related spans with genAI recording enabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -139,7 +137,6 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-options.mjs', (createRunner, test) => {
     test('creates google genai related spans with custom options', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -176,7 +173,6 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-tools.mjs', 'instrument-with-options.mjs', (createRunner, test) => {
     test('creates google genai related spans with tool calls', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -237,7 +233,21 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-streaming.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates google genai streaming spans with genAI recording disabled', async () => {
       await createRunner()
-        .ignore('event')
+        // The provider surfaces blocked content within the stream and never returns it to the caller as
+        // a thrown error, so the instrumentation intentionally captures it as an event.
+        .unordered()
+        .expect({
+          event: {
+            exception: {
+              values: [
+                {
+                  value: 'Content blocked: The prompt was blocked due to safety concerns',
+                  mechanism: { type: 'auto.ai.google_genai', handled: false },
+                },
+              ],
+            },
+          },
+        })
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -295,7 +305,21 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-streaming.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates google genai streaming spans with genAI recording enabled', async () => {
       await createRunner()
-        .ignore('event')
+        // The provider surfaces blocked content within the stream and never returns it to the caller as
+        // a thrown error, so the instrumentation intentionally captures it as an event.
+        .unordered()
+        .expect({
+          event: {
+            exception: {
+              values: [
+                {
+                  value: 'Content blocked: The prompt was blocked due to safety concerns',
+                  mechanism: { type: 'auto.ai.google_genai', handled: false },
+                },
+              ],
+            },
+          },
+        })
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -400,7 +424,6 @@ describe('Google GenAI integration', () => {
     (createRunner, test) => {
       test('extracts system instructions from messages', async () => {
         await createRunner()
-          .ignore('event')
           .expect({ transaction: { transaction: 'main' } })
           .expect({
             span: container => {
@@ -424,7 +447,6 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-embeddings.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates google genai embeddings spans with genAI recording disabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -463,7 +485,6 @@ describe('Google GenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-embeddings.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates google genai embeddings spans with genAI recording enabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {

--- a/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/openai-tool-calls/test.ts
@@ -79,7 +79,6 @@ describe('OpenAI Tool Calls integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates openai tool calls related spans with genAI recording disabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -327,7 +326,6 @@ describe('OpenAI Tool Calls integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates openai tool calls related spans with genAI recording enabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {

--- a/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
@@ -33,7 +33,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-chat.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates openai related spans with genAI recording disabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -333,7 +332,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-chat.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates openai related spans with genAI recording enabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -705,7 +703,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-chat.mjs', 'instrument-with-options.mjs', (createRunner, test) => {
     test('creates openai related spans with custom options', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'main' } })
         .expect({
           span: container => {
@@ -813,7 +810,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-embeddings.mjs', 'instrument.mjs', (createRunner, test) => {
     test('creates openai related spans with genAI recording disabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'main',
@@ -946,7 +942,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-embeddings.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('creates openai related spans with genAI recording enabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'main',
@@ -1332,7 +1327,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-conversation.mjs', 'instrument.mjs', (createRunner, test) => {
     test('captures conversation ID from Conversations API and previous_response_id', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'conversation-test',
@@ -1452,7 +1446,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-manual-conversation-id.mjs', 'instrument.mjs', (createRunner, test) => {
     test('attaches manual conversation ID set via setConversationId() to all chat spans', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'chat-with-manual-conversation-id',
@@ -1485,7 +1478,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-separate-scope-1.mjs', 'instrument.mjs', (createRunner, test) => {
     test('isolates conversation IDs across separate scopes - conversation 1', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'GET /chat/conversation-1',
@@ -1517,7 +1509,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-separate-scope-2.mjs', 'instrument.mjs', (createRunner, test) => {
     test('isolates conversation IDs across separate scopes - conversation 2', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'GET /chat/conversation-2',
@@ -1553,7 +1544,6 @@ describe('OpenAI integration', () => {
     (createRunner, test) => {
       test('extracts system instructions from messages', async () => {
         await createRunner()
-          .ignore('event')
           .expect({
             transaction: {
               transaction: 'main',
@@ -1580,7 +1570,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-with-response.mjs', 'instrument.mjs', (createRunner, test) => {
     test('preserves .withResponse() method and works correctly', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'main',
@@ -1611,7 +1600,6 @@ describe('OpenAI integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-vision.mjs', 'instrument-with-truncation.mjs', (createRunner, test) => {
     test('redacts inline base64 image data in vision requests', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'main',

--- a/dev-packages/node-integration-tests/suites/tracing/openai/v6/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/v6/test.ts
@@ -36,7 +36,6 @@ describe('OpenAI integration (V6)', () => {
     (createRunner, test) => {
       test('creates openai related spans with genAI recording disabled (v6)', async () => {
         await createRunner()
-          .ignore('event')
           .expect({ transaction: { transaction: 'main' } })
           .expect({
             span: container => {
@@ -346,7 +345,6 @@ describe('OpenAI integration (V6)', () => {
     (createRunner, test) => {
       test('creates openai related spans with genAI recording enabled (v6)', async () => {
         await createRunner()
-          .ignore('event')
           .expect({ transaction: { transaction: 'main' } })
           .expect({
             span: container => {
@@ -728,7 +726,6 @@ describe('OpenAI integration (V6)', () => {
     (createRunner, test) => {
       test('creates openai related spans with custom options (v6)', async () => {
         await createRunner()
-          .ignore('event')
           .expect({ transaction: { transaction: 'main' } })
           .expect({
             span: container => {
@@ -801,7 +798,6 @@ describe('OpenAI integration (V6)', () => {
     (createRunner, test) => {
       test('creates openai related spans with genAI recording disabled (v6)', async () => {
         await createRunner()
-          .ignore('event')
           .expect({
             transaction: {
               transaction: 'main',
@@ -944,7 +940,6 @@ describe('OpenAI integration (V6)', () => {
     (createRunner, test) => {
       test('creates openai related spans with genAI recording enabled (v6)', async () => {
         await createRunner()
-          .ignore('event')
           .expect({
             transaction: {
               transaction: 'main',

--- a/packages/core/src/tracing/ai/utils.ts
+++ b/packages/core/src/tracing/ai/utils.ts
@@ -1,7 +1,6 @@
 /**
  * Shared utils for AI integrations (OpenAI, Anthropic, Verce.AI, etc.)
  */
-import { captureException } from '../../exports';
 import { getClient } from '../../currentScopes';
 import { hasSpanStreamingEnabled } from '../spans/hasSpanStreamingEnabled';
 import type { Span } from '../../types/span';
@@ -259,22 +258,11 @@ export function extractSystemInstructions(messages: unknown[] | unknown): {
 async function createWithResponseWrapper<T>(
   originalWithResponse: Promise<unknown>,
   instrumentedPromise: Promise<T>,
-  mechanismType: string,
 ): Promise<unknown> {
-  // Attach catch handler to originalWithResponse immediately to prevent unhandled rejection
-  // If instrumentedPromise rejects first, we still need this handled
-  const safeOriginalWithResponse = originalWithResponse.catch(error => {
-    captureException(error, {
-      mechanism: {
-        handled: false,
-        type: mechanismType,
-      },
-    });
-    throw error;
-  });
-
-  const instrumentedResult = await instrumentedPromise;
-  const originalWrapper = await safeOriginalWithResponse;
+  // Awaited together rather than in sequence so both promises get a handler attached synchronously.
+  // Awaiting them one after the other leaves the second unobserved when the first rejects, which
+  // surfaces as an unhandled rejection.
+  const [instrumentedResult, originalWrapper] = await Promise.all([instrumentedPromise, originalWithResponse]);
 
   // Combine instrumented result with original metadata
   if (originalWrapper && typeof originalWrapper === 'object' && 'data' in originalWrapper) {
@@ -297,7 +285,6 @@ async function createWithResponseWrapper<T>(
 export function wrapPromiseWithMethods<R>(
   originalPromiseLike: Promise<R>,
   instrumentedPromise: Promise<R>,
-  mechanismType: string,
 ): Promise<R> {
   // If the original result is not thenable, return the instrumented promise
   if (!isThenable(originalPromiseLike)) {
@@ -321,7 +308,7 @@ export function wrapPromiseWithMethods<R>(
       if (prop === 'withResponse' && typeof value === 'function') {
         return function wrappedWithResponse(this: unknown): unknown {
           const originalWithResponse = (value as (...args: unknown[]) => unknown).call(target);
-          return createWithResponseWrapper(originalWithResponse, instrumentedPromise, mechanismType);
+          return createWithResponseWrapper(originalWithResponse, instrumentedPromise);
         };
       }
 

--- a/packages/core/src/tracing/anthropic-ai/index.ts
+++ b/packages/core/src/tracing/anthropic-ai/index.ts
@@ -1,4 +1,3 @@
-import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR } from '../../tracing';
 import { startSpan, startSpanManual } from '../../tracing/trace';
@@ -180,11 +179,7 @@ export function addResponseAttributes(span: Span, response: AnthropicAiResponse,
 /**
  * Handle common error catching and reporting for streaming requests
  */
-function handleStreamingError(error: unknown, span: Span, methodPath: string): never {
-  captureException(error, {
-    mechanism: { handled: false, type: 'auto.ai.anthropic', data: { function: methodPath } },
-  });
-
+function handleStreamingError(error: unknown, span: Span): never {
   if (span.isRecording()) {
     span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
     span.end();
@@ -234,12 +229,12 @@ function handleStreamingRequest<T extends unknown[], R>(
             options.recordOutputs ?? false,
           ) as unknown as R;
         } catch (error) {
-          return handleStreamingError(error, span, methodPath);
+          return handleStreamingError(error, span);
         }
       })();
     });
 
-    return wrapPromiseWithMethods(originalResult, instrumentedPromise, 'auto.ai.anthropic');
+    return wrapPromiseWithMethods(originalResult, instrumentedPromise);
   } else {
     return startSpanManual(spanConfig, span => {
       try {
@@ -254,7 +249,7 @@ function handleStreamingRequest<T extends unknown[], R>(
         return instrumentMessageStream(messageStream, span, options.recordOutputs ?? false);
       } catch (error) {
         suppressDelegatedCreate = false;
-        return handleStreamingError(error, span, methodPath);
+        return handleStreamingError(error, span);
       }
     });
   }
@@ -326,28 +321,14 @@ function instrumentMethod<T extends unknown[], R>(
             addPrivateRequestAttributes(span, params, shouldEnableTruncation(options.enableTruncation));
           }
 
-          return originalResult.then(
-            result => {
-              addResponseAttributes(span, result as AnthropicAiResponse, options.recordOutputs);
-              return result;
-            },
-            error => {
-              captureException(error, {
-                mechanism: {
-                  handled: false,
-                  type: 'auto.ai.anthropic',
-                  data: {
-                    function: methodPath,
-                  },
-                },
-              });
-              throw error;
-            },
-          );
+          return originalResult.then(result => {
+            addResponseAttributes(span, result as AnthropicAiResponse, options.recordOutputs);
+            return result;
+          });
         },
       );
 
-      return wrapPromiseWithMethods(originalResult, instrumentedPromise, 'auto.ai.anthropic');
+      return wrapPromiseWithMethods(originalResult, instrumentedPromise);
     },
   }) as (...args: T) => R | Promise<R>;
 }

--- a/packages/core/src/tracing/anthropic-ai/streaming.ts
+++ b/packages/core/src/tracing/anthropic-ai/streaming.ts
@@ -49,16 +49,10 @@ interface StreamingState {
 
 function isErrorEvent(event: AnthropicAiStreamingEvent, span: Span): boolean {
   if ('type' in event && typeof event.type === 'string') {
-    // If the event is an error, set the span status and capture the error
-    // These error events are not rejected by the API by default, but are sent as metadata of the response
     if (event.type === 'error') {
+      // The SDK surfaces this error to the caller (the async iterator rejects / their `error`
+      // listener fires), so we only mark the span failed and do not record it.
       span.setStatus({ code: SPAN_STATUS_ERROR, message: mapAnthropicErrorToStatusMessage(event.error?.type) });
-      captureException(event.error, {
-        mechanism: {
-          handled: false,
-          type: 'auto.ai.anthropic.anthropic_error',
-        },
-      });
       return true;
     }
   }
@@ -267,6 +261,8 @@ export function instrumentMessageStream<R extends { on: (...args: unknown[]) => 
   });
 
   stream.on('error', (error: unknown) => {
+    // Attaching this listener stops the stream error from being raised as an unhandled rejection, so
+    // we capture it here to avoid swallowing it (e.g. for callers that don't await/iterate the stream).
     captureException(error, {
       mechanism: {
         handled: false,

--- a/packages/core/src/tracing/google-genai/index.ts
+++ b/packages/core/src/tracing/google-genai/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR } from '../../tracing';
 import { startSpan, startSpanManual } from '../../tracing/trace';
@@ -309,13 +308,6 @@ function instrumentMethod<T extends unknown[], R>(
               return instrumentStream(stream, span, Boolean(options.recordOutputs)) as R;
             } catch (error) {
               span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-              captureException(error, {
-                mechanism: {
-                  handled: false,
-                  type: 'auto.ai.google_genai',
-                  data: { function: methodPath },
-                },
-              });
               span.end();
               throw error;
             }
@@ -334,13 +326,11 @@ function instrumentMethod<T extends unknown[], R>(
             addPrivateRequestAttributes(span, params, operationName, shouldEnableTruncation(options.enableTruncation));
           }
 
+          // `onError` is a no-op because the rejection is rethrown to the caller and `startSpan` already
+          // marks the span errored; both leading callbacks are positional and only exist to reach `onSuccess`.
           return handleCallbackErrors(
             () => target.apply(context, args),
-            error => {
-              captureException(error, {
-                mechanism: { handled: false, type: 'auto.ai.google_genai', data: { function: methodPath } },
-              });
-            },
+            () => {},
             () => {},
             result => {
               // Only add response attributes for content-producing methods, not for embeddings

--- a/packages/core/src/tracing/openai/index.ts
+++ b/packages/core/src/tracing/openai/index.ts
@@ -1,5 +1,4 @@
 import { DEBUG_BUILD } from '../../debug-build';
-import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR } from '../../tracing';
 import { startSpan, startSpanManual } from '../../tracing/trace';
@@ -185,20 +184,13 @@ function instrumentMethod<T extends unknown[], R>(
             ) as unknown as R;
           } catch (error) {
             span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-            captureException(error, {
-              mechanism: {
-                handled: false,
-                type: 'auto.ai.openai.stream',
-                data: { function: methodPath },
-              },
-            });
             span.end();
             throw error;
           }
         })();
       });
 
-      return wrapPromiseWithMethods(originalResult, instrumentedPromise, 'auto.ai.openai');
+      return wrapPromiseWithMethods(originalResult, instrumentedPromise);
     }
 
     // Non-streaming
@@ -212,25 +204,13 @@ function instrumentMethod<T extends unknown[], R>(
         addRequestAttributes(span, params, operationName, shouldEnableTruncation(options.enableTruncation));
       }
 
-      return originalResult.then(
-        result => {
-          addResponseAttributes(span, result, options.recordOutputs);
-          return result;
-        },
-        error => {
-          captureException(error, {
-            mechanism: {
-              handled: false,
-              type: 'auto.ai.openai',
-              data: { function: methodPath },
-            },
-          });
-          throw error;
-        },
-      );
+      return originalResult.then(result => {
+        addResponseAttributes(span, result, options.recordOutputs);
+        return result;
+      });
     });
 
-    return wrapPromiseWithMethods(originalResult, instrumentedPromise, 'auto.ai.openai');
+    return wrapPromiseWithMethods(originalResult, instrumentedPromise);
   };
 }
 

--- a/packages/core/test/lib/tracing/ai/utils.test.ts
+++ b/packages/core/test/lib/tracing/ai/utils.test.ts
@@ -167,7 +167,7 @@ describe('wrapPromiseWithMethods', () => {
       request_id: 'req_123',
     });
     const instrumented = Promise.resolve('instrumented-data');
-    const wrapped = wrapPromiseWithMethods(original, instrumented, 'auto.ai.test');
+    const wrapped = wrapPromiseWithMethods(original, instrumented);
 
     const result = await wrapped;
     expect(result).toBe('instrumented-data');
@@ -179,7 +179,7 @@ describe('wrapPromiseWithMethods', () => {
       request_id: 'req_123',
     });
     const instrumented = Promise.resolve('instrumented-data');
-    const wrapped = wrapPromiseWithMethods(original, instrumented, 'auto.ai.test');
+    const wrapped = wrapPromiseWithMethods(original, instrumented);
 
     const withResponseResult = await (wrapped as typeof original).withResponse();
     expect(withResponseResult).toEqual({
@@ -196,7 +196,7 @@ describe('wrapPromiseWithMethods', () => {
       request_id: 'req_123',
     });
     const instrumented = Promise.resolve('instrumented-data');
-    const wrapped = wrapPromiseWithMethods(original, instrumented, 'auto.ai.test');
+    const wrapped = wrapPromiseWithMethods(original, instrumented);
 
     const response = await (wrapped as typeof original).asResponse();
     expect(response).toBe(mockResponse);
@@ -205,7 +205,7 @@ describe('wrapPromiseWithMethods', () => {
   it('returns instrumentedPromise when original is not thenable', async () => {
     const instrumented = Promise.resolve('instrumented-data');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const wrapped = wrapPromiseWithMethods(null as any, instrumented, 'auto.ai.test');
+    const wrapped = wrapPromiseWithMethods(null as any, instrumented);
 
     const result = await wrapped;
     expect(result).toBe('instrumented-data');
@@ -217,7 +217,7 @@ describe('wrapPromiseWithMethods', () => {
       request_id: 'req_123',
     });
     const instrumented = Promise.reject(new Error('instrumented-error'));
-    const wrapped = wrapPromiseWithMethods(original, instrumented, 'auto.ai.test');
+    const wrapped = wrapPromiseWithMethods(original, instrumented);
 
     await expect(wrapped).rejects.toThrow('instrumented-error');
   });


### PR DESCRIPTION
Backport of: #23024

## Differences to the original PR

- On v10 the AI instrumentation lives in `packages/core/src/tracing/` (it moved to `@sentry/server-utils` on v11), so the same change is applied there with v10's internal imports and `GEN_AI_*_ATTRIBUTE` names.
- Anthropic test only: v10 also captured the handled `error-model` rejection on the non-orchestrion path, so its tests asserted that event. The fix stops that capture, so those `EXPECTED_MODEL_ERROR` expectations are removed. v10's existing truncation test is kept next to the new error-shaped-response test.
