### PR TITLE
ref(core)!: Remove `getLocationHref` export from core

### DIFF
--- a/packages/browser-utils/src/getLocationHref.ts
+++ b/packages/browser-utils/src/getLocationHref.ts
@@ -1,0 +1,12 @@
+import { WINDOW } from './types';
+
+/**
+ * A safe form of location.href.
+ */
+export function getLocationHref(): string {
+  try {
+    return WINDOW.document?.location.href ?? '';
+  } catch {
+    return '';
+  }
+}

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -22,6 +22,8 @@ export { interactionsIntegration } from './performance/interactions';
 
 export { isBotUserAgent } from './isBotUserAgent';
 
+export { getLocationHref } from './getLocationHref';
+
 export { userTimingIntegration } from './performance/userTiming';
 
 export { extractNetworkProtocol } from './performance/utils';

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -9,6 +9,7 @@ import {
   markFunctionWrapped,
   withScope,
 } from '@sentry/core/browser';
+import { getLocationHref } from '@sentry/browser-utils';
 
 export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
@@ -203,17 +204,4 @@ export function getHttpRequestData(): { url: string; headers: Record<string, str
   };
 
   return request;
-}
-
-
-
-/**
- * A safe form of location.href.
- */
-export function getLocationHref(): string {
-  try {
-    return WINDOW.document.location.href;
-  } catch {
-    return '';
-  }
 }

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -4,7 +4,6 @@ import {
   addExceptionTypeValue,
   addNonEnumerableProperty,
   captureException,
-  getLocationHref,
   getOriginalFunction,
   GLOBAL_OBJ,
   markFunctionWrapped,
@@ -204,4 +203,17 @@ export function getHttpRequestData(): { url: string; headers: Record<string, str
   };
 
   return request;
+}
+
+
+
+/**
+ * A safe form of location.href.
+ */
+export function getLocationHref(): string {
+  try {
+    return WINDOW.document.location.href;
+  } catch {
+    return '';
+  }
 }

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -13,8 +13,9 @@ import {
 } from '@sentry/core/browser';
 import type { BrowserClient } from '../client';
 import { DEBUG_BUILD } from '../debug-build';
+import { getLocationHref } from '@sentry/browser-utils';
 import { eventFromUnknownInput } from '../eventbuilder';
