### PR TITLE
ref(core): Move browser-only types out of core

### DIFF
--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -50,4 +50,13 @@ export { isElement } from './is';
 
 export { getAbsoluteUrl } from './instrumentation/location';
 
-export type { FetchHint, NetworkMetaWarning, XhrHint } from './types';
+export type {
+  FetchHint,
+  HandlerDataDom,
+  HandlerDataHistory,
+  HandlerDataXhr,
+  NetworkMetaWarning,
+  SentryWrappedXMLHttpRequest,
+  SentryXhrData,
+  XhrHint,
+} from './types';

--- a/packages/browser-utils/src/instrumentation/dom.ts
+++ b/packages/browser-utils/src/instrumentation/dom.ts
@@ -1,5 +1,5 @@
-import type { HandlerDataDom } from '@sentry/core';
 import { addHandler, addNonEnumerableProperty, fill, maybeInstrument, triggerHandlers, uuid4 } from '@sentry/core';
+import type { HandlerDataDom } from '../types';
 import { WINDOW } from '../types';
 
 type SentryWrappedTarget = HTMLElement & { _sentryId?: string };

--- a/packages/browser-utils/src/instrumentation/history.ts
+++ b/packages/browser-utils/src/instrumentation/history.ts
@@ -1,5 +1,5 @@
-import type { HandlerDataHistory } from '@sentry/core';
 import { addHandler, fill, maybeInstrument, supportsHistory, triggerHandlers } from '@sentry/core';
+import type { HandlerDataHistory } from '../types';
 import { WINDOW } from '../types';
 
 let lastHref: string | undefined;

--- a/packages/browser-utils/src/instrumentation/xhr.ts
+++ b/packages/browser-utils/src/instrumentation/xhr.ts
@@ -1,5 +1,5 @@
-import type { HandlerDataXhr, SentryWrappedXMLHttpRequest } from '@sentry/core';
 import { addHandler, isString, maybeInstrument, timestampInSeconds, triggerHandlers } from '@sentry/core';
+import type { HandlerDataXhr, SentryWrappedXMLHttpRequest } from '../types';
 import { WINDOW } from '../types';
 
 export const SENTRY_XHR_DATA_KEY = '__sentry_xhr_v3__';

--- a/packages/browser-utils/src/types.ts
+++ b/packages/browser-utils/src/types.ts
@@ -1,9 +1,4 @@
-import type {
-  FetchBreadcrumbHint,
-  HandlerDataFetch,
-  SentryWrappedXMLHttpRequest,
-  XhrBreadcrumbHint,
-} from '@sentry/core';
+import type { FetchBreadcrumbHint, HandlerDataFetch, XhrBreadcrumbHint } from '@sentry/core';
 import { GLOBAL_OBJ } from '@sentry/core';
 
 export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ &
@@ -29,3 +24,50 @@ export type FetchHint = FetchBreadcrumbHint & {
   input: HandlerDataFetch['args'];
   response: Response;
 };
+
+// This should be: null | Blob | BufferSource | FormData | URLSearchParams | string
+// But since not all of those are available in node, we just use `unknown` here for now
+type XHRSendInput = unknown;
+
+export interface SentryWrappedXMLHttpRequest {
+  __sentry_xhr_v3__?: SentryXhrData;
+  __sentry_own_request__?: boolean;
+  // span id for the xhr request
+  __sentry_xhr_span_id__?: string;
+  setRequestHeader?: (key: string, val: string) => void;
+  getResponseHeader?: (key: string) => string | null;
+}
+
+// WARNING: When the shape of this type is changed bump the version in `SentryWrappedXMLHttpRequest`
+export interface SentryXhrData {
+  method: string;
+  url: string;
+  status_code?: number;
+  body?: XHRSendInput;
+  request_body_size?: number;
+  response_body_size?: number;
+  request_headers: Record<string, string>;
+}
+
+export interface HandlerDataXhr {
+  xhr: SentryWrappedXMLHttpRequest;
+  startTimestamp?: number;
+  endTimestamp?: number;
+  error?: unknown;
+  // This is to be consumed by the HttpClient integration
+  virtualError?: unknown;
+}
+
+export interface HandlerDataDom {
+  // TODO: Replace `object` here with a vendored type for browser Events. We can't depend on the `DOM` or `react` TS types package here.
+  event: object | { target: object };
+  name: string;
+  global?: boolean;
+}
+
+export interface HandlerDataHistory {
+  /** The full URL of the previous page */
+  from: string | undefined;
+  /** The full URL of the new page */
+  to: string;
+}

