### PR TITLE
feat(v10/nestjs): Add support for NestJS v12

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -111,15 +111,9 @@ jobs:
           - test-application: 'tanstackstart-react'
             build-command: 'test:build-latest'
             label: 'tanstackstart-react (latest)'
-          - test-application: 'nestjs-11'
+          - test-application: 'nestjs-12'
             build-command: 'test:build-latest'
-            label: 'nestjs-11 (latest)'
-          - test-application: 'nestjs-websockets'
-            build-command: 'test:build-latest'
-            label: 'nestjs-websockets (latest)'
-          - test-application: 'nestjs-microservices'
-            build-command: 'test:build-latest'
-            label: 'nestjs-microservices (latest)'
+            label: 'nestjs-12 (latest)'
 
     steps:
       - name: Check out current commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
   Across all AI integrations (OpenAI, Anthropic, Google GenAI, LangChain, and LangGraph), the SDK no longer sends an event to Sentry for errors that the AI framework propagates to your code. Previously the instrumentation reported these as unhandled (`handled: false`) before your own error handling ran, so an error your code caught still showed up in Sentry as an unhandled crash. The span is still marked as errored and the error still propagates, so reporting is left to your application: if your code does not handle the error, it reaches Sentry's global error handlers and is captured as unhandled, just like any other uncaught error. Errors that a provider surfaces as data on an otherwise successful response (such as Anthropic error-shaped responses or Google GenAI blocked content) are still captured, since your code never sees them propagate.
 
