### PR TITLE
fix(v10/core): Store child span timeout handle in _childSpanTimeoutID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
   Across all AI integrations (OpenAI, Anthropic, Google GenAI, LangChain, and LangGraph), the SDK no longer sends an event to Sentry for errors that the AI framework propagates to your code. Previously the instrumentation reported these as unhandled (`handled: false`) before your own error handling ran, so an error your code caught still showed up in Sentry as an unhandled crash. The span is still marked as errored and the error still propagates, so reporting is left to your application: if your code does not handle the error, it reaches Sentry's global error handlers and is captured as unhandled, just like any other uncaught error. Errors that a provider surfaces as data on an otherwise successful response (such as Anthropic error-shaped responses or Google GenAI blocked content) are still captured, since your code never sees them propagate.
 
-Work in this release was contributed by @ryanrho-mercor and @lux-in-tenebris-lucet. Thank you for your contributions!
+Work in this release was contributed by @ryanrho-mercor, @lux-in-tenebris-lucet, and @suhailopensource. Thank you for your contributions!
 
 ## 10.71.0
 

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -245,7 +245,7 @@ export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Parti
    */
   function _restartChildSpanTimeout(endTimestamp?: number): void {
     _cancelChildSpanTimeout();
-    _idleTimeoutID = setTimeout(() => {
+    _childSpanTimeoutID = setTimeout(() => {
       if (!_finished && _autoFinishAllowed) {
         _finishReason = FINISH_REASON_HEARTBEAT_FAILED;
         span.end(endTimestamp);

--- a/packages/core/test/lib/tracing/idleSpan.test.ts
+++ b/packages/core/test/lib/tracing/idleSpan.test.ts
@@ -765,6 +765,29 @@ describe('startIdleSpan', () => {
       expect(spanToJSON(idleSpan).timestamp).toBeDefined();
     });
 
+    it('measures the idle timeout from the last child end, not from the auto-finish signal', () => {
+      const idleSpan = startIdleSpan({ name: 'idle span' }, { disableAutoFinish: true, finalTimeout: 99_999 });
+      const idleSpanId = idleSpan.spanContext().spanId;
+
+      const child = startInactiveSpan({ name: 'inner' });
+
+      vi.advanceTimersByTime(500);
+      getClient()!.emit('idleSpanEnableAutoFinish', idleSpan);
+
+      vi.advanceTimersByTime(700);
+      child!.end();
+
+      vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout - 199);
+      expect(spanToJSON(idleSpan).timestamp).toBeUndefined();
+
+      const lateChild = startInactiveSpan({ name: 'late' });
+      expect(spanToJSON(lateChild!).parent_span_id).toBe(idleSpanId);
+
+      lateChild!.end();
+      vi.advanceTimersByTime(TRACING_DEFAULTS.idleTimeout);
+      expect(spanToJSON(idleSpan).timestamp).toBeDefined();
+    });
+
     it('times out at final timeout if disableAutoFinish=true', () => {
       const idleSpan = startIdleSpan({ name: 'idle span' }, { disableAutoFinish: true });
       expect(idleSpan).toBeDefined();


### PR DESCRIPTION
Backport of: #23429

## Differences to the original PR

- `packages/core/test/lib/tracing/idleSpan.test.ts`: the new "measures the idle timeout from the last child end" test asserts on `spanToJSON(idleSpan).timestamp` instead of `.end_timestamp`. On v10, `spanToJSON()` exposes the span's end time as `timestamp`; the rename to `end_timestamp` only exists on `develop` (v11). Without this adaptation both assertions read `undefined` and the test fails. The source fix and all other assertions are unchanged.
