### PR TITLE
fix(node): Only end the process session when it is still ok

### DIFF
--- a/packages/node/src/integrations/processSession.ts
+++ b/packages/node/src/integrations/processSession.ts
@@ -18,11 +18,11 @@ export const processSessionIntegration = defineIntegration(() => {
       process.on('beforeExit', () => {
         const session = getIsolationScope().getSession();
 
-        // Only call endSession, if the Session exists on Scope and SessionStatus is not a
-        // Terminal Status i.e. Exited or Crashed because
-        // "When a session is moved away from ok it must not be updated anymore."
+        // Only call endSession if a Session exists on the Scope and has not already reached a
+        // Terminal Status, because "When a session is moved away from ok it must not be updated
+        // anymore." `ok` is the only non-terminal status.
         // Ref: https://develop.sentry.dev/sdk/sessions/
-        if (session?.status !== 'ok') {
+        if (session?.status === 'ok') {
           endSession();
         }
       });

--- a/packages/node/test/integrations/processSession.test.ts
+++ b/packages/node/test/integrations/processSession.test.ts
@@ -1,0 +1,73 @@
+import { getIsolationScope, setCurrentClient } from '@sentry/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { processSessionIntegration } from '../../src/integrations/processSession';
+import { NodeClient } from '../../src/sdk/client';
+import { getDefaultNodeClientOptions } from '../helpers/getDefaultNodeClientOptions';
+
+describe('processSessionIntegration', () => {
+  let client: NodeClient;
+  let sendSession: ReturnType<typeof vi.spyOn>;
+  let beforeExitHandler: () => void;
+
+  beforeEach(() => {
+    getIsolationScope().setSession(undefined);
+
+    client = new NodeClient(getDefaultNodeClientOptions({ release: '1.0.0' }));
+    setCurrentClient(client);
+    client.init();
+    sendSession = vi.spyOn(client, 'sendSession').mockImplementation(() => undefined);
+
+    const processOn = vi.spyOn(process, 'on').mockImplementation(((event: string, listener: () => void) => {
+      if (event === 'beforeExit') {
+        beforeExitHandler = listener;
+      }
+      return process;
+    }) as never);
+
+    processSessionIntegration().setupOnce!();
+    processOn.mockRestore();
+  });
+
+  it('has a name', () => {
+    expect(processSessionIntegration().name).toBe('ProcessSession');
+  });
+
+  it('starts a session on setup', () => {
+    expect(getIsolationScope().getSession()).toEqual(expect.objectContaining({ status: 'ok' }));
+  });
+
+  it('ends the session with status "exited" on a healthy exit', () => {
+    beforeExitHandler();
+
+    expect(sendSession).toHaveBeenCalledTimes(1);
+    expect(sendSession).toHaveBeenCalledWith(expect.objectContaining({ status: 'exited', errors: 0 }));
+  });
+
+  it('ends a session that recorded a handled error', () => {
+    const session = getIsolationScope().getSession()!;
+    session.errors = 1;
+
+    beforeExitHandler();
+
+    expect(sendSession).toHaveBeenCalledWith(expect.objectContaining({ status: 'exited', errors: 1 }));
+  });
+
+  it.each(['exited', 'crashed', 'abnormal', 'unhandled'] as const)('does not update an already-%s session', status => {
+    const session = getIsolationScope().getSession()!;
+    session.status = status;
+    sendSession.mockClear();
+
+    beforeExitHandler();
+
+    expect(sendSession).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no session is on the scope', () => {
+    getIsolationScope().setSession(undefined);
+    sendSession.mockClear();
+
+    beforeExitHandler();
+
+    expect(sendSession).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The `beforeExit` handler guarded `endSession()` with `if (session?.status !== 'ok')`, which is the inverse of
the condition described by the comment directly above it, so a healthy process sent no session envelope at all
while an already-terminal one sent a second, post-terminal update.

_Root cause_

`startSession()` only creates the session and puts it on the isolation scope; the only route to a
`type: 'session'` envelope is `endSession()` -> `closeSession()` -> `_sendSessionUpdate()` ->
`client.captureSession()`. Unlike the browser SDK, which follows `startSession()` with an explicit
`captureSession()`, Node has no initial send, and this handler is the only `endSession()` call site in
`packages/node/src`. So skipping it for `status === 'ok'` meant release health received nothing for any process
that exited cleanly — scripts, CLIs, workers and serverless invocations, none of which are covered by the
HTTP-server request-session aggregates. In the other direction, `closeSession()` leaves a non-`ok` status
untouched but `updateSession()` still bumps `timestamp` and recomputes `duration`, so an already-terminal
session was re-sent with mutated duration, which is what the quoted spec rule forbids.

`ok` is the only non-terminal status: `SessionStatus` is
`'ok' | 'exited' | 'crashed' | 'abnormal' | 'unhandled'` and the spec linked in the comment lists the latter
four as terminal. So the guard is expressed as `=== 'ok'` rather than as a denylist of terminal states — this
matches how the rest of the SDK already decides terminality (`sessionNonTerminal` in
`packages/core/src/client.ts`, and `startSession()` itself in `packages/core/src/exports.ts`), and keeps the
two decisions in sync. I also dropped the stale "i.e. Exited or Crashed" from the comment, since it enumerated
only half the terminal states.

`processSession.test.ts` is new — there was no test for this integration. Six of its nine cases fail against
the previous guard; the remaining three (name, session started on setup, no session on scope) pin the rest of
the contract.

Fixes #23699

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [x] Link an issue if there is one related to your pull request.
