### PR TITLE
fix(node): Build-time instrument the ESM build of graphql

### DIFF
--- a/packages/server-utils/src/orchestrion/config/graphql.ts
+++ b/packages/server-utils/src/orchestrion/config/graphql.ts
@@ -5,22 +5,25 @@ import { getModuleNames } from './module-names';
 // `parse`/`validate`/`execute` are top-level named `function` declarations in graphql's compiled
 // files, stable across the supported majors, so `functionName` matches. `execute` returns
 // `PromiseOrValue`, so `Auto` covers both async (settles on `asyncEnd`) and sync (`end`) schemas.
+// graphql ships dual CJS/ESM and the matcher compares `filePath` exactly, hence one entry per built
+// file (`.js` for `require`, `.mjs` for `import`) — a bundler resolving the ESM build (e.g. webpack
+// with `outputModule`) would otherwise never be transformed.
 export const graphqlConfig = [
-  {
+  ...['language/parser.js', 'language/parser.mjs'].map(filePath => ({
     channelName: 'parse',
-    module: { name: 'graphql', versionRange: '>=14.0.0 <17', filePath: 'language/parser.js' },
-    functionQuery: { functionName: 'parse', kind: 'Sync' },
-  },
-  {
+    module: { name: 'graphql', versionRange: '>=14.0.0 <17', filePath },
+    functionQuery: { functionName: 'parse', kind: 'Sync' as const },
+  })),
+  ...['validation/validate.js', 'validation/validate.mjs'].map(filePath => ({
     channelName: 'validate',
-    module: { name: 'graphql', versionRange: '>=14.0.0 <17', filePath: 'validation/validate.js' },
-    functionQuery: { functionName: 'validate', kind: 'Sync' },
-  },
-  {
+    module: { name: 'graphql', versionRange: '>=14.0.0 <17', filePath },
+    functionQuery: { functionName: 'validate', kind: 'Sync' as const },
+  })),
+  ...['execution/execute.js', 'execution/execute.mjs'].map(filePath => ({
     channelName: 'execute',
-    module: { name: 'graphql', versionRange: '>=14.0.0 <17', filePath: 'execution/execute.js' },
-    functionQuery: { functionName: 'execute', kind: 'Auto' },
-  },
+    module: { name: 'graphql', versionRange: '>=14.0.0 <17', filePath },
+    functionQuery: { functionName: 'execute', kind: 'Auto' as const },
+  })),
 ] satisfies InstrumentationConfig[];
 
 export const graphqlChannels = {


### PR DESCRIPTION
Build-time instrumentation of `graphql` silently produced no spans when a bundler resolved graphql's ESM build. The orchestrion transform ran, the app worked, but no `auto.graphql.diagnostic_channel` spans were emitted — the same failure class as [orchestrion-treeshake-repro](https://github.com/logaretm/orchestrion-treeshake-repro).

### Root cause

graphql ships dual CJS/ESM per-file builds (`language/parser.js` and `language/parser.mjs`, etc.), and the orchestrion matcher compares `filePath` **exactly**. The graphql config only listed the CommonJS paths, so a bundler that resolves graphql's ESM build never matched:

- **Bundlers** honor graphql's `module` field → load `index.mjs` → `.mjs` files → no match → uninstrumented.
- **Node's native ESM resolver ignores `module`** (graphql has no `exports` map) → `import 'graphql'` loads `index.js` (CJS) → `.js` files → matched. So the runtime `--import` path and the existing node-integration-tests (CJS *and* ESM) were unaffected; this gap was bundler-path-only.

This is why the issue went unnoticed: everything that goes through Node's loader used the CJS build.

### Fix

Mirror the dual-path pattern already used by the `openai` config: emit one entry per built file (`.js` for `require`, `.mjs` for `import`). No behavior change for the CJS path.

The stacked test PR on top exercises this across webpack/vite/rollup/rolldown (ESM) and esbuild (CJS).