### PR TITLE
test(cloudflare): Set unordered to spans from 2 separate bindings

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/tracing/durableobject/test.ts
@@ -22,6 +22,7 @@ it('traces a durable object method', async ({ signal }) => {
         }),
       );
     })
+    .unordered()
     .start(signal);
   await runner.makeRequest('get', '/hello');
   await runner.completed();


### PR DESCRIPTION
This test was a bit flaky. It retrieves also the DO envelope, which we are not interested int and it could be that the DO envelope is first and then the worker envelope.