+- **feat(v10/nestjs): Add support for NestJS v12 ([#23729](https://github.com/getsentry/sentry-javascript/pull/23729))**
+
+  `@sentry/nestjs` is now compatible with NestJS v12 applications.
+
 Work in this release was contributed by @ryanrho-mercor, @lux-in-tenebris-lucet, and @suhailopensource. Thank you for your contributions!
 
 ## 10.71.0

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/.gitignore
@@ -1,0 +1,56 @@
+# compiled output
+/dist
+/node_modules
+/build
+
+# Logs
+logs
+*.log
+npm-debug.log*
+pnpm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# temp directory
+.temp
+.tmp
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/nest-cli.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/package.json
@@ -1,24 +1,26 @@
 {
-  "name": "nestjs-11",
+  "name": "nestjs-12",
   "version": "0.0.1",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "nest build",
-    "start": "nest start",
+    "start": "node --import ./dist/instrument.js dist/main.js",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test": "playwright test",
-    "test:build": "pnpm install",
+    "test:build": "pnpm install && pnpm build",
+    "test:build-latest": "pnpm install && pnpm add @nestjs/common@latest @nestjs/core@latest @nestjs/platform-express@latest @nestjs/microservices@latest && pnpm add -D @nestjs/cli@latest @nestjs/testing@latest && pnpm build",
     "test:assert": "pnpm test"
   },
   "dependencies": {
-    "@nestjs/common": "^11.0.0",
-    "@nestjs/core": "^11.0.0",
-    "@nestjs/microservices": "^11.0.0",
-    "@nestjs/schedule": "^5.0.0",
-    "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/common": "^12.0.0",
+    "@nestjs/core": "^12.0.0",
+    "@nestjs/microservices": "^12.0.0",
+    "@nestjs/schedule": "^12.0.0",
+    "@nestjs/platform-express": "^12.0.0",
     "@sentry/nestjs": "file:../../packed/sentry-nestjs-packed.tgz",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
@@ -26,11 +28,11 @@
   "devDependencies": {
     "@playwright/test": "~1.56.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
-    "@nestjs/cli": "^11.0.0",
-    "@nestjs/schematics": "^11.0.0",
-    "@nestjs/testing": "^11.0.0",
-    "@types/express": "^4.17.17",
-    "@types/node": "^18.19.1",
+    "@nestjs/cli": "^12.0.0",
+    "@nestjs/schematics": "^12.0.0",
+    "@nestjs/testing": "^12.0.0",
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
@@ -39,7 +41,7 @@
     "supertest": "^6.3.3",
     "ts-loader": "^9.4.3",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "~5.0.0"
+    "typescript": "~5.9.0"
   },
   "pnpm": {
     "overrides": {

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/playwright.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/app.controller.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/app.controller.ts
@@ -1,0 +1,124 @@
+import { Controller, Get, Param, ParseIntPipe, UseFilters, UseGuards, UseInterceptors } from '@nestjs/common';
+import { flush } from '@sentry/nestjs';
+import { AppService } from './app.service.js';
+import { AsyncInterceptor } from './async-example.interceptor.js';
+import { ExampleInterceptor1 } from './example-1.interceptor.js';
+import { ExampleInterceptor2 } from './example-2.interceptor.js';
+import { ExampleExceptionGlobalFilter } from './example-global-filter.exception.js';
+import { ExampleExceptionLocalFilter } from './example-local-filter.exception.js';
+import { ExampleLocalFilter } from './example-local.filter.js';
+import { ExampleGuard } from './example.guard.js';
+
+@Controller()
+@UseFilters(ExampleLocalFilter)
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get('test-transaction')
+  testTransaction() {
+    return this.appService.testTransaction();
+  }
+
+  @Get('test-middleware-instrumentation')
+  testMiddlewareInstrumentation() {
+    return this.appService.testSpan();
+  }
+
+  @Get('test-guard-instrumentation')
+  @UseGuards(ExampleGuard)
+  testGuardInstrumentation() {
+    return {};
+  }
+
+  @Get('test-interceptor-instrumentation')
+  @UseInterceptors(ExampleInterceptor1, ExampleInterceptor2)
+  testInterceptorInstrumentation() {
+    return this.appService.testSpan();
+  }
+
+  @Get('test-async-interceptor-instrumentation')
+  @UseInterceptors(AsyncInterceptor)
+  testAsyncInterceptorInstrumentation() {
+    return this.appService.testSpan();
+  }
+
+  @Get('test-pipe-instrumentation/:id')
+  testPipeInstrumentation(@Param('id', ParseIntPipe) id: number) {
+    return { value: id };
+  }
+
+  @Get('test-exception/:id')
+  async testException(@Param('id') id: string) {
+    return this.appService.testException(id);
+  }
+
+  @Get('test-expected-400-exception/:id')
+  async testExpected400Exception(@Param('id') id: string) {
+    return this.appService.testExpected400Exception(id);
+  }
+
+  @Get('test-expected-500-exception/:id')
+  async testExpected500Exception(@Param('id') id: string) {
+    return this.appService.testExpected500Exception(id);
+  }
+
+  @Get('test-expected-rpc-exception/:id')
+  async testExpectedRpcException(@Param('id') id: string) {
+    return this.appService.testExpectedRpcException(id);
+  }
+
+  @Get('test-span-decorator-async')
+  async testSpanDecoratorAsync() {
+    return { result: await this.appService.testSpanDecoratorAsync() };
+  }
+
+  @Get('test-span-decorator-sync')
+  async testSpanDecoratorSync() {
+    return { result: await this.appService.testSpanDecoratorSync() };
+  }
+
+  @Get('kill-test-cron/:job')
+  async killTestCron(@Param('job') job: string) {
+    this.appService.killTestCron(job);
+  }
+
+  @Get('flush')
+  async flush() {
+    await flush();
+  }
+
+  @Get('example-exception-global-filter')
+  async exampleExceptionGlobalFilter() {
+    throw new ExampleExceptionGlobalFilter();
+  }
+
+  @Get('example-exception-local-filter')
+  async exampleExceptionLocalFilter() {
+    throw new ExampleExceptionLocalFilter();
+  }
+
+  @Get('test-service-use')
+  testServiceWithUseMethod() {
+    return this.appService.use();
+  }
+
+  @Get('test-service-transform')
+  testServiceWithTransform() {
+    return this.appService.transform();
+  }
+
+  @Get('test-service-intercept')
+  testServiceWithIntercept() {
+    return this.appService.intercept();
+  }
+
+  @Get('test-service-canActivate')
+  testServiceWithCanActivate() {
+    return this.appService.canActivate();
+  }
+
+  @Get('test-function-name')
+  testFunctionName() {
+    return this.appService.getFunctionName();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/app.module.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/app.module.ts
@@ -1,0 +1,29 @@
+import { MiddlewareConsumer, Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
+import { ScheduleModule } from '@nestjs/schedule';
+import { SentryGlobalFilter, SentryModule } from '@sentry/nestjs/setup';
+import { AppController } from './app.controller.js';
+import { AppService } from './app.service.js';
+import { ExampleGlobalFilter } from './example-global.filter.js';
+import { ExampleMiddleware } from './example.middleware.js';
+
+@Module({
+  imports: [SentryModule.forRoot(), ScheduleModule.forRoot()],
+  controllers: [AppController],
+  providers: [
+    AppService,
+    {
+      provide: APP_FILTER,
+      useClass: SentryGlobalFilter,
+    },
+    {
+      provide: APP_FILTER,
+      useClass: ExampleGlobalFilter,
+    },
+  ],
+})
+export class AppModule {
+  configure(consumer: MiddlewareConsumer): void {
+    consumer.apply(ExampleMiddleware).forRoutes('test-middleware-instrumentation');
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/app.service.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/app.service.ts
@@ -1,0 +1,112 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { RpcException } from '@nestjs/microservices';
+import { Cron, SchedulerRegistry } from '@nestjs/schedule';
+import * as Sentry from '@sentry/nestjs';
+import { SentryCron, SentryTraced } from '@sentry/nestjs';
+
+const monitorConfig = {
+  schedule: {
+    type: 'crontab',
+    value: '* * * * *',
+  },
+} as const;
+
+@Injectable()
+export class AppService {
+  constructor(private schedulerRegistry: SchedulerRegistry) {}
+
+  testTransaction() {
+    Sentry.startSpan({ name: 'test-span' }, () => {
+      Sentry.startSpan({ name: 'child-span' }, () => {});
+    });
+  }
+
+  testSpan() {
+    // span that should not be a child span of the middleware span
+    Sentry.startSpan({ name: 'test-controller-span' }, () => {});
+  }
+
+  testException(id: string) {
+    throw new Error(`This is an exception with id ${id}`);
+  }
+
+  testExpected400Exception(id: string) {
+    throw new HttpException(`This is an expected 400 exception with id ${id}`, HttpStatus.BAD_REQUEST);
+  }
+
+  testExpected500Exception(id: string) {
+    throw new HttpException(`This is an expected 500 exception with id ${id}`, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  testExpectedRpcException(id: string) {
+    throw new RpcException(`This is an expected RPC exception with id ${id}`);
+  }
+
+  @SentryTraced('wait and return a string')
+  async wait() {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    return 'test';
+  }
+
+  async testSpanDecoratorAsync() {
+    return await this.wait();
+  }
+
+  @SentryTraced('return a string')
+  getString(): { result: string } {
+    return { result: 'test' };
+  }
+
+  @SentryTraced('return the function name')
+  getFunctionName(): { result: string } {
+    return { result: this.getFunctionName.name };
+  }
+
+  async testSpanDecoratorSync() {
+    const returned = this.getString();
+    // Will fail if getString() is async, because returned will be a Promise<>
+    return returned.result;
+  }
+
+  /*
+  Actual cron schedule differs from schedule defined in config because Sentry
+  only supports minute granularity, but we don't want to wait (worst case) a
+  full minute for the tests to finish.
+  */
+  @Cron('*/5 * * * * *', { name: 'test-cron-job' })
+  @SentryCron('test-cron-slug', monitorConfig)
+  async testCron() {
+    console.log('Test cron!');
+  }
+
+  /*
+  Actual cron schedule differs from schedule defined in config because Sentry
+  only supports minute granularity, but we don't want to wait (worst case) a
+  full minute for the tests to finish.
+  */
+  @Cron('*/5 * * * * *', { name: 'test-cron-error' })
+  @SentryCron('test-cron-error-slug', monitorConfig)
+  async testCronError() {
+    throw new Error('Test error from cron job');
+  }
+
+  async killTestCron(job: string) {
+    this.schedulerRegistry.deleteCronJob(job);
+  }
+
+  use() {
+    console.log('Test use!');
+  }
+
+  transform() {
+    console.log('Test transform!');
+  }
+
+  intercept() {
+    console.log('Test intercept!');
+  }
+
+  canActivate() {
+    console.log('Test canActivate!');
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/async-example.interceptor.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/async-example.interceptor.ts
@@ -1,0 +1,17 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { tap } from 'rxjs';
+
+@Injectable()
+export class AsyncInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    Sentry.startSpan({ name: 'test-async-interceptor-span' }, () => {});
+    return Promise.resolve(
+      next.handle().pipe(
+        tap(() => {
+          Sentry.startSpan({ name: 'test-async-interceptor-span-after-route' }, () => {});
+        }),
+      ),
+    );
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-1.interceptor.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-1.interceptor.ts
@@ -1,0 +1,15 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { tap } from 'rxjs';
+
+@Injectable()
+export class ExampleInterceptor1 implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    Sentry.startSpan({ name: 'test-interceptor-span-1' }, () => {});
+    return next.handle().pipe(
+      tap(() => {
+        Sentry.startSpan({ name: 'test-interceptor-span-after-route' }, () => {});
+      }),
+    );
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-2.interceptor.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-2.interceptor.ts
@@ -1,0 +1,10 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+@Injectable()
+export class ExampleInterceptor2 implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    Sentry.startSpan({ name: 'test-interceptor-span-2' }, () => {});
+    return next.handle().pipe();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-global-filter.exception.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-global-filter.exception.ts
@@ -1,0 +1,5 @@
+export class ExampleExceptionGlobalFilter extends Error {
+  constructor() {
+    super('Original global example exception!');
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-global.filter.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-global.filter.ts
@@ -1,0 +1,19 @@
+import { ArgumentsHost, BadRequestException, Catch, ExceptionFilter } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { ExampleExceptionGlobalFilter } from './example-global-filter.exception.js';
+
+@Catch(ExampleExceptionGlobalFilter)
+export class ExampleGlobalFilter implements ExceptionFilter {
+  catch(exception: BadRequestException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    response.status(400).json({
+      statusCode: 400,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      message: 'Example exception was handled by global filter!',
+    });
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-local-filter.exception.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-local-filter.exception.ts
@@ -1,0 +1,5 @@
+export class ExampleExceptionLocalFilter extends Error {
+  constructor() {
+    super('Original local example exception!');
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-local.filter.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example-local.filter.ts
@@ -1,0 +1,19 @@
+import { ArgumentsHost, BadRequestException, Catch, ExceptionFilter } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { ExampleExceptionLocalFilter } from './example-local-filter.exception.js';
+
+@Catch(ExampleExceptionLocalFilter)
+export class ExampleLocalFilter implements ExceptionFilter {
+  catch(exception: BadRequestException, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    response.status(400).json({
+      statusCode: 400,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      message: 'Example exception was handled by local filter!',
+    });
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example.guard.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example.guard.ts
@@ -1,0 +1,10 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+
+@Injectable()
+export class ExampleGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    Sentry.startSpan({ name: 'test-guard-span' }, () => {});
+    return true;
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/example.middleware.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/example.middleware.ts
@@ -1,0 +1,12 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
+import { NextFunction, Request, Response } from 'express';
+
+@Injectable()
+export class ExampleMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    // span that should be a child span of the middleware span
+    Sentry.startSpan({ name: 'test-middleware-span' }, () => {});
+    next();
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/instrument.ts
@@ -1,0 +1,13 @@
+import * as Sentry from '@sentry/nestjs';
+
+Sentry.init({
+  traceLifecycle: 'static',
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  dsn: process.env.E2E_TEST_DSN,
+  tunnel: `http://localhost:3031/`, // proxy server
+  tracesSampleRate: 1,
+  transportOptions: {
+    // We expect the app to send a lot of events in a short time
+    bufferSize: 1000,
+  },
+});

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/src/main.ts
@@ -1,0 +1,16 @@
+// Loaded via `node --import ./dist/instrument.js` so Sentry's ESM instrumentation
+// hooks register before any application module is linked. Kept here too so the
+// file is part of the build output (ESM caches it, so it is not re-executed).
+import './instrument.js';
+
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module.js';
+
+const PORT = 3030;
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(PORT);
+}
+
+bootstrap();

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'nestjs-12',
+});

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/tests/cron-decorator.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/tests/cron-decorator.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from '@playwright/test';
+import { waitForEnvelopeItem, waitForError } from '@sentry-internal/test-utils';
+
+test('Cron job triggers send of in_progress envelope', async ({ baseURL }) => {
+  const inProgressEnvelopePromise = waitForEnvelopeItem('nestjs-12', envelope => {
+    return (
+      envelope[0].type === 'check_in' &&
+      envelope[1]['monitor_slug'] === 'test-cron-slug' &&
+      envelope[1]['status'] === 'in_progress'
+    );
+  });
+
+  const okEnvelopePromise = waitForEnvelopeItem('nestjs-12', envelope => {
+    return (
+      envelope[0].type === 'check_in' &&
+      envelope[1]['monitor_slug'] === 'test-cron-slug' &&
+      envelope[1]['status'] === 'ok'
+    );
+  });
+
+  const inProgressEnvelope = await inProgressEnvelopePromise;
+  const okEnvelope = await okEnvelopePromise;
+
+  expect(inProgressEnvelope[1]).toEqual(
+    expect.objectContaining({
+      check_in_id: expect.any(String),
+      monitor_slug: 'test-cron-slug',
+      status: 'in_progress',
+      environment: 'qa',
+      monitor_config: {
+        schedule: {
+          type: 'crontab',
+          value: '* * * * *',
+        },
+      },
+      contexts: {
+        trace: {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        },
+      },
+    }),
+  );
+
+  expect(okEnvelope[1]).toEqual(
+    expect.objectContaining({
+      check_in_id: expect.any(String),
+      monitor_slug: 'test-cron-slug',
+      status: 'ok',
+      environment: 'qa',
+      duration: expect.any(Number),
+      contexts: {
+        trace: {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        },
+      },
+    }),
+  );
+
+  // kill cron so tests don't get stuck
+  await fetch(`${baseURL}/kill-test-cron/test-cron-job`);
+});
+
+test('Sends exceptions to Sentry on error in cron job', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('nestjs-12', event => {
+    return (
+      !event.type &&
+      event.exception?.values?.[0]?.value === 'Test error from cron job' &&
+      event.exception?.values?.[0]?.mechanism?.type === 'auto.function.nestjs.cron'
+    );
+  });
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('Test error from cron job');
+  expect(errorEvent.exception?.values?.[0]?.mechanism).toEqual({
+    handled: false,
+    type: 'auto.function.nestjs.cron',
+  });
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+  });
+
+  // kill cron so tests don't get stuck
+  await fetch(`${baseURL}/kill-test-cron/test-cron-error`);
+});

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/tests/errors.test.ts
@@ -1,0 +1,171 @@
+import { expect, test } from '@playwright/test';
+import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Sends exception to Sentry', async ({ baseURL }) => {
+  const errorEventPromise = waitForError('nestjs-12', event => {
+    return !event.type && event.exception?.values?.[0]?.value === 'This is an exception with id 123';
+  });
+
+  const response = await fetch(`${baseURL}/test-exception/123`);
+  expect(response.status).toBe(500);
+
+  const errorEvent = await errorEventPromise;
+
+  expect(errorEvent.exception?.values).toHaveLength(1);
+  expect(errorEvent.exception?.values?.[0]?.value).toBe('This is an exception with id 123');
+  expect(errorEvent.exception?.values?.[0]?.mechanism).toEqual({
+    handled: false,
+    type: 'auto.http.nestjs.global_filter',
+  });
+
+  expect(errorEvent.request).toEqual({
+    method: 'GET',
+    cookies: {},
+    headers: expect.any(Object),
+    url: 'http://localhost:3030/test-exception/123',
+  });
+
+  expect(errorEvent.transaction).toEqual('GET /test-exception/:id');
+
+  expect(errorEvent.contexts?.trace).toEqual({
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+  });
+});
+
+test('Does not send HttpExceptions to Sentry', async ({ baseURL }) => {
+  let errorEventOccurred = false;
+
+  waitForError('nestjs-12', event => {
+    if (!event.type && event.exception?.values?.[0]?.value === 'This is an expected 400 exception with id 123') {
+      errorEventOccurred = true;
+    }
+
+    return event?.transaction === 'GET /test-expected-400-exception/:id';
+  });
+
+  waitForError('nestjs-12', event => {
+    if (!event.type && event.exception?.values?.[0]?.value === 'This is an expected 500 exception with id 123') {
+      errorEventOccurred = true;
+    }
+
+    return event?.transaction === 'GET /test-expected-500-exception/:id';
+  });
+
+  const transactionEventPromise400 = waitForTransaction('nestjs-12', transactionEvent => {
+    return transactionEvent?.transaction === 'GET /test-expected-400-exception/:id';
+  });
+
+  const transactionEventPromise500 = waitForTransaction('nestjs-12', transactionEvent => {
+    return transactionEvent?.transaction === 'GET /test-expected-500-exception/:id';
+  });
+
+  const response400 = await fetch(`${baseURL}/test-expected-400-exception/123`);
+  expect(response400.status).toBe(400);
+
+  const response500 = await fetch(`${baseURL}/test-expected-500-exception/123`);
+  expect(response500.status).toBe(500);
+
+  await transactionEventPromise400;
+  await transactionEventPromise500;
+
+  (await fetch(`${baseURL}/flush`)).text();
+
+  expect(errorEventOccurred).toBe(false);
+});
+
+test('Does not send RpcExceptions to Sentry', async ({ baseURL }) => {
+  let errorEventOccurred = false;
+
+  waitForError('nestjs-12', event => {
+    if (!event.type && event.exception?.values?.[0]?.value === 'This is an expected RPC exception with id 123') {
+      errorEventOccurred = true;
+    }
+
+    return event?.transaction === 'GET /test-expected-rpc-exception/:id';
+  });
+
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return transactionEvent?.transaction === 'GET /test-expected-rpc-exception/:id';
+  });
+
+  const response = await fetch(`${baseURL}/test-expected-rpc-exception/123`);
+  expect(response.status).toBe(500);
+
+  await transactionEventPromise;
+
+  (await fetch(`${baseURL}/flush`)).text();
+
+  expect(errorEventOccurred).toBe(false);
+});
+
+test('Global exception filter registered in main module is applied and exception is not sent to Sentry', async ({
+  baseURL,
+}) => {
+  let errorEventOccurred = false;
+
+  waitForError('nestjs-12', event => {
+    if (!event.type && event.exception?.values?.[0]?.value === 'Example exception was handled by global filter!') {
+      errorEventOccurred = true;
+    }
+
+    return event?.transaction === 'GET /example-exception-global-filter';
+  });
+
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return transactionEvent?.transaction === 'GET /example-exception-global-filter';
+  });
+
+  const response = await fetch(`${baseURL}/example-exception-global-filter`);
+  const responseBody = await response.json();
+
+  expect(response.status).toBe(400);
+  expect(responseBody).toEqual({
+    statusCode: 400,
+    timestamp: expect.any(String),
+    path: '/example-exception-global-filter',
+    message: 'Example exception was handled by global filter!',
+  });
+
+  await transactionEventPromise;
+
+  (await fetch(`${baseURL}/flush`)).text();
+
+  expect(errorEventOccurred).toBe(false);
+});
+
+test('Local exception filter registered in main module is applied and exception is not sent to Sentry', async ({
+  baseURL,
+}) => {
+  let errorEventOccurred = false;
+
+  waitForError('nestjs-12', event => {
+    if (!event.type && event.exception?.values?.[0]?.value === 'Example exception was handled by local filter!') {
+      errorEventOccurred = true;
+    }
+
+    return event?.transaction === 'GET /example-exception-local-filter';
+  });
+
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return transactionEvent?.transaction === 'GET /example-exception-local-filter';
+  });
+
+  const response = await fetch(`${baseURL}/example-exception-local-filter`);
+  const responseBody = await response.json();
+
+  expect(response.status).toBe(400);
+  expect(responseBody).toEqual({
+    statusCode: 400,
+    timestamp: expect.any(String),
+    path: '/example-exception-local-filter',
+    message: 'Example exception was handled by local filter!',
+  });
+
+  await transactionEventPromise;
+
+  (await fetch(`${baseURL}/flush`)).text();
+
+  expect(errorEventOccurred).toBe(false);
+});

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/tests/span-decorator.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/tests/span-decorator.test.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Transaction includes span and correct value for decorated async function', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-span-decorator-async'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-span-decorator-async`);
+  const body = await response.json();
+
+  expect(body.result).toEqual('test');
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent.spans).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        span_id: expect.stringMatching(/[a-f0-9]{16}/),
+        trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        data: {
+          'sentry.origin': 'auto.function.nestjs.sentry_traced',
+          'sentry.op': 'wait and return a string',
+        },
+        description: 'wait',
+        parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+        start_timestamp: expect.any(Number),
+        status: 'ok',
+        op: 'wait and return a string',
+        origin: 'auto.function.nestjs.sentry_traced',
+      }),
+    ]),
+  );
+});
+
+test('Transaction includes span and correct value for decorated sync function', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-span-decorator-sync'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-span-decorator-sync`);
+  const body = await response.json();
+
+  expect(body.result).toEqual('test');
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent.spans).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        span_id: expect.stringMatching(/[a-f0-9]{16}/),
+        trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+        data: {
+          'sentry.origin': 'auto.function.nestjs.sentry_traced',
+          'sentry.op': 'return a string',
+        },
+        description: 'getString',
+        parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+        start_timestamp: expect.any(Number),
+        status: 'ok',
+        op: 'return a string',
+        origin: 'auto.function.nestjs.sentry_traced',
+      }),
+    ]),
+  );
+});
+
+test('preserves original function name on decorated functions', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-function-name`);
+  const body = await response.json();
+
+  expect(body.result).toEqual('getFunctionName');
+});

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/tests/transactions.test.ts
@@ -1,0 +1,737 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Sends an API route transaction', async ({ baseURL }) => {
+  const pageloadTransactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-transaction'
+    );
+  });
+
+  await fetch(`${baseURL}/test-transaction`);
+
+  const transactionEvent = await pageloadTransactionEventPromise;
+
+  expect(transactionEvent.contexts?.trace).toEqual({
+    data: {
+      'sentry.segment.name.source': 'route',
+      'sentry.origin': 'auto.http.http_server',
+      'sentry.op': 'http.server',
+      'sentry.sample_rate': 1,
+      'sentry.kind': 'server',
+      'http.response.status_code': 200,
+      'url.full': 'http://localhost:3030/test-transaction',
+      'url.path': '/test-transaction',
+      'server.address': 'localhost',
+      'http.request.method': 'GET',
+      'url.scheme': 'http',
+      'user_agent.original': 'node',
+      'client.address': '::1',
+      'client.port': expect.any(Number),
+      'network.transport': 'tcp',
+      'network.local.address': expect.any(String),
+      'network.local.port': expect.any(Number),
+      'network.peer.address': expect.any(String),
+      'network.peer.port': expect.any(Number),
+      'network.protocol.name': 'http',
+      'network.protocol.version': '1.1',
+      'server.port': 3030,
+      'http.response.status_text': 'OK',
+      'http.route': '/test-transaction',
+      'http.request.header.accept': '*/*',
+      'http.request.header.accept_encoding': 'gzip, deflate',
+      'http.request.header.accept_language': '*',
+      'http.request.header.connection': 'keep-alive',
+      'http.request.header.host': expect.any(String),
+      'http.request.header.sec_fetch_mode': 'cors',
+      'http.request.header.user_agent': 'node',
+    },
+    op: 'http.server',
+    span_id: expect.stringMatching(/[a-f0-9]{16}/),
+    status: 'ok',
+    trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+    origin: 'auto.http.http_server',
+  });
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          data: {
+            'express.name': '/test-transaction',
+            'express.type': 'request_handler',
+            'http.route': '/test-transaction',
+            'sentry.origin': 'auto.http.express',
+            'sentry.op': 'handler',
+          },
+          op: 'handler',
+          description: '/test-transaction',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          status: 'ok',
+          timestamp: expect.any(Number),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          origin: 'auto.http.express',
+        },
+        {
+          data: {
+            'sentry.origin': 'manual',
+          },
+          description: 'test-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          status: 'ok',
+          timestamp: expect.any(Number),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          origin: 'manual',
+        },
+        {
+          data: {
+            'sentry.origin': 'manual',
+          },
+          description: 'child-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          status: 'ok',
+          timestamp: expect.any(Number),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          origin: 'manual',
+        },
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.origin': 'auto.http.nestjs',
+            'sentry.op': 'handler',
+            component: '@nestjs/core',
+            'nestjs.version': expect.any(String),
+            'nestjs.type': 'handler',
+            'nestjs.callback': 'testTransaction',
+          },
+          description: 'testTransaction',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'auto.http.nestjs',
+          op: 'handler',
+        },
+      ]),
+      transaction: 'GET /test-transaction',
+      type: 'transaction',
+      transaction_info: {
+        source: 'route',
+      },
+    }),
+  );
+});
+
+test('API route transaction includes nest middleware span. Spans created in and after middleware are nested correctly', async ({
+  baseURL,
+}) => {
+  const pageloadTransactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-middleware-instrumentation'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-middleware-instrumentation`);
+  expect(response.status).toBe(200);
+
+  const transactionEvent = await pageloadTransactionEventPromise;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs',
+          },
+          description: 'ExampleMiddleware',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs',
+        },
+      ]),
+    }),
+  );
+
+  const exampleMiddlewareSpan = transactionEvent.spans.find(span => span.description === 'ExampleMiddleware');
+  const exampleMiddlewareSpanId = exampleMiddlewareSpan?.span_id;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-controller-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-middleware-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testMiddlewareSpan = transactionEvent.spans.find(span => span.description === 'test-middleware-span');
+  const testControllerSpan = transactionEvent.spans.find(span => span.description === 'test-controller-span');
+
+  // 'ExampleMiddleware' is the parent of 'test-middleware-span'
+  expect(testMiddlewareSpan.parent_span_id).toBe(exampleMiddlewareSpanId);
+
+  // 'ExampleMiddleware' is NOT the parent of 'test-controller-span'
+  expect(testControllerSpan.parent_span_id).not.toBe(exampleMiddlewareSpanId);
+});
+
+test('API route transaction includes nest guard span and span started in guard is nested correctly', async ({
+  baseURL,
+}) => {
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-guard-instrumentation'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-guard-instrumentation`);
+  expect(response.status).toBe(200);
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.guard',
+          },
+          description: 'ExampleGuard',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.guard',
+        },
+      ]),
+    }),
+  );
+
+  const exampleGuardSpan = transactionEvent.spans.find(span => span.description === 'ExampleGuard');
+  const exampleGuardSpanId = exampleGuardSpan?.span_id;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-guard-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testGuardSpan = transactionEvent.spans.find(span => span.description === 'test-guard-span');
+
+  // 'ExampleGuard' is the parent of 'test-guard-span'
+  expect(testGuardSpan.parent_span_id).toBe(exampleGuardSpanId);
+});
+
+test('API route transaction includes nest pipe span for valid request', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-pipe-instrumentation/:id' &&
+      transactionEvent?.request?.url?.includes('/test-pipe-instrumentation/123')
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-pipe-instrumentation/123`);
+  expect(response.status).toBe(200);
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.pipe',
+          },
+          description: 'ParseIntPipe',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.pipe',
+        },
+      ]),
+    }),
+  );
+});
+
+test('API route transaction includes nest pipe span for invalid request', async ({ baseURL }) => {
+  const transactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-pipe-instrumentation/:id' &&
+      transactionEvent?.request?.url?.includes('/test-pipe-instrumentation/abc')
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-pipe-instrumentation/abc`);
+  expect(response.status).toBe(400);
+
+  const transactionEvent = await transactionEventPromise;
+
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.pipe',
+          },
+          description: 'ParseIntPipe',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'internal_error',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.pipe',
+        },
+      ]),
+    }),
+  );
+});
+
+test('API route transaction includes nest interceptor spans before route execution. Spans created in and after interceptor are nested correctly', async ({
+  baseURL,
+}) => {
+  const pageloadTransactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-interceptor-instrumentation'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-interceptor-instrumentation`);
+  expect(response.status).toBe(200);
+
+  const transactionEvent = await pageloadTransactionEventPromise;
+
+  // check if interceptor spans before route execution exist
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.interceptor',
+          },
+          description: 'ExampleInterceptor1',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.interceptor',
+        },
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.interceptor',
+          },
+          description: 'ExampleInterceptor2',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.interceptor',
+        },
+      ]),
+    }),
+  );
+
+  // get interceptor spans
+  const exampleInterceptor1Span = transactionEvent.spans.find(span => span.description === 'ExampleInterceptor1');
+  const exampleInterceptor1SpanId = exampleInterceptor1Span?.span_id;
+  const exampleInterceptor2Span = transactionEvent.spans.find(span => span.description === 'ExampleInterceptor2');
+  const exampleInterceptor2SpanId = exampleInterceptor2Span?.span_id;
+
+  // check if manually started spans exist
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-controller-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-interceptor-span-1',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-interceptor-span-2',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testInterceptor1Span = transactionEvent.spans.find(span => span.description === 'test-interceptor-span-1');
+  const testInterceptor2Span = transactionEvent.spans.find(span => span.description === 'test-interceptor-span-2');
+  const testControllerSpan = transactionEvent.spans.find(span => span.description === 'test-controller-span');
+
+  // 'ExampleInterceptor1' is the parent of 'test-interceptor-span-1'
+  expect(testInterceptor1Span.parent_span_id).toBe(exampleInterceptor1SpanId);
+
+  // 'ExampleInterceptor1' is NOT the parent of 'test-controller-span'
+  expect(testControllerSpan.parent_span_id).not.toBe(exampleInterceptor1SpanId);
+
+  // 'ExampleInterceptor2' is the parent of 'test-interceptor-span-2'
+  expect(testInterceptor2Span.parent_span_id).toBe(exampleInterceptor2SpanId);
+
+  // 'ExampleInterceptor2' is NOT the parent of 'test-controller-span'
+  expect(testControllerSpan.parent_span_id).not.toBe(exampleInterceptor2SpanId);
+});
+
+test('API route transaction includes exactly one nest interceptor span after route execution. Spans created in controller and in interceptor are nested correctly', async ({
+  baseURL,
+}) => {
+  const pageloadTransactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-interceptor-instrumentation'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-interceptor-instrumentation`);
+  expect(response.status).toBe(200);
+
+  const transactionEvent = await pageloadTransactionEventPromise;
+
+  // check if interceptor spans after route execution exist
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.interceptor',
+          },
+          description: 'Interceptors - After Route',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.interceptor',
+        },
+      ]),
+    }),
+  );
+
+  // check that exactly one after route span is sent
+  const allInterceptorSpansAfterRoute = transactionEvent.spans.filter(
+    span => span.description === 'Interceptors - After Route',
+  );
+  expect(allInterceptorSpansAfterRoute.length).toBe(1);
+
+  // get interceptor span
+  const exampleInterceptorSpanAfterRoute = transactionEvent.spans.find(
+    span => span.description === 'Interceptors - After Route',
+  );
+  const exampleInterceptorSpanAfterRouteId = exampleInterceptorSpanAfterRoute?.span_id;
+
+  // check if manually started span in interceptor after route exists
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-interceptor-span-after-route',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testInterceptorSpanAfterRoute = transactionEvent.spans.find(
+    span => span.description === 'test-interceptor-span-after-route',
+  );
+  const testControllerSpan = transactionEvent.spans.find(span => span.description === 'test-controller-span');
+
+  // 'Interceptor - After Route' is the parent of 'test-interceptor-span-after-route'
+  expect(testInterceptorSpanAfterRoute.parent_span_id).toBe(exampleInterceptorSpanAfterRouteId);
+
+  // 'Interceptor - After Route' is NOT the parent of 'test-controller-span'
+  expect(testControllerSpan.parent_span_id).not.toBe(exampleInterceptorSpanAfterRouteId);
+});
+
+test('API route transaction includes nest async interceptor spans before route execution. Spans created in and after async interceptor are nested correctly', async ({
+  baseURL,
+}) => {
+  const pageloadTransactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-async-interceptor-instrumentation'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-async-interceptor-instrumentation`);
+  expect(response.status).toBe(200);
+
+  const transactionEvent = await pageloadTransactionEventPromise;
+
+  // check if interceptor spans before route execution exist
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.interceptor',
+          },
+          description: 'AsyncInterceptor',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.interceptor',
+        },
+      ]),
+    }),
+  );
+
+  // get interceptor spans
+  const exampleAsyncInterceptor = transactionEvent.spans.find(span => span.description === 'AsyncInterceptor');
+  const exampleAsyncInterceptorSpanId = exampleAsyncInterceptor?.span_id;
+
+  // check if manually started spans exist
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-controller-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-async-interceptor-span',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testAsyncInterceptorSpan = transactionEvent.spans.find(
+    span => span.description === 'test-async-interceptor-span',
+  );
+  const testControllerSpan = transactionEvent.spans.find(span => span.description === 'test-controller-span');
+
+  // 'AsyncInterceptor' is the parent of 'test-async-interceptor-span'
+  expect(testAsyncInterceptorSpan.parent_span_id).toBe(exampleAsyncInterceptorSpanId);
+
+  // 'AsyncInterceptor' is NOT the parent of 'test-controller-span'
+  expect(testControllerSpan.parent_span_id).not.toBe(exampleAsyncInterceptorSpanId);
+});
+
+test('API route transaction includes exactly one nest async interceptor span after route execution. Spans created in controller and in async interceptor are nested correctly', async ({
+  baseURL,
+}) => {
+  const pageloadTransactionEventPromise = waitForTransaction('nestjs-12', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-async-interceptor-instrumentation'
+    );
+  });
+
+  const response = await fetch(`${baseURL}/test-async-interceptor-instrumentation`);
+  expect(response.status).toBe(200);
+
+  const transactionEvent = await pageloadTransactionEventPromise;
+
+  // check if interceptor spans after route execution exist
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: {
+            'sentry.op': 'middleware',
+            'sentry.origin': 'auto.middleware.nestjs.interceptor',
+          },
+          description: 'Interceptors - After Route',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          op: 'middleware',
+          origin: 'auto.middleware.nestjs.interceptor',
+        },
+      ]),
+    }),
+  );
+
+  // check that exactly one after route span is sent
+  const allInterceptorSpansAfterRoute = transactionEvent.spans.filter(
+    span => span.description === 'Interceptors - After Route',
+  );
+  expect(allInterceptorSpansAfterRoute.length).toBe(1);
+
+  // get interceptor span
+  const exampleInterceptorSpanAfterRoute = transactionEvent.spans.find(
+    span => span.description === 'Interceptors - After Route',
+  );
+  const exampleInterceptorSpanAfterRouteId = exampleInterceptorSpanAfterRoute?.span_id;
+
+  // check if manually started span in interceptor after route exists
+  expect(transactionEvent).toEqual(
+    expect.objectContaining({
+      spans: expect.arrayContaining([
+        {
+          span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+          data: expect.any(Object),
+          description: 'test-async-interceptor-span-after-route',
+          parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
+          start_timestamp: expect.any(Number),
+          timestamp: expect.any(Number),
+          status: 'ok',
+          origin: 'manual',
+        },
+      ]),
+    }),
+  );
+
+  // verify correct span parent-child relationships
+  const testInterceptorSpanAfterRoute = transactionEvent.spans.find(
+    span => span.description === 'test-async-interceptor-span-after-route',
+  );
+  const testControllerSpan = transactionEvent.spans.find(span => span.description === 'test-controller-span');
+
+  // 'Interceptor - After Route' is the parent of 'test-interceptor-span-after-route'
+  expect(testInterceptorSpanAfterRoute.parent_span_id).toBe(exampleInterceptorSpanAfterRouteId);
+
+  // 'Interceptor - After Route' is NOT the parent of 'test-controller-span'
+  expect(testControllerSpan.parent_span_id).not.toBe(exampleInterceptorSpanAfterRouteId);
+});
+
+test('Calling use method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-use`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling transform method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-transform`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling intercept method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-intercept`);
+  expect(response.status).toBe(200);
+});
+
+test('Calling canActivate method on service with Injectable decorator returns 200', async ({ baseURL }) => {
+  const response = await fetch(`${baseURL}/test-service-canActivate`);
+  expect(response.status).toBe(200);
+});

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/tsconfig.build.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "tests", "dist"]
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strictNullChecks": false,
+    "noImplicitAny": false,
+    "strictBindCallApply": false,
+    "forceConsistentCasingInFileNames": false,
+    "noFallthroughCasesInSwitch": false,
+    "moduleResolution": "NodeNext"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/nestjs-microservices/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-microservices/package.json
@@ -8,7 +8,6 @@
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test": "playwright test",
     "test:build": "pnpm install && pnpm build",