--- a/packages/browser-utils/test/instrumentation/xhr.test.ts
+++ b/packages/browser-utils/test/instrumentation/xhr.test.ts
@@ -1,6 +1,6 @@
-import type { HandlerDataXhr } from '@sentry/core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { addXhrInstrumentationHandler, instrumentXHR } from '../../src/instrumentation/xhr';
+import type { HandlerDataXhr } from '../../src/types';
 import { WINDOW } from '../../src/types';
 
 const win = WINDOW as typeof WINDOW & { XMLHttpRequest?: typeof XMLHttpRequest };

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,5 +1,4 @@
 import type {
-  BrowserClientProfilingOptions,
   BrowserClientReplayOptions,
   ClientOptions,
   Event,
@@ -18,6 +17,29 @@ import type { BrowserTransportOptions } from './transports/types';
  * A magic string that build tooling can leverage in order to inject a release value into the SDK.
  */
 declare const __SENTRY_RELEASE__: string | undefined;
+
+export type BrowserClientProfilingOptions = {
+  /**
+   * Sets profiling session sample rate for the entire profiling session.
+   *
+   * A profiling session corresponds to a user session, meaning it is set once at integration initialization and
+   * persisted until the next page reload. This rate determines what percentage of user sessions will have profiling enabled.
+   * @default 0
+   */
+  profileSessionSampleRate?: number;
+
+  /**
+   * Set the lifecycle mode of the profiler.
+   * - **manual**: The profiler will be manually started and stopped via `startProfiler`/`stopProfiler`.
+   *    If a session is sampled, is dependent on the `profileSessionSampleRate`.
+   * - **trace**: The profiler will be automatically started when a root span exists and stopped when there are no
+   *    more sampled root spans. Whether a session is sampled, is dependent on the `profileSessionSampleRate` and the
+   *    existing sampling configuration for tracing (`tracesSampleRate`/`tracesSampler`).
+   *
+   * @default 'manual'
+   */
+  profileLifecycle?: 'manual' | 'trace';
+};
 
 type BrowserSpecificOptions = BrowserClientReplayOptions &
   BrowserClientProfilingOptions & {

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -7,10 +7,7 @@ import type {
   FetchBreadcrumbData,
   FetchBreadcrumbHint,
   HandlerDataConsole,
-  HandlerDataDom,
   HandlerDataFetch,
-  HandlerDataHistory,
-  HandlerDataXhr,
   IntegrationFn,
   XhrBreadcrumbData,
   XhrBreadcrumbHint,
@@ -28,7 +25,7 @@ import {
   safeJoin,
   severityLevelFromString,
 } from '@sentry/core/browser';
-import type { FetchHint, XhrHint } from '@sentry/browser-utils';
+import type { FetchHint, HandlerDataDom, HandlerDataHistory, HandlerDataXhr, XhrHint } from '@sentry/browser-utils';
 import {
   addClickKeypressInstrumentationHandler,
   addHistoryInstrumentationHandler,

--- a/packages/browser/src/integrations/httpclient.ts
+++ b/packages/browser/src/integrations/httpclient.ts
@@ -1,4 +1,4 @@
-import type { Client, Event as SentryEvent, IntegrationFn, SentryWrappedXMLHttpRequest } from '@sentry/core/browser';
+import type { Client, Event as SentryEvent, IntegrationFn } from '@sentry/core/browser';
 import {
   _INTERNAL_filterCookies,
   _INTERNAL_filterKeyValueData,
@@ -12,6 +12,7 @@ import {
   isSentryRequestUrl,
   supportsNativeFetch,
 } from '@sentry/core/browser';
+import type { SentryWrappedXMLHttpRequest } from '@sentry/browser-utils';
 import { addXhrInstrumentationHandler, SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
 import { DEBUG_BUILD } from '../debug-build';
 

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -1,13 +1,5 @@
 /* eslint-disable max-lines */
-import type {
-  Client,
-  HandlerDataXhr,
-  RequestHookInfo,
-  ResponseHookInfo,
-  SentryWrappedXMLHttpRequest,
-  Span,
-  SpanTimeInput,
-} from '@sentry/core/browser';
+import type { Client, RequestHookInfo, ResponseHookInfo, Span, SpanTimeInput } from '@sentry/core/browser';
 import {
   addFetchInstrumentationHandler,
   getActiveSpan,
@@ -32,7 +24,7 @@ import {
   stripUrlQueryAndFragment,
   timestampInSeconds,
 } from '@sentry/core/browser';
-import type { XhrHint } from '@sentry/browser-utils';
+import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, XhrHint } from '@sentry/browser-utils';
 import { filterCollectedUrl, filterCollectedUrlQuery } from '@sentry/core';
 import {
   addPerformanceInstrumentationHandler,

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -90,7 +90,7 @@ describe('instrumentOutgoingRequests', () => {
   });
 
   it('creates a QUERY XHR span with the QUERY method attribute', () => {
-    let xhrHandler: ((data: utils.HandlerDataXhr) => void) | undefined;
+    let xhrHandler: ((data: browserUtils.HandlerDataXhr) => void) | undefined;
     let requestSpan: utils.Span | undefined;
 
     vi.spyOn(browserUtils, 'addXhrInstrumentationHandler').mockImplementation(handler => {
@@ -117,7 +117,7 @@ describe('instrumentOutgoingRequests', () => {
         setRequestHeader: vi.fn(),
       },
       startTimestamp: Date.now(),
-    } as utils.HandlerDataXhr);
+    } as browserUtils.HandlerDataXhr);
 
     expect(xhrHandler).toBeDefined();
     expect(requestSpan).toBeDefined();
@@ -134,7 +134,7 @@ describe('instrumentOutgoingRequests', () => {
     it('uses the active propagation context for an ignored child span', () => {
       const activeSpan = new utils.SentryNonRecordingSpan();
       const ignoredSpan = new utils.SentryNonRecordingSpan({ dropReason: 'ignored' });
-      let xhrHandler: ((data: utils.HandlerDataXhr) => void) | undefined;
+      let xhrHandler: ((data: browserUtils.HandlerDataXhr) => void) | undefined;
 
       vi.spyOn(browserUtils, 'addXhrInstrumentationHandler').mockImplementation(handler => {
         xhrHandler = handler;
@@ -163,7 +163,7 @@ describe('instrumentOutgoingRequests', () => {
           setRequestHeader: vi.fn(),
         },
         startTimestamp: Date.now(),
-      } as utils.HandlerDataXhr);
+      } as browserUtils.HandlerDataXhr);
 
       expect(xhrHandler).toBeDefined();
       expect(getTraceDataSpy).toHaveBeenCalledWith({

--- a/packages/core/src/browser-exports.ts
+++ b/packages/core/src/browser-exports.ts
@@ -18,11 +18,4 @@ export { spanStreamingIntegration } from './integrations/browserSpanStreaming';
 export { getLocationHref } from './utils/browser';
 export { supportsDOMError, supportsHistory, supportsNativeFetch, supportsReportingObserver } from './utils/supports';
 export type { XhrBreadcrumbData, XhrBreadcrumbHint } from './types/breadcrumb';
-export type {
-  HandlerDataXhr,
-  HandlerDataDom,
-  HandlerDataHistory,
-  SentryXhrData,
-  SentryWrappedXMLHttpRequest,
-} from './types/instrument';
-export type { BrowserClientReplayOptions, BrowserClientProfilingOptions } from './types/browseroptions';
+export type { BrowserClientReplayOptions } from './types/browseroptions';

--- a/packages/core/src/types/browseroptions.ts
+++ b/packages/core/src/types/browseroptions.ts
@@ -16,26 +16,3 @@ export type BrowserClientReplayOptions = {
    */
   replaysOnErrorSampleRate?: number;
 };
-
-export type BrowserClientProfilingOptions = {
-  /**
-   * Sets profiling session sample rate for the entire profiling session.
-   *
-   * A profiling session corresponds to a user session, meaning it is set once at integration initialization and
-   * persisted until the next page reload. This rate determines what percentage of user sessions will have profiling enabled.
-   * @default 0
-   */
-  profileSessionSampleRate?: number;
-
-  /**
-   * Set the lifecycle mode of the profiler.
-   * - **manual**: The profiler will be manually started and stopped via `startProfiler`/`stopProfiler`.
-   *    If a session is sampled, is dependent on the `profileSessionSampleRate`.
-   * - **trace**: The profiler will be automatically started when a root span exists and stopped when there are no
-   *    more sampled root spans. Whether a session is sampled, is dependent on the `profileSessionSampleRate` and the
-   *    existing sampling configuration for tracing (`tracesSampleRate`/`tracesSampler`).
-   *
-   * @default 'manual'
-   */
-  profileLifecycle?: 'manual' | 'trace';
-};

--- a/packages/core/src/types/instrument.ts
+++ b/packages/core/src/types/instrument.ts
@@ -1,41 +1,6 @@
-// This should be: null | Blob | BufferSource | FormData | URLSearchParams | string
-// But since not all of those are available in node, we just export `unknown` here for now
-
 import type { WebFetchHeaders } from './webfetchapi';
 
-// Make sure to cast it where needed!
-type XHRSendInput = unknown;
-
 export type ConsoleLevel = 'debug' | 'info' | 'warn' | 'error' | 'log' | 'assert' | 'trace';
-
-export interface SentryWrappedXMLHttpRequest {
-  __sentry_xhr_v3__?: SentryXhrData;
-  __sentry_own_request__?: boolean;
-  // span id for the xhr request
-  __sentry_xhr_span_id__?: string;
-  setRequestHeader?: (key: string, val: string) => void;
-  getResponseHeader?: (key: string) => string | null;
-}
-
-// WARNING: When the shape of this type is changed bump the version in `SentryWrappedXMLHttpRequest`
-export interface SentryXhrData {
-  method: string;
-  url: string;
-  status_code?: number;
-  body?: XHRSendInput;
-  request_body_size?: number;
-  response_body_size?: number;
-  request_headers: Record<string, string>;
-}
-
-export interface HandlerDataXhr {
-  xhr: SentryWrappedXMLHttpRequest;
-  startTimestamp?: number;
-  endTimestamp?: number;
-  error?: unknown;
-  // This is to be consumed by the HttpClient integration
-  virtualError?: unknown;
-}
 
 interface SentryFetchData {
   method: string;
@@ -66,24 +31,10 @@ export interface HandlerDataFetch {
   headers?: WebFetchHeaders;
 }
 
-export interface HandlerDataDom {
-  // TODO: Replace `object` here with a vendored type for browser Events. We can't depend on the `DOM` or `react` TS types package here.
-  event: object | { target: object };
-  name: string;
-  global?: boolean;
-}
-
 export interface HandlerDataConsole {
   level: ConsoleLevel;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any[];
-}
-
-export interface HandlerDataHistory {
-  /** The full URL of the previous page */
-  from: string | undefined;
-  /** The full URL of the new page */
-  to: string;
 }
 
 export interface HandlerDataError {

--- a/packages/replay-internal/src/coreHandlers/handleDom.ts
+++ b/packages/replay-internal/src/coreHandlers/handleDom.ts
@@ -1,5 +1,6 @@
+import type { HandlerDataDom } from '@sentry/browser-utils';
 import { htmlTreeAsString } from '@sentry/browser-utils';
-import type { Breadcrumb, HandlerDataDom } from '@sentry/core';
+import type { Breadcrumb } from '@sentry/core';
 import { record } from '@sentry/rrweb';
 import type { serializedElementNodeWithId, serializedNodeWithId } from '@sentry/rrweb-snapshot';
 import { NodeType } from '@sentry/rrweb-snapshot';

--- a/packages/replay-internal/src/coreHandlers/handleHistory.ts
+++ b/packages/replay-internal/src/coreHandlers/handleHistory.ts
@@ -1,4 +1,4 @@
-import type { HandlerDataHistory } from '@sentry/core';
+import type { HandlerDataHistory } from '@sentry/browser-utils';
 import type { HistoryData, ReplayContainer, ReplayPerformanceEntry } from '../types';
 import { createPerformanceSpans } from '../util/createPerformanceSpans';
 

--- a/packages/replay-internal/test/types.ts
+++ b/packages/replay-internal/test/types.ts
@@ -1,3 +1,3 @@
-import type { HandlerDataDom } from '@sentry/core';
+import type { HandlerDataDom } from '@sentry/browser-utils';
 
 export type DomHandler = (data: HandlerDataDom) => void;

--- a/packages/replay-internal/test/unit/coreHandlers/handleDom.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleDom.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 
-import type { HandlerDataDom } from '@sentry/core';
+import type { HandlerDataDom } from '@sentry/browser-utils';
 import { describe, expect, test } from 'vitest';
 import { handleDom } from '../../../src/coreHandlers/handleDom';
 

--- a/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
+++ b/packages/replay-internal/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
@@ -3,13 +3,8 @@
  */
 
 import '../../utils/mock-internal-setTimeout';
-import type {
-  Breadcrumb,
-  BreadcrumbHint,
-  FetchBreadcrumbHint,
-  SentryWrappedXMLHttpRequest,
-  XhrBreadcrumbHint,
-} from '@sentry/core';
+import type { Breadcrumb, BreadcrumbHint, FetchBreadcrumbHint, XhrBreadcrumbHint } from '@sentry/core';
+import type { SentryWrappedXMLHttpRequest } from '@sentry/browser-utils';
 import { SENTRY_XHR_DATA_KEY } from '@sentry/browser-utils';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NETWORK_BODY_MAX_SIZE } from '../../../src/constants';


### PR DESCRIPTION
Relocates browser-specific types that were exported from `@sentry/core`'s browser entry (`browser-exports.ts`) but are never used by core's own logic. They now live in the package where they belong, next to their only consumers.

**Moved to `@sentry/browser-utils`** (the package containing the xhr/dom/history instrumentation that produces this data):
- `HandlerDataXhr`, `HandlerDataDom`, `HandlerDataHistory`
- `SentryWrappedXMLHttpRequest`, `SentryXhrData` (the latter had no external consumers at all — it's only referenced internally by `SentryWrappedXMLHttpRequest`)

**Moved to `@sentry/browser`** (client.ts, its sole consumer):
- `BrowserClientProfilingOptions`

### Why these and not the rest

The other types in that export block stay in core because moving them isn't clean:
- `XhrBreadcrumbHint` is genuinely used by core's `Client` API.
- `BrowserClientReplayOptions` is consumed by `@sentry/feedback`, which only depends on `@sentry/core` — moving it would force a new dependency.
- `XhrBreadcrumbData` is the data counterpart to `XhrBreadcrumbHint`; splitting the pair across packages for little gain.

The chosen moves are safe because every consumer (`browser`, `browser-utils`, `replay-internal`) already depends on `@sentry/browser-utils`, so no new dependency edges or cycles are introduced.

### Note

These types were only exposed via the `browser` export condition of `@sentry/core` (they are not in core's main/node index), so this removes them from that surface. Downstream imports have been repointed to `@sentry/browser-utils` / `@sentry/browser` accordingly.