-import { getLocationHref, shouldIgnoreOnError } from '../helpers';
+import { shouldIgnoreOnError } from '../helpers';
 
 type GlobalHandlersIntegrationsOptionKeys = 'onerror' | 'onunhandledrejection';
 

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -6,7 +6,6 @@ import {
   debug,
   defineIntegration,
   getClient,
-  getLocationHref,
   isPrimitive,
   isString,
   stripDataUrlContent,
@@ -15,7 +14,7 @@ import {
 import type { BrowserClient } from '../client';
 import { DEBUG_BUILD } from '../debug-build';
 import { eventFromUnknownInput } from '../eventbuilder';
-import { shouldIgnoreOnError } from '../helpers';
+import { getLocationHref, shouldIgnoreOnError } from '../helpers';
 
 type GlobalHandlersIntegrationsOptionKeys = 'onerror' | 'onunhandledrejection';
 

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -40,13 +40,14 @@ import {
 import {
   addHistoryInstrumentationHandler,
   addPerformanceEntries,
+  getLocationHref,
   isBotUserAgent,
   startTrackingLongAnimationFrames,
   startTrackingLongTasks,
 } from '@sentry/browser-utils';
 import { DEBUG_BUILD } from '../debug-build';
 import { filterCollectedUrl } from '@sentry/core';
-import { getHttpRequestData, getLocationHref, WINDOW } from '../helpers';
+import { getHttpRequestData, WINDOW } from '../helpers';
 import { WEB_VITALS_INTEGRATION_NAME, webVitalsIntegration } from '../integrations/webVitals';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -18,7 +18,6 @@ import {
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromSpan,
-  getLocationHref,
   GLOBAL_OBJ,
   hasSpansEnabled,
   hasSpanStreamingEnabled,
@@ -47,7 +46,7 @@ import {
 } from '@sentry/browser-utils';
 import { DEBUG_BUILD } from '../debug-build';
 import { filterCollectedUrl } from '@sentry/core';
-import { getHttpRequestData, WINDOW } from '../helpers';
+import { getHttpRequestData, getLocationHref, WINDOW } from '../helpers';
 import { WEB_VITALS_INTEGRATION_NAME, webVitalsIntegration } from '../integrations/webVitals';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -12,7 +12,6 @@ import {
   addFetchInstrumentationHandler,
   getActiveSpan,
   getClient,
-  getLocationHref,
   getTraceData,
   getUrlFragment,
   getUrlQuery,
@@ -44,6 +43,7 @@ import {
 import type { BrowserClient } from '../client';
 import { baggageHeaderHasSentryValues, createHeadersSafely, getFullURL, isPerformanceResourceTiming } from './utils';
 import { HTTP_REQUEST_METHOD, SERVER_ADDRESS, URL_FRAGMENT, URL_FULL, URL_QUERY } from '@sentry/conventions/attributes';
+import { getLocationHref } from '../helpers';
 
 /** Options for Request Instrumentation */
 export interface RequestInstrumentationOptions {

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -36,6 +36,7 @@ import { filterCollectedUrl, filterCollectedUrlQuery } from '@sentry/core';
 import {
   addPerformanceInstrumentationHandler,
   addXhrInstrumentationHandler,
+  getLocationHref,
   parseXhrResponseHeaders,
   resourceTimingToSpanAttributes,
   SENTRY_XHR_DATA_KEY,
@@ -43,7 +44,6 @@ import {
 import type { BrowserClient } from '../client';
 import { baggageHeaderHasSentryValues, createHeadersSafely, getFullURL, isPerformanceResourceTiming } from './utils';
 import { HTTP_REQUEST_METHOD, SERVER_ADDRESS, URL_FRAGMENT, URL_FULL, URL_QUERY } from '@sentry/conventions/attributes';
-import { getLocationHref } from '../helpers';
 
 /** Options for Request Instrumentation */
 export interface RequestInstrumentationOptions {

--- a/packages/browser/src/utils/detectBrowserExtension.ts
+++ b/packages/browser/src/utils/detectBrowserExtension.ts
@@ -1,6 +1,6 @@
-import { consoleSandbox, getLocationHref } from '@sentry/core/browser';
+import { consoleSandbox } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
-import { WINDOW } from '../helpers';
+import { getLocationHref, WINDOW } from '../helpers';
 
 type ExtensionRuntime = {
   runtime?: {

--- a/packages/browser/src/utils/detectBrowserExtension.ts
+++ b/packages/browser/src/utils/detectBrowserExtension.ts
@@ -1,6 +1,7 @@
+import { getLocationHref } from '@sentry/browser-utils';
 import { consoleSandbox } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
-import { getLocationHref, WINDOW } from '../helpers';
+import { WINDOW } from '../helpers';
 
 type ExtensionRuntime = {
   runtime?: {

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, test, vi } from 'vitest';
 import type { BrowserOptions } from '../src';
 import { WINDOW } from '../src';
 import { init } from '../src/sdk';
-import * as helpers from '../src/helpers';
+import * as browserUtils from '@sentry/browser-utils';
 
 const PUBLIC_DSN = 'https://username@domain/123';
 
@@ -169,7 +169,7 @@ describe('init', () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
         const locationHrefSpy = vi
-          .spyOn(helpers, 'getLocationHref')
+          .spyOn(browserUtils, 'getLocationHref')
           .mockImplementation(() => `${extensionProtocol}://mock-extension-id/dedicated-page.html`);
 
         Object.defineProperty(WINDOW, 'browser', { value: { runtime: { id: 'mock-extension-id' } }, writable: true });

--- a/packages/browser/test/sdk.test.ts
+++ b/packages/browser/test/sdk.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, test, vi } from 'vitest';
 import type { BrowserOptions } from '../src';
 import { WINDOW } from '../src';
 import { init } from '../src/sdk';
+import * as helpers from '../src/helpers';
 
 const PUBLIC_DSN = 'https://username@domain/123';
 
@@ -168,7 +169,7 @@ describe('init', () => {
         const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
         const locationHrefSpy = vi
-          .spyOn(SentryCore, 'getLocationHref')
+          .spyOn(helpers, 'getLocationHref')
           .mockImplementation(() => `${extensionProtocol}://mock-extension-id/dedicated-page.html`);
 
         Object.defineProperty(WINDOW, 'browser', { value: { runtime: { id: 'mock-extension-id' } }, writable: true });

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -1,5 +1,6 @@
 import type { Client } from '@sentry/core/browser';
 import * as utils from '@sentry/core/browser';
+import * as helpers from '../../src/helpers';
 import * as browserUtils from '@sentry/browser-utils';
 import { HTTP_REQUEST_METHOD } from '@sentry/conventions/attributes';
 import type { MockInstance } from 'vitest';
@@ -193,7 +194,7 @@ describe('shouldAttachHeaders', () => {
     let locationHrefSpy: MockInstance;
 
     beforeEach(() => {
-      locationHrefSpy = vi.spyOn(utils, 'getLocationHref').mockImplementation(() => 'https://my-origin.com');
+      locationHrefSpy = vi.spyOn(helpers, 'getLocationHref').mockImplementation(() => 'https://my-origin.com');
     });
 
     afterEach(() => {
@@ -232,7 +233,7 @@ describe('shouldAttachHeaders', () => {
 
     beforeEach(() => {
       locationHrefSpy = vi
-        .spyOn(utils, 'getLocationHref')
+        .spyOn(helpers, 'getLocationHref')
         .mockImplementation(() => 'https://my-origin.com/api/my-route');
     });
 
@@ -364,7 +365,7 @@ describe('shouldAttachHeaders', () => {
     let locationHrefSpy: MockInstance;
 
     beforeEach(() => {
-      locationHrefSpy = vi.spyOn(utils, 'getLocationHref').mockImplementation(() => '');
+      locationHrefSpy = vi.spyOn(helpers, 'getLocationHref').mockImplementation(() => '');
     });
 
     afterEach(() => {

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -1,6 +1,5 @@
 import type { Client } from '@sentry/core/browser';
 import * as utils from '@sentry/core/browser';
-import * as helpers from '../../src/helpers';
 import * as browserUtils from '@sentry/browser-utils';
 import { HTTP_REQUEST_METHOD } from '@sentry/conventions/attributes';
 import type { MockInstance } from 'vitest';
@@ -194,7 +193,7 @@ describe('shouldAttachHeaders', () => {
     let locationHrefSpy: MockInstance;
 
     beforeEach(() => {
-      locationHrefSpy = vi.spyOn(helpers, 'getLocationHref').mockImplementation(() => 'https://my-origin.com');
+      locationHrefSpy = vi.spyOn(browserUtils, 'getLocationHref').mockImplementation(() => 'https://my-origin.com');
     });
 
     afterEach(() => {
@@ -233,7 +232,7 @@ describe('shouldAttachHeaders', () => {
 
     beforeEach(() => {
       locationHrefSpy = vi
-        .spyOn(helpers, 'getLocationHref')
+        .spyOn(browserUtils, 'getLocationHref')
         .mockImplementation(() => 'https://my-origin.com/api/my-route');
     });
 
@@ -365,7 +364,7 @@ describe('shouldAttachHeaders', () => {
     let locationHrefSpy: MockInstance;
 
     beforeEach(() => {
-      locationHrefSpy = vi.spyOn(helpers, 'getLocationHref').mockImplementation(() => '');
+      locationHrefSpy = vi.spyOn(browserUtils, 'getLocationHref').mockImplementation(() => '');
     });
 
     afterEach(() => {

--- a/packages/core/src/browser-exports.ts
+++ b/packages/core/src/browser-exports.ts
@@ -15,7 +15,6 @@ export { startIdleSpan } from './tracing/idleSpan';
 
 export { spanStreamingIntegration } from './integrations/browserSpanStreaming';
 
-export { getLocationHref } from './utils/browser';
 export { supportsDOMError, supportsHistory, supportsNativeFetch, supportsReportingObserver } from './utils/supports';
 export type { XhrBreadcrumbData, XhrBreadcrumbHint } from './types/breadcrumb';
 export type {

--- a/packages/feedback/src/core/sendFeedback.ts
+++ b/packages/feedback/src/core/sendFeedback.ts
@@ -6,8 +6,8 @@ import type {
   SendFeedbackParams,
   TransportMakeRequestResponse,
 } from '@sentry/core';
-import { captureFeedback, getClient, getCurrentScope, getLocationHref } from '@sentry/core';
-import { FEEDBACK_API_SOURCE } from '../constants';
+import { captureFeedback, getClient, getCurrentScope } from '@sentry/core';
+import { FEEDBACK_API_SOURCE, WINDOW } from '../constants';
 import { createFeedbackError } from '../util/createFeedbackError';
 
 /**
@@ -36,7 +36,7 @@ export const sendFeedback: SendFeedback = (
   const eventId = captureFeedback(
     {
       source: FEEDBACK_API_SOURCE,
-      url: getLocationHref(),
+      url: _getLocationHref(),
       ...params,
     },
     hint,
@@ -113,3 +113,14 @@ export const sendFeedback: SendFeedback = (
  *     },
  *   }
  */
+
+/**
+ * A safe form of location.href.
+ */
+function _getLocationHref(): string {
+  try {
+    return WINDOW.document.location.href;
+  } catch {
+    return '';
+  }
+}

--- a/packages/replay-internal/src/coreHandlers/handleBeforeSendEvent.ts
+++ b/packages/replay-internal/src/coreHandlers/handleBeforeSendEvent.ts
@@ -1,5 +1,5 @@
+import { getLocationHref } from '@sentry/browser-utils';
 import type { ErrorEvent, Event } from '@sentry/core';
-import { getLocationHref } from '@sentry/core';
 import type { ReplayContainer } from '../types';
 import { createBreadcrumb } from '../util/createBreadcrumb';
 import { isErrorEvent } from '../util/eventUtils';


### PR DESCRIPTION
Remove the `getLocationHref` export from `@sentry/core`. The single in-core consumer inlines the one-liner it needed (per feedback), so core no longer needs to expose this browser-specific helper.

The browser helper itself now lives in `@sentry/browser-utils` instead of `@sentry/browser`, so it can be shared across browser-side packages without pulling in the full `@sentry/browser` package. Browser consumers and `replay-internal` (previously importing it from `@sentry/core`) now import it from `@sentry/browser-utils`.

Note that `browser-utils`' `WINDOW` types `document` as optional (webworker environments), so the moved helper uses optional chaining where the previous `@sentry/browser` version relied on `WINDOW` being a full `Window`.

The remaining private copy in `@sentry/core` is untouched.