-    "test:build-latest": "pnpm install && pnpm add @nestjs/common@latest @nestjs/core@latest @nestjs/platform-express@latest @nestjs/microservices@latest && pnpm add -D @nestjs/cli@latest @nestjs/schematics@latest && pnpm build",
     "test:assert": "pnpm test"
   },
   "dependencies": {

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/package.json
@@ -7,7 +7,6 @@
     "start": "nest start",
     "test": "playwright test",
     "test:build": "pnpm install && pnpm build",
-    "test:build-latest": "pnpm install && pnpm add @nestjs/common@latest @nestjs/core@latest @nestjs/platform-express@latest @nestjs/websockets@latest @nestjs/platform-socket.io@latest && pnpm add -D @nestjs/cli@latest && pnpm build",
     "test:assert": "pnpm test"
   },
   "dependencies": {

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -58,8 +58,8 @@
     "rxjs": "^7.8.2"
   },
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+    "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+    "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
+++ b/packages/nestjs/src/integrations/sentry-nest-instrumentation.ts
@@ -9,7 +9,7 @@ import { SDK_VERSION } from '@sentry/core';
 import { patchCatchTarget, patchInjectableTarget } from './wrap-components';
 import type { CatchTarget, InjectableTarget, MinimalNestJsExecutionContext } from './types';
 
