### PR TITLE
fix(sveltekit): Read SvelteKit config from the Vite plugin

### DIFF
--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -4,7 +4,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Plugin } from 'vite';
 import { WRAPPED_MODULE_SUFFIX } from '../common/utils';
-import type { BackwardsForwardsCompatibleKitConfig, BackwardsForwardsCompatibleSvelteConfig } from './svelteConfig';
+import type { ResolvedKitConfig } from './kitConfig';
+import { isNativeServerTracingEnabled } from './kitConfig';
 
 const AcornParser = acorn.Parser.extend(tsPlugin());
 
@@ -29,7 +30,7 @@ export type AutoInstrumentSelection = {
 
 type AutoInstrumentPluginOptions = AutoInstrumentSelection & {
   debug: boolean;
-  onlyInstrumentClient: boolean;
+  getKitConfig: () => Promise<ResolvedKitConfig>;
 };
 
 /**
@@ -42,14 +43,15 @@ type AutoInstrumentPluginOptions = AutoInstrumentSelection & {
  * @returns the plugin
  */
 export function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptions): Plugin {
-  const { load: wrapLoadEnabled, serverLoad: wrapServerLoadEnabled, debug } = options;
+  const { load: wrapLoadEnabled, serverLoad: wrapServerLoadEnabled, debug, getKitConfig } = options;
 
   let isServerBuild: boolean | undefined = undefined;
 
   // Whether we should skip server-side load instrumentation because SvelteKit's native server
-  // tracing is enabled. Initialized from the option (derived from `svelte.config.js`), but may be
-  // flipped to `true` in `configResolved` once we can read SvelteKit's resolved config (see below).
-  let onlyInstrumentClient = options.onlyInstrumentClient;
+  // tracing is enabled. If it is, adding our own wrapper on top would emit duplicate spans.
+  let onlyInstrumentClientPromise: Promise<boolean> | undefined;
+  const shouldOnlyInstrumentClient = (): Promise<boolean> =>
+    (onlyInstrumentClientPromise ??= getKitConfig().then(isNativeServerTracingEnabled));
 
   return {
     name: 'sentry-auto-instrumentation',
@@ -62,16 +64,6 @@ export function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptio
       // `config.build.ssr` is `true` for that first build and `false` in the other ones.
       // Hence we can use it as a switch to upload source maps only once in main build.
       isServerBuild = !!config.build.ssr;
-
-      // As of SvelteKit 3, the native server-tracing config is no longer read from
-      // `svelte.config.js` (so the `onlyInstrumentClient` option, derived from it, is `false`).
-      // It's passed to the `sveltekit()` Vite plugin instead, which exposes the resolved config
-      // via its plugin `api.options`. Reading it here lets us reliably detect native tracing
-      // regardless of SvelteKit version. When it's enabled, we must not add our own server-side
-      // load instrumentation, otherwise we'd emit duplicate spans on top of SvelteKit's.
-      if (!onlyInstrumentClient && isNativeServerTracingEnabled(config.plugins)) {
-        onlyInstrumentClient = true;
-      }
     },
 
     async load(id) {
@@ -81,7 +73,7 @@ export function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptio
       const environmentName = (this as { environment?: { name?: string } }).environment?.name;
       const isServerEnvironment = environmentName != null ? environmentName === 'ssr' : !!isServerBuild;
 
-      if (onlyInstrumentClient && isServerEnvironment) {
+      if (isServerEnvironment && (await shouldOnlyInstrumentClient())) {
         return null;
       }
 
@@ -96,9 +88,9 @@ export function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptio
         return getWrapperCode('wrapLoadWithSentry', `${id}${WRAPPED_MODULE_SUFFIX}`);
       }
 
-      if (onlyInstrumentClient) {
+      if (await shouldOnlyInstrumentClient()) {
         // Now that we've checked universal files, we can early return and avoid further
-        // regexp checks below for server-only files, in case `onlyInstrumentClient` is `true`.
+        // regexp checks below for server-only files.
         return null;
       }
 
@@ -116,39 +108,6 @@ export function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptio
       return null;
     },
   };
-}
-
-/**
- * Detects whether SvelteKit's native server-side tracing is enabled by reading the resolved
- * SvelteKit config that the `sveltekit()` Vite plugin exposes via its plugin `api.options`.
- *
- * This is the source of truth as of SvelteKit 3, where the config moved out of `svelte.config.js`
- * and into the `sveltekit()` plugin. On older SvelteKit versions that don't expose the config this
- * way, it simply returns `false` and we fall back to the `svelte.config.js`-derived value.
- */
-function isNativeServerTracingEnabled(plugins: readonly Plugin[] | undefined): boolean {
-  if (!plugins) {
-    return false;
-  }
-
-  for (const plugin of plugins) {
-    const options = (
-      plugin?.api as
-        | { options?: BackwardsForwardsCompatibleSvelteConfig & BackwardsForwardsCompatibleKitConfig }
-        | undefined
-    )?.options;
-
-    // SvelteKit 3 flattened the plugin config: what used to live under `kit` now sits
-    // at the top level of the exposed options.
-    const kitConfig = options?.kit ?? options;
-
-    // SvelteKit 3 promoted `tracing` out of `experimental`; older versions nest it there.
-    if (kitConfig?.tracing?.server || kitConfig?.experimental?.tracing?.server) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 /**

--- a/packages/sveltekit/src/vite/detectAdapter.ts
+++ b/packages/sveltekit/src/vite/detectAdapter.ts
@@ -1,7 +1,7 @@
 import type { Package } from '@sentry/core';
 import * as fs from 'fs';
 import * as path from 'path';
-import type { BackwardsForwardsCompatibleSvelteConfig } from './svelteConfig';
+import type { ResolvedKitConfig } from './kitConfig';
 
 /**
  * Supported @sveltejs/adapters-[adapter] SvelteKit adapters
@@ -21,33 +21,33 @@ const ADAPTER_NAME_MAP: Record<string, SupportedSvelteKitAdapters> = {
 
 /**
  * Tries to detect the used adapter for SvelteKit.
- * 1. If svelteConfig is provided and has kit.adapter.name, uses that (source of truth from svelte.config.js).
+ * 1. If kitConfig is provided and has adapter.name, uses that (source of truth from SvelteKit itself).
  * 2. Otherwise falls back to inferring from package.json dependencies.
  * Returns the name of the adapter or 'other' if no supported adapter was found.
  *
- * @param svelteConfig - Loaded svelte config (e.g. from loadSvelteConfig()). Pass `undefined` to skip config-based detection.
+ * @param kitConfig - Resolved SvelteKit config (e.g. from the kit config resolver). Pass `undefined` to skip config-based detection.
  * @param debug - Whether to log detection result. Pass `undefined` for false.
  */
 export async function detectAdapter(
-  svelteConfig: BackwardsForwardsCompatibleSvelteConfig | undefined,
+  kitConfig: ResolvedKitConfig | undefined,
   debug: boolean | undefined,
 ): Promise<SupportedSvelteKitAdapters> {
-  const adapterName = svelteConfig?.kit?.adapter?.name;
+  const adapterName = kitConfig?.adapter?.name;
   if (adapterName && typeof adapterName === 'string') {
     const mapped = ADAPTER_NAME_MAP[adapterName];
     if (mapped) {
       if (debug) {
         // eslint-disable-next-line no-console
-        console.log(`[Sentry SvelteKit Plugin] Detected SvelteKit ${mapped} adapter from \`svelte.config.js\``);
+        console.log(`[Sentry SvelteKit Plugin] Detected SvelteKit ${mapped} adapter from your SvelteKit config`);
       }
       return mapped;
     }
     // We found an adapter name but it's not in our supported list -> return 'other'
-    // svelte.config.js is the source of truth, so we don't need to fall back to package.json.
+    // The SvelteKit config is the source of truth, so we don't need to fall back to package.json.
     if (debug) {
       // eslint-disable-next-line no-console
       console.warn(
-        `[Sentry SvelteKit Plugin] Detected unsupported adapter name ${adapterName} in \`svelte.config.js\`. Please set the 'adapter' option manually`,
+        `[Sentry SvelteKit Plugin] Detected unsupported adapter name ${adapterName} in your SvelteKit config. Please set the 'adapter' option manually`,
       );
     }
     return 'other';

--- a/packages/sveltekit/src/vite/injectGlobalValues.ts
+++ b/packages/sveltekit/src/vite/injectGlobalValues.ts
@@ -1,8 +1,8 @@
 import { escapeStringForRegex, type InternalGlobal } from '@sentry/core';
 import MagicString from 'magic-string';
 import type { Plugin } from 'vite';
-import { type BackwardsForwardsCompatibleSvelteConfig, getAdapterOutputDir, getHooksFileName } from './svelteConfig';
-import type { SentrySvelteKitPluginOptions } from './types';
+import type { ResolvedKitConfig } from './kitConfig';
+import { getHooksFileName } from './svelteConfig';
 
 export type GlobalSentryValues = {
   __sentry_sveltekit_output_dir?: string;
@@ -32,33 +32,56 @@ export function getGlobalValueInjectionCode(globalSentryValues: GlobalSentryValu
   return `${injectedValuesCode}\n`;
 }
 
+type GlobalValuesInjectionOptions = {
+  getKitConfig: () => Promise<ResolvedKitConfig>;
+  getAdapterOutputDir: () => Promise<string>;
+  debug?: boolean;
+};
+
 /**
- * Injects SvelteKit app configuration values the svelte.config.js into the
- * server's global object so that the SDK can pick up the information at runtime
+ * Injects SvelteKit app configuration values into the server's global object
+ * so that the SDK can pick up the information at runtime.
  */
-export async function makeGlobalValuesInjectionPlugin(
-  svelteConfig: BackwardsForwardsCompatibleSvelteConfig,
-  options: Pick<SentrySvelteKitPluginOptions, 'adapter' | 'debug'>,
-): Promise<Plugin> {
-  const { adapter = 'other', debug = false } = options;
+export function makeGlobalValuesInjectionPlugin(options: GlobalValuesInjectionOptions): Plugin {
+  const { getKitConfig, getAdapterOutputDir, debug = false } = options;
 
-  const serverHooksFile = getHooksFileName(svelteConfig, 'server');
-  const adapterOutputDir = await getAdapterOutputDir(svelteConfig, adapter);
+  // The SvelteKit config is only available once Vite has resolved its plugins, so we compute
+  // the injected values lazily (but only once) instead of at plugin creation time.
+  let injectionValuesPromise: Promise<{ globalSentryValues: GlobalSentryValues; hooksFileRegexp: RegExp }> | undefined;
 
-  const globalSentryValues: GlobalSentryValues = {
-    __sentry_sveltekit_output_dir: adapterOutputDir,
-  };
+  const getInjectionValues = (): Promise<{ globalSentryValues: GlobalSentryValues; hooksFileRegexp: RegExp }> =>
+    (injectionValuesPromise ??= (async () => {
+      const kitConfig = await getKitConfig();
 
-  if (debug) {
-    // eslint-disable-next-line no-console
-    console.log('[Sentry SvelteKit] Global values:', globalSentryValues);
-  }
+      const serverHooksFile = getHooksFileName(kitConfig, 'server');
+      const adapterOutputDir = await getAdapterOutputDir();
 
-  // oxlint-disable-next-line sdk/no-regexp-constructor -- not end user input + escaped anyway
-  const hooksFileRegexp = new RegExp(`/${escapeStringForRegex(serverHooksFile)}(.(js|ts|mjs|mts))?`);
+      const globalSentryValues: GlobalSentryValues = {
+        __sentry_sveltekit_output_dir: adapterOutputDir,
+      };
+
+      if (debug) {
+        // eslint-disable-next-line no-console
+        console.log('[Sentry SvelteKit] Global values:', globalSentryValues);
+      }
+
+      return {
+        globalSentryValues,
+        // oxlint-disable-next-line sdk/no-regexp-constructor -- not end user input + escaped anyway
+        hooksFileRegexp: new RegExp(`/${escapeStringForRegex(serverHooksFile)}(.(js|ts|mjs|mts))?`),
+      };
+    })());
 
   return {
     name: 'sentry-sveltekit-global-values-injection-plugin',
+
+    // Resolve eagerly rather than on the first `transform`: see the note on the adapter output dir
+    // in `sentrySvelteKit()`. Awaited so a failure surfaces as a config error instead of an
+    // unhandled rejection.
+    configResolved: async () => {
+      await getInjectionValues();
+    },
+
     resolveId: (id, _importer, _ref) => {
       if (id === VIRTUAL_GLOBAL_VALUES_FILE) {
         return {
@@ -70,8 +93,9 @@ export async function makeGlobalValuesInjectionPlugin(
       return null;
     },
 
-    load: id => {
+    load: async id => {
       if (id === VIRTUAL_GLOBAL_VALUES_FILE) {
+        const { globalSentryValues } = await getInjectionValues();
         return {
           code: getGlobalValueInjectionCode(globalSentryValues),
         };
@@ -80,6 +104,8 @@ export async function makeGlobalValuesInjectionPlugin(
     },
 
     transform: async (code, id) => {
+      const { hooksFileRegexp } = await getInjectionValues();
+
       const isServerEntryFile = /instrumentation\.server\./.test(id) || hooksFileRegexp.test(id);
 
       if (isServerEntryFile) {

--- a/packages/sveltekit/src/vite/injectGlobalValues.ts
+++ b/packages/sveltekit/src/vite/injectGlobalValues.ts
@@ -75,9 +75,8 @@ export function makeGlobalValuesInjectionPlugin(options: GlobalValuesInjectionOp
   return {
     name: 'sentry-sveltekit-global-values-injection-plugin',
 
-    // Resolve eagerly rather than on the first `transform`: see the note on the adapter output dir
-    // in `sentrySvelteKit()`. Awaited so a failure surfaces as a config error instead of an
-    // unhandled rejection.
+    // Eagerly, not on the first `transform`: see the note on the adapter output dir in
+    // `sentrySvelteKit()`. Awaited so a failure surfaces as a config error, not a stray rejection.
     configResolved: async () => {
       await getInjectionValues();
     },

--- a/packages/sveltekit/src/vite/kitConfig.ts
+++ b/packages/sveltekit/src/vite/kitConfig.ts
@@ -1,4 +1,5 @@
 import type { Adapter } from '@sveltejs/kit';
+import * as path from 'path';
 import type { Plugin } from 'vite';
 import { loadSvelteConfig } from './svelteConfig';
 
@@ -91,7 +92,8 @@ export function createKitConfigResolver(): KitConfigResolver {
 
   const plugin: Plugin = {
     name: 'sentry-sveltekit-kit-config-resolver',
-    // Run before our other plugins so that they can await `get()` from within their own hooks.
+    // Vite runs `configResolved` hooks concurrently, so the plugins below can await `get()` from
+    // theirs no matter how they're ordered. `pre` only buys us the `config` hook running first.
     enforce: 'pre',
 
     config: config => {
@@ -107,11 +109,16 @@ export function createKitConfigResolver(): KitConfigResolver {
         return;
       }
 
-      // Plugins added by a promise-returning factory aren't visible in the `config` hook yet,
-      // so we take a second look at the fully resolved plugin list.
-      const kitConfig = findKitConfigInPlugins(config.plugins);
+      try {
+        // Plugins added by a promise-returning factory aren't visible in the `config` hook yet,
+        // so we take a second look at the fully resolved plugin list.
+        const kitConfig = findKitConfigInPlugins(config.plugins);
 
-      settle(kitConfig ?? normalizeKitConfig(await loadSvelteConfig()));
+        settle(kitConfig ?? normalizeKitConfig(await loadSvelteConfig()));
+      } finally {
+        // Never leave `get()` pending: awaiting it would hang the build without surfacing a reason.
+        settle({});
+      }
     },
   };
 
@@ -143,11 +150,41 @@ export function findKitConfigInPlugins(plugins: unknown): ResolvedKitConfig | un
 }
 
 /**
- * Flattens a SvelteKit 2 config (`{ kit: { ... } }`) to the SvelteKit 3 shape (`{ ... }`).
+ * Flattens a SvelteKit 2 config (`{ kit: { ... } }`) to the SvelteKit 3 shape (`{ ... }`) and
+ * brings its paths into the shape the rest of the SDK expects.
+ *
+ * SvelteKit resolves `outDir` and `files.hooks.*` to absolute, platform-separated paths before it
+ * exposes them on `api.options`, whereas `svelte.config.js` holds whatever the user wrote (usually
+ * nothing, so we'd fall back to a cwd-relative default). Everything downstream needs that relative,
+ * `/`-separated form: the hooks file regexp is matched against Vite module ids, the injected output
+ * dir is matched against runtime stack frames on a machine that isn't the build machine, and the
+ * source map deletion globs are relative to the project root.
+ *
  * Exported only for testing.
  */
 export function normalizeKitConfig(config: ResolvedKitConfig & { kit?: ResolvedKitConfig }): ResolvedKitConfig {
-  return config?.kit ?? config ?? {};
+  const kitConfig: ResolvedKitConfig = config?.kit ?? config ?? {};
+  const hooks = kitConfig.files?.hooks;
+
+  return {
+    ...kitConfig,
+    ...(kitConfig.outDir !== undefined && { outDir: toRelativePosixPath(kitConfig.outDir) }),
+    ...(hooks && {
+      files: {
+        ...kitConfig.files,
+        hooks: {
+          ...hooks,
+          ...(hooks.client !== undefined && { client: toRelativePosixPath(hooks.client) }),
+          ...(hooks.server !== undefined && { server: toRelativePosixPath(hooks.server) }),
+        },
+      },
+    }),
+  };
+}
+
+function toRelativePosixPath(filePath: string): string {
+  const relativePath = path.isAbsolute(filePath) ? path.relative(process.cwd(), filePath) : filePath;
+  return relativePath.split(path.sep).join('/');
 }
 
 /**

--- a/packages/sveltekit/src/vite/kitConfig.ts
+++ b/packages/sveltekit/src/vite/kitConfig.ts
@@ -1,0 +1,155 @@
+import type { Adapter } from '@sveltejs/kit';
+import type { Plugin } from 'vite';
+import { loadSvelteConfig } from './svelteConfig';
+
+/**
+ * The subset of SvelteKit's configuration that this SDK reads, in a shape that's normalized
+ * across SvelteKit majors:
+ *
+ * - SvelteKit 2 keeps its options nested under `kit` in `svelte.config.js`
+ * - SvelteKit 3 removed `svelte.config.js` and passes a flat config to the `sveltekit()` Vite plugin
+ *
+ * We always work with the flat shape (see {@link normalizeKitConfig}).
+ */
+export type ResolvedKitConfig = {
+  adapter?: Adapter;
+  outDir?: string;
+  files?: {
+    hooks?: {
+      client?: string;
+      server?: string;
+    };
+  };
+  paths?: {
+    // Matches SvelteKit's own type for this option, so it can be handed to an adapter `Builder` as-is
+    base?: '' | `/${string}`;
+  };
+  /** SvelteKit 3 (>= 3.0.0-next.8) promoted native tracing out of `experimental` */
+  tracing?: {
+    server?: boolean;
+  };
+  /** SvelteKit 2.31+ and early SvelteKit 3 prereleases nest native tracing here */
+  experimental?: {
+    tracing?: {
+      server?: boolean;
+    };
+  };
+};
+
+/**
+ * The SvelteKit Vite plugin exposes the resolved SvelteKit config on its plugin `api`.
+ * This is the case in SvelteKit 2 and 3 alike.
+ */
+const SVELTEKIT_SETUP_PLUGIN_NAME = 'vite-plugin-sveltekit-setup';
+
+type KitPluginApi = {
+  options?: ResolvedKitConfig & { kit?: ResolvedKitConfig };
+};
+
+export type KitConfigResolver = {
+  /**
+   * Add this to the Vite plugins **before** any plugin that calls {@link KitConfigResolver.get},
+   * so that its `config` hook runs first. Otherwise `get()` never resolves.
+   */
+  plugin: Plugin;
+  get: () => Promise<ResolvedKitConfig>;
+};
+
+/**
+ * Creates a Vite plugin that resolves the SvelteKit config once, plus a getter for other plugins
+ * to await it.
+ *
+ * We read the config from the `sveltekit()` Vite plugin's `api.options` instead of importing
+ * `svelte.config.js`: SvelteKit 3 removed that file entirely, and SvelteKit 2.66+ lets users move
+ * their config into `vite.config.js` as well.
+ *
+ * Loading `svelte.config.js` stays as the fallback, and isn't just an edge case: SvelteKit only
+ * exposes `api.options` from 2.62 on, so every older 2.x app still resolves through the file, as
+ * do setups where the SvelteKit plugin isn't registered at all (or is added by a plugin factory we
+ * can't see in time).
+ *
+ * Not `@sveltejs/load-config`: it re-resolves the `vite.config.js` we're being constructed by, so
+ * it ends up waiting on itself and hangs - and it reads this same `api.options` to begin with.
+ */
+export function createKitConfigResolver(): KitConfigResolver {
+  let resolveConfig: (config: ResolvedKitConfig) => void;
+  const configPromise = new Promise<ResolvedKitConfig>(resolve => {
+    resolveConfig = resolve;
+  });
+
+  let isResolved = false;
+  const settle = (config: ResolvedKitConfig): void => {
+    if (!isResolved) {
+      isResolved = true;
+      resolveConfig(config);
+    }
+  };
+
+  const plugin: Plugin = {
+    name: 'sentry-sveltekit-kit-config-resolver',
+    // Run before our other plugins so that they can await `get()` from within their own hooks.
+    enforce: 'pre',
+
+    config: config => {
+      const kitConfig = findKitConfigInPlugins(config.plugins);
+      if (kitConfig) {
+        settle(kitConfig);
+      }
+      return null;
+    },
+
+    configResolved: async config => {
+      if (isResolved) {
+        return;
+      }
+
+      // Plugins added by a promise-returning factory aren't visible in the `config` hook yet,
+      // so we take a second look at the fully resolved plugin list.
+      const kitConfig = findKitConfigInPlugins(config.plugins);
+
+      settle(kitConfig ?? normalizeKitConfig(await loadSvelteConfig()));
+    },
+  };
+
+  return { plugin, get: () => configPromise };
+}
+
+/**
+ * Picks the SvelteKit options off the SvelteKit Vite plugin, if it's registered.
+ * Exported only for testing.
+ */
+export function findKitConfigInPlugins(plugins: unknown): ResolvedKitConfig | undefined {
+  if (!Array.isArray(plugins)) {
+    return undefined;
+  }
+
+  // Plugins can be nested arrays; entries can also be (unresolved) promises, which we skip.
+  for (const plugin of plugins.flat(Infinity)) {
+    if (!plugin || typeof plugin !== 'object' || (plugin as Plugin).name !== SVELTEKIT_SETUP_PLUGIN_NAME) {
+      continue;
+    }
+
+    const options = ((plugin as Plugin).api as KitPluginApi | undefined)?.options;
+    if (options) {
+      return normalizeKitConfig(options);
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Flattens a SvelteKit 2 config (`{ kit: { ... } }`) to the SvelteKit 3 shape (`{ ... }`).
+ * Exported only for testing.
+ */
+export function normalizeKitConfig(config: ResolvedKitConfig & { kit?: ResolvedKitConfig }): ResolvedKitConfig {
+  return config?.kit ?? config ?? {};
+}
+
+/**
+ * Whether SvelteKit's native server-side tracing is enabled. If it is, we must not add our own
+ * server-side instrumentation on top of SvelteKit's, or we'd emit duplicate spans.
+ */
+export function isNativeServerTracingEnabled(kitConfig: ResolvedKitConfig): boolean {
+  return !!(kitConfig.tracing?.server || kitConfig.experimental?.tracing?.server);
+}

--- a/packages/sveltekit/src/vite/kitConfig.ts
+++ b/packages/sveltekit/src/vite/kitConfig.ts
@@ -48,8 +48,12 @@ type KitPluginApi = {
 
 export type KitConfigResolver = {
   /**
-   * Add this to the Vite plugins **before** any plugin that calls {@link KitConfigResolver.get},
-   * so that its `config` hook runs first. Otherwise `get()` never resolves.
+   * Add this to the Vite plugins before the plugins that call {@link KitConfigResolver.get}.
+   *
+   * Never `await` {@link KitConfigResolver.get} from a `config` hook: `sveltekit()` is an async
+   * factory in both SvelteKit majors, so the plugins array Vite passes to `config` still holds an
+   * unresolved promise in its place and the SvelteKit config can only be found in `configResolved`.
+   * Awaiting it earlier blocks the `config` phase that would resolve it, and the build hangs.
    */
   plugin: Plugin;
   get: () => Promise<ResolvedKitConfig>;

--- a/packages/sveltekit/src/vite/kitConfig.ts
+++ b/packages/sveltekit/src/vite/kitConfig.ts
@@ -37,10 +37,7 @@ export type ResolvedKitConfig = {
   };
 };
 
-/**
- * The SvelteKit Vite plugin exposes the resolved SvelteKit config on its plugin `api`.
- * This is the case in SvelteKit 2 and 3 alike.
- */
+/** The plugin that carries the resolved SvelteKit config on its `api`, in SvelteKit 2 and 3 alike. */
 const SVELTEKIT_SETUP_PLUGIN_NAME = 'vite-plugin-sveltekit-setup';
 
 type KitPluginApi = {
@@ -49,12 +46,12 @@ type KitPluginApi = {
 
 export type KitConfigResolver = {
   /**
-   * Add this to the Vite plugins before the plugins that call {@link KitConfigResolver.get}.
+   * Register this before the plugins that call {@link KitConfigResolver.get}.
    *
    * Never `await` {@link KitConfigResolver.get} from a `config` hook: `sveltekit()` is an async
-   * factory in both SvelteKit majors, so the plugins array Vite passes to `config` still holds an
-   * unresolved promise in its place and the SvelteKit config can only be found in `configResolved`.
-   * Awaiting it earlier blocks the `config` phase that would resolve it, and the build hangs.
+   * factory in both majors, so the plugin array Vite passes to `config` still holds an unresolved
+   * promise where the SvelteKit plugin will be - it's only findable in `configResolved`. Awaiting
+   * from `config` blocks the very phase that would resolve it, and the build hangs.
    */
   plugin: Plugin;
   get: () => Promise<ResolvedKitConfig>;
@@ -64,14 +61,11 @@ export type KitConfigResolver = {
  * Creates a Vite plugin that resolves the SvelteKit config once, plus a getter for other plugins
  * to await it.
  *
- * We read the config from the `sveltekit()` Vite plugin's `api.options` instead of importing
- * `svelte.config.js`: SvelteKit 3 removed that file entirely, and SvelteKit 2.66+ lets users move
- * their config into `vite.config.js` as well.
- *
- * Loading `svelte.config.js` stays as the fallback, and isn't just an edge case: SvelteKit only
- * exposes `api.options` from 2.62 on, so every older 2.x app still resolves through the file, as
- * do setups where the SvelteKit plugin isn't registered at all (or is added by a plugin factory we
- * can't see in time).
+ * The config comes from the `sveltekit()` Vite plugin's `api.options` rather than from
+ * `svelte.config.js`: SvelteKit 3 removed that file, and 2.66+ lets users move their config into
+ * `vite.config.js`. Loading `svelte.config.js` stays as the fallback, and isn't just an edge case:
+ * `api.options` only exists from 2.62 on, so every older 2.x app still resolves through the file,
+ * as do setups where the SvelteKit plugin isn't registered at all.
  *
  * Not `@sveltejs/load-config`: it re-resolves the `vite.config.js` we're being constructed by, so
  * it ends up waiting on itself and hangs - and it reads this same `api.options` to begin with.
@@ -92,8 +86,8 @@ export function createKitConfigResolver(): KitConfigResolver {
 
   const plugin: Plugin = {
     name: 'sentry-sveltekit-kit-config-resolver',
-    // Vite runs `configResolved` hooks concurrently, so the plugins below can await `get()` from
-    // theirs no matter how they're ordered. `pre` only buys us the `config` hook running first.
+    // Vite runs `configResolved` hooks concurrently, so plugin order doesn't gate `get()`.
+    // `pre` only matters for the `config` hook below.
     enforce: 'pre',
 
     config: config => {
@@ -150,15 +144,12 @@ export function findKitConfigInPlugins(plugins: unknown): ResolvedKitConfig | un
 }
 
 /**
- * Flattens a SvelteKit 2 config (`{ kit: { ... } }`) to the SvelteKit 3 shape (`{ ... }`) and
- * brings its paths into the shape the rest of the SDK expects.
+ * Flattens a SvelteKit 2 config (`{ kit: { ... } }`) to the SvelteKit 3 shape (`{ ... }`) and makes
+ * the paths we read relative and `/`-separated.
  *
- * SvelteKit resolves `outDir` and `files.hooks.*` to absolute, platform-separated paths before it
- * exposes them on `api.options`, whereas `svelte.config.js` holds whatever the user wrote (usually
- * nothing, so we'd fall back to a cwd-relative default). Everything downstream needs that relative,
- * `/`-separated form: the hooks file regexp is matched against Vite module ids, the injected output
- * dir is matched against runtime stack frames on a machine that isn't the build machine, and the
- * source map deletion globs are relative to the project root.
+ * SvelteKit resolves `outDir` and `files.hooks.*` against the cwd before exposing them on
+ * `api.options`, but everything downstream matches them as relative paths: the hooks file regexp
+ * against Vite module ids, the injected output dir against stack frames from another machine.
  *
  * Exported only for testing.
  */

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -5,10 +5,12 @@ import * as path from 'path';
 import type { Plugin } from 'vite';
 import type { AutoInstrumentSelection } from './autoInstrument';
 import { makeAutoInstrumentationPlugin } from './autoInstrument';
+import type { SupportedSvelteKitAdapters } from './detectAdapter';
 import { detectAdapter } from './detectAdapter';
 import { makeGlobalValuesInjectionPlugin } from './injectGlobalValues';
+import { createKitConfigResolver } from './kitConfig';
 import { makeCustomSentryVitePlugins } from './sourceMaps';
-import { loadSvelteConfig } from './svelteConfig';
+import { getAdapterOutputDir } from './svelteConfig';
 import type { CustomSentryVitePluginOptions, SentrySvelteKitPluginOptions } from './types';
 
 const DEFAULT_PLUGIN_OPTIONS: SentrySvelteKitPluginOptions = {
@@ -27,20 +29,33 @@ const DEFAULT_PLUGIN_OPTIONS: SentrySvelteKitPluginOptions = {
 export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}): Promise<Plugin[]> {
   warnOnRemovedBuildOptions(options, ['unstable_sentryVitePluginOptions']);
 
-  const svelteConfig = await loadSvelteConfig();
+  const kitConfigResolver = createKitConfigResolver();
+  const getKitConfig = kitConfigResolver.get;
+
+  // The adapter can only be detected once the SvelteKit config is available, so it's resolved
+  // lazily (but only once) by the plugins that need it.
+  let adapterPromise: Promise<SupportedSvelteKitAdapters> | undefined;
+  const getAdapter = (): Promise<SupportedSvelteKitAdapters> =>
+    (adapterPromise ??= (async () => options.adapter || detectAdapter(await getKitConfig(), options.debug))());
+
+  // Resolving this has a side effect: for the Node adapter we have to invoke `adapter.adapt()` to
+  // learn the output directory, and `@sveltejs/adapter-node` v6 wipes that directory when it runs.
+  // So it must happen once, and early (while the build output doesn't exist yet) - never lazily
+  // from a late hook like `closeBundle`, which runs *after* SvelteKit invoked the adapter.
+  let adapterOutputDirPromise: Promise<string> | undefined;
+  const getAdapterOutputDirOnce = (): Promise<string> =>
+    (adapterOutputDirPromise ??= (async () => getAdapterOutputDir(await getKitConfig(), await getAdapter()))());
 
   const mergedOptions = {
     ...DEFAULT_PLUGIN_OPTIONS,
     ...options,
-    adapter: options.adapter || (await detectAdapter(svelteConfig, options.debug)),
   };
 
-  const sentryPlugins: Plugin[] = [makeBrowserTracingVariantResolverPlugin()];
+  // The config resolver has to come first so that its `config` hook runs before any plugin
+  // below awaits the resolved SvelteKit config.
+  const sentryPlugins: Plugin[] = [kitConfigResolver.plugin, makeBrowserTracingVariantResolverPlugin()];
 
   if (mergedOptions.autoInstrument) {
-    // SvelteKit 3 (>= next.8) promoted `tracing` out of `experimental`; older versions nest it there.
-    const kitTracingEnabled = !!(svelteConfig.kit?.tracing?.server || svelteConfig.kit?.experimental?.tracing?.server);
-
     const pluginOptions: AutoInstrumentSelection = {
       load: true,
       serverLoad: true,
@@ -51,8 +66,7 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
       makeAutoInstrumentationPlugin({
         ...pluginOptions,
         debug: options.debug || false,
-        // if kit-internal tracing is enabled, we only want to wrap and instrument client-side code.
-        onlyInstrumentClient: kitTracingEnabled,
+        getKitConfig,
       }),
     );
   }
@@ -72,11 +86,19 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     // TODO: I don't think this is technically correct. Either we always or never inject the output directory.
     // Stack traces shouldn't be different, depending on source maps config. With debugIds, we might not even
     // need to rewrite frames anymore.
-    sentryPlugins.push(await makeGlobalValuesInjectionPlugin(svelteConfig, mergedOptions));
+    sentryPlugins.push(
+      makeGlobalValuesInjectionPlugin({
+        getKitConfig,
+        getAdapterOutputDir: getAdapterOutputDirOnce,
+        debug: mergedOptions.debug,
+      }),
+    );
   }
 
   if (sentryVitePluginsOptions) {
-    const sentryVitePlugins = await makeCustomSentryVitePlugins(sentryVitePluginsOptions, svelteConfig);
+    const sentryVitePlugins = await makeCustomSentryVitePlugins(sentryVitePluginsOptions, {
+      getAdapterOutputDir: getAdapterOutputDirOnce,
+    });
     sentryPlugins.push(...sentryVitePlugins);
   }
 
@@ -197,6 +219,9 @@ export function generateVitePluginOptions(
       autoUploadSourceMaps: _filtered1,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       autoInstrument: _filtered2,
+      // Consumed by the kit config resolver, not by the Vite plugin
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      adapter: _filtered3,
       sentryUrl,
       ...newSvelteKitPluginOptions
     } = svelteKitPluginOptions;
@@ -208,7 +233,6 @@ export function generateVitePluginOptions(
 
       url: sentryUrl,
 
-      adapter: svelteKitPluginOptions.adapter,
       // override the plugin's debug flag with the one from the top-level options
       debug: svelteKitPluginOptions.debug,
     };

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -38,10 +38,9 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
   const getAdapter = (): Promise<SupportedSvelteKitAdapters> =>
     (adapterPromise ??= (async () => options.adapter || detectAdapter(await getKitConfig(), options.debug))());
 
-  // Resolving this has a side effect: for the Node adapter we have to invoke `adapter.adapt()` to
-  // learn the output directory, and `@sveltejs/adapter-node` v6 wipes that directory when it runs.
-  // So it must happen once, and early (while the build output doesn't exist yet) - never lazily
-  // from a late hook like `closeBundle`, which runs *after* SvelteKit invoked the adapter.
+  // Side effect: for the Node adapter we invoke `adapter.adapt()` to learn the output directory,
+  // and `@sveltejs/adapter-node` v6 wipes that directory when it runs. So this must happen once,
+  // before the build writes anything - never from a late hook like `closeBundle`.
   let adapterOutputDirPromise: Promise<string> | undefined;
   const getAdapterOutputDirOnce = (): Promise<string> =>
     (adapterOutputDirPromise ??= (async () => getAdapterOutputDir(await getKitConfig(), await getAdapter()))());
@@ -51,8 +50,8 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     ...options,
   };
 
-  // The config resolver has to come first so that its `config` hook runs before any plugin
-  // below awaits the resolved SvelteKit config.
+  // First so the config settles as early as possible. The plugins below read it in `configResolved`,
+  // which Vite runs concurrently, so their order relative to the resolver doesn't matter.
   const sentryPlugins: Plugin[] = [kitConfigResolver.plugin, makeBrowserTracingVariantResolverPlugin()];
 
   if (mergedOptions.autoInstrument) {
@@ -219,7 +218,7 @@ export function generateVitePluginOptions(
       autoUploadSourceMaps: _filtered1,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       autoInstrument: _filtered2,
-      // Consumed by the kit config resolver, not by the Vite plugin
+      // Consumed by `sentrySvelteKit()` for adapter detection, not by the Vite plugin
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       adapter: _filtered3,
       sentryUrl,

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -125,16 +125,16 @@ export async function makeCustomSentryVitePlugins(
     },
   };
 
-  // Whether the user set `build.sourcemap` themselves. Has to be read in `config`, before our own
-  // source map settings plugin sets it - but note that nothing here may *await* the SvelteKit
+  // Whether `build.sourcemap` is already set when this `config` hook runs. Read here rather than in
+  // `configResolved`, where it is always set - but note that nothing here may *await* the SvelteKit
   // config from a `config` hook, see the note in `kitConfig.ts`.
-  let userSpecifiedSourcemapSetting = false;
+  let sourcemapSettingAlreadySet = false;
 
   const filesToDeleteAfterUploadConfigPlugin: Plugin = {
     name: 'sentry-sveltekit-files-to-delete-after-upload-setting-plugin',
     apply: 'build', // only apply this plugin at build time
     config: (config: UserConfig) => {
-      userSpecifiedSourcemapSetting = typeof config.build?.sourcemap !== 'undefined';
+      sourcemapSettingAlreadySet = typeof config.build?.sourcemap !== 'undefined';
       return config;
     },
     configResolved: async () => {
@@ -144,7 +144,7 @@ export async function makeCustomSentryVitePlugins(
 
       const originalFilesToDeleteAfterUpload = options?.sourcemaps?.filesToDeleteAfterUpload;
 
-      if (typeof originalFilesToDeleteAfterUpload === 'undefined' && !userSpecifiedSourcemapSetting) {
+      if (typeof originalFilesToDeleteAfterUpload === 'undefined' && !sourcemapSettingAlreadySet) {
         // Including all hidden (`.*`) directories by default so that folders like .vercel,
         // .netlify, etc are also cleaned up. Additionally, we include the adapter output
         // dir which could be a non-hidden directory, like `build` for the Node adapter.

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -125,17 +125,26 @@ export async function makeCustomSentryVitePlugins(
     },
   };
 
+  // Whether the user set `build.sourcemap` themselves. Has to be read in `config`, before our own
+  // source map settings plugin sets it - but note that nothing here may *await* the SvelteKit
+  // config from a `config` hook, see the note in `kitConfig.ts`.
+  let userSpecifiedSourcemapSetting = false;
+
   const filesToDeleteAfterUploadConfigPlugin: Plugin = {
     name: 'sentry-sveltekit-files-to-delete-after-upload-setting-plugin',
     apply: 'build', // only apply this plugin at build time
-    config: async (config: UserConfig) => {
-      // Kick this off here (not in `closeBundle`) so the adapter is invoked before the build
-      // writes its output - see the note on the adapter output dir in `sentrySvelteKit()`.
+    config: (config: UserConfig) => {
+      userSpecifiedSourcemapSetting = typeof config.build?.sourcemap !== 'undefined';
+      return config;
+    },
+    configResolved: async () => {
+      // Resolved here (not in `closeBundle`) so the adapter is invoked before the build writes its
+      // output - see the note on the adapter output dir in `sentrySvelteKit()`.
       const adapterOutputDir = await getAdapterOutputDir();
 
       const originalFilesToDeleteAfterUpload = options?.sourcemaps?.filesToDeleteAfterUpload;
 
-      if (typeof originalFilesToDeleteAfterUpload === 'undefined' && typeof config.build?.sourcemap === 'undefined') {
+      if (typeof originalFilesToDeleteAfterUpload === 'undefined' && !userSpecifiedSourcemapSetting) {
         // Including all hidden (`.*`) directories by default so that folders like .vercel,
         // .netlify, etc are also cleaned up. Additionally, we include the adapter output
         // dir which could be a non-hidden directory, like `build` for the Node adapter.
@@ -153,8 +162,6 @@ export async function makeCustomSentryVitePlugins(
       } else {
         _resolveFilesToDeleteAfterUpload?.(originalFilesToDeleteAfterUpload);
       }
-
-      return config;
     },
   };
 

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -7,8 +7,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { Plugin, UserConfig } from 'vite';
 import { WRAPPED_MODULE_SUFFIX } from '../common/utils';
-import type { BackwardsForwardsCompatibleSvelteConfig } from './svelteConfig';
-import { getAdapterOutputDir } from './svelteConfig';
 import type { CustomSentryVitePluginOptions } from './types';
 
 // sorcery has no types, so these are some basic type definitions:
@@ -44,10 +42,12 @@ type FilesToDeleteAfterUpload = string | string[] | undefined;
  */
 export async function makeCustomSentryVitePlugins(
   options: CustomSentryVitePluginOptions,
-  svelteConfig: BackwardsForwardsCompatibleSvelteConfig,
+  deps: {
+    /** Resolved once and shared with the other Sentry plugins - see the note in `sentrySvelteKit()` */
+    getAdapterOutputDir: () => Promise<string>;
+  },
 ): Promise<Plugin[]> {
-  const usedAdapter = options?.adapter || 'other';
-  const adapterOutputDir = await getAdapterOutputDir(svelteConfig, usedAdapter);
+  const { getAdapterOutputDir } = deps;
 
   const defaultPluginOptions: SentryVitePluginOptions = {
     release: {
@@ -128,7 +128,11 @@ export async function makeCustomSentryVitePlugins(
   const filesToDeleteAfterUploadConfigPlugin: Plugin = {
     name: 'sentry-sveltekit-files-to-delete-after-upload-setting-plugin',
     apply: 'build', // only apply this plugin at build time
-    config: (config: UserConfig) => {
+    config: async (config: UserConfig) => {
+      // Kick this off here (not in `closeBundle`) so the adapter is invoked before the build
+      // writes its output - see the note on the adapter output dir in `sentrySvelteKit()`.
+      const adapterOutputDir = await getAdapterOutputDir();
+
       const originalFilesToDeleteAfterUpload = options?.sourcemaps?.filesToDeleteAfterUpload;
 
       if (typeof originalFilesToDeleteAfterUpload === 'undefined' && typeof config.build?.sourcemap === 'undefined') {
@@ -176,7 +180,7 @@ export async function makeCustomSentryVitePlugins(
         return;
       }
 
-      const outDir = path.resolve(process.cwd(), adapterOutputDir);
+      const outDir = path.resolve(process.cwd(), await getAdapterOutputDir());
       // eslint-disable-next-line no-console
       debug && console.log('[Source Maps Plugin] Looking up source maps in', outDir);
 

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -18,8 +18,8 @@ export type SvelteConfigFileContents = {
  * The sveltekit plugins import the config in the same way.
  * See: https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/config/index.js#L63
  *
- * Only a fallback these days: as of SvelteKit 3 there is no `svelte.config.js` anymore, and the
- * config is read from the SvelteKit Vite plugin instead (see `kitConfig.ts`).
+ * Only a fallback now - the config is read from the SvelteKit Vite plugin instead, and SvelteKit 3
+ * removed this file entirely (see `kitConfig.ts`).
  */
 export async function loadSvelteConfig(): Promise<SvelteConfigFileContents> {
   // This can only be .js (see https://github.com/sveltejs/kit/pull/4031#issuecomment-1049475388)

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -1,39 +1,27 @@
-import type { Builder, Config } from '@sveltejs/kit';
+import type { Builder } from '@sveltejs/kit';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
 import type { SupportedSvelteKitAdapters } from './detectAdapter';
-
-export type SvelteKitTracingConfig = {
-  tracing?: {
-    server: boolean;
-  };
-  // TODO: Once instrumentation is promoted stable, this will be removed!
-  instrumentation?: {
-    server: boolean;
-  };
-};
+import type { ResolvedKitConfig } from './kitConfig';
 
 /**
- * The location of SvelteKit's native tracing config differs by version:
- * - SvelteKit 2.31+ and early Kit 3 prereleases nest it under `kit.experimental.tracing`
- * - SvelteKit 3 (>= 3.0.0-next.8) promoted it to `kit.tracing`
- * - SvelteKit 3 (>= 3.0.0-next.21) dropped the `kit` nesting entirely, leaving `tracing`
- * We type (and read) all of them so detection works across the supported peer range.
+ * The contents of a `svelte.config.js` file. SvelteKit 3 removed this file; it only exists in
+ * SvelteKit 1 and 2, where all SvelteKit options are nested under `kit`.
  */
-export type BackwardsForwardsCompatibleKitConfig = Config['kit'] &
-  Pick<SvelteKitTracingConfig, 'tracing'> & { experimental?: SvelteKitTracingConfig };
-
-export interface BackwardsForwardsCompatibleSvelteConfig extends Config {
-  kit?: BackwardsForwardsCompatibleKitConfig;
-}
+export type SvelteConfigFileContents = {
+  kit?: ResolvedKitConfig;
+};
 
 /**
  * Imports the svelte.config.js file and returns the config object.
  * The sveltekit plugins import the config in the same way.
  * See: https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/config/index.js#L63
+ *
+ * Only a fallback these days: as of SvelteKit 3 there is no `svelte.config.js` anymore, and the
+ * config is read from the SvelteKit Vite plugin instead (see `kitConfig.ts`).
  */
-export async function loadSvelteConfig(): Promise<BackwardsForwardsCompatibleSvelteConfig> {
+export async function loadSvelteConfig(): Promise<SvelteConfigFileContents> {
   // This can only be .js (see https://github.com/sveltejs/kit/pull/4031#issuecomment-1049475388)
   const SVELTE_CONFIG_FILE = 'svelte.config.js';
 
@@ -46,7 +34,7 @@ export async function loadSvelteConfig(): Promise<BackwardsForwardsCompatibleSve
     const svelteConfigModule = await import(`${url.pathToFileURL(configFile).href}`);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return (svelteConfigModule?.default as BackwardsForwardsCompatibleSvelteConfig) || {};
+    return (svelteConfigModule?.default as SvelteConfigFileContents) || {};
   } catch (e) {
     // eslint-disable-next-line no-console
     console.warn("[Source Maps Plugin] Couldn't load svelte.config.js:");
@@ -61,12 +49,8 @@ export async function loadSvelteConfig(): Promise<BackwardsForwardsCompatibleSve
  * Reads a custom hooks directory from the SvelteKit config. In case no custom hooks
  * directory is specified, the default directory is returned.
  */
-export function getHooksFileName(svelteConfig: Config, hookType: 'client' | 'server'): string {
-  // `files` is deprecated in favour of unchangeable file names. Once it is removed, only the
-  // fallback will be necessary. We can remove the curstom files path once we drop support
-  // for that version range (presumably sveltekit 2).
-  // eslint-disable-next-line typescript/no-deprecated
-  return svelteConfig.kit?.files?.hooks?.[hookType] || `src/hooks.${hookType}`;
+export function getHooksFileName(kitConfig: ResolvedKitConfig, hookType: 'client' | 'server'): string {
+  return kitConfig.files?.hooks?.[hookType] || `src/hooks.${hookType}`;
 }
 
 /**
@@ -74,18 +58,21 @@ export function getHooksFileName(svelteConfig: Config, hookType: 'client' | 'ser
  * of a SvelteKit adapter. If no custom output directory is specified, the default
  * directory is returned.
  */
-export async function getAdapterOutputDir(svelteConfig: Config, adapter: SupportedSvelteKitAdapters): Promise<string> {
+export async function getAdapterOutputDir(
+  kitConfig: ResolvedKitConfig,
+  adapter: SupportedSvelteKitAdapters,
+): Promise<string> {
   if (adapter === 'node') {
-    return getNodeAdapterOutputDir(svelteConfig);
+    return getNodeAdapterOutputDir(kitConfig);
   }
   if (adapter === 'cloudflare') {
     // Cloudflare outputs to outDir\cloudflare as the output dir
-    return path.join(svelteConfig.kit?.outDir || '.svelte-kit', 'cloudflare');
+    return path.join(kitConfig.outDir || '.svelte-kit', 'cloudflare');
   }
 
   // Auto and Vercel adapters simply use config.kit.outDir
   // Let's also use this directory for the 'other' case
-  return path.join(svelteConfig.kit?.outDir || '.svelte-kit', 'output');
+  return path.join(kitConfig.outDir || '.svelte-kit', 'output');
 }
 
 /**
@@ -96,15 +83,15 @@ export async function getAdapterOutputDir(svelteConfig: Config, adapter: Support
  *
  * see: https://github.com/sveltejs/kit/blob/master/packages/adapter-node/index.js#L17
  */
-async function getNodeAdapterOutputDir(svelteConfig: Config): Promise<string> {
+async function getNodeAdapterOutputDir(kitConfig: ResolvedKitConfig): Promise<string> {
   // 'build' is the default output dir for the node adapter
   let outputDir = 'build';
 
-  if (!svelteConfig.kit?.adapter) {
+  if (!kitConfig.adapter) {
     return outputDir;
   }
 
-  const nodeAdapter = svelteConfig.kit.adapter;
+  const nodeAdapter = kitConfig.adapter;
 
   const adapterBuilder: Builder = {
     writeClient(dest: string) {
@@ -123,7 +110,7 @@ async function getNodeAdapterOutputDir(svelteConfig: Config): Promise<string> {
       kit: {
         // @ts-expect-error - the builder expects a validated config but for our purpose it's fine to just pass this partial config
         paths: {
-          base: svelteConfig.kit?.paths?.base || '',
+          base: kitConfig.paths?.base || '',
         },
       },
     },

--- a/packages/sveltekit/src/vite/types.ts
+++ b/packages/sveltekit/src/vite/types.ts
@@ -4,9 +4,7 @@ import type { AutoInstrumentSelection } from './autoInstrument';
 import type { SupportedSvelteKitAdapters } from './detectAdapter';
 
 /** Options for the Custom Sentry Vite plugin */
-export type CustomSentryVitePluginOptions = SentryVitePluginOptions & {
-  adapter?: SupportedSvelteKitAdapters;
-};
+export type CustomSentryVitePluginOptions = SentryVitePluginOptions;
 
 /** Options for the Sentry SvelteKit plugin */
 export type SentrySvelteKitPluginOptions = BuildTimeOptionsBase & {

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -225,7 +225,6 @@ describe('makeAutoInstrumentationPlugin()', () => {
     // The location of the tracing flag differs by SvelteKit version:
     // - SvelteKit 3 (>= 3.0.0-next.8): `tracing.server`
     // - SvelteKit 2.31+ and early Kit 3 prereleases: `experimental.tracing.server`
-    // (the `kit` nesting of SvelteKit 2 configs is flattened away by the kit config resolver)
     function kitConfigWithTracing(serverTracing: boolean, location: 'tracing' | 'experimental'): ResolvedKitConfig {
       const tracing = { tracing: { server: serverTracing } };
       return location === 'tracing' ? tracing : { experimental: tracing };

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { canWrapLoad, makeAutoInstrumentationPlugin } from '../../src/vite/autoInstrument';
+import type { ResolvedKitConfig } from '../../src/vite/kitConfig';
 
 const DEFAULT_CONTENT = `
   export const load = () => {};
@@ -45,7 +46,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
       debug: true,
       load: true,
       serverLoad: true,
-      onlyInstrumentClient: false,
+      getKitConfig: async () => ({}),
     });
     expect(plugin.name).toEqual('sentry-auto-instrumentation');
     expect(plugin.enforce).toEqual('pre');
@@ -67,7 +68,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         debug: false,
         load: true,
         serverLoad: true,
-        onlyInstrumentClient: false,
+        getKitConfig: async () => ({}),
       });
       // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
@@ -84,7 +85,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         debug: false,
         load: false,
         serverLoad: false,
-        onlyInstrumentClient: false,
+        getKitConfig: async () => ({}),
       });
       // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
@@ -107,7 +108,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         debug: false,
         load: false,
         serverLoad: true,
-        onlyInstrumentClient: false,
+        getKitConfig: async () => ({}),
       });
       // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
@@ -124,7 +125,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         debug: false,
         load: false,
         serverLoad: false,
-        onlyInstrumentClient: false,
+        getKitConfig: async () => ({}),
       });
       // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
@@ -132,7 +133,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
     });
   });
 
-  describe('when `onlyInstrumentClient` is `true`', () => {
+  describe('when SvelteKit native server tracing is enabled (client-only instrumentation)', () => {
     it.each([
       // server-only files
       'path/to/+page.server.ts',
@@ -145,7 +146,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         debug: false,
         load: true,
         serverLoad: true,
-        onlyInstrumentClient: true,
+        getKitConfig: async () => ({ tracing: { server: true } }),
       });
 
       // @ts-expect-error this exists and is callable
@@ -168,7 +169,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
           debug: false,
           load: true,
           serverLoad: true,
-          onlyInstrumentClient: true,
+          getKitConfig: async () => ({ tracing: { server: true } }),
         });
 
         // @ts-expect-error this exists and is callable
@@ -202,7 +203,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
           debug: false,
           load: true,
           serverLoad: true,
-          onlyInstrumentClient: true,
+          getKitConfig: async () => ({ tracing: { server: true } }),
         });
 
         // @ts-expect-error this exists and is callable
@@ -220,48 +221,29 @@ describe('makeAutoInstrumentationPlugin()', () => {
     );
   });
 
-  describe('when SvelteKit native server tracing is detected via the Vite plugin `api`', () => {
-    // SvelteKit 3 no longer reads native-tracing config from `svelte.config.js` (so the
-    // `onlyInstrumentClient` option computed from it is `false`); the config is exposed on the
-    // SvelteKit Vite plugin's `api.options` instead.
-    // The tracing config location differs by SvelteKit version:
-    // - SvelteKit 3 (>= 3.0.0-next.21): `tracing.server` (the `kit` nesting was flattened away)
-    // - SvelteKit 3 (>= 3.0.0-next.8): `kit.tracing.server`
-    // - SvelteKit 2.31+ and early Kit 3 prereleases: `kit.experimental.tracing.server`
-    function configWithKitTracing(
-      ssr: boolean,
-      serverTracing: boolean,
-      location: 'tracing' | 'experimental' | 'flat' = 'tracing',
-    ): unknown {
+  describe('when SvelteKit native server tracing is enabled', () => {
+    // The location of the tracing flag differs by SvelteKit version:
+    // - SvelteKit 3 (>= 3.0.0-next.8): `tracing.server`
+    // - SvelteKit 2.31+ and early Kit 3 prereleases: `experimental.tracing.server`
+    // (the `kit` nesting of SvelteKit 2 configs is flattened away by the kit config resolver)
+    function kitConfigWithTracing(serverTracing: boolean, location: 'tracing' | 'experimental'): ResolvedKitConfig {
       const tracing = { tracing: { server: serverTracing } };
-      const options =
-        location === 'flat' ? tracing : { kit: location === 'tracing' ? tracing : { experimental: tracing } };
-
-      return {
-        build: { ssr },
-        plugins: [
-          { name: 'some-other-plugin' },
-          {
-            name: 'vite-plugin-sveltekit-setup',
-            api: { options },
-          },
-        ],
-      };
+      return location === 'tracing' ? tracing : { experimental: tracing };
     }
 
-    describe.each(['tracing', 'experimental', 'flat'] as const)('with the config in the `%s` location', location => {
+    describe.each(['tracing', 'experimental'] as const)('with the flag in the `%s` location', location => {
       it.each(['path/to/+page.server.ts', 'path/to/+layout.server.js', 'path/to/+page.ts', 'path/to/+layout.mjs'])(
-        "doesn't wrap %s in the SSR build when native tracing is enabled, even if `onlyInstrumentClient` is `false`",
+        "doesn't wrap %s in the SSR build",
         async (path: string) => {
           const plugin = makeAutoInstrumentationPlugin({
             debug: false,
             load: true,
             serverLoad: true,
-            onlyInstrumentClient: false,
+            getKitConfig: async () => kitConfigWithTracing(true, location),
           });
 
           // @ts-expect-error this exists and is callable
-          plugin.configResolved(configWithKitTracing(true, true, location));
+          plugin.configResolved({ build: { ssr: true } });
 
           // @ts-expect-error this exists and is callable
           const loadResult = await plugin.load(path);
@@ -275,11 +257,11 @@ describe('makeAutoInstrumentationPlugin()', () => {
           debug: false,
           load: true,
           serverLoad: true,
-          onlyInstrumentClient: false,
+          getKitConfig: async () => kitConfigWithTracing(false, location),
         });
 
         // @ts-expect-error this exists and is callable
-        plugin.configResolved(configWithKitTracing(true, false, location));
+        plugin.configResolved({ build: { ssr: true } });
 
         const path = 'path/to/+page.server.ts';
         // @ts-expect-error this exists and is callable
@@ -298,7 +280,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
   describe('when the server build is detected via the Vite Environment API', () => {
     // On Vite 6+ `config.build.ssr` no longer reliably reflects the per-environment
     // build, so the plugin relies on the current environment (`this.environment.name`). When
-    // `onlyInstrumentClient` is `true`, universal load must not be wrapped in the `ssr` environment
+    // native tracing is enabled, universal load must not be wrapped in the `ssr` environment
     // (but should still be wrapped in `client`), even when `config.build.ssr`/`configResolved`
     // didn't flag a server build.
     it.each(['path/to/+page.ts', 'path/to/+layout.js', 'path/to/+page.server.ts'])(
@@ -308,7 +290,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
           debug: false,
           load: true,
           serverLoad: true,
-          onlyInstrumentClient: true,
+          getKitConfig: async () => ({ tracing: { server: true } }),
         });
 
         // `configResolved` is intentionally not called - `isServerBuild` stays `undefined`
@@ -324,7 +306,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         debug: false,
         load: true,
         serverLoad: true,
-        onlyInstrumentClient: true,
+        getKitConfig: async () => ({ tracing: { server: true } }),
       });
 
       const path = 'path/to/+page.ts';

--- a/packages/sveltekit/test/vite/detectAdapter.test.ts
+++ b/packages/sveltekit/test/vite/detectAdapter.test.ts
@@ -28,40 +28,40 @@ describe('detectAdapter', () => {
   const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
   const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
-  describe('svelte.config.js (source of truth)', () => {
+  describe('SvelteKit config (source of truth)', () => {
     it.each(['auto', 'vercel', 'node', 'cloudflare'])(
-      'returns adapter from kit.adapter.name when provided (adapter %s)',
+      'returns adapter from adapter.name when provided (adapter %s)',
       async adapter => {
-        const svelteConfig = { kit: { adapter: { name: `@sveltejs/adapter-${adapter}` } } };
-        const detectedAdapter = await detectAdapter(svelteConfig, undefined);
+        const kitConfig = { adapter: { name: `@sveltejs/adapter-${adapter}` } };
+        const detectedAdapter = await detectAdapter(kitConfig, undefined);
         expect(detectedAdapter).toEqual(adapter);
       },
     );
 
-    it('prefers svelte.config.js over package.json when both are present', async () => {
+    it('prefers the SvelteKit config over package.json when both are present', async () => {
       pkgJson.dependencies['@sveltejs/adapter-vercel'] = '1.0.0';
-      const svelteConfig = { kit: { adapter: { name: '@sveltejs/adapter-node' } } };
-      const detectedAdapter = await detectAdapter(svelteConfig, undefined);
+      const kitConfig = { adapter: { name: '@sveltejs/adapter-node' } };
+      const detectedAdapter = await detectAdapter(kitConfig, undefined);
       expect(detectedAdapter).toEqual('node');
     });
 
-    it('returns "other" when found adapter name in svelte.config.js is unsupported', async () => {
+    it('returns "other" when the adapter name in the SvelteKit config is unsupported', async () => {
       pkgJson.dependencies['@sveltejs/adapter-vercel'] = '1.0.0';
-      const svelteConfig = { kit: { adapter: { name: '@sveltejs/adapter-netlify' } } };
-      const detectedAdapter = await detectAdapter(svelteConfig, undefined);
+      const kitConfig = { adapter: { name: '@sveltejs/adapter-netlify' } };
+      const detectedAdapter = await detectAdapter(kitConfig, undefined);
       expect(detectedAdapter).toEqual('other');
     });
 
-    it('logs a warning if in debug mode and an unsupported adapter name is found in svelte.config.js', async () => {
-      const svelteConfig = { kit: { adapter: { name: '@sveltejs/adapter-netlify' } } };
-      await detectAdapter(svelteConfig, true);
+    it('logs a warning if in debug mode and an unsupported adapter name is found in the SvelteKit config', async () => {
+      const kitConfig = { adapter: { name: '@sveltejs/adapter-netlify' } };
+      await detectAdapter(kitConfig, true);
       expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Detected unsupported adapter name'));
     });
 
-    it('logs "from svelte.config.js" in debug when adapter comes from config', async () => {
-      const svelteConfig = { kit: { adapter: { name: '@sveltejs/adapter-vercel' } } };
-      await detectAdapter(svelteConfig, true);
-      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('from `svelte.config.js`'));
+    it('logs the config as the source in debug when the adapter comes from it', async () => {
+      const kitConfig = { adapter: { name: '@sveltejs/adapter-vercel' } };
+      await detectAdapter(kitConfig, true);
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('from your SvelteKit config'));
     });
   });
 

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -94,7 +94,7 @@ describe('adapter output dir resolution', () => {
   // `@sveltejs/adapter-node` v6 wipes the output directory when it runs. So it has to happen
   // once, at config time - if it were deferred to e.g. the source maps plugin's `closeBundle`,
   // it would delete the app SvelteKit just built.
-  it('resolves once, at config time, even when `filesToDeleteAfterUpload` is user-specified', async () => {
+  it('resolves once, before the build, even when `filesToDeleteAfterUpload` is user-specified', async () => {
     const adapt = vi.fn((builder: { writeClient: (dest: string) => void }) => {
       builder.writeClient('custom-build/client');
     });
@@ -122,9 +122,11 @@ describe('adapter output dir resolution', () => {
     const globalValuesPlugin = getGlobalValuesPlugin(plugins);
 
     // This takes the branch that leaves `filesToDeleteAfterUpload` untouched - the adapter still
-    // has to be resolved here, not later in `closeBundle`
+    // has to be resolved by `configResolved`, not later in `closeBundle`
     // @ts-expect-error these hooks exist and are callable
-    await filesToDeletePlugin.config({ build: { sourcemap: true } });
+    filesToDeletePlugin.config({ build: { sourcemap: true } });
+    // @ts-expect-error these hooks exist and are callable
+    await filesToDeletePlugin.configResolved();
 
     expect(adapt).toHaveBeenCalledTimes(1);
 

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import type { Plugin } from 'vite';
 import { describe, expect, it, vi } from 'vitest';
 import { getGlobalValueInjectionCode, VIRTUAL_GLOBAL_VALUES_FILE } from '../../src/vite/injectGlobalValues';
@@ -29,6 +30,14 @@ describe('getGlobalValueInjectionCode', () => {
 
 function getGlobalValuesPlugin(plugins: Plugin[]): Plugin {
   return plugins.find(plugin => plugin.name === 'sentry-sveltekit-global-values-injection-plugin')!;
+}
+
+/**
+ * SvelteKit resolves the paths in its config against the cwd before exposing them on `api.options`,
+ * so the fixtures have to be absolute to match what the SDK actually gets handed.
+ */
+function fromCwd(...segments: string[]): string {
+  return path.join(process.cwd(), ...segments);
 }
 
 describe('global values injection plugin', () => {
@@ -66,17 +75,42 @@ describe('global values injection plugin', () => {
   it('injects into a custom server hooks file', async () => {
     const plugins = await getPluginsForKitConfig({
       adapter: nodeAdapterWithCustomOutDir,
-      files: { hooks: { server: 'src/my-hooks.server' } },
+      files: { hooks: { server: fromCwd('src/my-hooks.server') } },
     });
     const plugin = getGlobalValuesPlugin(plugins);
 
     // @ts-expect-error this hook exists and is callable
-    const customHooksResult = await plugin.transform('const a = 1;', '/project/src/my-hooks.server.ts');
+    const customHooksResult = await plugin.transform('const a = 1;', `${fromCwd('src/my-hooks.server')}.ts`);
     // @ts-expect-error this hook exists and is callable
-    const defaultHooksResult = await plugin.transform('const a = 1;', '/project/src/hooks.server.ts');
+    const defaultHooksResult = await plugin.transform('const a = 1;', `${fromCwd('src/hooks.server')}.ts`);
 
     expect(customHooksResult.code).toContain(VIRTUAL_GLOBAL_VALUES_FILE);
     expect(defaultHooksResult).toBeNull();
+  });
+
+  // SvelteKit always populates `files.hooks.server` in the config it exposes, and as an absolute
+  // path. Injecting the global values depends on that path still matching the Vite module id.
+  it('injects into the default server hooks file that SvelteKit resolves for us', async () => {
+    const plugins = await getPluginsForKitConfig({
+      adapter: nodeAdapterWithCustomOutDir,
+      files: { hooks: { client: fromCwd('src/hooks.client'), server: fromCwd('src/hooks.server') } },
+    });
+
+    // @ts-expect-error this hook exists and is callable
+    const result = await getGlobalValuesPlugin(plugins).transform('const a = 1;', `${fromCwd('src/hooks.server')}.ts`);
+
+    expect(result.code).toContain(VIRTUAL_GLOBAL_VALUES_FILE);
+  });
+
+  // The injected value is matched against stack frames at runtime, on a machine that generally
+  // isn't the machine that built the app - an absolute build-time path would never match.
+  it('injects a project-relative output directory', async () => {
+    const plugins = await getPluginsForKitConfig({ outDir: fromCwd('.svelte-kit') });
+
+    // @ts-expect-error this hook exists and is callable
+    const result = await getGlobalValuesPlugin(plugins).load(VIRTUAL_GLOBAL_VALUES_FILE);
+
+    expect(result.code).toContain('globalThis["__sentry_sveltekit_output_dir"] = ".svelte-kit/output";');
   });
 
   it('falls back to the default output directory if the config has no adapter', async () => {

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
-import { getGlobalValueInjectionCode } from '../../src/vite/injectGlobalValues';
+import type { Plugin } from 'vite';
+import { describe, expect, it, vi } from 'vitest';
+import { getGlobalValueInjectionCode, VIRTUAL_GLOBAL_VALUES_FILE } from '../../src/vite/injectGlobalValues';
+import { sentrySvelteKit } from '../../src/vite/sentryVitePlugins';
 
 describe('getGlobalValueInjectionCode', () => {
   it('returns code that injects values into the global object', () => {
@@ -22,5 +24,116 @@ describe('getGlobalValueInjectionCode', () => {
 
   it('returns empty string if no values are passed', () => {
     expect(getGlobalValueInjectionCode({})).toEqual('');
+  });
+});
+
+function getGlobalValuesPlugin(plugins: Plugin[]): Plugin {
+  return plugins.find(plugin => plugin.name === 'sentry-sveltekit-global-values-injection-plugin')!;
+}
+
+describe('global values injection plugin', () => {
+  // The whole chain: the SvelteKit Vite plugin's `api.options` -> kit config resolver ->
+  // adapter detection -> adapter output dir + hooks file. Before SvelteKit 3 this came from
+  // `svelte.config.js`, which no longer exists there.
+  async function getPluginsForKitConfig(kitConfigOptions: unknown): Promise<Plugin[]> {
+    const plugins = await sentrySvelteKit({ autoUploadSourceMaps: true, autoInstrument: false });
+
+    const resolver = plugins.find(plugin => plugin.name === 'sentry-sveltekit-kit-config-resolver')!;
+    // @ts-expect-error this hook exists and is callable
+    resolver.config({
+      plugins: [{ name: 'vite-plugin-sveltekit-setup', api: { options: kitConfigOptions } }],
+    });
+
+    return plugins;
+  }
+
+  const nodeAdapterWithCustomOutDir = {
+    name: '@sveltejs/adapter-node',
+    adapt: (builder: { writeClient: (dest: string) => void }) => {
+      builder.writeClient('custom-build/client');
+    },
+  };
+
+  it("injects the adapter's custom output directory", async () => {
+    const plugins = await getPluginsForKitConfig({ adapter: nodeAdapterWithCustomOutDir });
+
+    // @ts-expect-error this hook exists and is callable
+    const result = await getGlobalValuesPlugin(plugins).load(VIRTUAL_GLOBAL_VALUES_FILE);
+
+    expect(result.code).toContain('globalThis["__sentry_sveltekit_output_dir"] = "custom-build";');
+  });
+
+  it('injects into a custom server hooks file', async () => {
+    const plugins = await getPluginsForKitConfig({
+      adapter: nodeAdapterWithCustomOutDir,
+      files: { hooks: { server: 'src/my-hooks.server' } },
+    });
+    const plugin = getGlobalValuesPlugin(plugins);
+
+    // @ts-expect-error this hook exists and is callable
+    const customHooksResult = await plugin.transform('const a = 1;', '/project/src/my-hooks.server.ts');
+    // @ts-expect-error this hook exists and is callable
+    const defaultHooksResult = await plugin.transform('const a = 1;', '/project/src/hooks.server.ts');
+
+    expect(customHooksResult.code).toContain(VIRTUAL_GLOBAL_VALUES_FILE);
+    expect(defaultHooksResult).toBeNull();
+  });
+
+  it('falls back to the default output directory if the config has no adapter', async () => {
+    const plugins = await getPluginsForKitConfig({});
+
+    // @ts-expect-error this hook exists and is callable
+    const result = await getGlobalValuesPlugin(plugins).load(VIRTUAL_GLOBAL_VALUES_FILE);
+
+    expect(result.code).toContain('globalThis["__sentry_sveltekit_output_dir"]');
+  });
+});
+
+describe('adapter output dir resolution', () => {
+  // Resolving the output directory for the Node adapter means calling `adapter.adapt()`, and
+  // `@sveltejs/adapter-node` v6 wipes the output directory when it runs. So it has to happen
+  // once, at config time - if it were deferred to e.g. the source maps plugin's `closeBundle`,
+  // it would delete the app SvelteKit just built.
+  it('resolves once, at config time, even when `filesToDeleteAfterUpload` is user-specified', async () => {
+    const adapt = vi.fn((builder: { writeClient: (dest: string) => void }) => {
+      builder.writeClient('custom-build/client');
+    });
+
+    const plugins = await sentrySvelteKit({
+      autoUploadSourceMaps: true,
+      autoInstrument: false,
+      sourcemaps: { filesToDeleteAfterUpload: ['./custom-build/**/*.map'] },
+    });
+
+    const resolver = plugins.find(plugin => plugin.name === 'sentry-sveltekit-kit-config-resolver')!;
+    // @ts-expect-error this hook exists and is callable
+    resolver.config({
+      plugins: [
+        {
+          name: 'vite-plugin-sveltekit-setup',
+          api: { options: { adapter: { name: '@sveltejs/adapter-node', adapt } } },
+        },
+      ],
+    });
+
+    const filesToDeletePlugin = plugins.find(
+      plugin => plugin.name === 'sentry-sveltekit-files-to-delete-after-upload-setting-plugin',
+    )!;
+    const globalValuesPlugin = getGlobalValuesPlugin(plugins);
+
+    // This takes the branch that leaves `filesToDeleteAfterUpload` untouched - the adapter still
+    // has to be resolved here, not later in `closeBundle`
+    // @ts-expect-error these hooks exist and are callable
+    await filesToDeletePlugin.config({ build: { sourcemap: true } });
+
+    expect(adapt).toHaveBeenCalledTimes(1);
+
+    // @ts-expect-error these hooks exist and are callable
+    await globalValuesPlugin.configResolved({});
+    // @ts-expect-error these hooks exist and are callable
+    await globalValuesPlugin.load(VIRTUAL_GLOBAL_VALUES_FILE);
+
+    // Shared across the plugins: the adapter must not be invoked once per consumer
+    expect(adapt).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -32,18 +32,14 @@ function getGlobalValuesPlugin(plugins: Plugin[]): Plugin {
   return plugins.find(plugin => plugin.name === 'sentry-sveltekit-global-values-injection-plugin')!;
 }
 
-/**
- * SvelteKit resolves the paths in its config against the cwd before exposing them on `api.options`,
- * so the fixtures have to be absolute to match what the SDK actually gets handed.
- */
+/** SvelteKit resolves config paths against the cwd before exposing them, so fixtures must be absolute. */
 function fromCwd(...segments: string[]): string {
   return path.join(process.cwd(), ...segments);
 }
 
 describe('global values injection plugin', () => {
-  // The whole chain: the SvelteKit Vite plugin's `api.options` -> kit config resolver ->
-  // adapter detection -> adapter output dir + hooks file. Before SvelteKit 3 this came from
-  // `svelte.config.js`, which no longer exists there.
+  // Exercises the whole chain: the SvelteKit Vite plugin's `api.options` -> kit config resolver ->
+  // adapter detection -> adapter output dir + hooks file.
   async function getPluginsForKitConfig(kitConfigOptions: unknown): Promise<Plugin[]> {
     const plugins = await sentrySvelteKit({ autoUploadSourceMaps: true, autoInstrument: false });
 
@@ -124,10 +120,9 @@ describe('global values injection plugin', () => {
 });
 
 describe('adapter output dir resolution', () => {
-  // Resolving the output directory for the Node adapter means calling `adapter.adapt()`, and
-  // `@sveltejs/adapter-node` v6 wipes the output directory when it runs. So it has to happen
-  // once, at config time - if it were deferred to e.g. the source maps plugin's `closeBundle`,
-  // it would delete the app SvelteKit just built.
+  // Resolving the Node adapter's output dir calls `adapter.adapt()`, and `@sveltejs/adapter-node`
+  // v6 wipes that dir when it runs - so once, at config time. Deferred to `closeBundle`, it would
+  // delete the app SvelteKit just built.
   it('resolves once, before the build, even when `filesToDeleteAfterUpload` is user-specified', async () => {
     const adapt = vi.fn((builder: { writeClient: (dest: string) => void }) => {
       builder.writeClient('custom-build/client');

--- a/packages/sveltekit/test/vite/kitConfig.test.ts
+++ b/packages/sveltekit/test/vite/kitConfig.test.ts
@@ -1,0 +1,179 @@
+import type { Plugin } from 'vite';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { VIRTUAL_GLOBAL_VALUES_FILE } from '../../src/vite/injectGlobalValues';
+import { createKitConfigResolver, isNativeServerTracingEnabled } from '../../src/vite/kitConfig';
+import { sentrySvelteKit } from '../../src/vite/sentryVitePlugins';
+
+const loadSvelteConfig = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+
+vi.mock('../../src/vite/svelteConfig', async () => {
+  const actual = (await vi.importActual('../../src/vite/svelteConfig')) as object;
+  return { ...actual, loadSvelteConfig };
+});
+
+/** The SvelteKit Vite plugin exposes the resolved SvelteKit config on its plugin `api`. */
+function kitPlugin(options: unknown): Plugin {
+  return { name: 'vite-plugin-sveltekit-setup', api: { options } } as Plugin;
+}
+
+function callConfigHook(resolver: ReturnType<typeof createKitConfigResolver>, plugins: unknown): void {
+  // @ts-expect-error this hook exists and is callable
+  resolver.plugin.config({ plugins });
+}
+
+function callConfigResolvedHook(resolver: ReturnType<typeof createKitConfigResolver>, plugins: unknown): Promise<void> {
+  // @ts-expect-error this hook exists and is callable
+  return resolver.plugin.configResolved({ plugins, build: {} });
+}
+
+describe('createKitConfigResolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadSvelteConfig.mockResolvedValue({});
+  });
+
+  it('returns a plugin that runs before other plugins', () => {
+    const resolver = createKitConfigResolver();
+
+    expect(resolver.plugin.name).toEqual('sentry-sveltekit-kit-config-resolver');
+    expect(resolver.plugin.enforce).toEqual('pre');
+  });
+
+  describe('from the SvelteKit Vite plugin `api.options`', () => {
+    it('reads the flat config of SvelteKit 3', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [
+        { name: 'some-other-plugin' },
+        kitPlugin({ outDir: 'custom-out', files: { hooks: { server: 'src/my-hooks.server' } } }),
+      ]);
+
+      await expect(resolver.get()).resolves.toEqual({
+        outDir: 'custom-out',
+        files: { hooks: { server: 'src/my-hooks.server' } },
+      });
+    });
+
+    it('flattens the `kit`-nested config of SvelteKit 2', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [kitPlugin({ preprocess: {}, kit: { outDir: 'custom-out' } })]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: 'custom-out' });
+    });
+
+    it('finds the plugin in nested plugin arrays', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [[{ name: 'some-other-plugin' }], [kitPlugin({ outDir: 'nested' })]]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: 'nested' });
+    });
+
+    it('skips entries that are still unresolved promises', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [Promise.resolve([{ name: 'some-plugin' }]), kitPlugin({ outDir: 'from-plugin' })]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: 'from-plugin' });
+    });
+
+    it('resolves in `configResolved` if the plugin was not visible in `config` yet', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [Promise.resolve(kitPlugin({ outDir: 'late' }))]);
+      await callConfigResolvedHook(resolver, [kitPlugin({ outDir: 'late' })]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: 'late' });
+      expect(loadSvelteConfig).not.toHaveBeenCalled();
+    });
+
+    it('keeps the config from the `config` hook, even if `configResolved` runs later', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [kitPlugin({ outDir: 'first' })]);
+      await callConfigResolvedHook(resolver, [kitPlugin({ outDir: 'second' })]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: 'first' });
+    });
+  });
+
+  describe('svelte.config.js fallback', () => {
+    it('falls back if no SvelteKit plugin is registered', async () => {
+      loadSvelteConfig.mockResolvedValue({ kit: { outDir: 'from-svelte-config' } });
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [{ name: 'some-other-plugin' }]);
+      await callConfigResolvedHook(resolver, [{ name: 'some-other-plugin' }]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: 'from-svelte-config' });
+    });
+
+    it('falls back if the SvelteKit plugin exposes no options', async () => {
+      loadSvelteConfig.mockResolvedValue({ kit: { outDir: 'from-svelte-config' } });
+      const resolver = createKitConfigResolver();
+
+      await callConfigResolvedHook(resolver, [{ name: 'vite-plugin-sveltekit-setup' }]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: 'from-svelte-config' });
+    });
+
+    it('resolves to an empty config if there is no svelte.config.js either', async () => {
+      const resolver = createKitConfigResolver();
+
+      await callConfigResolvedHook(resolver, undefined);
+
+      await expect(resolver.get()).resolves.toEqual({});
+    });
+  });
+});
+
+describe('isNativeServerTracingEnabled', () => {
+  it.each([
+    ['SvelteKit 3 (>= next.8)', { tracing: { server: true } }, true],
+    ['SvelteKit 2.31+ / early Kit 3 prereleases', { experimental: { tracing: { server: true } } }, true],
+    ['explicitly disabled', { tracing: { server: false } }, false],
+    ['not configured', {}, false],
+  ])('returns %s -> %s', (_name, config, expected) => {
+    expect(isNativeServerTracingEnabled(config)).toBe(expected);
+  });
+});
+
+describe('resolution through a real Vite config resolution', () => {
+  // The unit tests above invoke the hooks by hand, so they'd still pass if the ordering invariant
+  // broke (resolver no longer first / no longer `enforce: 'pre'`). This lets Vite drive the hooks
+  // instead: if a consumer ever awaits the resolver from a hook that runs before it settles, this
+  // hangs instead of passing.
+  it('resolves the SvelteKit config when Vite runs the plugins', async () => {
+    const { resolveConfig } = await import('vite');
+
+    const sentryPlugins = await sentrySvelteKit({ autoUploadSourceMaps: true, autoInstrument: false });
+
+    const resolved = await resolveConfig(
+      {
+        configFile: false,
+        logLevel: 'error',
+        plugins: [
+          sentryPlugins,
+          {
+            name: 'vite-plugin-sveltekit-setup',
+            api: { options: { outDir: 'resolved-through-vite' } },
+          },
+        ],
+      },
+      'build',
+    );
+
+    expect(resolved.plugins.map(plugin => plugin.name)).toContain('sentry-sveltekit-kit-config-resolver');
+
+    const globalValuesPlugin = resolved.plugins.find(
+      plugin => plugin.name === 'sentry-sveltekit-global-values-injection-plugin',
+    )!;
+
+    // @ts-expect-error this hook exists and is callable
+    const result = await globalValuesPlugin.load(VIRTUAL_GLOBAL_VALUES_FILE);
+
+    // `.svelte-kit` is the default; `resolved-through-vite` proves the plugin config was read
+    expect(result.code).toContain('resolved-through-vite/output');
+  });
+});

--- a/packages/sveltekit/test/vite/kitConfig.test.ts
+++ b/packages/sveltekit/test/vite/kitConfig.test.ts
@@ -17,10 +17,7 @@ function kitPlugin(options: unknown): Plugin {
   return { name: 'vite-plugin-sveltekit-setup', api: { options } } as Plugin;
 }
 
-/**
- * SvelteKit resolves the paths in its config against the cwd before exposing them on `api.options`,
- * so the fixtures have to be absolute to match what the SDK actually gets handed.
- */
+/** SvelteKit resolves config paths against the cwd before exposing them, so fixtures must be absolute. */
 function fromCwd(...segments: string[]): string {
   return path.join(process.cwd(), ...segments);
 }
@@ -185,12 +182,8 @@ describe('isNativeServerTracingEnabled', () => {
 
 describe('resolution through a real Vite config resolution', () => {
   // The unit tests above invoke the hooks by hand, so they'd still pass if the ordering invariant
-  // broke. This lets Vite drive the hooks instead.
-  //
-  // `sveltekit()` is an async factory in both SvelteKit majors, so the plugins array Vite hands to
-  // `config` hooks holds an unresolved promise where the SvelteKit plugin will be - the config is
-  // only findable in `configResolved`. Awaiting it from a `config` hook therefore hangs the build,
-  // so this mirrors the real shape: an async factory, with source map upload enabled so the
+  // broke. This lets Vite drive them instead, against the real shape: an async `sveltekit()`
+  // factory (which hides the plugin from `config` hooks), and source map upload enabled so the
   // plugins that consume the config are actually registered.
   function sveltekitLike(options: unknown): Promise<Plugin[]> {
     return Promise.resolve([{ name: 'vite-plugin-sveltekit-setup', api: { options } } as Plugin]);

--- a/packages/sveltekit/test/vite/kitConfig.test.ts
+++ b/packages/sveltekit/test/vite/kitConfig.test.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import type { Plugin } from 'vite';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VIRTUAL_GLOBAL_VALUES_FILE } from '../../src/vite/injectGlobalValues';
@@ -14,6 +15,14 @@ vi.mock('../../src/vite/svelteConfig', async () => {
 /** The SvelteKit Vite plugin exposes the resolved SvelteKit config on its plugin `api`. */
 function kitPlugin(options: unknown): Plugin {
   return { name: 'vite-plugin-sveltekit-setup', api: { options } } as Plugin;
+}
+
+/**
+ * SvelteKit resolves the paths in its config against the cwd before exposing them on `api.options`,
+ * so the fixtures have to be absolute to match what the SDK actually gets handed.
+ */
+function fromCwd(...segments: string[]): string {
+  return path.join(process.cwd(), ...segments);
 }
 
 function callConfigHook(resolver: ReturnType<typeof createKitConfigResolver>, plugins: unknown): void {
@@ -45,7 +54,7 @@ describe('createKitConfigResolver', () => {
 
       callConfigHook(resolver, [
         { name: 'some-other-plugin' },
-        kitPlugin({ outDir: 'custom-out', files: { hooks: { server: 'src/my-hooks.server' } } }),
+        kitPlugin({ outDir: fromCwd('custom-out'), files: { hooks: { server: fromCwd('src/my-hooks.server') } } }),
       ]);
 
       await expect(resolver.get()).resolves.toEqual({
@@ -57,9 +66,44 @@ describe('createKitConfigResolver', () => {
     it('flattens the `kit`-nested config of SvelteKit 2', async () => {
       const resolver = createKitConfigResolver();
 
-      callConfigHook(resolver, [kitPlugin({ preprocess: {}, kit: { outDir: 'custom-out' } })]);
+      callConfigHook(resolver, [kitPlugin({ preprocess: {}, kit: { outDir: fromCwd('custom-out') } })]);
 
       await expect(resolver.get()).resolves.toEqual({ outDir: 'custom-out' });
+    });
+
+    // SvelteKit hands us absolute, platform-separated paths; everything downstream (the hooks file
+    // regexp, the injected output dir, the source map globs) needs them relative to the project and
+    // `/`-separated, or it silently stops matching.
+    it('relativizes the absolute paths SvelteKit resolves', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [
+        kitPlugin({
+          kit: {
+            outDir: fromCwd('.svelte-kit'),
+            files: {
+              routes: fromCwd('src/routes'),
+              hooks: { client: fromCwd('src/hooks.client'), server: fromCwd('src/hooks.server') },
+            },
+          },
+        }),
+      ]);
+
+      await expect(resolver.get()).resolves.toEqual({
+        outDir: '.svelte-kit',
+        files: {
+          routes: fromCwd('src/routes'),
+          hooks: { client: 'src/hooks.client', server: 'src/hooks.server' },
+        },
+      });
+    });
+
+    it('leaves already-relative paths alone', async () => {
+      const resolver = createKitConfigResolver();
+
+      callConfigHook(resolver, [kitPlugin({ kit: { outDir: '.svelte-kit', files: { hooks: {} } } })]);
+
+      await expect(resolver.get()).resolves.toEqual({ outDir: '.svelte-kit', files: { hooks: {} } });
     });
 
     it('finds the plugin in nested plugin arrays', async () => {
@@ -161,7 +205,7 @@ describe('resolution through a real Vite config resolution', () => {
       {
         configFile: false,
         logLevel: 'error',
-        plugins: [sentryPlugins, sveltekitLike({ outDir: 'resolved-through-vite' })],
+        plugins: [sentryPlugins, sveltekitLike({ kit: { outDir: fromCwd('resolved-through-vite') } })],
       },
       'build',
     );

--- a/packages/sveltekit/test/vite/kitConfig.test.ts
+++ b/packages/sveltekit/test/vite/kitConfig.test.ts
@@ -141,9 +141,17 @@ describe('isNativeServerTracingEnabled', () => {
 
 describe('resolution through a real Vite config resolution', () => {
   // The unit tests above invoke the hooks by hand, so they'd still pass if the ordering invariant
-  // broke (resolver no longer first / no longer `enforce: 'pre'`). This lets Vite drive the hooks
-  // instead: if a consumer ever awaits the resolver from a hook that runs before it settles, this
-  // hangs instead of passing.
+  // broke. This lets Vite drive the hooks instead.
+  //
+  // `sveltekit()` is an async factory in both SvelteKit majors, so the plugins array Vite hands to
+  // `config` hooks holds an unresolved promise where the SvelteKit plugin will be - the config is
+  // only findable in `configResolved`. Awaiting it from a `config` hook therefore hangs the build,
+  // so this mirrors the real shape: an async factory, with source map upload enabled so the
+  // plugins that consume the config are actually registered.
+  function sveltekitLike(options: unknown): Promise<Plugin[]> {
+    return Promise.resolve([{ name: 'vite-plugin-sveltekit-setup', api: { options } } as Plugin]);
+  }
+
   it('resolves the SvelteKit config when Vite runs the plugins', async () => {
     const { resolveConfig } = await import('vite');
 
@@ -153,13 +161,7 @@ describe('resolution through a real Vite config resolution', () => {
       {
         configFile: false,
         logLevel: 'error',
-        plugins: [
-          sentryPlugins,
-          {
-            name: 'vite-plugin-sveltekit-setup',
-            api: { options: { outDir: 'resolved-through-vite' } },
-          },
-        ],
+        plugins: [sentryPlugins, sveltekitLike({ outDir: 'resolved-through-vite' })],
       },
       'build',
     );

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -64,15 +64,18 @@ describe('sentrySvelteKit()', () => {
     const plugins = await getSentrySvelteKitPlugins();
 
     expect(plugins).toBeInstanceOf(Array);
-    // 1 browser-tracing variant resolver + 1 auto instrument plugin + 1 orchestrion plugin
-    // + 1 global values injection plugin + 1 modified main plugin + 3 custom plugins
-    expect(plugins).toHaveLength(8);
+    // 1 kit config resolver + 1 browser-tracing variant resolver + 1 auto instrument plugin
+    // + 1 orchestrion plugin + 1 global values injection plugin + 1 modified main plugin
+    // + 3 custom plugins
+    expect(plugins).toHaveLength(9);
   });
 
   it('returns the custom sentry source maps upload plugin, unmodified sourcemaps plugins and the auto-instrument plugin by default', async () => {
     const plugins = await getSentrySvelteKitPlugins();
     const pluginNames = plugins.map(plugin => plugin.name);
     expect(pluginNames).toEqual([
+      // kit config resolver (must come first so later plugins can await the resolved config):
+      'sentry-sveltekit-kit-config-resolver',
       // browser-tracing variant resolver:
       'sentry-sveltekit-browser-tracing-variant',
       // auto instrument plugin:
@@ -92,7 +95,7 @@ describe('sentrySvelteKit()', () => {
 
   it("doesn't return the sentry source maps plugins if autoUploadSourcemaps is `false`", async () => {
     const plugins = await getSentrySvelteKitPlugins({ autoUploadSourceMaps: false });
-    expect(plugins).toHaveLength(3); // browser-tracing variant resolver + auto instrument + orchestrion
+    expect(plugins).toHaveLength(4); // kit config resolver + browser-tracing variant resolver + auto instrument + orchestrion
   });
 
   it("doesn't return the sentry source maps plugins if `NODE_ENV` is development", async () => {
@@ -100,9 +103,9 @@ describe('sentrySvelteKit()', () => {
 
     process.env.NODE_ENV = 'development';
     const plugins = await getSentrySvelteKitPlugins({ autoUploadSourceMaps: true, autoInstrument: true });
-    const instrumentPlugin = plugins[1];
+    const instrumentPlugin = plugins[2];
 
-    expect(plugins).toHaveLength(4); // browser-tracing variant resolver + auto instrument + orchestrion + global values injection
+    expect(plugins).toHaveLength(5); // kit config resolver + browser-tracing variant resolver + auto instrument + orchestrion + global values injection
     expect(instrumentPlugin?.name).toEqual('sentry-auto-instrumentation');
 
     process.env.NODE_ENV = previousEnv;
@@ -111,7 +114,7 @@ describe('sentrySvelteKit()', () => {
   it("doesn't return the auto instrument plugin if autoInstrument is `false`", async () => {
     const plugins = await getSentrySvelteKitPlugins({ autoInstrument: false });
     const pluginNames = plugins.map(plugin => plugin.name);
-    expect(plugins).toHaveLength(7); // browser-tracing variant resolver + orchestrion + global values injection + 1 modified main plugin + 3 custom plugins
+    expect(plugins).toHaveLength(8); // kit config resolver + browser-tracing variant resolver + orchestrion + global values injection + 1 modified main plugin + 3 custom plugins
     expect(pluginNames).not.toContain('sentry-auto-instrumentation');
   });
 
@@ -161,9 +164,8 @@ describe('sentrySvelteKit()', () => {
           ignore: ['bar/*.js'],
           filesToDeleteAfterUpload: ['baz/*.js'],
         },
-        adapter: 'vercel',
       },
-      {},
+      { getAdapterOutputDir: expect.any(Function) },
     );
   });
 
@@ -208,9 +210,8 @@ describe('sentrySvelteKit()', () => {
         headers: {
           'X-My-Header': 'foo',
         },
-        adapter: 'vercel',
       },
-      {},
+      { getAdapterOutputDir: expect.any(Function) },
     );
   });
 
@@ -225,14 +226,14 @@ describe('sentrySvelteKit()', () => {
       // just to ignore the source maps plugin:
       autoUploadSourceMaps: false,
     });
-    const plugin = plugins[1]!;
+    const plugin = plugins[2]!;
 
     expect(plugin.name).toEqual('sentry-auto-instrumentation');
     expect(makePluginSpy).toHaveBeenCalledWith({
       debug: true,
       load: true,
       serverLoad: false,
-      onlyInstrumentClient: false,
+      getKitConfig: expect.any(Function),
     });
   });
 });
@@ -326,7 +327,7 @@ describe('generateVitePluginOptions', () => {
     process.env.NODE_ENV = originalEnv;
   });
 
-  it('handles adapter and debug options correctly', () => {
+  it("handles the debug option and doesn't forward the adapter", () => {
     const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production'; // Ensure we're not in development mode
 
@@ -338,11 +339,11 @@ describe('generateVitePluginOptions', () => {
       org: 'org',
       project: 'project',
     };
+    // The adapter is resolved through the kit config resolver, not forwarded to the Vite plugin
     const expected: CustomSentryVitePluginOptions = {
       authToken: 'token',
       org: 'org',
       project: 'project',
-      adapter: 'vercel',
       debug: true,
     };
     const result = generateVitePluginOptions(options);
@@ -451,7 +452,6 @@ describe('generateVitePluginOptions', () => {
         name: 'root-1.0.0',
         inject: false,
       },
-      adapter: undefined,
       debug: false,
     });
   });

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -47,9 +47,8 @@ async function getSentryViteSubPlugin(name: string): Promise<Plugin | undefined>
       authToken: 'token',
       org: 'org',
       project: 'project',
-      adapter: 'other',
     },
-    { kit: {} },
+    { getAdapterOutputDir: async () => '.svelte-kit/output' },
   );
 
   return plugins.find(plugin => plugin.name === name);
@@ -313,9 +312,8 @@ describe('deleteFilesAfterUpload', () => {
         authToken: 'token',
         org: 'org',
         project: 'project',
-        adapter: 'other',
       },
-      { kit: {} },
+      { getAdapterOutputDir: async () => '.svelte-kit/output' },
     );
 
     // @ts-expect-error this function exists!
@@ -330,7 +328,6 @@ describe('deleteFilesAfterUpload', () => {
       authToken: 'token',
       org: 'org',
       project: 'project',
-      adapter: 'other',
       release: {
         name: expect.any(String),
       },
@@ -391,12 +388,11 @@ describe('deleteFilesAfterUpload', () => {
           authToken: 'token',
           org: 'org',
           project: 'project',
-          adapter: 'other',
           sourcemaps: {
             filesToDeleteAfterUpload,
           },
         },
-        { kit: {} },
+        { getAdapterOutputDir: async () => '.svelte-kit/output' },
       );
 
       // @ts-expect-error this function exists!
@@ -411,7 +407,6 @@ describe('deleteFilesAfterUpload', () => {
         authToken: 'token',
         org: 'org',
         project: 'project',
-        adapter: 'other',
         release: {
           name: expect.any(String),
         },

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -348,9 +348,12 @@ describe('deleteFilesAfterUpload', () => {
       plugin => plugin.name === 'sentry-sveltekit-files-to-delete-after-upload-setting-plugin',
     )!;
 
-    // call this to ensure the filesToDeleteAfterUpload setting is resolved
-    // @ts-expect-error this function exists!
-    await filesToDeleteAfterUploadSettingPlugin.config(viteConfig);
+    // `config` records whether the user set `build.sourcemap`; `configResolved` resolves the
+    // setting (it can't be awaited from `config` - see the note in `kitConfig.ts`)
+    // @ts-expect-error these functions exist!
+    filesToDeleteAfterUploadSettingPlugin.config(viteConfig);
+    // @ts-expect-error these functions exist!
+    await filesToDeleteAfterUploadSettingPlugin.configResolved();
 
     await expect(mergedOptions.sourcemaps.filesToDeleteAfterUpload).resolves.toEqual([
       './.*/**/*.map',
@@ -427,9 +430,12 @@ describe('deleteFilesAfterUpload', () => {
         plugin => plugin.name === 'sentry-sveltekit-files-to-delete-after-upload-setting-plugin',
       )!;
 
-      // call this to ensure the filesToDeleteAfterUpload setting is resolved
-      // @ts-expect-error this function exists!
-      await filesToDeleteAfterUploadSettingPlugin.config(viteConfig);
+      // `config` records whether the user set `build.sourcemap`; `configResolved` resolves the
+      // setting (it can't be awaited from `config` - see the note in `kitConfig.ts`)
+      // @ts-expect-error these functions exist!
+      filesToDeleteAfterUploadSettingPlugin.config(viteConfig);
+      // @ts-expect-error these functions exist!
+      await filesToDeleteAfterUploadSettingPlugin.configResolved();
 
       await expect(mergedOptions.sourcemaps.filesToDeleteAfterUpload).resolves.toEqual(
         filesToDeleteAfterUploadExpected,

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -63,25 +63,25 @@ describe('getAdapterOutputDir', () => {
   };
 
   it('returns the output directory of the Node adapter', async () => {
-    const outputDir = await getAdapterOutputDir({ kit: { adapter: mockedAdapter } }, 'node');
+    const outputDir = await getAdapterOutputDir({ adapter: mockedAdapter }, 'node');
     expect(outputDir).toEqual('customBuildDir');
   });
 
   it('returns the output directory of the Cloudflare adapter', async () => {
-    const outputDir = await getAdapterOutputDir({ kit: { outDir: 'customOutDir' } }, 'cloudflare');
+    const outputDir = await getAdapterOutputDir({ outDir: 'customOutDir' }, 'cloudflare');
     expect(outputDir).toEqual('customOutDir/cloudflare');
   });
 
   it.each(['vercel', 'auto', 'other'] as SupportedSvelteKitAdapters[])(
     'returns the config.kit.outdir directory for adapter-%s',
     async adapter => {
-      const outputDir = await getAdapterOutputDir({ kit: { outDir: 'customOutDir' } }, adapter);
+      const outputDir = await getAdapterOutputDir({ outDir: 'customOutDir' }, adapter);
       expect(outputDir).toEqual('customOutDir/output');
     },
   );
 
   it('falls back to the default out dir for all other adapters if outdir is not specified in the config', async () => {
-    const outputDir = await getAdapterOutputDir({ kit: {} }, 'vercel');
+    const outputDir = await getAdapterOutputDir({}, 'vercel');
     expect(outputDir).toEqual('.svelte-kit/output');
   });
 });
@@ -93,7 +93,7 @@ describe('getHooksFileName', () => {
   });
 
   it('returns the custom hooks file name if specified in the config', () => {
-    const hooksFileName = getHooksFileName({ kit: { files: { hooks: { server: 'serverhooks' } } } }, 'server');
+    const hooksFileName = getHooksFileName({ files: { hooks: { server: 'serverhooks' } } }, 'server');
     expect(hooksFileName).toEqual('serverhooks');
   });
 });


### PR DESCRIPTION
SvelteKit 3 removed `svelte.config.js` (adapter, `files` and `outDir` now go to the `sveltekit()` Vite plugin), and SvelteKit 2.66+ lets users move their config there too. The SDK still imported `svelte.config.js`, so those setups silently fell back to defaults, breaking source map upload paths and `rewriteFrames` for custom adapter `out`, `outDir` or hooks paths.

The config now comes from the SvelteKit Vite plugin's `api.options`, normalized across both majors. `svelte.config.js` stays as the fallback — SvelteKit only exposes `api.options` from 2.62 on, so older 2.x apps still resolve through the file.

**Why not `@sveltejs/load-config`?**

It re-resolves the `vite.config.js` we're being constructed by, so it
waits on itself and hangs (verified on Vite 8) — and it reads this same `api.options` anyway.