### PR TITLE
feat(v10/node): Deprecate `shouldHandleError` on `setupExpressErrorHandler` and `setupFasitfyErrorHandler`

### DIFF
--- a/packages/core/src/integrations/express/index.ts
+++ b/packages/core/src/integrations/express/index.ts
@@ -29,11 +29,13 @@
 
 import { debug } from '../../utils/debug-logger';
 import { captureException } from '../../exports';
+import { getClient } from '../../currentScopes';
 import { DEBUG_BUILD } from '../../debug-build';
 import type {
   ExpressApplication,
   ExpressErrorMiddleware,
   ExpressHandlerOptions,
+  ExpressIntegration,
   ExpressIntegrationOptions,
   ExpressLayer,
   ExpressMiddleware,
@@ -43,6 +45,7 @@ import type {
   ExpressRouter,
   ExpressRouterv4,
   ExpressRouterv5,
+  ExpressShouldHandleError,
   MiddlewareError,
 } from './types';
 import {
@@ -198,6 +201,17 @@ export function patchExpressModule(
 }
 
 /**
+ * The `shouldHandleError` configured on the registered Express integration, if any.
+ *
+ * The integration is defined per platform (e.g. `expressIntegration()` in `@sentry/node`), so it is
+ * looked up by name here — the same way `getIntegrationByName` is used for `VercelAI` and
+ * `ProfilingIntegration`.
+ */
+function getIntegrationShouldHandleError(): ExpressShouldHandleError | undefined {
+  return getClient()?.getIntegrationByName<ExpressIntegration>('Express')?.getShouldHandleError?.();
+}
+
+/**
  * An Express-compatible error handler, used by setupExpressErrorHandler
  */
 export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressErrorMiddleware {
@@ -210,7 +224,13 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressErr
     // When an error happens, the `expressRequestHandler` middleware does not run, so we set it here too
     setSDKProcessingMetadata(request);
     // oxlint-disable-next-line typescript/no-deprecated
-    const shouldHandleError = options?.shouldHandleError || defaultShouldHandleError;
+    const shouldHandleError =
+      options?.shouldHandleError ?? getIntegrationShouldHandleError() ?? defaultShouldHandleError;
+
+    if (shouldHandleError === false) {
+      next(error);
+      return;
+    }
 
     if (shouldHandleError(error)) {
       const eventId = captureException(error, {
@@ -229,8 +249,8 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressErr
  * The error handler must be before any other middleware and after all controllers.
  *
  * @param app The Express instances
- * @param options {ExpressHandlerOptions} Configuration options for the handler. Deprecated: the
- * `shouldHandleError` option will be removed in v11, where `expressIntegration()` accepts it instead.
+ * @param options {ExpressHandlerOptions} Configuration options for the handler. Deprecated: set
+ * `shouldHandleError` on `expressIntegration()` instead. This parameter will be removed in v11.
  *
  * @example
  * ```javascript

--- a/packages/core/src/integrations/express/index.ts
+++ b/packages/core/src/integrations/express/index.ts
@@ -209,6 +209,7 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressErr
   ): void {
     // When an error happens, the `expressRequestHandler` middleware does not run, so we set it here too
     setSDKProcessingMetadata(request);
+    // oxlint-disable-next-line typescript/no-deprecated
     const shouldHandleError = options?.shouldHandleError || defaultShouldHandleError;
 
     if (shouldHandleError(error)) {
@@ -228,7 +229,8 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressErr
  * The error handler must be before any other middleware and after all controllers.
  *
  * @param app The Express instances
- * @param options {ExpressHandlerOptions} Configuration options for the handler
+ * @param options {ExpressHandlerOptions} Configuration options for the handler. Deprecated: the
+ * `shouldHandleError` option will be removed in v11, where `expressIntegration()` accepts it instead.
  *
  * @example
  * ```javascript

--- a/packages/core/src/integrations/express/index.ts
+++ b/packages/core/src/integrations/express/index.ts
@@ -223,8 +223,8 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressErr
   ): void {
     // When an error happens, the `expressRequestHandler` middleware does not run, so we set it here too
     setSDKProcessingMetadata(request);
-    // oxlint-disable-next-line typescript/no-deprecated
     const shouldHandleError =
+      // oxlint-disable-next-line typescript/no-deprecated
       options?.shouldHandleError ?? getIntegrationShouldHandleError() ?? defaultShouldHandleError;
 
     if (shouldHandleError === false) {
@@ -249,8 +249,7 @@ export function expressErrorHandler(options?: ExpressHandlerOptions): ExpressErr
  * The error handler must be before any other middleware and after all controllers.
  *
  * @param app The Express instances
- * @param options {ExpressHandlerOptions} Configuration options for the handler. Deprecated: set
- * `shouldHandleError` on `expressIntegration()` instead. This parameter will be removed in v11.
+ * @param options {ExpressHandlerOptions} Configuration options for the handler
  *
  * @example
  * ```javascript

--- a/packages/core/src/integrations/express/types.ts
+++ b/packages/core/src/integrations/express/types.ts
@@ -185,7 +185,10 @@ export type ExpressErrorMiddleware = (
 export interface ExpressHandlerOptions {
   /**
    * Callback method deciding whether error should be captured and sent to Sentry
+   *
    * @param error Captured middleware error
+   *
+   * @deprecated This option will be removed in v11. In v11, `expressIntegration()` captures Express errors on its own and accepts `shouldHandleError` instead.
    */
   shouldHandleError?(this: void, error: MiddlewareError): boolean;
 }

--- a/packages/core/src/integrations/express/types.ts
+++ b/packages/core/src/integrations/express/types.ts
@@ -27,6 +27,7 @@
  * limitations under the License.
  */
 
+import type { Integration } from '../../types/integration';
 import type { RequestEventData } from '../../types/request';
 import type { SpanAttributes } from '../../types/span';
 
@@ -152,6 +153,33 @@ export type ExpressIntegrationOptions = {
    * resolved route to the underlying transport layer (e.g. OTel RPCMetadata).
    */
   onRouteResolved?: (route: string | undefined) => void;
+
+  /**
+   * Callback deciding whether an error passed to `next(error)` should be captured
+   * and sent to Sentry.
+   *
+   * By default, 5xx errors (and errors without a resolvable status) are sent, while
+   * 3xx and 4xx errors are not. Set to `false` to capture no errors at all.
+   *
+   * Capturing Express errors still requires `setupExpressErrorHandler(app)`. Passing
+   * `shouldHandleError` to that call instead is deprecated: it takes precedence over
+   * this option, but will be removed in v11.
+   *
+   * @example
+   *
+   * ```javascript
+   * Sentry.init({
+   *   integrations: [
+   *     Sentry.expressIntegration({
+   *       shouldHandleError(error) {
+   *         return (error.statusCode ?? 500) >= 500;
+   *       },
+   *     }),
+   *   ],
+   * });
+   * ```
+   */
+  shouldHandleError?: ExpressShouldHandleError;
 };
 
 export type LayerMetadata = {
@@ -182,13 +210,25 @@ export type ExpressErrorMiddleware = (
   next: (error: MiddlewareError) => void,
 ) => void;
 
+/** Callback deciding whether an error should be captured; `false` disables capture entirely. */
+export type ExpressShouldHandleError = ((error: MiddlewareError) => boolean) | false;
+
+/**
+ * The Express integration is defined per platform (e.g. `expressIntegration()` in `@sentry/node`), so
+ * `expressErrorHandler` reads its `shouldHandleError` back off the registered instance by name.
+ * `getShouldHandleError` is optional because not every platform's Express integration implements it.
+ */
+export interface ExpressIntegration extends Integration {
+  getShouldHandleError?: () => ExpressShouldHandleError | undefined;
+}
+
 export interface ExpressHandlerOptions {
   /**
    * Callback method deciding whether error should be captured and sent to Sentry
    *
    * @param error Captured middleware error
    *
-   * @deprecated This option will be removed in v11. In v11, `expressIntegration()` captures Express errors on its own and accepts `shouldHandleError` instead.
+   * @deprecated Set `shouldHandleError` on `expressIntegration()` instead. This option will be removed in v11.
    */
   shouldHandleError?(this: void, error: MiddlewareError): boolean;
 }

--- a/packages/core/src/integrations/express/types.ts
+++ b/packages/core/src/integrations/express/types.ts
@@ -228,7 +228,22 @@ export interface ExpressHandlerOptions {
    *
    * @param error Captured middleware error
    *
-   * @deprecated Set `shouldHandleError` on `expressIntegration()` instead. This option will be removed in v11.
+   * @deprecated Configure `shouldHandleError` on `expressIntegration()` rather than here. Keep calling
+   * `setupExpressErrorHandler(app)` as that is what captures the errors. This option will be removed in v11.
+   *
+   * @example
+   *
+   * ```javascript
+   * Sentry.init({
+   *   integrations: [
+   *     Sentry.expressIntegration({
+   *       shouldHandleError(error) {
+   *         return (error.statusCode ?? 500) >= 500;
+   *       },
+   *     }),
+   *   ],
+   * });
+   * ```
    */
   shouldHandleError?(this: void, error: MiddlewareError): boolean;
 }

--- a/packages/core/src/server-exports.ts
+++ b/packages/core/src/server-exports.ts
@@ -18,10 +18,12 @@ export { safeUnref as _INTERNAL_safeUnref } from './utils/timer';
 // eslint-disable-next-line typescript/no-deprecated
 export { patchExpressModule, setupExpressErrorHandler, expressErrorHandler } from './integrations/express/index';
 export type {
+  ExpressIntegration,
   ExpressIntegrationOptions,
   ExpressHandlerOptions,
   ExpressMiddleware,
   ExpressErrorMiddleware,
+  ExpressShouldHandleError,
 } from './integrations/express/types';
 export {
   instrumentPostgresJsSql,

--- a/packages/core/test/lib/integrations/express/index.test.ts
+++ b/packages/core/test/lib/integrations/express/index.test.ts
@@ -34,9 +34,17 @@ const isolationScope = {
   },
 };
 
+let integrationShouldHandleError: ExpressIntegrationOptions['shouldHandleError'];
 vi.mock('../../../../src/currentScopes', () => ({
   getIsolationScope() {
     return isolationScope;
+  },
+  getClient() {
+    return {
+      getIntegrationByName(name: string) {
+        return name === 'Express' ? { name, getShouldHandleError: () => integrationShouldHandleError } : undefined;
+      },
+    };
   },
 }));
 
@@ -332,6 +340,66 @@ describe('expressErrorHandler', () => {
     sdkProcessingMetadata.length = 0;
     expect(next).toHaveBeenCalledExactlyOnceWith(err);
     next.mockReset();
+  });
+
+  it('falls back to `shouldHandleError` from the Express integration', () => {
+    integrationShouldHandleError = () => false;
+    const errorMiddleware = expressErrorHandler();
+    const res = { status: 500 } as unknown as ExpressResponse;
+    const req = { headers: {} } as unknown as ExpressRequest;
+    const next = vi.fn();
+    const err = new Error('err');
+    errorMiddleware(err, req, res, next);
+    expect(capturedExceptions).toStrictEqual([]);
+    sdkProcessingMetadata.length = 0;
+    expect(next).toHaveBeenCalledExactlyOnceWith(err);
+  });
+
+  it('prefers the deprecated per-call option over the integration option', () => {
+    integrationShouldHandleError = () => false;
+    // oxlint-disable-next-line typescript/no-deprecated
+    const errorMiddleware = expressErrorHandler({ shouldHandleError: () => true });
+    const res = { status: 500 } as unknown as ExpressResponse;
+    const req = { headers: {} } as unknown as ExpressRequest;
+    const next = vi.fn();
+    const err = new Error('err');
+    errorMiddleware(err, req, res, next);
+    expect(capturedExceptions).toHaveLength(1);
+    capturedExceptions.length = 0;
+    sdkProcessingMetadata.length = 0;
+    expect(next).toHaveBeenCalledExactlyOnceWith(err);
+  });
+
+  it('captures nothing when the integration option is `false`', () => {
+    integrationShouldHandleError = false;
+    const errorMiddleware = expressErrorHandler();
+    const res = { status: 500 } as unknown as ExpressResponse;
+    const req = { headers: {} } as unknown as ExpressRequest;
+    const next = vi.fn();
+    const err = new Error('err');
+    errorMiddleware(err, req, res, next);
+    expect((res as unknown as { sentry?: string }).sentry).toBe(undefined);
+    expect(capturedExceptions).toStrictEqual([]);
+    sdkProcessingMetadata.length = 0;
+    expect(next).toHaveBeenCalledExactlyOnceWith(err);
+  });
+
+  it('uses the default gate when neither option is set', () => {
+    integrationShouldHandleError = undefined;
+    const errorMiddleware = expressErrorHandler();
+    const res = {} as unknown as ExpressResponse;
+    const req = { headers: {} } as unknown as ExpressRequest;
+    const next = vi.fn();
+
+    // A 4xx error is skipped by `defaultShouldHandleError`, a 5xx one is captured.
+    errorMiddleware(Object.assign(new Error('client'), { status: 404 }), req, res, next);
+    expect(capturedExceptions).toStrictEqual([]);
+
+    errorMiddleware(Object.assign(new Error('server'), { status: 503 }), req, res, next);
+    expect(capturedExceptions).toHaveLength(1);
+
+    capturedExceptions.length = 0;
+    sdkProcessingMetadata.length = 0;
   });
 });
 

--- a/packages/node/src/integrations/tracing/express.ts
+++ b/packages/node/src/integrations/tracing/express.ts
@@ -4,6 +4,7 @@ import { InstrumentationBase, InstrumentationNodeModuleDefinition } from '@opent
 
 import { ensureIsWrapped, generateInstrumentOnce } from '@sentry/node-core';
 import {
+  type ExpressIntegration,
   type ExpressIntegrationOptions,
   type IntegrationFn,
   debug,
@@ -72,7 +73,11 @@ const _expressIntegration = ((options?: ExpressInstrumentationConfig) => {
     setupOnce() {
       instrumentExpress(options);
     },
-  };
+    // Read back by `expressErrorHandler` in `@sentry/core`, which is what captures Express errors.
+    getShouldHandleError() {
+      return options?.shouldHandleError;
+    },
+  } satisfies ExpressIntegration;
 }) satisfies IntegrationFn;
 
 export const expressIntegration = defineIntegration(_expressIntegration);

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -78,7 +78,7 @@ interface FastifyHandlerOptions {
    * @param reply Fastify reply (or any object containing at least statusCode)
    *
    * @deprecated Set `shouldHandleError` on `fastifyIntegration()` instead. It applies to every supported
-   * Fastify version. This option will be removed in v11, together with `setupFastifyErrorHandler`.
+   * Fastify version. This option will be removed in v11.
    *
    * ```javascript
    * Sentry.init({

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -77,8 +77,10 @@ interface FastifyHandlerOptions {
    * @param request Fastify request (or any object containing at least method, routeOptions.url, and routerPath)
    * @param reply Fastify reply (or any object containing at least statusCode)
    *
-   * @deprecated Set `shouldHandleError` on `fastifyIntegration()` instead. It applies to every supported
-   * Fastify version. This option will be removed in v11.
+   * @deprecated Configure `shouldHandleError` on `fastifyIntegration()` rather than here, where it
+   * applies to every supported Fastify version. This option will be removed in v11.
+   *
+   * @example
    *
    * ```javascript
    * Sentry.init({
@@ -145,8 +147,7 @@ export const fastifyIntegration = defineIntegration((options: Partial<FastifyInt
  * Add an Fastify error handler to capture errors to Sentry.
  *
  * @param fastify The Fastify instance to which to add the error handler
- * @param options Configuration options for the handler. Deprecated: set `shouldHandleError` on
- * `fastifyIntegration()` instead. This parameter will be removed in v11.
+ * @param options Configuration options for the handler
  *
  * @example
  * ```javascript

--- a/packages/node/src/integrations/tracing/fastify/index.ts
+++ b/packages/node/src/integrations/tracing/fastify/index.ts
@@ -24,8 +24,6 @@ export { instrumentFastify };
  * Options for the Fastify integration.
  *
  * `shouldHandleError` - Callback method deciding whether error should be captured and sent to Sentry
- * This is used on Fastify v5 where Sentry handles errors in the diagnostics channel.
- * Fastify v3 and v4 use `setupFastifyErrorHandler` instead.
  *
  * @example
  *
@@ -51,6 +49,22 @@ interface FastifyIntegrationOptions {
    * @param error Captured Fastify error
    * @param request Fastify request (or any object containing at least method, routeOptions.url, and routerPath)
    * @param reply Fastify reply (or any object containing at least statusCode)
+   *
+   * @example
+   *
+   * If using TypeScript, you can cast the request and reply to get full type safety.
+   *
+   * ```typescript
+   * import type { FastifyRequest, FastifyReply } from 'fastify';
+   *
+   * Sentry.fastifyIntegration({
+   *   shouldHandleError(error, minimalRequest, minimalReply) {
+   *     const request = minimalRequest as FastifyRequest;
+   *     const reply = minimalReply as FastifyReply;
+   *     return reply.statusCode >= 500;
+   *   },
+   * });
+   * ```
    */
   shouldHandleError: (error: Error, request: FastifyRequest, reply: FastifyReply) => boolean;
 }
@@ -63,29 +77,18 @@ interface FastifyHandlerOptions {
    * @param request Fastify request (or any object containing at least method, routeOptions.url, and routerPath)
    * @param reply Fastify reply (or any object containing at least statusCode)
    *
-   * @example
-   *
+   * @deprecated Set `shouldHandleError` on `fastifyIntegration()` instead. It applies to every supported
+   * Fastify version. This option will be removed in v11, together with `setupFastifyErrorHandler`.
    *
    * ```javascript
-   * setupFastifyErrorHandler(app, {
-   *   shouldHandleError(_error, _request, reply) {
-   *     return reply.statusCode >= 400;
-   *   },
-   * });
-   * ```
-   *
-   *
-   * If using TypeScript, you can cast the request and reply to get full type safety.
-   *
-   * ```typescript
-   * import type { FastifyRequest, FastifyReply } from 'fastify';
-   *
-   * setupFastifyErrorHandler(app, {
-   *   shouldHandleError(error, minimalRequest, minimalReply) {
-   *     const request = minimalRequest as FastifyRequest;
-   *     const reply = minimalReply as FastifyReply;
-   *     return reply.statusCode >= 500;
-   *   },
+   * Sentry.init({
+   *   integrations: [
+   *     Sentry.fastifyIntegration({
+   *       shouldHandleError(_error, _request, reply) {
+   *         return reply.statusCode >= 500;
+   *       },
+   *     }),
+   *   ],
    * });
    * ```
    */
@@ -142,7 +145,8 @@ export const fastifyIntegration = defineIntegration((options: Partial<FastifyInt
  * Add an Fastify error handler to capture errors to Sentry.
  *
  * @param fastify The Fastify instance to which to add the error handler
- * @param options Configuration options for the handler
+ * @param options Configuration options for the handler. Deprecated: set `shouldHandleError` on
+ * `fastifyIntegration()` instead. This parameter will be removed in v11.
  *
  * @example
  * ```javascript
@@ -159,7 +163,9 @@ export const fastifyIntegration = defineIntegration((options: Partial<FastifyInt
  * ```
  */
 export function setupFastifyErrorHandler(fastify: FastifyMinimal, options?: Partial<FastifyHandlerOptions>): void {
+  // oxlint-disable-next-line typescript/no-deprecated
   if (options?.shouldHandleError) {
+    // oxlint-disable-next-line typescript/no-deprecated
     getFastifyIntegration()?.setShouldHandleError(options.shouldHandleError);
   }
 

--- a/packages/server-utils/src/integrations/tracing-channel/express/index.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/express/index.ts
@@ -1,5 +1,5 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
-import type { IntegrationFn } from '@sentry/core';
+import type { ExpressIntegration, IntegrationFn } from '@sentry/core';
 import { defineIntegration, waitForTracingChannelBinding } from '@sentry/core';
 import type { ExpressIntegrationOptions } from './types';
 import { instrumentExpress } from './instrumentation';
@@ -21,7 +21,11 @@ const _expressChannelIntegration = ((options: ExpressIntegrationOptions = {}) =>
         instrumentExpress(options, diagnosticsChannel.tracingChannel);
       });
     },
-  };
+    // Read back by `expressErrorHandler` in `@sentry/core`, which is what captures Express errors.
+    getShouldHandleError() {
+      return options.shouldHandleError;
+    },
+  } satisfies ExpressIntegration;
 }) satisfies IntegrationFn;
 
 /**

--- a/packages/server-utils/src/integrations/tracing-channel/express/types.ts
+++ b/packages/server-utils/src/integrations/tracing-channel/express/types.ts
@@ -1,3 +1,5 @@
+import type { ExpressShouldHandleError } from '@sentry/core';
+
 export type ExpressLayerType = 'router' | 'middleware' | 'request_handler';
 
 /**
@@ -60,4 +62,15 @@ export interface ExpressIntegrationOptions {
   ignoreLayers?: IgnoreMatcher[];
   /** Ignore specific layers based on their type */
   ignoreLayersType?: ExpressLayerType[];
+  /**
+   * Callback deciding whether an error passed to `next(error)` should be captured
+   * and sent to Sentry.
+   *
+   * By default, 5xx errors (and errors without a resolvable status) are sent, while
+   * 3xx and 4xx errors are not. Set to `false` to capture no errors at all.
+   *
+   * Capturing Express errors still requires `setupExpressErrorHandler(app)`, which
+   * reads this option back off the integration.
+   */
+  shouldHandleError?: ExpressShouldHandleError;
 }

--- a/packages/server-utils/test/integrations/tracing-channel/fastify-errors.test.ts
+++ b/packages/server-utils/test/integrations/tracing-channel/fastify-errors.test.ts
@@ -1,0 +1,105 @@
+import * as SentryCore from '@sentry/core';
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
+import { handleFastifyError } from '../../../src/integrations/tracing-channel/fastify/errors';
+import { fastifyIntegration } from '../../../src/integrations/tracing-channel/fastify/index';
+import type { FastifyReply, FastifyRequest } from '../../../src/integrations/tracing-channel/fastify/types';
+
+type ShouldHandleError = (error: Error, request: FastifyRequest, reply: FastifyReply) => boolean;
+
+const request = {} as FastifyRequest;
+
+function reply(statusCode: number): FastifyReply {
+  return { statusCode } as FastifyReply;
+}
+
+/** Register a `Fastify` integration exposing `shouldHandleError`, as `fastifyIntegration()` does. */
+function mockFastifyIntegration(shouldHandleError?: ShouldHandleError): void {
+  vi.spyOn(SentryCore, 'getClient').mockReturnValue({
+    getIntegrationByName: (name: string) =>
+      name === 'Fastify' ? { name, getShouldHandleError: () => shouldHandleError } : undefined,
+  } as unknown as SentryCore.Client);
+}
+
+describe('handleFastifyError', () => {
+  let captureExceptionSpy: MockInstance;
+
+  beforeEach(() => {
+    captureExceptionSpy = vi.spyOn(SentryCore, 'captureException').mockReturnValue('eventId');
+    // `handleFastifyError` keeps `diagnosticsChannelExists` on the function object itself, so it
+    // survives between tests unless it is cleared.
+    (handleFastifyError as { diagnosticsChannelExists?: boolean }).diagnosticsChannelExists = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // The `onError` hook is the path `setupFastifyErrorHandler` registers — Fastify v3 and v4.
+  describe('via the `onError` hook', () => {
+    it('skips the error when the integration option returns false', () => {
+      mockFastifyIntegration(() => false);
+
+      handleFastifyError.call(handleFastifyError, new Error('err'), request, reply(500), 'onError-hook');
+
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+    });
+
+    it('captures the error when the integration option returns true', () => {
+      mockFastifyIntegration(() => true);
+
+      handleFastifyError.call(handleFastifyError, new Error('err'), request, reply(404), 'onError-hook');
+
+      expect(captureExceptionSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  // Fastify v5 publishes errors on a diagnostics channel, which the integration subscribes to.
+  describe('via the diagnostics channel', () => {
+    it('skips the error when the integration option returns false', () => {
+      mockFastifyIntegration(() => false);
+
+      handleFastifyError.call(handleFastifyError, new Error('err'), request, reply(500), 'diagnostics-channel');
+
+      expect(captureExceptionSpy).not.toHaveBeenCalled();
+    });
+
+    it('captures the error when the integration option returns true', () => {
+      mockFastifyIntegration(() => true);
+
+      handleFastifyError.call(handleFastifyError, new Error('err'), request, reply(404), 'diagnostics-channel');
+
+      expect(captureExceptionSpy).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('falls back to the default gate when the integration sets no option', () => {
+    mockFastifyIntegration(undefined);
+
+    handleFastifyError.call(handleFastifyError, new Error('client'), request, reply(404), 'onError-hook');
+    expect(captureExceptionSpy).not.toHaveBeenCalled();
+
+    handleFastifyError.call(handleFastifyError, new Error('server'), request, reply(503), 'onError-hook');
+    expect(captureExceptionSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('fastifyIntegration', () => {
+  it('exposes the configured `shouldHandleError` so the `onError` hook can read it back', () => {
+    const shouldHandleError: ShouldHandleError = () => false;
+    const integration = fastifyIntegration({ shouldHandleError });
+
+    integration.setupOnce?.();
+
+    expect(integration.getShouldHandleError()).toBe(shouldHandleError);
+  });
+
+  it('falls back to the default gate when no option is configured', () => {
+    const integration = fastifyIntegration();
+
+    integration.setupOnce?.();
+
+    const gate = integration.getShouldHandleError();
+    expect(gate(new Error('client'), request, reply(404))).toBe(false);
+    expect(gate(new Error('server'), request, reply(503))).toBe(true);
+  });
+});


### PR DESCRIPTION
Express:
- https://github.com/getsentry/sentry-javascript/pull/23732
- https://github.com/getsentry/sentry-javascript/pull/23464
- https://github.com/getsentry/sentry-javascript/pull/23763
Fastify:
- https://github.com/getsentry/sentry-javascript/pull/23460
- https://github.com/getsentry/sentry-javascript/pull/23464
- https://github.com/getsentry/sentry-javascript/pull/23411