-const supportedVersions = ['>=8.0.0 <12'];
+const supportedVersions = ['>=8.0.0 <13'];
 const COMPONENT = '@nestjs/common';
 
 /**

--- a/packages/nestjs/src/integrations/vendored/instrumentation.ts
+++ b/packages/nestjs/src/integrations/vendored/instrumentation.ts
@@ -34,7 +34,7 @@ interface RouterExecutionContext {
   create(instance: Controller, callback: (...args: unknown[]) => unknown, ...args: unknown[]): unknown;
 }
 
-const supportedVersions = ['>=4.0.0 <12'];
+const supportedVersions = ['>=4.0.0 <13'];
 
 export class NestInstrumentation extends InstrumentationBase {
   static readonly COMPONENT = '@nestjs/core';

--- a/packages/server-utils/src/orchestrion/config/nestjs.ts
+++ b/packages/server-utils/src/orchestrion/config/nestjs.ts
@@ -31,12 +31,12 @@ function astQueryInstrumentation(config: {
 export const nestjsConfig = [
   {
     channelName: 'nestFactoryCreate',
-    module: { name: '@nestjs/core', versionRange: '>=8.0.0 <12', filePath: 'nest-factory.js' },
+    module: { name: '@nestjs/core', versionRange: '>=8.0.0 <13', filePath: 'nest-factory.js' },
     functionQuery: { className: 'NestFactoryStatic', methodName: 'create', kind: 'Async' },
   },
   {
     channelName: 'routerExecutionContextCreate',
-    module: { name: '@nestjs/core', versionRange: '>=8.0.0 <12', filePath: 'router/router-execution-context.js' },
+    module: { name: '@nestjs/core', versionRange: '>=8.0.0 <13', filePath: 'router/router-execution-context.js' },
     functionQuery: { className: 'RouterExecutionContext', methodName: 'create', kind: 'Sync' },
   },
   astQueryInstrumentation({
@@ -51,7 +51,7 @@ export const nestjsConfig = [
     channelName: 'injectableDecorator',
     module: {
       name: '@nestjs/common',
-      versionRange: '>=8.0.0 <12',
+      versionRange: '>=8.0.0 <13',
       filePath: 'decorators/core/injectable.decorator.js',
     },
     astQuery: 'FunctionDeclaration[id.name="Injectable"] ReturnStatement > ArrowFunctionExpression',
@@ -66,7 +66,7 @@ export const nestjsConfig = [
     //
     // Mirrors the vendored `SentryNestInstrumentation` `@Catch` wrap.
     channelName: 'catchDecorator',
-    module: { name: '@nestjs/common', versionRange: '>=8.0.0 <12', filePath: 'decorators/core/catch.decorator.js' },
+    module: { name: '@nestjs/common', versionRange: '>=8.0.0 <13', filePath: 'decorators/core/catch.decorator.js' },
     astQuery: 'FunctionDeclaration[id.name="Catch"] ReturnStatement > ArrowFunctionExpression',
     functionQuery: { kind: 'Sync' },
   }),


### PR DESCRIPTION
Backport of: #23721

## Differences to the original PR

v10 ships **both** the IITM/OTel and orchestrion Nest instrumentations, with IITM as the default; `develop` is orchestrion-only. The original PR only raised the orchestrion version caps, so on v10 the default (IITM) path would still skip NestJS 12. This backport additionally raises the equivalent `supportedVersions` caps on the IITM path:

- `packages/nestjs/src/integrations/sentry-nest-instrumentation.ts`: `>=8.0.0 <12` → `>=8.0.0 <13` (injectable/catch → middleware/guard/pipe/interceptor + exception-filter spans).
- `packages/nestjs/src/integrations/vendored/instrumentation.ts`: `>=4.0.0 <12` → `>=4.0.0 <13` (nest-factory + router-execution-context → app-creation + request-handler spans).

These files don't exist on `develop`, which is why the original PR didn't touch them.
