### PR TITLE
build(rollup-utils): Skip bare side-effect imports for `sideEffects: false` externals

### DIFF
--- a/dev-packages/rollup-utils/npmHelpers.mjs
+++ b/dev-packages/rollup-utils/npmHelpers.mjs
@@ -29,6 +29,38 @@ const packageDotJSON = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), '.
 
 const ignoreSideEffects = /[\\/]debug-build\.ts$/;
 
+const repoRoot = path.resolve(__dirname, '../..');
+const sideEffectsCache = new Map();
+
+/**
+ * Whether an external package declares `"sideEffects": false` in its `package.json`.
+ * Unknown packages are treated as having side effects.
+ */
+function isSideEffectFreePackage(packageName) {
+  const cached = sideEffectsCache.get(packageName);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let sideEffectFree = false;
+  try {
+    const json = JSON.parse(
+      fs.readFileSync(path.resolve(repoRoot, 'node_modules', packageName, 'package.json'), { encoding: 'utf8' }),
+    );
+    sideEffectFree = json.sideEffects === false;
+  } catch {
+    // Not resolvable from the repo root - assume side effects.
+  }
+
+  sideEffectsCache.set(packageName, sideEffectFree);
+  return sideEffectFree;
+}
+
+function getPackageName(id) {
+  const segments = id.split('/');
+  return id.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+}
+
 export function makeBaseNPMConfig(options = {}) {
   const {
     entrypoints = ['src/index.ts'],
@@ -109,9 +141,11 @@ export function makeBaseNPMConfig(options = {}) {
           return false;
         }
 
-        // @sentry/conventions only exports constants (sideEffects: false),
-        // so Rollup shouldn't emit bare side-effect imports for it.
-        if (external && id.startsWith('@sentry/conventions')) {
+        // Rollup keeps a bare `import '<pkg>'` alive whenever it tree-shakes away every
+        // binding of an external it believes has side effects. For a package that declares
+        // `"sideEffects": false` that import contradicts its own manifest, and bundlers such
+        // as esbuild warn about it (`ignored-bare-import`).
+        if (external && isSideEffectFreePackage(getPackageName(id))) {
           return false;
         }
 


### PR DESCRIPTION
For CF integration tests there were a lot of warnings printed: 

```
▲ [WARNING] Ignoring this import because ".../packages/core/build/esm/index.js"
  was marked as having no side effects [ignored-bare-import]

packages/cloudflare/build/esm/prod/sdk.js:3:7:
  3 │ import '@sentry/core';
```

### Root cause

`treeshake.moduleSideEffects` in `dev-packages/rollup-utils/npmHelpers.mjs` told Rollup that every external module has side effects. When Rollup tree-shakes away all named bindings of such an external, it keeps a bare side-effect import to preserve those effects. That import contradicts the dependency's own `"sideEffects": false`, which is what the consuming bundler reports.

The Cloudflare instance is reachable from a single line in `packages/cloudflare/src/sdk.ts`:

```ts
export { _clearGlobalClientCache } from './clientCache';
```

_clearGlobalClientCache is a test-only helper that no entrypoint reaches, so Rollup drops the re-export. clientCache.ts imports GLOBAL_OBJ from @sentry/core, and Rollup hoists that external dependency into sdk.js as a bare import to keep its supposed side effects alive.

#22015 already hit this and special-cased @sentry/conventions. That patched one instance rather than the mechanism, so the next package to trip it, @sentry/core, brought the warnings straight back.

### Solution

Now we check for the key `sideEffects` in the respesctitive `package.json`. If there is `sideEffects` set it will take its value, and if there is non then we assume there are side effects, just as before.  With that the warnings are gone.