### PR TITLE
test(v10/e2e): Look up the symbolicated event via the eventids endpoint

### DIFF
--- a/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/server.test.ts
@@ -4,8 +4,29 @@ import { test } from 'vitest';
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
-const sentryTestProject = process.env.E2E_TEST_SENTRY_PROJECT;
 const EVENT_POLLING_TIMEOUT = 90_000;
+
+/**
+ * The event serializer emits source context as `[lineNo, line]` pairs spanning the frame's line
+ * and its surroundings, rather than the separate pre/context/post fields of the raw event.
+ */
+interface SerializedFrame {
+  lineNo: number | null;
+  colNo: number | null;
+  context: [number, string][] | null;
+}
+
+function splitFrameContext(frame: SerializedFrame): Record<string, unknown> {
+  const context = frame.context ?? [];
+
+  return {
+    preContext: context.filter(([lineNo]) => lineNo < (frame.lineNo ?? 0)).map(([, line]) => line),
+    contextLine: context.find(([lineNo]) => lineNo === frame.lineNo)?.[1],
+    postContext: context.filter(([lineNo]) => lineNo > (frame.lineNo ?? 0)).map(([, line]) => line),
+    lineno: frame.lineNo,
+    colno: frame.colNo,
+  };
+}
 
 test(
   'Find symbolicated event on sentry',
@@ -23,10 +44,18 @@ test(
 
     while (!timedOut) {
       await new Promise(resolve => setTimeout(resolve, 2000)); // poll every two seconds
-      const response = await fetch(
-        `https://sentry.io/api/0/projects/${sentryTestOrgSlug}/${sentryTestProject}/events/${eventId}/json/`,
-        { headers: { Authorization: `Bearer ${authToken}` } },
-      );
+      const response = await fetch(`https://sentry.io/api/0/organizations/${sentryTestOrgSlug}/eventids/${eventId}/`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+
+      // This is org scoped, so the auth token needs `org:read` on top of the project scopes.
+      // That never resolves by waiting, so fail loudly rather than timing out.
+      if (response.status === 401 || response.status === 403) {
+        throw new Error(
+          `Event lookup was rejected with ${response.status}: ${await response.text()}. ` +
+            'E2E_TEST_AUTH_TOKEN needs the `org:read` scope.',
+        );
+      }
 
       // Only allow ok responses or 404
       if (!response.ok) {
@@ -34,16 +63,16 @@ test(
         continue;
       }
 
-      const eventPayload = await response.json();
-      const frames = eventPayload.exception?.values?.[0]?.stacktrace?.frames;
+      const { event } = await response.json();
+      const exception = event.entries.find((entry: { type: string }) => entry.type === 'exception');
+      const frames: SerializedFrame[] = exception.data.values[0].stacktrace.frames;
       const topFrame = frames[frames.length - 1];
-      expect({
-        preContext: topFrame?.pre_context,
-        contextLine: topFrame?.context_line,
-        postContext: topFrame?.post_context,
-        lineno: topFrame?.lineno,
-        colno: topFrame?.colno,
-      }).toMatchSnapshot();
+
+      if (topFrame === undefined) {
+        throw new Error('Symbolicated event has no stack frames.');
+      }
+
+      expect(splitFrameContext(topFrame)).toMatchSnapshot();
       return;
     }
 


### PR DESCRIPTION
Backport of: #23387