### PR TITLE
ref(core)!: Remove `supportsNativeFetch` export

### DIFF
--- a/packages/browser/src/integrations/httpclient.ts
+++ b/packages/browser/src/integrations/httpclient.ts
@@ -10,7 +10,6 @@ import {
   getClient,
   GLOBAL_OBJ,
   isSentryRequestUrl,
-  supportsNativeFetch,
 } from '@sentry/core/browser';
 import type { SentryWrappedXMLHttpRequest } from '@sentry/browser-utils';
 import { addXhrInstrumentationHandler, SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
@@ -282,10 +281,6 @@ function _isInGivenStatusRanges(
  * Wraps `fetch` function to capture request and response data
  */
 function _wrapFetch(client: Client, options: HttpClientOptions): void {
-  if (!supportsNativeFetch()) {
-    return;
-  }
-
   addFetchInstrumentationHandler(handlerData => {
     if (getClient() !== client) {
       return;

--- a/packages/browser/test/integrations/httpclient.test.ts
+++ b/packages/browser/test/integrations/httpclient.test.ts
@@ -26,7 +26,6 @@ describe('httpClientIntegration', () => {
     const client = new BrowserClient(getDefaultBrowserClientOptions(options));
 
     vi.spyOn(SentryCore, 'getClient').mockReturnValue(client);
-    vi.spyOn(SentryCore, 'supportsNativeFetch').mockReturnValue(true);
     const addFetchSpy = vi
       .spyOn(SentryCore, 'addFetchInstrumentationHandler')
       .mockImplementation(() => () => undefined);

--- a/packages/core/src/browser-exports.ts
+++ b/packages/core/src/browser-exports.ts
@@ -13,6 +13,5 @@ export {
 
 export { startIdleSpan } from './tracing/idleSpan';
 
-export { supportsNativeFetch } from './utils/supports';
 export type { XhrBreadcrumbData, XhrBreadcrumbHint } from './types/breadcrumb';
 export type { BrowserClientReplayOptions } from './types/browseroptions';


### PR DESCRIPTION
Removes this export from core. It was only used by `HttpClient` integration to guard adding the fetch instrumentation, which should not be necessary (we do not do this for other places).