### PR TITLE
fix(v10/core): Don't capture caller-handled LangGraph errors

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langgraph/test.ts
@@ -28,7 +28,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('should instrument LangGraph with default PII settings', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'langgraph-test' } })
         .expect({
           span: container => {
@@ -67,7 +66,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('should instrument LangGraph with genAI recording enabled', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'langgraph-test' } })
         .expect({
           span: container => {
@@ -107,7 +105,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-tools.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
     test('should capture tools from LangGraph agent', { timeout: 30000 }, async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'langgraph-tools-test' } })
         .expect({
           span: container => {
@@ -173,7 +170,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-thread-id.mjs', 'instrument.mjs', (createRunner, test) => {
     test('should capture thread_id as gen_ai.conversation.id', async () => {
       await createRunner()
-        .ignore('event')
         .expect({ transaction: { transaction: 'langgraph-thread-id-test' } })
         .expect({
           span: container => {
@@ -219,7 +215,6 @@ describe('LangGraph integration', () => {
     (createRunner, test) => {
       test('extracts system instructions from messages', async () => {
         await createRunner()
-          .ignore('event')
           .expect({ transaction: { transaction: 'main' } })
           .expect({
             span: container => {
@@ -242,7 +237,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-resume.mjs', 'instrument.mjs', (createRunner, test) => {
     test('should not throw when invoke is called with null input (resume scenario)', async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: {
             transaction: 'langgraph-resume-test',
@@ -372,7 +366,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'agent-scenario.mjs', 'instrument-agent.mjs', (createRunner, test) => {
     test('should instrument createReactAgent with agent and chat spans', { timeout: 30000 }, async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: event => {
             const spans = event.spans ?? [];
@@ -411,7 +404,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'agent-tools-scenario.mjs', 'instrument-agent.mjs', (createRunner, test) => {
     test('should create tool execution spans for createReactAgent with tools', { timeout: 30000 }, async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: event => {
             const spans = event.spans ?? [];
@@ -463,7 +455,6 @@ describe('LangGraph integration', () => {
   createEsmAndCjsTests(__dirname, 'scenario-stategraph-chat.mjs', 'instrument-agent.mjs', (createRunner, test) => {
     test('auto-injects langchain handler for plain StateGraph and emits chat spans', { timeout: 30000 }, async () => {
       await createRunner()
-        .ignore('event')
         .expect({
           transaction: event => {
             const spans = event.spans ?? [];

--- a/packages/core/src/tracing/langgraph/index.ts
+++ b/packages/core/src/tracing/langgraph/index.ts
@@ -1,4 +1,3 @@
-import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR } from '../../tracing';
 import {
@@ -119,13 +118,9 @@ export function instrumentStateGraphCompile(
 
           return compiledGraph;
         } catch (error) {
+          // The error is rethrown to the caller (compile() throws), so we only mark the span failed
+          // and do not record it.
           span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-          captureException(error, {
-            mechanism: {
-              handled: false,
-              type: 'auto.ai.langgraph.error',
-            },
-          });
           throw error;
         }
       });
@@ -242,13 +237,9 @@ export function instrumentCompiledGraphInvoke(
 
             return result;
           } catch (error) {
+            // The error is rethrown to the caller (invoke() rejects), so we only mark the span failed
+            // and do not record it.
             span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-            captureException(error, {
-              mechanism: {
-                handled: false,
-                type: 'auto.ai.langgraph.error',
-              },
-            });
             throw error;
           }
         },

--- a/packages/core/src/tracing/langgraph/utils.ts
+++ b/packages/core/src/tracing/langgraph/utils.ts
@@ -1,4 +1,3 @@
-import { captureException } from '../../exports';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR } from '../../tracing';
 import type { Span, SpanAttributes } from '../../types/span';
@@ -140,13 +139,9 @@ export function wrapToolsWithSpans(tools: unknown[], options: LangGraphOptions, 
 
               return result;
             } catch (error) {
+              // The error is rethrown to the caller (invoke() rejects), so we only mark the span
+              // failed and do not record it.
               span.setStatus({ code: SPAN_STATUS_ERROR, message: 'internal_error' });
-              captureException(error, {
-                mechanism: {
-                  handled: false,
-                  type: 'auto.ai.langgraph.error',
-                },
-              });
               throw error;
             }
           },


### PR DESCRIPTION
Backport of: #23594

## Differences to the original PR

- On v10 the LangGraph instrumentation lives in `packages/core/src/tracing/langgraph/` (it moved to `@sentry/server-utils` on v11), so the change is applied there with v10's internal imports.
- v10's `instrumentStateGraphCompile` has an extra `catch` around `compile()` that also captured the error. That site does not exist on v11, but it is the same caller-handled pattern, so it is dropped too. v10 now has zero LangGraph captures, matching develop.
