### PR TITLE
feat(nuxt)!: Remove support for `instrument.server.mjs`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -940,6 +940,22 @@ The deprecated `sourceMapsUploadOptions` and other deprecated Vite/build plugin 
 
 ### `@sentry/nuxt`
 
+Removed support for the `public/instrument.server.[ext]` file. Move the file to the root of your project, next to `nuxt.config.ts`, and rename it to `sentry.server.config.[ext]`. Its contents do not change.
+
+```
+// before
+public/instrument.server.ts
+
+// after
+sentry.server.config.ts
+```
+
+After the rename, the SDK also emits `.output/server/sentry.server.config.mjs` for you to preload:
+
+```bash
+node --import ./.output/server/sentry.server.config.mjs .output/server/index.mjs
+```
+
 The deprecated `sourceMapsUploadOptions` module option was removed. Move its fields to the root level of the `sentry` module options. Note that `url` was renamed to `sentryUrl`, and `enabled` was replaced by `sourcemaps.disable` (inverted: `enabled: false` becomes `sourcemaps: { disable: true }`).
 
 ```ts

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -29,7 +29,6 @@ import {
   addOTelCommonJSImportAlias,
   findDefaultSdkInitFile,
   getNitroMajorVersion,
-  isSentryServerConfigFile,
   toImportSpecifier,
 } from './vite/utils';
 
@@ -127,7 +126,7 @@ export default defineNuxtModule<ModuleOptions>({
       addDatabaseInstrumentation(nuxt.options.nitro, !isNitroV3, moduleOptions);
 
       // Outside `nitro:init` so that `nuxt prepare` writes the file before the first `nuxt dev`.
-      if (isNitroV3 && isSentryServerConfigFile(serverConfigFile)) {
+      if (isNitroV3) {
         addDevServerConfigFile(nuxt, serverConfigFile);
       }
     }
@@ -194,9 +193,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       if (serverConfigFile) {
         addMiddlewareInstrumentation(nitro);
-      }
 
-      if (serverConfigFile && isSentryServerConfigFile(serverConfigFile)) {
         consoleSandbox(() => {
           const serverDir = nitro.options.output.serverDir;
 

--- a/packages/nuxt/src/vite/utils.ts
+++ b/packages/nuxt/src/vite/utils.ts
@@ -25,7 +25,6 @@ export async function getNitroMajorVersion(): Promise<number> {
 
 /**
  *  Find the default SDK init file for the given type (client or server).
- *  The sentry.server.config file is prioritized over the instrument.server file.
  */
 export async function findDefaultSdkInitFile(
   type: 'server' | 'client',
@@ -33,19 +32,7 @@ export async function findDefaultSdkInitFile(
   options?: SentryNuxtModuleOptions,
 ): Promise<string | undefined> {
   const possibleFileExtensions = ['ts', 'js', 'mjs', 'cjs', 'mts', 'cts'];
-  const relativePaths: string[] = [];
-
-  if (type === 'server') {
-    for (const ext of possibleFileExtensions) {
-      relativePaths.push(`sentry.${type}.config.${ext}`);
-      // TODO: instrument.server could be removed - in the docs/wizard we only provide sentry.server.config.[ext]
-      relativePaths.push(path.join('public', `instrument.${type}.${ext}`));
-    }
-  } else {
-    for (const ext of possibleFileExtensions) {
-      relativePaths.push(`sentry.${type}.config.${ext}`);
-    }
-  }
+  const relativePaths = possibleFileExtensions.map(ext => `sentry.${type}.config.${ext}`);
 
   // Get layers from highest priority to lowest
   const layers = [...(nuxt?.options._layers ?? [])].reverse();
@@ -72,15 +59,6 @@ export async function findDefaultSdkInitFile(
 }
 
 export const SERVER_CONFIG_FILENAME = 'sentry.server.config';
-
-/**
- * Whether `findDefaultSdkInitFile('server')` resolved a `sentry.server.config` file.
- *
- * We won't need this helper anymore once we remove support for `public/instrument.server.*` in `findDefaultSdkInitFile()`.
- */
-export function isSentryServerConfigFile(filePath: string): boolean {
-  return path.basename(filePath).startsWith(SERVER_CONFIG_FILENAME);
-}
 
 /** Builds the value for `node --import`. Node reads it as a URL, so it needs forward slashes on Windows too. */
 export function toImportSpecifier(fromDir: string, filePath: string): string {

--- a/packages/nuxt/test/vite/utils.test.ts
+++ b/packages/nuxt/test/vite/utils.test.ts
@@ -9,7 +9,6 @@ import {
   extractFunctionReexportQueryParameters,
   findDefaultSdkInitFile,
   getFilenameFromNodeStartCommand,
-  isSentryServerConfigFile,
   QUERY_END_INDICATOR,
   removeSentryQueryFromPath,
   SENTRY_REEXPORTED_FUNCTIONS,
@@ -109,17 +108,13 @@ describe('findDefaultSdkInitFile', () => {
     expect(result).toBeUndefined();
   });
 
-  it('should return the server config file path if server.config and instrument exist', async () => {
+  it('ignores a public/instrument.server file', async () => {
     vi.spyOn(fs, 'existsSync').mockImplementation(filePath => {
-      return (
-        !(filePath instanceof URL) &&
-        (filePath.toString().includes('sentry.server.config.js') ||
-          filePath.toString().includes('instrument.server.js'))
-      );
+      return !(filePath instanceof URL) && filePath.toString().includes('instrument.server.js');
     });
 
     const result = await findDefaultSdkInitFile('server');
-    expect(result).toMatch('packages/nuxt/sentry.server.config.js');
+    expect(result).toBeUndefined();
   });
 
   it('should return the latest layer config file path if client config exists', async () => {
@@ -146,11 +141,7 @@ describe('findDefaultSdkInitFile', () => {
 
   it('should return the latest layer config file path if server config exists', async () => {
     vi.spyOn(fs, 'existsSync').mockImplementation(filePath => {
-      return (
-        !(filePath instanceof URL) &&
-        (filePath.toString().includes('sentry.server.config.ts') ||
-          filePath.toString().includes('instrument.server.ts'))
-      );
+      return !(filePath instanceof URL) && filePath.toString().includes('sentry.server.config.ts');
     });
 
     const nuxtMock = {
@@ -190,23 +181,6 @@ describe('findDefaultSdkInitFile', () => {
 
     const result = await findDefaultSdkInitFile('client', nuxtMock);
     expect(result).toMatch('packages/nuxt/sentry.client.config.ts');
-  });
-});
-
-describe('isSentryServerConfigFile', () => {
-  it.each(['/my/app/sentry.server.config.ts', '/my/app/sentry.server.config.js', '/my/app/sentry.server.config.mts'])(
-    'returns true for %s',
-    filePath => {
-      expect(isSentryServerConfigFile(filePath)).toBe(true);
-    },
-  );
-
-  it('returns false for an instrument.server file', () => {
-    expect(isSentryServerConfigFile('/my/app/public/instrument.server.ts')).toBe(false);
-  });
-
-  it('only matches the basename', () => {
-    expect(isSentryServerConfigFile('/my.server.config.app/public/instrument.server.ts')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Sentry is set up on the server-side with `sentry.server.config.ts` since a long time already and this is the first and very old version, which can be removed.

First merge this: https://github.com/getsentry/sentry-javascript/pull/23644

Closes https://github.com/getsentry/sentry-javascript/issues/23645
