### PR TITLE
ref(core)!: Unify `tracePropagation` vs `propagateTrace` option names

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -591,6 +591,29 @@ Sentry.init({
 
 `sessionFlushingDelayMS` is also configurable now, and defaults to `60000` (60s) as in the other SDKs.
 
+### `propagateTrace` renamed to `tracePropagation`
+
+Affected SDKs: `@sentry/core` and dependents.
+
+The low-level HTTP instrumentation helpers exported from `@sentry/core` (`getHttpClientSubscriptions` and
+`patchHttpModuleClient`) took a `propagateTrace` option, while the public `httpIntegration` and
+`nativeNodeFetchIntegration` options were already named `tracePropagation`. The option is now called
+`tracePropagation` at every layer, matching `tracePropagationTargets`:
+
+```js
+// before
+patchHttpModuleClient(http, { propagateTrace: true });
+
+// after
+patchHttpModuleClient(http, { tracePropagation: true });
+```
+
+If you only configure `httpIntegration`, `nativeNodeFetchIntegration`, or `denoHttpIntegration`, nothing changes — those
+options were already named `tracePropagation`.
+
+This is unrelated to `propagateTraceparent` (whether the W3C `traceparent` header is sent alongside `sentry-trace`) and
+`tracePropagationTargets` (which URLs receive trace headers). Both keep their names.
+
 ### `tracePropagationTargets` matching is now case-insensitive
 
 Affected SDKs: All SDKs.

--- a/packages/core/src/integrations/http/client-patch.ts
+++ b/packages/core/src/integrations/http/client-patch.ts
@@ -119,8 +119,8 @@ function patchModule(httpModuleExport: HttpModuleExport, options: HttpInstrument
  * @example
  * ```javascript
  * import http from 'http';
- * import { patchHttpModule } from '@sentry/core';
- * patchHttpModule(http, { propagateTrace: true });
+ * import { patchHttpModuleClient } from '@sentry/core';
+ * patchHttpModuleClient(http, { tracePropagation: true });
  * ```
  */
 export const patchHttpModuleClient = (

--- a/packages/core/src/integrations/http/client-subscriptions.ts
+++ b/packages/core/src/integrations/http/client-subscriptions.ts
@@ -56,7 +56,7 @@ export function getHttpClientSubscriptions(options: HttpInstrumentationOptions):
     const {
       errorMonitor = 'error',
       spans: createSpans = clientOptions ? hasSpansEnabled(clientOptions) : true,
-      propagateTrace = false,
+      tracePropagation = false,
       breadcrumbs = true,
       http,
       https,
@@ -96,7 +96,7 @@ export function getHttpClientSubscriptions(options: HttpInstrumentationOptions):
       if (breadcrumbs) {
         breadcrumbsOnly(request);
       }
-      if (propagateTrace) {
+      if (tracePropagation) {
         injectTracePropagationHeaders(request, propagationDecisionMap);
       }
       return;
@@ -116,7 +116,7 @@ export function getHttpClientSubscriptions(options: HttpInstrumentationOptions):
     // Inject trace headers after span creation so sentry-trace contains the
     // outgoing span's ID (not the parent's), enabling downstream services to
     // link to this span.
-    if (propagateTrace) {
+    if (tracePropagation) {
       if (span.isRecording()) {
         withActiveSpan(span, () => {
           injectTracePropagationHeaders(request, propagationDecisionMap);

--- a/packages/core/src/integrations/http/types.ts
+++ b/packages/core/src/integrations/http/types.ts
@@ -148,7 +148,7 @@ export interface HttpInstrumentationOptions {
    * (`sentry-trace`, `baggage`, `traceparent`) into outgoing requests.
    * @default false
    */
-  propagateTrace?: boolean;
+  tracePropagation?: boolean;
 
   /**
    * Skip span / breadcrumb creation for requests to matching URLs.

--- a/packages/core/test/lib/integrations/http/client-patch.test.ts
+++ b/packages/core/test/lib/integrations/http/client-patch.test.ts
@@ -114,10 +114,10 @@ describe('patchHttpModuleClient', () => {
       .mockReturnValueOnce({ [HTTP_ON_CLIENT_REQUEST]: handler1 })
       .mockReturnValueOnce({ [HTTP_ON_CLIENT_REQUEST]: handler2 });
 
-    patchHttpModuleClient(httpModule, { propagateTrace: true });
+    patchHttpModuleClient(httpModule, { tracePropagation: true });
     const wrappedStoreHeader = httpModule.ClientRequest.prototype._storeHeader;
 
-    patchHttpModuleClient(httpModule, { propagateTrace: false });
+    patchHttpModuleClient(httpModule, { tracePropagation: false });
 
     // The wrapper itself is preserved (no double-wrapping)...
     expect(httpModule.ClientRequest.prototype._storeHeader).toBe(wrappedStoreHeader);

--- a/packages/core/test/lib/integrations/http/client-subscriptions.test.ts
+++ b/packages/core/test/lib/integrations/http/client-subscriptions.test.ts
@@ -81,7 +81,7 @@ describe('getHttpClientSubscriptions', () => {
     });
 
     it('does not propagate trace headers when suppressTracing is active', () => {
-      const subscriptions = getHttpClientSubscriptions({ breadcrumbs: false, spans: false, propagateTrace: true });
+      const subscriptions = getHttpClientSubscriptions({ breadcrumbs: false, spans: false, tracePropagation: true });
       const handler = subscriptions[HTTP_ON_CLIENT_REQUEST];
 
       withScope(scope => {

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -119,7 +119,7 @@ const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
       const { [HTTP_ON_CLIENT_REQUEST]: onHttpClientRequest } = getHttpClientSubscriptions({
         ...options,
         breadcrumbs,
-        propagateTrace: tracePropagation,
+        tracePropagation,
         ignoreOutgoingRequests: options.ignoreOutgoingRequests
           ? (url, request) => options.ignoreOutgoingRequests!(url, getRequestOptions(request))
           : undefined,

--- a/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
+++ b/packages/node/src/integrations/http/SentryHttpInstrumentation.ts
@@ -38,7 +38,7 @@ export interface OutgoingHttpRequestInstrumentationOptions {
    *
    * @default `true`
    */
-  propagateTrace?: boolean;
+  tracePropagation?: boolean;
 
   /**
    * Do not instrument outgoing HTTP requests to URLs where the given callback returns `true`.
@@ -76,7 +76,7 @@ export function instrumentHttpOutgoingRequests(
   const patchOptions = {
     applyCustomAttributesOnSpan,
     ...options,
-    propagateTrace: options.propagateTrace ?? true,
+    tracePropagation: options.tracePropagation ?? true,
     spans: options.spans ?? true,
     ignoreOutgoingRequests(url, request) {
       return isTracingSuppressed() || !!options.ignoreOutgoingRequests?.(url, getRequestOptions(request));

--- a/packages/node/src/integrations/http/index.ts
+++ b/packages/node/src/integrations/http/index.ts
@@ -102,7 +102,7 @@ export const httpIntegration = defineIntegration((options: HttpOptions = {}) => 
       const outgoingRequestOptions: OutgoingHttpRequestInstrumentationOptions = {
         breadcrumbs: options.breadcrumbs,
         spans,
-        propagateTrace: options.tracePropagation ?? true,
+        tracePropagation: options.tracePropagation ?? true,
         ignoreOutgoingRequests: options.ignoreOutgoingRequests,
         outgoingRequestHook: (span: Span, request: ClientRequest) => {
           // Sanitize data URLs to prevent long base64 strings in span attributes


### PR DESCRIPTION
This renames the internal option so one name is used end-to-end.

Kept `tracePropagation` as the surviving name rather than renaming the public option back: it is already the released public name in three integrations, and it reads naturally next to `tracePropagationTargets`.

`propagateTraceparent` and `tracePropagationTargets` are deliberately untouched — they are separate concepts, and `propagateTraceparent` is a released top-level client option.

_Breaking:_ `HttpInstrumentationOptions` is exported from `@sentry/core`, so this changes the public signature of `getHttpClientSubscriptions` and `patchHttpModuleClient`.

Fixes #23571