### PR TITLE
Fix: spelling of parameterized in port-span-names skill

### DIFF
--- a/.agents/skills/port-span-names/SKILL.md
+++ b/.agents/skills/port-span-names/SKILL.md
@@ -60,7 +60,7 @@ grep -rn "spanToJSON(.*)\.name" packages/*/src
 
 Classify each write site: does it set a low cardinality value? Low cardinality values are for example:
 
-- a paramterized route (i.e. one without dynamic parameters)
+- a parameterized route (i.e. one without dynamic parameters)
 - an http origin without url path, query or fragment parameters
 - a component name
 - a static string


### PR DESCRIPTION
## Summary

Corrects a misspelling in `.agents/skills/port-span-names/SKILL.md` (`paramterized` → `parameterized`).

This skill instructs agents on low-cardinality span names. The misspelled technical term is easy to copy into comments or searches; the rest of the SDK already uses `parameterized` (`parameterizedRoute`, etc.).

Docs-only, no code changes.