### PR TITLE
ref: Use op constants from conventions

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/langchain/test.ts
@@ -17,8 +17,8 @@ import {
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_EMBEDDINGS } from '@sentry/conventions/op';
 import {
-  GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE,
   GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE,
   GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE,
 } from '../../../../../packages/server-utils/src/ai/core/gen-ai-attributes';
@@ -315,7 +315,7 @@ describe('LangChain integration', () => {
             );
             expect(successfulSpans).toHaveLength(2);
             for (const span of successfulSpans) {
-              expect(span.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+              expect(span.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS);
               expect(span.attributes['sentry.origin'].value).toBe('auto.ai.langchain');
               expect(span.attributes[GEN_AI_OPERATION_NAME].value).toBe('embeddings');
               expect(span.attributes[GEN_AI_PROVIDER_NAME].value).toBe('openai');
@@ -326,7 +326,7 @@ describe('LangChain integration', () => {
             const errorSpan = container.items.find(span => span.name === 'embeddings error-model');
             expect(errorSpan).toBeDefined();
             expect(errorSpan!.status).toBe('error');
-            expect(errorSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+            expect(errorSpan!.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS);
             expect(errorSpan!.attributes[GEN_AI_PROVIDER_NAME].value).toBe('openai');
           },
         })
@@ -342,7 +342,7 @@ describe('LangChain integration', () => {
             // The scenario makes 3 embedding calls (2 successful + 1 error).
             expect(container.items).toHaveLength(3);
             for (const span of container.items) {
-              expect(span.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+              expect(span.attributes['sentry.op'].value).toBe(GEN_AI_EMBEDDINGS);
             }
           },
         })

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -28,7 +28,7 @@ import {
   URL_PATH,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
-import { FUNCTION } from '@sentry/conventions/op';
+import { FUNCTION, ROUTER } from '@sentry/conventions/op';
 import type { Integration, Span } from '@sentry/core';
 import {
   debug,
@@ -151,8 +151,7 @@ export class TraceService implements OnDestroy {
               // known at `ResolveEnd`, well after this span starts, so there is nothing but the fallback.
               name: hasSpanStreamingEnabled(client) ? ROUTER_SPAN_NAME_FALLBACK : `${navigationEvent.url}`,
               attributes: {
-                // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
-                [SENTRY_OP]: 'router',
+                [SENTRY_OP]: ROUTER,
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.angular',
                 [URL_FULL]: strippedUrl,
                 ...(navigationEvent.navigationTrigger && {

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -8,6 +8,7 @@ import {
   URL_PATH,
   URL_QUERY,
 } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   addNonEnumerableProperty,
@@ -220,6 +221,7 @@ async function instrumentRequestStartHttpServerSpan(
           // invoke the catch block if next() throws
 
           const attributes: SpanAttributes = {
+            [SENTRY_OP]: HTTP_SERVER,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.astro',
             [SENTRY_SEGMENT_NAME_SOURCE]: source,
             [SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD]: method,
@@ -252,7 +254,6 @@ async function instrumentRequestStartHttpServerSpan(
             {
               attributes,
               name,
-              op: 'http.server',
             },
             async span => {
               try {

--- a/packages/astro/src/server/sdk.ts
+++ b/packages/astro/src/server/sdk.ts
@@ -1,3 +1,4 @@
+import { HTTP_SERVER } from '@sentry/conventions/op';
 import { applySdkMetadata } from '@sentry/core';
 import type { NodeClient, NodeOptions } from '@sentry/node';
 import { init as initNodeSdk } from '@sentry/node';
@@ -19,7 +20,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
     // we want to drop them
     // this is the case with http.server spans of prerendered pages
     // we do not care about those, as they are effectively static
-    { op: 'http.server', attributes: { 'sentry.origin': 'auto.http.http_server' } },
+    { op: HTTP_SERVER, attributes: { 'sentry.origin': 'auto.http.http_server' } },
   ];
 
   return initNodeSdk(opts);

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -116,6 +116,7 @@ describe('sentryMiddleware', () => {
     expect(startSpanSpy).toHaveBeenCalledWith(
       {
         attributes: {
+          'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.astro',
           method: 'GET',
           [URL_FULL]: 'https://mydomain.io/users/123/details',
@@ -125,7 +126,6 @@ describe('sentryMiddleware', () => {
           'http.route': '/users/[id]/details',
         },
         name: 'GET /users/[id]/details',
-        op: 'http.server',
       },
       expect.any(Function), // the `next` function
     );
@@ -218,6 +218,7 @@ describe('sentryMiddleware', () => {
     expect(startSpanSpy).toHaveBeenCalledWith(
       {
         attributes: {
+          'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.astro',
           method: 'GET',
           [URL_FULL]: 'http://localhost:1234/a%xx',
@@ -226,7 +227,6 @@ describe('sentryMiddleware', () => {
           [SentryCore.SEMANTIC_ATTRIBUTE_HTTP_REQUEST_METHOD]: 'GET',
         },
         name: 'GET a%xx',
-        op: 'http.server',
       },
       expect.any(Function), // the `next` function
     );

--- a/packages/browser-utils/src/performance/entries.ts
+++ b/packages/browser-utils/src/performance/entries.ts
@@ -26,7 +26,22 @@ import {
   URL_FULL,
   URL_SCHEME,
 } from '@sentry/conventions/attributes';
-import { BROWSER_PAINT, UI_LONG_ANIMATION_FRAME, UI_LONG_TASK } from '@sentry/conventions/op';
+import {
+  BROWSER_CACHE,
+  BROWSER_CONNECT,
+  BROWSER_DNS,
+  BROWSER_DOM_CONTENT_LOADED_EVENT,
+  BROWSER_LOAD_EVENT,
+  BROWSER_PAINT,
+  BROWSER_REDIRECT,
+  BROWSER_REQUEST,
+  BROWSER_RESPONSE,
+  BROWSER_TLS_SSL,
+  BROWSER_UNLOAD_EVENT,
+  RESOURCE_OTHER,
+  UI_LONG_ANIMATION_FRAME,
+  UI_LONG_TASK,
+} from '@sentry/conventions/op';
 import {
   addPerformanceInstrumentationHandler,
   type PerformanceLongAnimationFrameTiming,
@@ -278,14 +293,14 @@ function _addPaintSpan(
  * exported only for tests
  */
 export function _addNavigationSpans(span: Span, entry: PerformanceNavigationTiming, timeOrigin: number): void {
-  _addPerformanceNavigationTiming(span, entry, 'unloadEvent', timeOrigin, 'unload_event');
-  _addPerformanceNavigationTiming(span, entry, 'redirect', timeOrigin, 'redirect');
-  _addPerformanceNavigationTiming(span, entry, 'domContentLoadedEvent', timeOrigin, 'dom_content_loaded_event');
-  _addPerformanceNavigationTiming(span, entry, 'loadEvent', timeOrigin, 'load_event');
-  _addPerformanceNavigationTiming(span, entry, 'connect', timeOrigin, 'connect');
-  _addPerformanceNavigationTiming(span, entry, 'secureConnection', timeOrigin, 'tls_ssl');
-  _addPerformanceNavigationTiming(span, entry, 'fetch', timeOrigin, 'cache');
-  _addPerformanceNavigationTiming(span, entry, 'domainLookup', timeOrigin, 'dns');
+  _addPerformanceNavigationTiming(span, entry, 'unloadEvent', timeOrigin);
+  _addPerformanceNavigationTiming(span, entry, 'redirect', timeOrigin);
+  _addPerformanceNavigationTiming(span, entry, 'domContentLoadedEvent', timeOrigin);
+  _addPerformanceNavigationTiming(span, entry, 'loadEvent', timeOrigin);
+  _addPerformanceNavigationTiming(span, entry, 'connect', timeOrigin);
+  _addPerformanceNavigationTiming(span, entry, 'secureConnection', timeOrigin);
+  _addPerformanceNavigationTiming(span, entry, 'fetch', timeOrigin);
+  _addPerformanceNavigationTiming(span, entry, 'domainLookup', timeOrigin);
 
   _addRequest(span, entry, timeOrigin);
 }
@@ -299,6 +314,17 @@ type StartEventName =
   | 'connect'
   | 'domContentLoadedEvent'
   | 'loadEvent';
+
+const NAVIGATION_TIMING_SPAN_OPS: Record<StartEventName, string> = {
+  secureConnection: BROWSER_TLS_SSL,
+  fetch: BROWSER_CACHE,
+  domainLookup: BROWSER_DNS,
+  unloadEvent: BROWSER_UNLOAD_EVENT,
+  redirect: BROWSER_REDIRECT,
+  connect: BROWSER_CONNECT,
+  domContentLoadedEvent: BROWSER_DOM_CONTENT_LOADED_EVENT,
+  loadEvent: BROWSER_LOAD_EVENT,
+};
 
 type EndEventName =
   | 'domainLookupStart'
@@ -315,7 +341,6 @@ function _addPerformanceNavigationTiming(
   entry: PerformanceNavigationTiming,
   event: StartEventName,
   timeOrigin: number,
-  name: string = event,
 ): void {
   const eventEnd = _getEndPropertyNameForNavigationTiming(event) satisfies keyof PerformanceNavigationTiming;
   const end = entry[eventEnd];
@@ -324,9 +349,9 @@ function _addPerformanceNavigationTiming(
     return;
   }
   startAndEndSpan(span, timeOrigin + msToSec(start), timeOrigin + msToSec(end), {
-    op: `browser.${name}`,
     name: entry.name,
     attributes: {
+      [SENTRY_OP]: NAVIGATION_TIMING_SPAN_OPS[event],
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
       ...(event === 'redirect' && entry.redirectCount != null ? { 'http.redirect_count': entry.redirectCount } : {}),
     },
@@ -354,17 +379,17 @@ function _addRequest(span: Span, entry: PerformanceNavigationTiming, timeOrigin:
     // In order not to produce faulty spans, where the end timestamp is before the start timestamp, we will only collect
     // these spans when the responseEnd value is available. The backend (Relay) would drop the entire span if it contained faulty spans.
     startAndEndSpan(span, requestStartTimestamp, responseEndTimestamp, {
-      op: 'browser.request',
       name: entry.name,
       attributes: {
+        [SENTRY_OP]: BROWSER_REQUEST,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
       },
     });
 
     startAndEndSpan(span, responseStartTimestamp, responseEndTimestamp, {
-      op: 'browser.response',
       name: entry.name,
       attributes: {
+        [SENTRY_OP]: BROWSER_RESPONSE,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.browser.metrics',
       },
     });
@@ -391,7 +416,7 @@ export function _addResourceSpans(
     return;
   }
 
-  const op = entry.initiatorType ? `resource.${entry.initiatorType}` : 'resource.other';
+  const op = entry.initiatorType ? `resource.${entry.initiatorType}` : RESOURCE_OTHER;
   if (ignoredResourceSpanOps?.includes(op)) {
     return;
   }

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -1,4 +1,5 @@
-import { HTTP_REQUEST_METHOD, URL_FULL } from '@sentry/conventions/attributes';
+import { HTTP_REQUEST_METHOD, SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
+import { HTTP_CLIENT_STREAM } from '@sentry/conventions/op';
 import type { IntegrationFn, Span } from '@sentry/core';
 import {
   addFetchEndInstrumentationHandler,
@@ -6,7 +7,6 @@ import {
   defineIntegration,
   getSanitizedUrlStringFromUrlObject,
   parseStringToURLObject,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   stripDataUrlContent,
   filterCollectedUrl,
@@ -85,7 +85,7 @@ export const fetchStreamPerformanceIntegration = defineIntegration(() => {
               [URL_FULL]: filterCollectedUrl(stripDataUrlContent(url)),
               [HTTP_REQUEST_METHOD]: method,
               type: 'fetch',
-              [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client.stream',
+              [SENTRY_OP]: HTTP_CLIENT_STREAM,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser.stream',
             },
           });

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -53,6 +53,7 @@ import { registerBackgroundTabDetection } from './backgroundtab';
 import { linkTraces } from './linkedTraces';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
 import { SENTRY_SEGMENT_NAME_SOURCE, SENTRY_OP, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
+import { NAVIGATION, NAVIGATION_REDIRECT, PAGELOAD } from '@sentry/conventions/op';
 
 export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 
@@ -484,7 +485,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
           _createRouteSpan(
             client,
             {
-              op: 'navigation.redirect',
+              op: NAVIGATION_REDIRECT,
               ...startSpanOptions,
             },
             false,
@@ -516,7 +517,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         _createRouteSpan(
           client,
           {
-            op: 'navigation',
+            op: NAVIGATION,
             ...startSpanOptions,
             // Navigation starts a new trace and is NOT parented under any active interaction (e.g. ui.action.click)
             parentSpan: null,
@@ -555,7 +556,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         });
 
         _createRouteSpan(client, {
-          op: 'pageload',
+          op: PAGELOAD,
           ...startSpanOptions,
         });
       });

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -12,7 +12,6 @@ import {
   instrumentFetchRequest,
   matchesTracePropagationTargets,
   parseUrl,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SentryNonRecordingSpan,
   setHttpStatus,
@@ -35,7 +34,15 @@ import {
 } from '@sentry/browser-utils';
 import type { BrowserClient } from '../client';
 import { baggageHeaderHasSentryValues, createHeadersSafely, getFullURL, isPerformanceResourceTiming } from './utils';
-import { HTTP_REQUEST_METHOD, SERVER_ADDRESS, URL_FRAGMENT, URL_FULL, URL_QUERY } from '@sentry/conventions/attributes';
+import {
+  HTTP_REQUEST_METHOD,
+  SENTRY_OP,
+  SERVER_ADDRESS,
+  URL_FRAGMENT,
+  URL_FULL,
+  URL_QUERY,
+} from '@sentry/conventions/attributes';
+import { HTTP_CLIENT } from '@sentry/conventions/op';
 
 /** Options for Request Instrumentation */
 export interface RequestInstrumentationOptions {
@@ -372,7 +379,7 @@ function xhrCallback(
             [URL_FULL]: filterCollectedUrl(sanitizedFullUrl),
             [SERVER_ADDRESS]: parsedUrl?.host,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser',
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client',
+            [SENTRY_OP]: HTTP_CLIENT,
             [URL_QUERY]: filterCollectedUrlQuery(getUrlQuery(parsedUrl?.search)),
             [URL_FRAGMENT]: getUrlFragment(parsedUrl?.hash),
           },

--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -21,6 +21,7 @@ import {
 } from '@sentry/core';
 import type { ServeOptions } from 'bun';
 import {
+  SENTRY_OP,
   SENTRY_SEGMENT_NAME_SOURCE,
   URL_DOMAIN,
   URL_FRAGMENT,
@@ -30,6 +31,7 @@ import {
   URL_QUERY,
   URL_SCHEME,
 } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 
 const INTEGRATION_NAME = 'BunServer' as const;
 
@@ -246,8 +248,7 @@ function wrapRequestHandler<T extends RouteHandler = RouteHandler>(
       () =>
         startSpan(
           {
-            attributes,
-            op: 'http.server',
+            attributes: { ...attributes, [SENTRY_OP]: HTTP_SERVER },
             // With span streaming, span names have to be low cardinality, so we can't fall back to the URL path.
             name:
               attributes[SENTRY_SEGMENT_NAME_SOURCE] === 'route' || !client || !hasSpanStreamingEnabled(client)

--- a/packages/bun/test/integrations/bunserver.test.ts
+++ b/packages/bun/test/integrations/bunserver.test.ts
@@ -59,6 +59,7 @@ describe('Bun Serve Integration', () => {
     expect(startSpanSpy).toHaveBeenLastCalledWith(
       {
         attributes: expect.objectContaining({
+          'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.bun.serve',
           'http.request.method': 'GET',
           'sentry.segment.name.source': 'url',
@@ -74,7 +75,6 @@ describe('Bun Serve Integration', () => {
           'http.request.header.host': expect.any(String),
           'http.request.header.user_agent': expect.stringContaining('Bun'),
         }),
-        op: 'http.server',
         name: 'GET',
       },
       expect.any(Function),
@@ -103,6 +103,7 @@ describe('Bun Serve Integration', () => {
     expect(startSpanSpy).toHaveBeenLastCalledWith(
       {
         attributes: expect.objectContaining({
+          'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.bun.serve',
           'http.request.method': 'POST',
           'sentry.segment.name.source': 'url',
@@ -118,7 +119,6 @@ describe('Bun Serve Integration', () => {
           'http.request.header.host': expect.any(String),
           'http.request.header.user_agent': expect.stringContaining('Bun'),
         }),
-        op: 'http.server',
         name: 'POST',
       },
       expect.any(Function),
@@ -145,9 +145,9 @@ describe('Bun Serve Integration', () => {
     expect(startSpanSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
+          'sentry.op': 'http.server',
           'http.request.method': 'QUERY',
         }),
-        op: 'http.server',
         name: 'QUERY',
       }),
       expect.any(Function),
@@ -222,6 +222,7 @@ describe('Bun Serve Integration', () => {
     expect(startSpanSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
+          'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.bun.serve',
           'http.request.method': 'POST',
           'sentry.segment.name.source': 'url',
@@ -242,7 +243,6 @@ describe('Bun Serve Integration', () => {
           'http.request.header.baggage': expect.any(String),
           'http.request.header.sentry_trace': expect.any(String),
         }),
-        op: 'http.server',
         name: 'POST',
       }),
       expect.any(Function),
@@ -299,6 +299,7 @@ describe('Bun Serve Integration', () => {
     expect(startSpanSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
+          'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.bun.serve',
           'http.request.method': 'GET',
           'sentry.segment.name.source': 'route',
@@ -310,7 +311,6 @@ describe('Bun Serve Integration', () => {
           'url.scheme': 'http:',
           'url.domain': 'localhost',
         }),
-        op: 'http.server',
         name: 'GET /users/:id',
       }),
       expect.any(Function),
@@ -338,6 +338,7 @@ describe('Bun Serve Integration', () => {
     expect(startSpanSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
+          'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.bun.serve',
           'http.request.method': 'GET',
           'sentry.segment.name.source': 'route',
@@ -348,7 +349,6 @@ describe('Bun Serve Integration', () => {
           'url.scheme': 'http:',
           'url.domain': 'localhost',
         }),
-        op: 'http.server',
         name: 'GET /api/*',
       }),
       expect.any(Function),
@@ -403,12 +403,12 @@ describe('Bun Serve Integration', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           attributes: expect.objectContaining({
+            'sentry.op': 'http.server',
             'sentry.origin': 'auto.http.bun.serve',
             'http.request.method': 'GET',
             'sentry.segment.name.source': 'route',
             'url.path': '/api/posts',
           }),
-          op: 'http.server',
           name: 'GET /api/posts',
         }),
         expect.any(Function),
@@ -440,12 +440,12 @@ describe('Bun Serve Integration', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           attributes: expect.objectContaining({
+            'sentry.op': 'http.server',
             'sentry.origin': 'auto.http.bun.serve',
             'http.request.method': 'POST',
             'sentry.segment.name.source': 'route',
             'url.path': '/api/posts',
           }),
-          op: 'http.server',
           name: 'POST /api/posts',
         }),
         expect.any(Function),
@@ -472,12 +472,12 @@ describe('Bun Serve Integration', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           attributes: expect.objectContaining({
+            'sentry.op': 'http.server',
             'sentry.origin': 'auto.http.bun.serve',
             'http.request.method': 'PUT',
             'sentry.segment.name.source': 'route',
             'url.path': '/api/posts',
           }),
-          op: 'http.server',
           name: 'PUT /api/posts',
         }),
         expect.any(Function),
@@ -504,12 +504,12 @@ describe('Bun Serve Integration', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         expect.objectContaining({
           attributes: expect.objectContaining({
+            'sentry.op': 'http.server',
             'sentry.origin': 'auto.http.bun.serve',
             'http.request.method': 'DELETE',
             'sentry.segment.name.source': 'route',
             'url.path': '/api/posts',
           }),
-          op: 'http.server',
           name: 'DELETE /api/posts',
         }),
         expect.any(Function),

--- a/packages/cloudflare/src/durableobject.ts
+++ b/packages/cloudflare/src/durableobject.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { WEBSOCKET } from '@sentry/conventions/op';
+import { FUNCTION, RPC, WEBSOCKET } from '@sentry/conventions/op';
 import { captureException, isObjectLike } from '@sentry/core';
 import type { DurableObject } from 'cloudflare:workers';
 import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';
@@ -186,7 +186,7 @@ function instrumentDurableObjectHandlers<E, T extends DurableObject<E>>(
         options,
         context,
         spanName: 'alarm',
-        spanOp: 'function',
+        spanOp: FUNCTION,
         startNewTrace: true,
         origin: 'auto.faas.cloudflare.durable_object',
       },
@@ -385,7 +385,7 @@ function createRpcPrototypeWrapper(methodName: string, originalMethod: Unchecked
           options: state.options,
           context: state.context,
           spanName: methodName,
-          spanOp: 'rpc',
+          spanOp: RPC,
           origin: 'auto.faas.cloudflare.durable_object',
         },
         originalMethod,

--- a/packages/cloudflare/src/instrumentations/agents/instrumentAgentCallableRpc.ts
+++ b/packages/cloudflare/src/instrumentations/agents/instrumentAgentCallableRpc.ts
@@ -1,4 +1,6 @@
-import { debug, SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { RPC } from '@sentry/conventions/op';
+import { debug, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 import { DEBUG_BUILD } from '../../debug-build';
 import { AGENT_SPAN_ORIGIN, type AgentInternals, getAgentAttributes, setAgentConversationId } from './types';
 
@@ -32,7 +34,7 @@ export function instrumentAgentCallableRpc(obj: AgentInternals): void {
         {
           name: method,
           attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'rpc',
+            [SENTRY_OP]: RPC,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: AGENT_SPAN_ORIGIN,
             ...getAgentAttributes(thisArg),
           },

--- a/packages/cloudflare/src/instrumentations/instrumentDurableObjectStorage.ts
+++ b/packages/cloudflare/src/instrumentations/instrumentDurableObjectStorage.ts
@@ -1,4 +1,6 @@
 import type { DurableObjectStorage, SyncKvStorage, SqlStorage } from '@cloudflare/workers-types';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import { getClient, isThenable, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 import type { CloudflareClientOptions } from '../client';
 import { getStorageKeys, targetsCloudflareInternalKey } from '../utils/internalStorageKey';
@@ -71,8 +73,8 @@ export function instrumentDurableObjectStorage(
           {
             // Use underscore naming to match Cloudflare's native instrumentation (e.g., "durable_object_storage_get")
             name: `durable_object_storage_${methodName}`,
-            op: 'db',
             attributes: {
+              [SENTRY_OP]: DB,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
               'db.system.name': 'cloudflare.durable_object.storage',
               'db.operation.name': methodName,

--- a/packages/cloudflare/src/instrumentations/instrumentDurableObjectSyncKvStorage.ts
+++ b/packages/cloudflare/src/instrumentations/instrumentDurableObjectSyncKvStorage.ts
@@ -1,4 +1,6 @@
 import type { SyncKvStorage } from '@cloudflare/workers-types';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 
 const SYNC_KV_METHODS_TO_INSTRUMENT = ['get', 'put', 'delete', 'list'] as const;
@@ -24,8 +26,8 @@ export function instrumentDurableObjectSyncKvStorage(syncKv: SyncKvStorage): Syn
         return startSpan(
           {
             name: `durable_object_storage_kv_${methodName}`,
-            op: 'db',
             attributes: {
+              [SENTRY_OP]: DB,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
               // keeping the value as close as possible to the Cloudflare Worker KV instrumentation
               // https://github.com/cloudflare/workerd/blob/6b8b11787e2b2a800ab0edd0690bfab3857b0529/src/workerd/api/sync-kv.c%2B%2B#L19

--- a/packages/cloudflare/src/instrumentations/instrumentSqlStorage.ts
+++ b/packages/cloudflare/src/instrumentations/instrumentSqlStorage.ts
@@ -1,4 +1,6 @@
 import type { SqlStorage } from '@cloudflare/workers-types';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { DB_QUERY } from '@sentry/conventions/op';
 import {
   _INTERNAL_getSqlQuerySummary,
   _INTERNAL_sanitizeSqlQuery,
@@ -40,9 +42,9 @@ export function instrumentSqlStorage(sql: SqlStorage): SqlStorage {
 
         return startSpan(
           {
-            op: 'db.query',
             name: querySummary || sanitizedQuery,
             attributes: {
+              [SENTRY_OP]: DB_QUERY,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object.sql',
               'db.system.name': 'cloudflare-durable-object-sql',
               'db.operation.name': 'exec',

--- a/packages/cloudflare/src/instrumentations/instrumentWorkerEntrypoint.ts
+++ b/packages/cloudflare/src/instrumentations/instrumentWorkerEntrypoint.ts
@@ -1,4 +1,5 @@
 import type { RpcStub, WorkerEntrypoint } from 'cloudflare:workers';
+import { RPC } from '@sentry/conventions/op';
 import { setAsyncLocalStorageAsyncContextStrategy } from '@sentry/server-utils/no-diagnostic-channels';
 import type { CloudflareOptions } from '../client';
 import { getFinalOptions } from '../options';
@@ -91,7 +92,7 @@ function instrumentMethod(
       options,
       context,
       spanName: rpcMeta => (rpcMeta ? prop : undefined),
-      spanOp: 'rpc',
+      spanOp: RPC,
       origin: WORKER_ENTRYPOINT_ORIGIN,
     },
     boundMethod,

--- a/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentD1.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { D1Database, D1DatabaseSession, D1PreparedStatement, D1Response } from '@cloudflare/workers-types';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { DB_QUERY } from '@sentry/conventions/op';
 import type { Span, SpanAttributes, StartSpanOptions } from '@sentry/core';
 import {
   _INTERNAL_getSqlQuerySummary,
@@ -136,9 +138,9 @@ function createStartSpanOptions(query: string, type: D1QueryType): StartSpanOpti
   const name = client && hasSpanStreamingEnabled(client) ? querySummary || 'cloudflare-d1' : query;
 
   return {
-    op: 'db.query',
     name,
     attributes: {
+      [SENTRY_OP]: DB_QUERY,
       'db.system.name': 'cloudflare-d1',
       'db.operation.name': type,
       'db.query.text': query,
@@ -174,9 +176,9 @@ function instrumentBatch(
 
       return startSpan(
         {
-          op: 'db.query',
           name: 'D1 batch',
           attributes: {
+            [SENTRY_OP]: DB_QUERY,
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'batch',
             'db.query.text': queryText || undefined,

--- a/packages/cloudflare/src/instrumentations/worker/instrumentQueueProducer.ts
+++ b/packages/cloudflare/src/instrumentations/worker/instrumentQueueProducer.ts
@@ -1,5 +1,7 @@
 import type { MessageSendRequest, Queue, QueueSendBatchOptions, QueueSendOptions } from '@cloudflare/workers-types';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { QUEUE_PUBLISH } from '@sentry/conventions/op';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan } from '@sentry/core';
 
 const ORIGIN = 'auto.faas.cloudflare.queue';
 
@@ -15,7 +17,6 @@ function startPublishSpan<T>(
 
   return startSpan(
     {
-      op: 'queue.publish',
       name: `send ${bindingName}`,
       attributes: {
         'messaging.system': 'cloudflare',
@@ -24,7 +25,7 @@ function startPublishSpan<T>(
         'messaging.operation.name': 'send',
         ...(messageCount !== undefined && { 'messaging.batch.message_count': messageCount }),
         'messaging.message.body.size': bodySize,
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'queue.publish',
+        [SENTRY_OP]: QUEUE_PUBLISH,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
       },
     },

--- a/packages/cloudflare/src/wrapRequestHandlerWithInit.ts
+++ b/packages/cloudflare/src/wrapRequestHandlerWithInit.ts
@@ -2,8 +2,10 @@ import type { CfProperties, IncomingRequestCfProperties } from '@cloudflare/work
 import {
   NETWORK_PROTOCOL_NAME,
   NETWORK_PROTOCOL_VERSION,
+  SENTRY_OP,
   SENTRY_SEGMENT_NAME_SOURCE,
 } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 import {
   captureException,
   continueTrace,
@@ -12,7 +14,6 @@ import {
   httpHeadersToSpanAttributes,
   HTTP_SPAN_NAME_FALLBACK,
   parseStringToURLObject,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   setHttpStatus,
   startSpanManual,
   winterCGHeadersToDict,
@@ -114,7 +115,7 @@ export function wrapRequestHandlerWithInit(
       );
     }
 
-    attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] = 'http.server';
+    attributes[SENTRY_OP] = HTTP_SERVER;
 
     addCloudResourceContext(isolationScope);
     addRequest(isolationScope, request);

--- a/packages/cloudflare/test/instrumentDurableObjectStorage.test.ts
+++ b/packages/cloudflare/test/instrumentDurableObjectStorage.test.ts
@@ -28,8 +28,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_get',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'get',
@@ -49,8 +49,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_get',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'get',
@@ -72,8 +72,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_put',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'put',
@@ -93,8 +93,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_put',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'put',
@@ -116,8 +116,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_delete',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'delete',
@@ -137,8 +137,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_delete',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'delete',
@@ -160,8 +160,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_list',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'list',
@@ -183,8 +183,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_setAlarm',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'setAlarm',
@@ -267,8 +267,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_getAlarm',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'getAlarm',
@@ -288,8 +288,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_deleteAlarm',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare.durable_object.storage',
             'db.operation.name': 'deleteAlarm',
@@ -310,8 +310,8 @@ describe('instrumentDurableObjectStorage', () => {
     expect(startSpanSpy).toHaveBeenCalledWith(
       {
         name: 'SELECT',
-        op: 'db.query',
         attributes: {
+          'sentry.op': 'db.query',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object.sql',
           'db.system.name': 'cloudflare-durable-object-sql',
           'db.operation.name': 'exec',
@@ -434,8 +434,8 @@ describe('instrumentDurableObjectStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_kv_get',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare-durable-object-sql',
             'db.operation.name': 'get',

--- a/packages/cloudflare/test/instrumentDurableObjectSyncKvStorage.test.ts
+++ b/packages/cloudflare/test/instrumentDurableObjectSyncKvStorage.test.ts
@@ -19,8 +19,8 @@ describe('instrumentDurableObjectSyncKvStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_kv_get',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare-durable-object-sql',
             'db.operation.name': 'get',
@@ -62,8 +62,8 @@ describe('instrumentDurableObjectSyncKvStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_kv_put',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare-durable-object-sql',
             'db.operation.name': 'put',
@@ -94,8 +94,8 @@ describe('instrumentDurableObjectSyncKvStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_kv_delete',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare-durable-object-sql',
             'db.operation.name': 'delete',
@@ -127,8 +127,8 @@ describe('instrumentDurableObjectSyncKvStorage', () => {
       expect(startSpanSpy).toHaveBeenCalledWith(
         {
           name: 'durable_object_storage_kv_list',
-          op: 'db',
           attributes: {
+            'sentry.op': 'db',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object',
             'db.system.name': 'cloudflare-durable-object-sql',
             'db.operation.name': 'list',

--- a/packages/cloudflare/test/instrumentSqlStorage.test.ts
+++ b/packages/cloudflare/test/instrumentSqlStorage.test.ts
@@ -17,9 +17,9 @@ describe('instrumentSqlStorage', () => {
 
     expect(startSpanSpy).toHaveBeenCalledWith(
       {
-        op: 'db.query',
         name: 'SELECT users',
         attributes: {
+          'sentry.op': 'db.query',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object.sql',
           'db.system.name': 'cloudflare-durable-object-sql',
           'db.operation.name': 'exec',
@@ -41,9 +41,9 @@ describe('instrumentSqlStorage', () => {
 
     expect(startSpanSpy).toHaveBeenCalledWith(
       {
-        op: 'db.query',
         name: 'SELECT users',
         attributes: {
+          'sentry.op': 'db.query',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object.sql',
           'db.system.name': 'cloudflare-durable-object-sql',
           'db.operation.name': 'exec',
@@ -74,9 +74,9 @@ describe('instrumentSqlStorage', () => {
 
     expect(startSpanSpy).toHaveBeenCalledWith(
       {
-        op: 'db.query',
         name: 'INSERT users',
         attributes: {
+          'sentry.op': 'db.query',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.cloudflare.durable_object.sql',
           'db.system.name': 'cloudflare-durable-object-sql',
           'db.operation.name': 'exec',

--- a/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
+++ b/packages/cloudflare/test/instrumentations/instrumentEnv.test.ts
@@ -40,7 +40,7 @@ describe('instrumentEnv', () => {
     await db.prepare('SELECT 1').first();
 
     expect(startSpanSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ op: 'db.query', name: 'SELECT 1' }),
+      expect.objectContaining({ name: 'SELECT 1', attributes: expect.objectContaining({ 'sentry.op': 'db.query' }) }),
       expect.any(Function),
     );
   });

--- a/packages/cloudflare/test/instrumentations/worker/instrumentD1.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentD1.test.ts
@@ -75,6 +75,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'first',
             'db.query.text': 'SELECT * FROM users',
@@ -82,7 +83,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'SELECT * FROM users',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -177,6 +177,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'run',
             'db.query.text': 'INSERT INTO users (name) VALUES (?)',
@@ -184,7 +185,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'INSERT INTO users (name) VALUES (?)',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -231,6 +231,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'all',
             'db.query.text': 'INSERT INTO users (name) VALUES (?)',
@@ -238,7 +239,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'INSERT INTO users (name) VALUES (?)',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -285,6 +285,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'raw',
             'db.query.text': 'SELECT * FROM users',
@@ -292,7 +293,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'SELECT * FROM users',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -336,6 +336,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'batch',
             'db.query.text': 'SELECT 1\nSELECT 2',
@@ -343,7 +344,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'D1 batch',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -375,6 +375,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'batch',
             'db.query.text': undefined,
@@ -382,7 +383,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'D1 batch',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -404,6 +404,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'exec',
             'db.query.text': 'CREATE TABLE users (id INTEGER PRIMARY KEY)',
@@ -411,7 +412,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'CREATE TABLE users (id INTEGER PRIMARY KEY)',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -442,6 +442,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'first',
             'db.query.text': 'SELECT * FROM users',
@@ -449,7 +450,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'SELECT * FROM users',
-          op: 'db.query',
         },
         expect.any(Function),
       );
@@ -479,6 +479,7 @@ describe('instrumentD1', () => {
       expect(startSpanSpy).toHaveBeenLastCalledWith(
         {
           attributes: {
+            'sentry.op': 'db.query',
             'db.system.name': 'cloudflare-d1',
             'db.operation.name': 'batch',
             'db.query.text': 'SELECT 1\nSELECT 2',
@@ -486,7 +487,6 @@ describe('instrumentD1', () => {
             'sentry.origin': 'auto.db.cloudflare.d1',
           },
           name: 'D1 batch',
-          op: 'db.query',
         },
         expect.any(Function),
       );

--- a/packages/cloudflare/test/instrumentations/worker/instrumentQueueProducer.test.ts
+++ b/packages/cloudflare/test/instrumentations/worker/instrumentQueueProducer.test.ts
@@ -36,7 +36,6 @@ describe('instrumentQueueProducer', () => {
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
       const [spanCtx] = startSpanSpy.mock.calls[0]!;
       expect(spanCtx).toMatchObject({
-        op: 'queue.publish',
         name: 'send MY_QUEUE',
         attributes: {
           'messaging.system': 'cloudflare',
@@ -108,7 +107,6 @@ describe('instrumentQueueProducer', () => {
       expect(startSpanSpy).toHaveBeenCalledTimes(1);
       const [spanCtx] = startSpanSpy.mock.calls[0]!;
       expect(spanCtx).toMatchObject({
-        op: 'queue.publish',
         name: 'send MY_QUEUE',
         attributes: {
           'messaging.system': 'cloudflare',

--- a/packages/core/src/fetch.ts
+++ b/packages/core/src/fetch.ts
@@ -2,15 +2,17 @@
 import {
   HTTP_REQUEST_METHOD,
   HTTP_RESPONSE_BODY_SIZE,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
   URL_FRAGMENT,
   URL_FULL,
   URL_QUERY,
 } from '@sentry/conventions/attributes';
+import { HTTP_CLIENT } from '@sentry/conventions/op';
 import type { Client } from './client';
 import { getClient } from './currentScopes';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from './semanticAttributes';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from './semanticAttributes';
 import { setHttpStatus, SPAN_STATUS_ERROR, spanIsIgnored } from './tracing';
 import { startInactiveSpan } from './tracing/trace';
 import { SentryNonRecordingSpan } from './tracing/sentryNonRecordingSpan';
@@ -369,7 +371,7 @@ function getFetchSpanAttributes(
     // oxlint-disable-next-line typescript/no-deprecated
     [HTTP_REQUEST_METHOD]: method,
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: spanOrigin,
-    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client',
+    [SENTRY_OP]: HTTP_CLIENT,
   };
   if (parsedUrl) {
     if (!isURLObjectRelative(parsedUrl)) {

--- a/packages/core/src/integrations/express/patch-layer.ts
+++ b/packages/core/src/integrations/express/patch-layer.ts
@@ -38,7 +38,7 @@ import {
   SENTRY_OP,
   SENTRY_SEGMENT_NAME_SOURCE,
 } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
+import { HANDLER, MIDDLEWARE, ROUTER } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../../debug-build';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { SPAN_STATUS_ERROR, withActiveSpan } from '../../tracing';
@@ -73,11 +73,10 @@ import { getDefaultIsolationScope } from '../../defaultScopes';
 import { getOriginalFunction, markFunctionWrapped } from '../../utils/object';
 import { setSDKProcessingMetadata } from './set-sdk-processing-metadata';
 
-// TODO(conventions): Replace `'handler'` and `'router'` with their span op constants once they are released in `@sentry/conventions`.
 const EXPRESS_TYPE_TO_SPAN_OP: Record<string, string> = {
   [ExpressLayerType_MIDDLEWARE]: MIDDLEWARE,
-  [ExpressLayerType_REQUEST_HANDLER]: 'handler',
-  [ExpressLayerType_ROUTER]: 'router',
+  [ExpressLayerType_REQUEST_HANDLER]: HANDLER,
+  [ExpressLayerType_ROUTER]: ROUTER,
 };
 
 export type ExpressPatchLayerOptions = Pick<

--- a/packages/core/src/integrations/http/get-outgoing-span-data.ts
+++ b/packages/core/src/integrations/http/get-outgoing-span-data.ts
@@ -1,5 +1,4 @@
 import type { Span, SpanAttributes } from '../../types/span';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP } from '../../semanticAttributes';
 import { filterCollectedUrl } from '../../utils/data-collection/filterCollectedUrl';
 import { getContentLengthFromHeaders } from '../../utils/request';
 import { getHttpSpanDetailsFromUrlObject, parseStringToURLObject } from '../../utils/url';
@@ -16,12 +15,14 @@ import {
   NETWORK_PROTOCOL_NAME,
   NETWORK_PROTOCOL_VERSION,
   NETWORK_TRANSPORT,
+  SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
-  SENTRY_KIND,
   URL_FULL,
   USER_AGENT_ORIGINAL,
 } from '@sentry/conventions/attributes';
+import { HTTP_CLIENT } from '@sentry/conventions/op';
 
 /**
  * Build the initial span name and attributes for an outgoing HTTP request.
@@ -41,7 +42,7 @@ export function getOutgoingRequestSpanData(request: HttpClientRequest): StartSpa
   return {
     name,
     attributes: {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client',
+      [SENTRY_OP]: HTTP_CLIENT,
       [SENTRY_KIND]: 'client',
       [URL_FULL]: filterCollectedUrl(url),
       // The old `http.target` (path plus query) has no separate replacement here: `url.path`,

--- a/packages/core/src/integrations/http/server-subscription.ts
+++ b/packages/core/src/integrations/http/server-subscription.ts
@@ -39,7 +39,7 @@ import { continueTrace, startSpanManual } from '../../tracing/trace';
 import { getSpanStatusFromHttpCode, SPAN_STATUS_ERROR } from '../../tracing';
 import { hasSpanStreamingEnabled } from '../../tracing/spans/hasSpanStreamingEnabled';
 import { HTTP_SPAN_NAME_FALLBACK } from '../../tracing/spans/spanNames';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { safeMathRandom } from '../../utils/randomSafeContext';
 import type { SpanStatus } from '../../types/spanStatus';
 import {
@@ -56,9 +56,10 @@ import {
   NETWORK_TRANSPORT,
   SENTRY_HTTP_PREFETCH,
   SENTRY_KIND,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
   SERVER_ADDRESS,
   SERVER_PORT,
-  SENTRY_SEGMENT_NAME_SOURCE,
   URL_FRAGMENT,
   URL_FULL,
   URL_PATH,
@@ -66,6 +67,7 @@ import {
   URL_SCHEME,
   USER_AGENT_ORIGINAL,
 } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 import { filterCollectedUrl, filterCollectedUrlQuery } from '../../utils/data-collection/filterCollectedUrl';
 
 // Tree-shakable guard to remove all code related to tracing
@@ -321,7 +323,7 @@ function buildServerSpanWrap(
           name,
           attributes: {
             // Sentry-specific attributes
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+            [SENTRY_OP]: HTTP_SERVER,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.server',
             [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
             [SENTRY_KIND]: 'server',

--- a/packages/core/src/integrations/mcp-server/attributes.ts
+++ b/packages/core/src/integrations/mcp-server/attributes.ts
@@ -141,21 +141,6 @@ export const CLIENT_PORT_ATTRIBUTE = 'client.port';
 // SENTRY-SPECIFIC MCP ATTRIBUTE VALUES
 // =============================================================================
 
-/** Sentry operation value for MCP server spans */
-export const MCP_SERVER_OP_VALUE = 'mcp.server';
-
-/**
- * Sentry operation value for client-to-server notifications
- * Following OpenTelemetry MCP semantic conventions
- */
-export const MCP_NOTIFICATION_CLIENT_TO_SERVER_OP_VALUE = 'mcp.notification.client_to_server';
-
-/**
- * Sentry operation value for server-to-client notifications
- * Following OpenTelemetry MCP semantic conventions
- */
-export const MCP_NOTIFICATION_SERVER_TO_CLIENT_OP_VALUE = 'mcp.notification.server_to_client';
-
 /** Sentry origin value for MCP function spans */
 export const MCP_FUNCTION_ORIGIN_VALUE = 'auto.function.mcp_server';
 

--- a/packages/core/src/integrations/mcp-server/spans.ts
+++ b/packages/core/src/integrations/mcp-server/spans.ts
@@ -6,8 +6,13 @@
  */
 
 import { getClient } from '../../currentScopes';
-import { SENTRY_SEGMENT_NAME_SOURCE } from '@sentry/conventions/attributes';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
+import { SENTRY_OP, SENTRY_SEGMENT_NAME_SOURCE } from '@sentry/conventions/attributes';
+import {
+  MCP_NOTIFICATION_CLIENT_TO_SERVER,
+  MCP_NOTIFICATION_SERVER_TO_CLIENT,
+  MCP_SERVER,
+} from '@sentry/conventions/op';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../../semanticAttributes';
 import { hasSpanStreamingEnabled } from '../../tracing/spans/hasSpanStreamingEnabled';
 import { MCP_NOTIFICATION_SPAN_NAME_FALLBACK, MCP_SERVER_SPAN_NAME_FALLBACK } from '../../tracing/spans/spanNames';
 import { startSpan } from '../../tracing/trace';
@@ -15,11 +20,8 @@ import { buildTransportAttributes, buildTypeSpecificAttributes } from './attribu
 import {
   MCP_FUNCTION_ORIGIN_VALUE,
   MCP_METHOD_NAME_ATTRIBUTE,
-  MCP_NOTIFICATION_CLIENT_TO_SERVER_OP_VALUE,
   MCP_NOTIFICATION_ORIGIN_VALUE,
-  MCP_NOTIFICATION_SERVER_TO_CLIENT_OP_VALUE,
   MCP_ROUTE_SOURCE_VALUE,
-  MCP_SERVER_OP_VALUE,
 } from './attributes';
 import { extractTargetInfo } from './methodConfig';
 import { filterMcpPiiFromSpanData } from './piiFiltering';
@@ -55,21 +57,21 @@ function buildSentryAttributes(type: McpSpanConfig['type']): Record<string, stri
 
   switch (type) {
     case 'request':
-      op = MCP_SERVER_OP_VALUE;
+      op = MCP_SERVER;
       origin = MCP_FUNCTION_ORIGIN_VALUE;
       break;
     case 'notification-incoming':
-      op = MCP_NOTIFICATION_CLIENT_TO_SERVER_OP_VALUE;
+      op = MCP_NOTIFICATION_CLIENT_TO_SERVER;
       origin = MCP_NOTIFICATION_ORIGIN_VALUE;
       break;
     case 'notification-outgoing':
-      op = MCP_NOTIFICATION_SERVER_TO_CLIENT_OP_VALUE;
+      op = MCP_NOTIFICATION_SERVER_TO_CLIENT;
       origin = MCP_NOTIFICATION_ORIGIN_VALUE;
       break;
   }
 
   return {
-    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: op,
+    [SENTRY_OP]: op,
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: origin,
     [SENTRY_SEGMENT_NAME_SOURCE]: MCP_ROUTE_SOURCE_VALUE,
   };
@@ -184,7 +186,6 @@ export function buildMcpServerSpanConfig(
   options?: ResolvedMcpOptions,
 ): {
   name: string;
-  op: string;
   forceTransaction: boolean;
   attributes: Record<string, string | number>;
 } {
@@ -210,7 +211,6 @@ export function buildMcpServerSpanConfig(
 
   return {
     name: spanName,
-    op: MCP_SERVER_OP_VALUE,
     forceTransaction: true,
     attributes,
   };

--- a/packages/core/src/integrations/supabase.ts
+++ b/packages/core/src/integrations/supabase.ts
@@ -3,13 +3,14 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-lines */
-import { DB_OPERATION_NAME, DB_SYSTEM_NAME } from '@sentry/conventions/attributes';
+import { DB_OPERATION_NAME, DB_SYSTEM_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import { addBreadcrumb } from '../breadcrumbs';
 import { getClient } from '../currentScopes';
 import { DEBUG_BUILD } from '../debug-build';
 import { captureException } from '../exports';
 import { defineIntegration } from '../integration';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '../semanticAttributes';
 import { setHttpStatus, SPAN_STATUS_ERROR, SPAN_STATUS_OK } from '../tracing';
 import { hasSpanStreamingEnabled } from '../tracing/spans/hasSpanStreamingEnabled';
 import { startSpan } from '../tracing/trace';
@@ -295,7 +296,7 @@ function instrumentAuthOperation(operation: AuthOperationFn, isAdmin = false): A
           name,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.supabase',
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+            [SENTRY_OP]: DB,
             [DB_SYSTEM_NAME]: 'postgresql',
             [DB_OPERATION_NAME]: operationName,
           },
@@ -462,7 +463,7 @@ function instrumentPostgRESTFilterBuilder(
           [DB_SYSTEM_NAME]: 'postgresql',
           [DB_OPERATION_NAME]: operation,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.supabase',
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+          [SENTRY_OP]: DB,
         };
 
         if (queryItems.length && shouldSendData) {

--- a/packages/core/test/lib/integrations/mcp-server/semanticConventions.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/semanticConventions.test.ts
@@ -47,7 +47,6 @@ describe('MCP Server Semantic Conventions', () => {
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         name: 'tools/call get-weather',
-        op: 'mcp.server',
         forceTransaction: true,
         attributes: {
           'mcp.method.name': 'tools/call',
@@ -81,7 +80,6 @@ describe('MCP Server Semantic Conventions', () => {
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         name: 'resources/read file:///docs/api.md',
-        op: 'mcp.server',
         forceTransaction: true,
         attributes: {
           'mcp.method.name': 'resources/read',
@@ -113,7 +111,6 @@ describe('MCP Server Semantic Conventions', () => {
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         name: 'prompts/get analyze-code',
-        op: 'mcp.server',
         forceTransaction: true,
         attributes: {
           'mcp.method.name': 'prompts/get',
@@ -419,12 +416,12 @@ describe('MCP Server Semantic Conventions', () => {
       expect(startInactiveSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'tools/call weather-lookup',
-          op: 'mcp.server',
           forceTransaction: true,
           attributes: expect.objectContaining({
             'mcp.method.name': 'tools/call',
             'mcp.tool.name': 'weather-lookup',
             'mcp.request.id': 'req-tool-result',
+            'sentry.op': 'mcp.server',
           }),
         }),
       );
@@ -492,12 +489,12 @@ describe('MCP Server Semantic Conventions', () => {
       expect(startInactiveSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'prompts/get code-review',
-          op: 'mcp.server',
           forceTransaction: true,
           attributes: expect.objectContaining({
             'mcp.method.name': 'prompts/get',
             'mcp.prompt.name': 'code-review',
             'mcp.request.id': 'req-prompt-result',
+            'sentry.op': 'mcp.server',
           }),
         }),
       );

--- a/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
+++ b/packages/core/test/lib/integrations/mcp-server/transportInstrumentation.test.ts
@@ -270,7 +270,6 @@ describe('MCP Server Transport Instrumentation', () => {
 
       expect(startInactiveSpanSpy).toHaveBeenCalledWith({
         name: 'tools/call process-file',
-        op: 'mcp.server',
         forceTransaction: true,
         attributes: {
           'mcp.method.name': 'tools/call',
@@ -420,7 +419,6 @@ describe('MCP Server Transport Instrumentation', () => {
 
       expect(config).toEqual({
         name: 'tools/call test-tool',
-        op: 'mcp.server',
         forceTransaction: true,
         attributes: expect.objectContaining({
           'mcp.method.name': 'tools/call',
@@ -1062,7 +1060,6 @@ describe('MCP Server Transport Instrumentation', () => {
       expect(startInactiveSpanSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: 'tools/call test-tool',
-          op: 'mcp.server',
         }),
       );
 

--- a/packages/deno/src/wrap-deno-request-handler.ts
+++ b/packages/deno/src/wrap-deno-request-handler.ts
@@ -2,8 +2,10 @@ import {
   CLIENT_ADDRESS,
   CLIENT_PORT,
   NETWORK_PROTOCOL_NAME,
+  SENTRY_OP,
   SENTRY_SEGMENT_NAME_SOURCE,
 } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 import type { Integration, MaxRequestBodySize } from '@sentry/core';
 import {
   captureBodyFromWinterCGRequest,
@@ -15,7 +17,6 @@ import {
   httpHeadersToSpanAttributes,
   HTTP_SPAN_NAME_FALLBACK,
   parseStringToURLObject,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   setHttpStatus,
   startSpanManual,
   winterCGHeadersToDict,
@@ -101,7 +102,7 @@ export const wrapDenoRequestHandler = <Addr extends Deno.Addr = Deno.Addr>(
     attributes[NETWORK_PROTOCOL_NAME] = 'http';
 
     Object.assign(attributes, httpHeadersToSpanAttributes(winterCGHeadersToDict(request.headers), dataCollection));
-    attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] = 'http.server';
+    attributes[SENTRY_OP] = HTTP_SERVER;
     isolationScope.setSDKProcessingMetadata({
       normalizedRequest: winterCGRequestToRequestData(request),
     });

--- a/packages/elysia/src/withElysia.ts
+++ b/packages/elysia/src/withElysia.ts
@@ -1,5 +1,5 @@
-import { SENTRY_SEGMENT_NAME_SOURCE, HTTP_ROUTE, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
+import { HTTP_ROUTE, SENTRY_OP, SENTRY_SEGMENT_NAME_SOURCE, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
+import { HANDLER, HTTP_SERVER, MIDDLEWARE } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   captureException,
@@ -37,8 +37,7 @@ const ELYSIA_LIFECYCLE_OP_MAP: Record<string, string> = {
   Parse: MIDDLEWARE,
   Transform: MIDDLEWARE,
   BeforeHandle: MIDDLEWARE,
-  // TODO(conventions): Replace with the `handler` span op constant once it is released in `@sentry/conventions`.
-  Handle: 'handler',
+  Handle: HANDLER,
   AfterHandle: MIDDLEWARE,
   MapResponse: MIDDLEWARE,
   AfterResponse: MIDDLEWARE,
@@ -206,7 +205,6 @@ export function withElysia<T extends AnyElysia>(app: T, options: ElysiaHandlerOp
               const client = getClient();
               return startSpanManual(
                 {
-                  op: 'http.server',
                   // With span streaming, span names have to be low cardinality, so we can't fall back to the
                   // URL path. `updateRouteTransactionName` renames the span once Elysia resolves the route.
                   name:
@@ -214,6 +212,7 @@ export function withElysia<T extends AnyElysia>(app: T, options: ElysiaHandlerOp
                       ? request.method?.toUpperCase() || HTTP_SPAN_NAME_FALLBACK
                       : `${request.method} ${new URL(request.url).pathname}`,
                   attributes: {
+                    [SENTRY_OP]: HTTP_SERVER,
                     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ELYSIA_ORIGIN,
                     [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
                     [URL_FULL]: filterCollectedUrl(request.url),

--- a/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
+++ b/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
@@ -13,6 +13,7 @@ import {
   URL_PATH,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
+import { ROUTER } from '@sentry/conventions/op';
 import {
   filterCollectedUrl,
   getCurrentScope,
@@ -145,8 +146,7 @@ export function instrumentEmberAppInstanceForPerformance(
 
     transitionSpan = startInactiveSpan({
       attributes: {
-        // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
-        [SENTRY_OP]: 'router',
+        [SENTRY_OP]: ROUTER,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.ember',
       },
       // With span streaming, span names have to be low cardinality, and Ember gives us no route

--- a/packages/nestjs/src/integrations/wrap-route.ts
+++ b/packages/nestjs/src/integrations/wrap-route.ts
@@ -1,5 +1,5 @@
 import { HTTP_REQUEST_METHOD, HTTP_ROUTE, SENTRY_OP, URL_FULL } from '@sentry/conventions/attributes';
-import { FUNCTION } from '@sentry/conventions/op';
+import { FUNCTION, HANDLER } from '@sentry/conventions/op';
 import type { SpanAttributes } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startSpan, filterCollectedUrl } from '@sentry/core';
 import type { AnyFn } from './helpers';
@@ -54,8 +54,7 @@ export function wrapRouteHandler(callback: AnyFn, moduleVersion?: string): AnyFn
   const spanName = callback.name || 'anonymous nest handler';
   const attributes: SpanAttributes = {
     component: NESTJS_COMPONENT,
-    // TODO(conventions): Replace with the `handler` span op constant once it is released in `@sentry/conventions`.
-    [SENTRY_OP]: 'handler',
+    [SENTRY_OP]: HANDLER,
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: HTTP_ORIGIN,
     [AttributeNames.TYPE]: NestType.REQUEST_HANDLER,
     [AttributeNames.CALLBACK]: callback.name,

--- a/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/appRouterRoutingInstrumentation.ts
@@ -4,7 +4,6 @@ import {
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   filterCollectedUrl,
 } from '@sentry/core';
@@ -15,7 +14,14 @@ import {
   getAbsoluteUrl,
 } from '@sentry/react';
 import { maybeParameterizeRoute } from './parameterization';
-import { SENTRY_SEGMENT_NAME_SOURCE, URL_FULL, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import {
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
+  URL_FULL,
+  URL_PATH,
+  URL_TEMPLATE,
+} from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 
 /**
  * Strips trailing slash from a pathname, unless it's the root path.
@@ -65,7 +71,7 @@ export function appRouterInstrumentPageLoad(client: Client): void {
     name: parameterizedPathname ?? (hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : pathname),
     // pageload should always start at timeOrigin (and needs to be in s, not ms)
     attributes: {
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+      [SENTRY_OP]: PAGELOAD,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.nextjs.app_router_instrumentation',
       [SENTRY_SEGMENT_NAME_SOURCE]: parameterizedPathname ? 'route' : 'url',
       ...(parameterizedPathname && { [URL_TEMPLATE]: parameterizedPathname }),
@@ -140,7 +146,7 @@ export function appRouterInstrumentNavigation(client: Client): void {
         {
           name: spanName,
           attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+            [SENTRY_OP]: NAVIGATION,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.nextjs.app_router_instrumentation',
             [SENTRY_SEGMENT_NAME_SOURCE]: parameterizedPathname ? 'route' : 'url',
             'navigation.type': `router.${navigationType}`,
@@ -248,7 +254,7 @@ function patchRouter(client: Client, router: NextRouter, currentNavigationSpanRe
 
           let transactionName = INCOMPLETE_APP_ROUTER_INSTRUMENTATION_TRANSACTION_NAME;
           const transactionAttributes: Record<string, string> = {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+            [SENTRY_OP]: NAVIGATION,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.nextjs.app_router_instrumentation',
             [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
           };

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -5,7 +5,6 @@ import {
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
   parseBaggageHeader,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   stripUrlQueryAndFragment,
 } from '@sentry/core';
@@ -19,7 +18,8 @@ import type { NEXT_DATA } from 'next/dist/shared/lib/utils';
 import RouterImport from 'next/router';
 import type { ParsedUrlQuery } from 'querystring';
 import { DEBUG_BUILD } from '../../common/debug-build';
-import { SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 
 // next/router v10 is CJS
 //
@@ -127,7 +127,7 @@ export function pagesRouterInstrumentPageLoad(client: Client): void {
     {
       name,
       attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+        [SENTRY_OP]: PAGELOAD,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.nextjs.pages_router_instrumentation',
         [SENTRY_SEGMENT_NAME_SOURCE]: route ? 'route' : 'url',
         ...(route && { [URL_TEMPLATE]: route }),
@@ -168,7 +168,7 @@ export function pagesRouterInstrumentNavigation(client: Client): void {
         // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
         name: spanSource === 'route' || !hasSpanStreamingEnabled(client) ? newLocation : NAVIGATION_SPAN_NAME_FALLBACK,
         attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+          [SENTRY_OP]: NAVIGATION,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.nextjs.pages_router_instrumentation',
           [SENTRY_SEGMENT_NAME_SOURCE]: spanSource,
           ...(spanSource === 'route' && { [URL_TEMPLATE]: newLocation }),

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -8,7 +8,6 @@ import {
   handleCallbackErrors,
   propagationContextFromHeaders,
   Scope,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   setCapturedScopesOnSpan,
   setHttpStatus,
   SPAN_STATUS_ERROR,
@@ -20,7 +19,8 @@ import { isNotFoundNavigationError, isRedirectNavigationError } from './nextNavi
 import type { RouteHandlerContext } from './types';
 import { flushSafelyWithTimeout, waitUntil } from './utils/responseEnd';
 import { commonObjectToIsolationScope } from './utils/tracingUtils';
-import { SENTRY_SEGMENT_NAME_SOURCE, HTTP_ROUTE } from '@sentry/conventions/attributes';
+import { HTTP_ROUTE, SENTRY_OP, SENTRY_SEGMENT_NAME_SOURCE } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 
 /**
  * Wraps a Next.js App Router Route handler with Sentry error and performance instrumentation.
@@ -50,7 +50,7 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
         rootSpan.updateName(`${method} ${parameterizedRoute}`);
         rootSpan.setAttributes({
           [SENTRY_SEGMENT_NAME_SOURCE]: 'route',
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+          [SENTRY_OP]: HTTP_SERVER,
           [HTTP_ROUTE]: parameterizedRoute,
         });
       }

--- a/packages/nextjs/src/edge/enhanceRunHandlerRootSpan.ts
+++ b/packages/nextjs/src/edge/enhanceRunHandlerRootSpan.ts
@@ -1,4 +1,5 @@
 import { SENTRY_SEGMENT_NAME_SOURCE, HTTP_METHOD, HTTP_REQUEST_METHOD } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 
 import { ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../common/nextSpanAttributes';
 import { ATTR_NEXT_PAGES_API_ROUTE_TYPE } from '../common/span-attributes-with-logic-attached';
@@ -32,7 +33,7 @@ export function enhanceRunHandlerRootSpan(span: MutableRootSpan): void {
     return;
   }
 
-  span.setOp('http.server');
+  span.setOp(HTTP_SERVER);
   attributes[SENTRY_SEGMENT_NAME_SOURCE] = 'route';
 
   const path = spanName.replace(ATTR_NEXT_PAGES_API_ROUTE_TYPE, '').trim();

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -38,10 +38,11 @@ import { enhanceRunHandlerRootSpan } from './enhanceRunHandlerRootSpan';
 import {
   HTTP_METHOD,
   HTTP_REQUEST_METHOD,
-  SENTRY_SEGMENT_NAME_SOURCE,
   SENTRY_KIND,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
 } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
+import { HTTP_SERVER, MIDDLEWARE } from '@sentry/conventions/op';
 
 export * from '@sentry/vercel-edge';
 export * from '../common';
@@ -174,14 +175,14 @@ export function init(options: VercelEdgeOptions = {}): void {
       spanAttributes?.[ATTR_NEXT_SPAN_TYPE] === 'Node.runHandler' &&
       String(spanAttributes?.[ATTR_NEXT_SPAN_NAME]).startsWith(ATTR_NEXT_PAGES_API_ROUTE_TYPE)
     ) {
-      span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'http.server');
+      span.setAttribute(SENTRY_OP, HTTP_SERVER);
       span.setAttribute(SENTRY_SEGMENT_NAME_SOURCE, 'route');
     }
 
     // The `BaseServer.handleRequest` span is the incoming request root span (e.g. for app-router server
     // components). Since we no longer infer the op from OTel semantic attributes, set it directly here.
     if (spanAttributes?.[ATTR_NEXT_SPAN_TYPE] === 'BaseServer.handleRequest') {
-      span.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_OP, 'http.server');
+      span.setAttribute(SENTRY_OP, HTTP_SERVER);
     }
 
     // We want to fork the isolation scope for incoming requests

--- a/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
+++ b/packages/nextjs/src/server/enhanceHandleRequestRootSpan.ts
@@ -1,13 +1,14 @@
 import {
-  SENTRY_SEGMENT_NAME_SOURCE,
   HTTP_METHOD,
   HTTP_REQUEST_METHOD,
   HTTP_ROUTE,
   HTTP_TARGET,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
   URL_PATH,
 } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, stripUrlQueryAndFragment } from '@sentry/core';
+import { HTTP_SERVER, MIDDLEWARE } from '@sentry/conventions/op';
+import { stripUrlQueryAndFragment } from '@sentry/core';
 import { ATTR_NEXT_ROUTE, ATTR_NEXT_SPAN_NAME, ATTR_NEXT_SPAN_TYPE } from '../common/nextSpanAttributes';
 import { TRANSACTION_ATTR_SENTRY_ROUTE_BACKFILL } from '../common/span-attributes-with-logic-attached';
 import { backfillHttpResponseStatusCode } from '../common/utils/backfillHttpResponseStatusCode';
@@ -37,8 +38,8 @@ export function enhanceHandleRequestRootSpan(span: MutableRootSpan): void {
     return;
   }
 
-  attributes[SEMANTIC_ATTRIBUTE_SENTRY_OP] = 'http.server';
-  span.setOp('http.server');
+  attributes[SENTRY_OP] = HTTP_SERVER;
+  span.setOp(HTTP_SERVER);
 
   backfillHttpResponseStatusCode(attributes);
 

--- a/packages/node/src/integrations/fs/vendored/instrumentation.ts
+++ b/packages/node/src/integrations/fs/vendored/instrumentation.ts
@@ -15,6 +15,7 @@
  */
 
 import { ERROR_TYPE } from '@sentry/conventions/attributes';
+import { FILE } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_OP,
@@ -33,7 +34,7 @@ import type { FMember, FPMember, FsInstrumentationConfig, GenericFunction } from
 import { indexFs } from './utils';
 
 const SPAN_ORIGIN = 'auto.file.fs';
-const SPAN_OP = 'file';
+const SPAN_OP = FILE;
 
 // The following lists categorize `fs` functions by the shape of their leading path arguments, so we can
 // record meaningful span attributes for them. These are Sentry-specific additions (not part of upstream).

--- a/packages/node/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node/src/integrations/http/httpServerSpansIntegration.ts
@@ -1,11 +1,10 @@
 /* eslint-disable max-lines */
 import { errorMonitor } from 'node:events';
 import {
-  SENTRY_SEGMENT_NAME_SOURCE,
-  HTTP_REQUEST_METHOD,
-  HTTP_RESPONSE_STATUS_CODE,
   CLIENT_ADDRESS,
   CLIENT_PORT,
+  HTTP_REQUEST_METHOD,
+  HTTP_RESPONSE_STATUS_CODE,
   NETWORK_LOCAL_ADDRESS,
   NETWORK_LOCAL_PORT,
   NETWORK_PEER_ADDRESS,
@@ -13,10 +12,12 @@ import {
   NETWORK_PROTOCOL_NAME,
   NETWORK_PROTOCOL_VERSION,
   NETWORK_TRANSPORT,
-  SERVER_ADDRESS,
-  SERVER_PORT,
   SENTRY_HTTP_PREFETCH,
   SENTRY_KIND,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
+  SERVER_ADDRESS,
+  SERVER_PORT,
   URL_FRAGMENT,
   URL_FULL,
   URL_PATH,
@@ -24,6 +25,7 @@ import {
   URL_SCHEME,
   USER_AGENT_ORIGINAL,
 } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 import type {
   Event,
   HttpIncomingMessage,
@@ -40,7 +42,6 @@ import {
   httpHeadersToSpanAttributes,
   getContentLengthFromHeaders,
   parseStringToURLObject,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   stripUrlQueryAndFragment,
@@ -165,7 +166,7 @@ const _httpServerSpansIntegration = ((options: HttpServerSpansIntegrationOptions
             attributes: {
               // Sentry specific attributes
               [SENTRY_KIND]: 'server',
-              [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+              [SENTRY_OP]: HTTP_SERVER,
               [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.http_server',
               [SENTRY_HTTP_PREFETCH]: isKnownPrefetchRequest(request) || undefined,

--- a/packages/node/src/integrations/node-fetch/undici-instrumentation.ts
+++ b/packages/node/src/integrations/node-fetch/undici-instrumentation.ts
@@ -56,6 +56,7 @@ import {
   URL_SCHEME,
   USER_AGENT_ORIGINAL,
 } from '@sentry/conventions/attributes';
+import { HTTP_CLIENT } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../../debug-build';
 import type {
   NodeFetchOptions,
@@ -216,7 +217,7 @@ function onRequestCreated(config: NodeFetchOptions, { request }: RequestMessage)
   const requestMethod = getRequestMethod(request.method);
   const attributes: SpanAttributes = {
     [SENTRY_KIND]: 'client',
-    [SENTRY_OP]: 'http.client',
+    [SENTRY_OP]: HTTP_CLIENT,
     [HTTP_REQUEST_METHOD]: requestMethod,
     [ATTR_HTTP_REQUEST_METHOD_ORIGINAL]: request.method,
     [URL_FULL]: filterCollectedUrl(requestUrl.toString()),

--- a/packages/nuxt/src/runtime/utils/instrumentDatabase.ts
+++ b/packages/nuxt/src/runtime/utils/instrumentDatabase.ts
@@ -1,9 +1,10 @@
+import { SENTRY_OP } from '@sentry/conventions/attributes';
+import { DB_QUERY } from '@sentry/conventions/op';
 import {
   addBreadcrumb,
   captureException,
   debug,
   flushIfServerless,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   type Span,
   SPAN_STATUS_ERROR,
@@ -225,7 +226,7 @@ function createStartSpanOptions(query: string, data: DatabaseSpanData): StartSpa
     attributes: {
       'db.query.text': query,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: SENTRY_ORIGIN,
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db.query',
+      [SENTRY_OP]: DB_QUERY,
       ...data,
     },
   };

--- a/packages/react-router/src/client/createClientInstrumentation.ts
+++ b/packages/react-router/src/client/createClientInstrumentation.ts
@@ -9,7 +9,6 @@ import {
   GLOBAL_OBJ,
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   spanToJSON,
   SPAN_STATUS_ERROR,
@@ -33,7 +32,7 @@ import {
   URL_FULL,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
-import { FUNCTION, MIDDLEWARE } from '@sentry/conventions/op';
+import { FUNCTION, MIDDLEWARE, NAVIGATION } from '@sentry/conventions/op';
 
 const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
@@ -118,7 +117,7 @@ export function createSentryClientInstrumentation(
               name: hasSpanStreamingEnabled(client) ? NAVIGATION_SPAN_NAME_FALLBACK : pathname,
               attributes: {
                 [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
-                [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+                [SENTRY_OP]: NAVIGATION,
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react_router.instrumentation_api',
                 'navigation.type': 'browser.popstate',
               },
@@ -163,7 +162,7 @@ export function createSentryClientInstrumentation(
                   name: hasSpanStreamingEnabled(client) ? NAVIGATION_SPAN_NAME_FALLBACK : currentPathname,
                   attributes: {
                     [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
-                    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+                    [SENTRY_OP]: NAVIGATION,
                     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react_router.instrumentation_api',
                     'navigation.type': navigationType,
                   },
@@ -210,7 +209,7 @@ export function createSentryClientInstrumentation(
                 name: hasSpanStreamingEnabled(client) ? NAVIGATION_SPAN_NAME_FALLBACK : toPath,
                 attributes: {
                   [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
-                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+                  [SENTRY_OP]: NAVIGATION,
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react_router.instrumentation_api',
                   'navigation.type': 'router.navigate',
                 },

--- a/packages/react-router/src/client/hydratedRouter.ts
+++ b/packages/react-router/src/client/hydratedRouter.ts
@@ -9,7 +9,6 @@ import {
   hasSpanStreamingEnabled,
   isThenable,
   NAVIGATION_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   spanToJSON,
 } from '@sentry/core';
@@ -24,6 +23,7 @@ import {
   updateSpanWithParameterizedRoute,
 } from './utils';
 import { SENTRY_SEGMENT_NAME_SOURCE, SENTRY_OP, URL_PATH, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION } from '@sentry/conventions/op';
 
 const GLOBAL_OBJ_WITH_DATA_ROUTER = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   __reactRouterDataRouter?: DataRouter;
@@ -186,7 +186,7 @@ function maybeCreateNavigationTransaction(name: string, url: string, source: 'ur
       name: source === 'route' || !hasSpanStreamingEnabled(client) ? name : NAVIGATION_SPAN_NAME_FALLBACK,
       attributes: {
         [SENTRY_SEGMENT_NAME_SOURCE]: source,
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        [SENTRY_OP]: NAVIGATION,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react_router',
         ...(source === 'route' ? { [URL_TEMPLATE]: name } : {}),
       },

--- a/packages/react-router/src/server/createServerInstrumentation.ts
+++ b/packages/react-router/src/server/createServerInstrumentation.ts
@@ -7,7 +7,7 @@ import {
   URL_FULL,
   URL_PATH,
 } from '@sentry/conventions/attributes';
-import { FUNCTION, MIDDLEWARE } from '@sentry/conventions/op';
+import { FUNCTION, HTTP_SERVER, MIDDLEWARE } from '@sentry/conventions/op';
 import {
   debug,
   flushIfServerless,
@@ -17,7 +17,6 @@ import {
   getRootSpan,
   hasSpanStreamingEnabled,
   HTTP_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   startSpan,
@@ -81,7 +80,7 @@ export function createSentryServerInstrumentation(
           if (existingRootSpan) {
             updateSpanName(existingRootSpan, unparameterizedName);
             existingRootSpan.setAttributes({
-              [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+              [SENTRY_OP]: HTTP_SERVER,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.react_router.instrumentation_api',
               [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
               [URL_FULL]: filterCollectedUrl(info.request.url),
@@ -106,7 +105,7 @@ export function createSentryServerInstrumentation(
                 name: unparameterizedName,
                 forceTransaction: true,
                 attributes: {
-                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+                  [SENTRY_OP]: HTTP_SERVER,
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.react_router.instrumentation_api',
                   [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
                   [HTTP_REQUEST_METHOD]: info.request.method,

--- a/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
+++ b/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
@@ -17,7 +17,6 @@ import {
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   spanToJSON,
 } from '@sentry/core';
@@ -50,6 +49,7 @@ import {
   transactionNameHasWildcard,
 } from './utils';
 import { SENTRY_SEGMENT_NAME_SOURCE, SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 
 let _useEffect: UseEffect;
 let _useLocation: UseLocation;
@@ -732,7 +732,7 @@ export function createReactRouterV6CompatibleTracingIntegration(
           name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : initPathName,
           attributes: {
             [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+            [SENTRY_OP]: PAGELOAD,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.pageload.react.reactrouter${version ? `_v${version}` : ''}`,
           },
         });
@@ -1041,7 +1041,7 @@ export function handleNavigation(opts: {
             : NAVIGATION_SPAN_NAME_FALLBACK,
         attributes: {
           [SENTRY_SEGMENT_NAME_SOURCE]: source,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+          [SENTRY_OP]: NAVIGATION,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.navigation.react.reactrouter${version ? `_v${version}` : ''}`,
           ...(source === 'route' && { [URL_TEMPLATE]: placeholderEntry.routeName }),
         },

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -20,7 +20,8 @@ import type { ReactElement } from 'react';
 import * as React from 'react';
 import { hoistNonReactStatics } from './hoist-non-react-statics';
 import type { Action, Location } from './types';
-import { SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 
 // We need to disable eslint no-explicit-any because any is required for the
 // react-router typings.
@@ -163,7 +164,7 @@ function instrumentReactRouter(
         // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
         name: source === 'route' || !hasSpanStreamingEnabled(client) ? name : PAGELOAD_SPAN_NAME_FALLBACK,
         attributes: {
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+          [SENTRY_OP]: PAGELOAD,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.pageload.react.${instrumentationName}`,
           [SENTRY_SEGMENT_NAME_SOURCE]: source,
           ...(source === 'route' && { [URL_TEMPLATE]: name }),
@@ -180,7 +181,7 @@ function instrumentReactRouter(
           // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
           name: source === 'route' || !hasSpanStreamingEnabled(client) ? name : NAVIGATION_SPAN_NAME_FALLBACK,
           attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+            [SENTRY_OP]: NAVIGATION,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.navigation.react.${instrumentationName}`,
             [SENTRY_SEGMENT_NAME_SOURCE]: source,
             ...(source === 'route' && { [URL_TEMPLATE]: name }),

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -9,11 +9,11 @@ import {
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
 } from '@sentry/core/browser';
 import type { Location } from './types';
-import { SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 
 // Many of the types below had to be mocked out to prevent typescript issues
 // these types are required for correct functionality.
@@ -69,7 +69,7 @@ export function reactRouterV3BrowserTracingIntegration(
               // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
               name: source === 'route' || !hasSpanStreamingEnabled(client) ? localName : PAGELOAD_SPAN_NAME_FALLBACK,
               attributes: {
-                [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+                [SENTRY_OP]: PAGELOAD,
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v3',
                 [SENTRY_SEGMENT_NAME_SOURCE]: source,
                 ...(source === 'route' && { [URL_TEMPLATE]: localName }),
@@ -92,7 +92,7 @@ export function reactRouterV3BrowserTracingIntegration(
                   name:
                     source === 'route' || !hasSpanStreamingEnabled(client) ? localName : NAVIGATION_SPAN_NAME_FALLBACK,
                   attributes: {
-                    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+                    [SENTRY_OP]: NAVIGATION,
                     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
                     [SENTRY_SEGMENT_NAME_SOURCE]: source,
                     ...(source === 'route' && { [URL_TEMPLATE]: localName }),

--- a/packages/react/src/tanstackrouter.ts
+++ b/packages/react/src/tanstackrouter.ts
@@ -12,16 +12,18 @@ import {
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
 } from '@sentry/core';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core/browser';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core/browser';
 import type { VendoredTanstackRouter, VendoredTanstackRouterRouteMatch } from './vendor/tanstackrouter-types';
 import {
-  SENTRY_SEGMENT_NAME_SOURCE,
   PARAMS_KEY_BASE,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
   URL_FULL,
   URL_PATH,
   URL_PATH_PARAMETER_KEY_BASE,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 
 interface TanstackRouterLocation {
   pathname: string;
@@ -101,7 +103,7 @@ export function tanstackRouterBrowserTracingIntegration(
               ? PAGELOAD_SPAN_NAME_FALLBACK
               : initialWindowLocation.pathname,
           attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+            [SENTRY_OP]: PAGELOAD,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.tanstack_router',
             [SENTRY_SEGMENT_NAME_SOURCE]: routeMatch ? 'route' : 'url',
             ...(routeMatch && { [URL_TEMPLATE]: routeMatch.routeId }),
@@ -158,7 +160,7 @@ export function tanstackRouterBrowserTracingIntegration(
             {
               name: routeMatch ? routeMatch.routeId : fallbackName,
               attributes: {
-                [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+                [SENTRY_OP]: NAVIGATION,
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.tanstack_router',
                 [SENTRY_SEGMENT_NAME_SOURCE]: routeMatch ? 'route' : 'url',
                 ...(routeMatch && { [URL_TEMPLATE]: routeMatch.routeId }),

--- a/packages/remix/src/client/performance.tsx
+++ b/packages/remix/src/client/performance.tsx
@@ -15,7 +15,8 @@ import { getClient, startBrowserTracingNavigationSpan, startBrowserTracingPageLo
 import * as React from 'react';
 import { DEBUG_BUILD } from '../utils/debug-build';
 import { hasManifest, maybeParameterizeRemixRoute } from './remixRouteParameterization';
-import { SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_OP, SENTRY_SEGMENT_NAME_SOURCE, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 
 export type Params<Key extends string = string> = {
   readonly [key in Key]: string | undefined;
@@ -101,8 +102,8 @@ export function startPageloadSpan(client: Client): void {
   const spanContext: StartSpanOptions = {
     // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
     name: source === 'route' || !hasSpanStreamingEnabled(client) ? spanName : PAGELOAD_SPAN_NAME_FALLBACK,
-    op: 'pageload',
     attributes: {
+      [SENTRY_OP]: PAGELOAD,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.remix',
       [SENTRY_SEGMENT_NAME_SOURCE]: source,
       ...(source === 'route' && { [URL_TEMPLATE]: spanName }),
@@ -126,8 +127,8 @@ function startNavigationSpan(matches: RouteMatch<string>[], location: ReturnType
   const spanContext: StartSpanOptions = {
     // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
     name: source === 'route' || !hasSpanStreamingEnabled(client) ? name : NAVIGATION_SPAN_NAME_FALLBACK,
-    op: 'navigation',
     attributes: {
+      [SENTRY_OP]: NAVIGATION,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.remix',
       [SENTRY_SEGMENT_NAME_SOURCE]: source,
       ...(source === 'route' && { [URL_TEMPLATE]: name }),

--- a/packages/remix/src/server/instrumentServer.ts
+++ b/packages/remix/src/server/instrumentServer.ts
@@ -27,7 +27,6 @@ import {
   httpHeadersToSpanAttributes,
   isNodeEnv,
   loadModule,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   setHttpStatus,
   spanToJSON,
@@ -50,7 +49,7 @@ import {
   URL_FULL,
   URL_PATH,
 } from '@sentry/conventions/attributes';
-import { FUNCTION } from '@sentry/conventions/op';
+import { FUNCTION, HTTP_SERVER } from '@sentry/conventions/op';
 
 type AppData = unknown;
 type RemixRequest = Parameters<RequestHandler>[0];
@@ -409,7 +408,7 @@ function wrapRequestHandler<T extends ServerBuild | (() => ServerBuild | Promise
                 attributes: {
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.remix',
                   [SENTRY_SEGMENT_NAME_SOURCE]: source,
-                  [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+                  [SENTRY_OP]: HTTP_SERVER,
                   [URL_FULL]: filterCollectedUrl(url.href),
                   [URL_PATH]: url.pathname,
                   method: request.method,

--- a/packages/remix/src/server/integrations/tracing-channel.ts
+++ b/packages/remix/src/server/integrations/tracing-channel.ts
@@ -9,7 +9,6 @@ import {
   isObjectLike,
   isURLObjectRelative,
   parseStringToURLObject,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   spanToJSON,
   startInactiveSpan,
@@ -28,7 +27,7 @@ import {
   HTTP_REQUEST_METHOD,
   HTTP_RESPONSE_STATUS_CODE,
 } from '@sentry/conventions/attributes';
-import { FUNCTION } from '@sentry/conventions/op';
+import { FUNCTION, HTTP_SERVER } from '@sentry/conventions/op';
 import { remixChannels } from '@sentry/server-utils/orchestrion/config';
 import type { FormDataCapture } from '../../utils/formData';
 import { applyFormDataAttributes } from '../../utils/formData';
@@ -160,7 +159,7 @@ function subscribeRequestHandler(): void {
         attributes: {
           [SENTRY_KIND]: 'server',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+          [SENTRY_OP]: HTTP_SERVER,
           ...(hasUrlName && { [SENTRY_SEGMENT_NAME_SOURCE]: 'url' }),
           [CODE_FUNCTION_NAME]: 'requestHandler',
           ...requestAttributes,

--- a/packages/server-utils/src/ai/core/gen-ai-attributes.ts
+++ b/packages/server-utils/src/ai/core/gen-ai-attributes.ts
@@ -31,21 +31,6 @@ export const GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE = 'gen_ai.request.dimensions';
 export const GEN_AI_RESPONSE_STOP_REASON_ATTRIBUTE = 'gen_ai.response.stop_reason';
 
 /**
- * The span operation name for invoking an agent
- */
-export const GEN_AI_INVOKE_AGENT_OPERATION_ATTRIBUTE = 'gen_ai.invoke_agent';
-
-/**
- * The span operation for embeddings
- */
-export const GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE = 'gen_ai.embeddings';
-
-/**
- * The span operation name for executing a tool
- */
-export const GEN_AI_EXECUTE_TOOL_OPERATION_ATTRIBUTE = 'gen_ai.execute_tool';
-
-/**
  * The tool call ID
  */
 export const GEN_AI_TOOL_CALL_ID_ATTRIBUTE = 'gen_ai.tool.call.id';

--- a/packages/server-utils/src/ai/langchain/embeddings.ts
+++ b/packages/server-utils/src/ai/langchain/embeddings.ts
@@ -1,7 +1,6 @@
 import {
   getClient,
   hasSpanStreamingEnabled,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startSpan,
   stringify,
@@ -12,9 +11,10 @@ import {
   GEN_AI_OPERATION_NAME,
   GEN_AI_PROVIDER_NAME,
   GEN_AI_REQUEST_MODEL,
+  SENTRY_OP,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_EMBEDDINGS } from '@sentry/conventions/op';
 import {
-  GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE,
   GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE,
   GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE,
 } from '../core/gen-ai-attributes';
@@ -46,7 +46,7 @@ function extractEmbeddingAttributes(instance: unknown): Record<string, unknown> 
 
   const attributes: Record<string, unknown> = {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: LANGCHAIN_ORIGIN,
-    [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE,
+    [SENTRY_OP]: GEN_AI_EMBEDDINGS,
     [GEN_AI_OPERATION_NAME]: 'embeddings',
     [GEN_AI_REQUEST_MODEL]: embeddingsInstance.model ?? 'unknown',
   };
@@ -72,7 +72,7 @@ export function _INTERNAL_getLangChainEmbeddingsSpanOptions(
   instance: unknown,
   input: unknown,
   options: LangChainOptions = {},
-): { name: string; op: string; attributes: Record<string, SpanAttributeValue> } {
+): { name: string; attributes: Record<string, SpanAttributeValue> } {
   const { recordInputs } = resolveAIRecordingOptions(options);
   const attributes = extractEmbeddingAttributes(instance);
   const modelName = attributes[GEN_AI_REQUEST_MODEL] || 'unknown';
@@ -88,7 +88,6 @@ export function _INTERNAL_getLangChainEmbeddingsSpanOptions(
       (typeof modelName === 'string' && modelName !== 'unknown') || !(client && hasSpanStreamingEnabled(client))
         ? `embeddings ${modelName}`
         : 'embeddings',
-    op: GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE,
     attributes: attributes as Record<string, SpanAttributeValue>,
   };
 }

--- a/packages/server-utils/src/ai/langchain/index.ts
+++ b/packages/server-utils/src/ai/langchain/index.ts
@@ -2,7 +2,6 @@
 import {
   getClient,
   hasSpanStreamingEnabled,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   SPAN_STATUS_ERROR,
   startSpanManual,
@@ -16,7 +15,9 @@ import {
   GEN_AI_TOOL_CALL_RESULT,
   GEN_AI_TOOL_DEFINITIONS,
   GEN_AI_TOOL_NAME,
+  SENTRY_OP,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_CHAT, GEN_AI_EXECUTE_TOOL, GEN_AI_INVOKE_AGENT } from '@sentry/conventions/op';
 import { resolveAIRecordingOptions } from '../core/utils';
 import { LANGCHAIN_ORIGIN } from './constants';
 import type {
@@ -113,11 +114,10 @@ export function createLangChainCallbackHandler(options: LangChainOptions = {}): 
             (typeof modelName === 'string' && modelName !== 'unknown') || !(client && hasSpanStreamingEnabled(client))
               ? `${operationName} ${modelName}`
               : operationName,
-          op: 'gen_ai.chat',
           attributes: {
             ...getAgentNameFromMetadata(metadata),
             ...attributes,
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
+            [SENTRY_OP]: GEN_AI_CHAT,
           },
         },
         span => {
@@ -164,11 +164,10 @@ export function createLangChainCallbackHandler(options: LangChainOptions = {}): 
             (typeof modelName === 'string' && modelName !== 'unknown') || !(client && hasSpanStreamingEnabled(client))
               ? `${operationName} ${modelName}`
               : operationName,
-          op: 'gen_ai.chat',
           attributes: {
             ...getAgentNameFromMetadata(metadata),
             ...attributes,
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.chat',
+            [SENTRY_OP]: GEN_AI_CHAT,
           },
         },
         span => {
@@ -247,10 +246,9 @@ export function createLangChainCallbackHandler(options: LangChainOptions = {}): 
             : chainName === 'unknown_chain'
               ? 'invoke_agent'
               : `invoke_agent ${chainName}`,
-          op: 'gen_ai.invoke_agent',
           attributes: {
             ...attributes,
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.invoke_agent',
+            [SENTRY_OP]: GEN_AI_INVOKE_AGENT,
           },
         },
         span => {
@@ -317,10 +315,9 @@ export function createLangChainCallbackHandler(options: LangChainOptions = {}): 
       startSpanManual(
         {
           name: `execute_tool ${toolName}`,
-          op: 'gen_ai.execute_tool',
           attributes: {
             ...attributes,
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'gen_ai.execute_tool',
+            [SENTRY_OP]: GEN_AI_EXECUTE_TOOL,
           },
         },
         span => {

--- a/packages/server-utils/src/ai/langgraph/index.ts
+++ b/packages/server-utils/src/ai/langgraph/index.ts
@@ -1,11 +1,5 @@
 /* eslint-disable typescript-eslint/no-deprecated */
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SPAN_STATUS_ERROR,
-  startSpan,
-  stringify,
-} from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SPAN_STATUS_ERROR, startSpan, stringify } from '@sentry/core';
 import {
   GEN_AI_AGENT_NAME,
   GEN_AI_CONVERSATION_ID,
@@ -15,8 +9,9 @@ import {
   GEN_AI_REQUEST_MODEL,
   GEN_AI_SYSTEM_INSTRUCTIONS,
   GEN_AI_TOOL_DEFINITIONS,
+  SENTRY_OP,
 } from '@sentry/conventions/attributes';
-import { GEN_AI_INVOKE_AGENT_OPERATION_ATTRIBUTE } from '../core/gen-ai-attributes';
+import { GEN_AI_INVOKE_AGENT } from '@sentry/conventions/op';
 import { extractSystemInstructions, resolveAIRecordingOptions } from '../core/utils';
 import { createLangChainCallbackHandler } from '../langchain';
 import type { BaseChatModel, LangChainMessage } from '../langchain/types';
@@ -99,11 +94,10 @@ export function instrumentCompiledGraphInvoke(
       const modelName = llm?.modelName ?? llm?.model;
       return startSpan(
         {
-          op: 'gen_ai.invoke_agent',
           name: 'invoke_agent',
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: LANGGRAPH_ORIGIN,
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GEN_AI_INVOKE_AGENT_OPERATION_ATTRIBUTE,
+            [SENTRY_OP]: GEN_AI_INVOKE_AGENT,
             [GEN_AI_OPERATION_NAME]: 'invoke_agent',
           },
         },

--- a/packages/server-utils/src/ai/langgraph/utils.ts
+++ b/packages/server-utils/src/ai/langgraph/utils.ts
@@ -1,10 +1,5 @@
 /* eslint-disable typescript-eslint/no-deprecated */
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  SPAN_STATUS_ERROR,
-  startSpan,
-} from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, SPAN_STATUS_ERROR, startSpan } from '@sentry/core';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   GEN_AI_AGENT_NAME,
@@ -20,8 +15,10 @@ import {
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
+  SENTRY_OP,
 } from '@sentry/conventions/attributes';
-import { GEN_AI_EXECUTE_TOOL_OPERATION_ATTRIBUTE, GEN_AI_TOOL_CALL_ID_ATTRIBUTE } from '../core/gen-ai-attributes';
+import { GEN_AI_EXECUTE_TOOL } from '@sentry/conventions/op';
+import { GEN_AI_TOOL_CALL_ID_ATTRIBUTE } from '../core/gen-ai-attributes';
 import type { BaseChatModel, LangChainMessage } from '../langchain/types';
 import { normalizeLangChainMessages } from '../langchain/utils';
 import { LANGGRAPH_ORIGIN } from './constants';
@@ -79,7 +76,7 @@ export function wrapToolsWithSpans(tools: unknown[], options: LangGraphOptions, 
       apply(target, thisArg, args: unknown[]): unknown {
         const spanAttributes: SpanAttributes = {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: LANGGRAPH_ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: GEN_AI_EXECUTE_TOOL_OPERATION_ATTRIBUTE,
+          [SENTRY_OP]: GEN_AI_EXECUTE_TOOL,
           [GEN_AI_OPERATION_NAME]: 'execute_tool',
           [GEN_AI_TOOL_NAME]: toolName,
         };
@@ -115,7 +112,6 @@ export function wrapToolsWithSpans(tools: unknown[], options: LangGraphOptions, 
 
         return startSpan(
           {
-            op: GEN_AI_EXECUTE_TOOL_OPERATION_ATTRIBUTE,
             name: `execute_tool ${toolName}`,
             attributes: spanAttributes,
           },

--- a/packages/server-utils/src/ai/workers-ai/index.ts
+++ b/packages/server-utils/src/ai/workers-ai/index.ts
@@ -1,3 +1,4 @@
+import { SENTRY_OP } from '@sentry/conventions/attributes';
 import {
   _INTERNAL_shouldSkipAiProviderWrapping,
   getClient,
@@ -12,7 +13,13 @@ import { resolveAIRecordingOptions } from '../core/utils';
 import { WORKERS_AI_INTEGRATION_NAME } from './constants';
 import { instrumentWorkersAiStream } from './streaming';
 import type { WorkersAiOptions } from './types';
-import { addRequestAttributes, addResponseAttributes, extractRequestAttributes, getOperationName } from './utils';
+import {
+  addRequestAttributes,
+  addResponseAttributes,
+  extractRequestAttributes,
+  getOperationName,
+  WORKERS_AI_OPERATION_SPAN_OPS,
+} from './utils';
 
 // Adapted from /server-utils/src/vercel-ai/util.ts
 // TODO(v11): Reuse this function once this gets moved to @sentry/server-utils
@@ -60,8 +67,10 @@ function instrumentRun(
         modelName !== 'unknown' || !(client && hasSpanStreamingEnabled(client))
           ? `${operationName} ${modelName}`
           : operationName,
-      op: `gen_ai.${operationName}`,
-      attributes: requestAttributes,
+      attributes: {
+        [SENTRY_OP]: WORKERS_AI_OPERATION_SPAN_OPS[operationName],
+        ...requestAttributes,
+      },
     };
 
     if (isStreamRequested && !returnsRawResponse) {

--- a/packages/server-utils/src/ai/workers-ai/utils.ts
+++ b/packages/server-utils/src/ai/workers-ai/utils.ts
@@ -16,6 +16,7 @@ import {
   GEN_AI_RESPONSE_TOOL_CALLS,
   GEN_AI_SYSTEM_INSTRUCTIONS,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_CHAT, GEN_AI_EMBEDDINGS } from '@sentry/conventions/op';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, stringify } from '@sentry/core';
 import type { Span, SpanAttributeValue } from '@sentry/core';
 import { GEN_AI_REQUEST_STREAM_ATTRIBUTE } from '../core/gen-ai-attributes';
@@ -27,7 +28,14 @@ import type { WorkersAiInput, WorkersAiOutput } from './types';
  * Determine the gen_ai operation name from the inputs passed to `AI.run`.
  * Workers AI exposes a single `run` method, so we infer the operation from the input shape.
  */
-export function getOperationName(inputs: unknown): string {
+export type WorkersAiOperationName = 'chat' | 'embeddings';
+
+export const WORKERS_AI_OPERATION_SPAN_OPS: Record<WorkersAiOperationName, string> = {
+  chat: GEN_AI_CHAT,
+  embeddings: GEN_AI_EMBEDDINGS,
+};
+
+export function getOperationName(inputs: unknown): WorkersAiOperationName {
   if (inputs && typeof inputs === 'object') {
     if ('messages' in inputs || 'prompt' in inputs) {
       return 'chat';

--- a/packages/server-utils/src/integrations/aws-sdk/index.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/index.ts
@@ -8,6 +8,7 @@ import {
   SENTRY_KIND,
   HTTP_RESPONSE_STATUS_CODE,
 } from '@sentry/conventions/attributes';
+import { RPC } from '@sentry/conventions/op';
 import { CHANNELS } from '../../orchestrion/channels';
 import { awsSdkModuleNames } from '../../orchestrion/config/aws-sdk';
 import { invokeOrchestrionInstrumentation } from '../../orchestrion/instrumentation';
@@ -107,7 +108,7 @@ function instrumentAwsSdk(servicesExtensions: ServicesExtensions): void {
         name: requestMetadata.spanName ?? `${normalizedRequest.serviceName}.${normalizedRequest.commandName}`,
         // `rpc` matches what the exporter infers from `rpc.service` for the OTel aws-sdk spans;
         // service extensions override it where inference yields a different op (DynamoDB: `db`).
-        op: requestMetadata.spanOp || 'rpc',
+        op: requestMetadata.spanOp || RPC,
         attributes: {
           [SENTRY_KIND]: 'client',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: AWS_SDK_ORIGIN,

--- a/packages/server-utils/src/integrations/aws-sdk/services/bedrock-runtime.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/services/bedrock-runtime.ts
@@ -12,6 +12,7 @@ import {
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_CHAT, GEN_AI_GENERATE_CONTENT } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../../../debug-build';
 import {
   GEN_AI_OPERATION_NAME_VALUE_CHAT,
@@ -117,7 +118,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
 
     return {
       spanName,
-      spanOp: 'gen_ai.chat',
+      spanOp: GEN_AI_CHAT,
       isStream,
       spanAttributes,
     };
@@ -243,7 +244,7 @@ export class BedrockRuntimeServiceExtension implements ServiceExtension {
 
     return {
       spanName,
-      spanOp: 'gen_ai.generate_content',
+      spanOp: GEN_AI_GENERATE_CONTENT,
       isStream,
       spanAttributes,
     };

--- a/packages/server-utils/src/integrations/aws-sdk/services/dynamodb.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/services/dynamodb.ts
@@ -25,6 +25,7 @@ import {
   DB_OPERATION_NAME,
   DB_SYSTEM_NAME,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import { DB_SYSTEM_VALUE_DYNAMODB } from '../constants';
 import type { NormalizedRequest, NormalizedResponse } from '../types';
 import type { RequestMetadata, ServiceExtension } from './ServiceExtension';
@@ -150,7 +151,7 @@ export class DynamodbServiceExtension implements ServiceExtension {
     return {
       spanAttributes,
       // Matches what the exporter infers from the db system for the OTel DynamoDB spans.
-      spanOp: 'db',
+      spanOp: DB,
     };
   }
 

--- a/packages/server-utils/src/integrations/express/instrumentation.ts
+++ b/packages/server-utils/src/integrations/express/instrumentation.ts
@@ -1,6 +1,6 @@
 import type * as diagnosticsChannel from 'node:diagnostics_channel';
 import { HTTP_ROUTE, SENTRY_OP } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
+import { HANDLER, MIDDLEWARE, ROUTER } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   captureException,
@@ -51,11 +51,10 @@ const ORIGIN = 'auto.http.express';
 const ATTR_EXPRESS_NAME = 'express.name';
 const ATTR_EXPRESS_TYPE = 'express.type';
 
-// TODO(conventions): Replace `'handler'` and `'router'` with their span op constants once they are released in `@sentry/conventions`.
 const EXPRESS_TYPE_TO_SPAN_OP: Record<string, string> = {
   middleware: MIDDLEWARE,
-  request_handler: 'handler',
-  router: 'router',
+  request_handler: HANDLER,
+  router: ROUTER,
 };
 
 const NOOP = (): void => {};

--- a/packages/server-utils/src/integrations/fastify/instrumentation.ts
+++ b/packages/server-utils/src/integrations/fastify/instrumentation.ts
@@ -22,7 +22,7 @@ import {
   SENTRY_OP,
   URL_PATH,
 } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
+import { HANDLER, MIDDLEWARE } from '@sentry/conventions/op';
 import type { Span } from '@sentry/core';
 import {
   isObjectLike,
@@ -38,9 +38,6 @@ import { setHttpServerSpanRouteAttribute } from '../../utils/setHttpServerSpanRo
 import { handleFastifyError } from './errors';
 
 const ORIGIN = 'auto.http.fastify';
-const HOOK_OP = MIDDLEWARE;
-// TODO(conventions): Replace with the `handler` span op constant once it is released in `@sentry/conventions`.
-const REQUEST_HANDLER_OP = 'handler';
 
 const FASTIFY_HOOKS = [
   'onRequest',
@@ -169,7 +166,7 @@ function onRequest(this: any, request: any, _reply: any, hookDone: () => void): 
 
   const attributes: Record<string, string> = {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-    [SENTRY_OP]: REQUEST_HANDLER_OP,
+    [SENTRY_OP]: HANDLER,
     [HTTP_REQUEST_METHOD]: request.method,
     [URL_PATH]: request.url,
   };
@@ -329,8 +326,7 @@ function handlerWrapper(handler: AnyFn, hookName: string, spanAttributes: Record
     const handlerName = handler.name?.length > 0 ? handler.name : (this.pluginName ?? ANONYMOUS_FUNCTION_NAME);
 
     const hookType = spanAttributes[ATTRIBUTE_FASTIFY_TYPE];
-    const op =
-      hookType === HOOK_TYPE_INSTANCE ? HOOK_OP : hookType === HOOK_TYPE_HANDLER ? REQUEST_HANDLER_OP : undefined;
+    const op = hookType === HOOK_TYPE_INSTANCE ? MIDDLEWARE : hookType === HOOK_TYPE_HANDLER ? HANDLER : undefined;
 
     const attributeHookName = spanAttributes[ATTRIBUTE_HOOK_NAME];
 

--- a/packages/server-utils/src/integrations/firebase/firestore.ts
+++ b/packages/server-utils/src/integrations/firebase/firestore.ts
@@ -5,9 +5,11 @@ import {
   DB_OPERATION_NAME,
   DB_SYSTEM_NAME,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB_QUERY } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 import type { FirebaseApp, FirebaseOptions, FirestoreReference, FirestoreSettings } from './firestore-types';
@@ -19,8 +21,8 @@ import type { FirebaseApp, FirebaseOptions, FirestoreReference, FirestoreSetting
 export function startFirestoreSpan(spanName: string, reference: FirestoreReference): Span {
   return startInactiveSpan({
     name: `${spanName} ${reference.path}`,
-    op: 'db.query',
     attributes: {
+      [SENTRY_OP]: DB_QUERY,
       [SENTRY_KIND]: 'client',
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.firebase.firestore',
       [DB_OPERATION_NAME]: spanName,

--- a/packages/server-utils/src/integrations/hapi/hapi-utils.ts
+++ b/packages/server-utils/src/integrations/hapi/hapi-utils.ts
@@ -19,7 +19,7 @@ import {
   startSpan,
 } from '@sentry/core';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
+import { HANDLER, MIDDLEWARE, ROUTER } from '@sentry/conventions/op';
 import type {
   HapiRequest,
   LifecycleMethod,
@@ -164,10 +164,9 @@ export const getExtMetadata = (
   };
 };
 
-// TODO(conventions): Replace `'handler'` and `'router'` with their span op constants once they are released in `@sentry/conventions`.
 const HAPI_TYPE_TO_SPAN_OP: Record<string, string> = {
-  [HapiLayerType.PLUGIN]: 'handler',
-  [HapiLayerType.ROUTER]: 'router',
+  [HapiLayerType.PLUGIN]: HANDLER,
+  [HapiLayerType.ROUTER]: ROUTER,
   [HapiLayerType.EXT]: MIDDLEWARE,
 };
 

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -22,9 +22,11 @@ import {
   DB_USER,
   NETWORK_TRANSPORT,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../debug-build';
 import { CHANNELS } from '../orchestrion/channels';
 import { bindTracingChannelToSpan } from '../tracing-channel';
@@ -168,6 +170,7 @@ function subscribeQuery(): void {
 
       const dbStatement = query?.sql != null ? truncate(query.sql, MAX_QUERY_LENGTH) : undefined;
       const attributes: SpanAttributes = {
+        [SENTRY_OP]: DB,
         [SENTRY_KIND]: 'client',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
         'knex.version': data.moduleVersion,
@@ -184,7 +187,6 @@ function subscribeQuery(): void {
 
       return startInactiveSpan({
         name: dbStatement ?? getName(name, operation, table) ?? 'knex.query',
-        op: 'db',
         parentSpan,
         attributes,
       });

--- a/packages/server-utils/src/integrations/koa/index.ts
+++ b/packages/server-utils/src/integrations/koa/index.ts
@@ -15,7 +15,7 @@ import {
 } from '@sentry/core';
 // oxlint-disable-next-line typescript/no-deprecated
 import { CODE_FUNCTION_NAME, HTTP_ROUTE, KOA_NAME, KOA_TYPE, SENTRY_OP } from '@sentry/conventions/attributes';
-import { MIDDLEWARE } from '@sentry/conventions/op';
+import { MIDDLEWARE, ROUTER } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../../debug-build';
 import { CHANNELS } from '../../orchestrion/channels';
 import { koaModuleNames } from '../../orchestrion/config/koa';
@@ -213,8 +213,7 @@ function patchLayer(
         name,
         attributes: {
           ...metadata.attributes,
-          // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
-          [SENTRY_OP]: layerType === LAYER_TYPE.MIDDLEWARE ? MIDDLEWARE : 'router',
+          [SENTRY_OP]: layerType === LAYER_TYPE.MIDDLEWARE ? MIDDLEWARE : ROUTER,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
         },
       },

--- a/packages/server-utils/src/integrations/mongodb/mongodb-span.ts
+++ b/packages/server-utils/src/integrations/mongodb/mongodb-span.ts
@@ -5,9 +5,11 @@ import {
   DB_QUERY_TEXT,
   DB_SYSTEM_NAME,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   getClient,
@@ -222,7 +224,7 @@ export function getV3SpanAttributes(
 /**
  * Start a mongodb client span on the stable conventions.
  *
- * `op: 'db'` is set explicitly rather than relying on `inferDbSpanData`,
+ * The `db` op is set explicitly rather than relying on `inferDbSpanData`,
  * to support platforms that lack it (ie, Deno).
  */
 export function startMongoSpan(attributes: SpanAttributes): Span {
@@ -239,8 +241,8 @@ export function startMongoSpan(attributes: SpanAttributes): Span {
 
   return startInactiveSpan({
     name,
-    op: 'db',
     attributes: {
+      [SENTRY_OP]: DB,
       [SENTRY_KIND]: 'client',
       ...attributes,
     },

--- a/packages/server-utils/src/integrations/mongoose/mongoose-dc-subscriber.ts
+++ b/packages/server-utils/src/integrations/mongoose/mongoose-dc-subscriber.ts
@@ -6,16 +6,12 @@ import {
   DB_OPERATION_NAME,
   DB_QUERY_TEXT,
   DB_SYSTEM_NAME,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
-import {
-  isObjectLike,
-  debug,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  startInactiveSpan,
-} from '@sentry/core';
+import { DB } from '@sentry/conventions/op';
+import { isObjectLike, debug, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 import { DEBUG_BUILD } from '../../debug-build';
 import { bindTracingChannelToSpan } from '../../tracing-channel';
 
@@ -125,7 +121,7 @@ function setupChannel(tracingChannel: MongooseTracingChannelFactory, channelName
       name: collection ? `mongoose.${collection}.${data.operation}` : `mongoose.${data.operation}`,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+        [SENTRY_OP]: DB,
         [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MONGODB,
         [DB_OPERATION_NAME]: data.operation,
         [DB_COLLECTION_NAME]: collection ?? undefined,

--- a/packages/server-utils/src/integrations/mongoose/mongoose-legacy-span.ts
+++ b/packages/server-utils/src/integrations/mongoose/mongoose-legacy-span.ts
@@ -5,9 +5,11 @@ import {
   DB_SYSTEM_NAME,
   DB_USER,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, startInactiveSpan } from '@sentry/core';
 
@@ -42,6 +44,7 @@ export function startMongooseLegacySpan({
   parentSpan,
 }: StartMongooseLegacySpanOptions): Span {
   const attributes: SpanAttributes = {
+    [SENTRY_OP]: DB,
     [SENTRY_KIND]: 'client',
     [DB_COLLECTION_NAME]: collection?.name,
     [DB_NAMESPACE]: collection?.conn?.name,
@@ -56,7 +59,6 @@ export function startMongooseLegacySpan({
   return startInactiveSpan({
     name: `mongoose.${modelName}.${operation}`,
     // Set this explicitly, for platforms lacking `inferDbSpanData`
-    op: 'db',
     attributes,
     parentSpan,
   });

--- a/packages/server-utils/src/integrations/mysql.ts
+++ b/packages/server-utils/src/integrations/mysql.ts
@@ -6,9 +6,11 @@ import {
   DB_SYSTEM_NAME,
   DB_USER,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import type { IntegrationFn, Scope } from '@sentry/core';
 import {
   _INTERNAL_getSqlQuerySummary,
@@ -97,8 +99,8 @@ function instrumentMysql(): void {
 
       return startInactiveSpan({
         name,
-        op: 'db',
         attributes: {
+          [SENTRY_OP]: DB,
           [SENTRY_KIND]: 'client',
           [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MYSQL,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.mysql',

--- a/packages/server-utils/src/integrations/mysql2/index.ts
+++ b/packages/server-utils/src/integrations/mysql2/index.ts
@@ -7,7 +7,6 @@ import {
   getClient,
   hasSpanStreamingEnabled,
   isObjectLike,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startInactiveSpan,
   waitForTracingChannelBinding,
@@ -25,9 +24,11 @@ import {
   DB_SYSTEM_NAME,
   DB_USER,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 
 const INTEGRATION_NAME = 'Mysql2' as const;
 const ORIGIN = 'auto.db.mysql2';
@@ -99,7 +100,7 @@ function subscribeQueryChannel(channelName: ChannelName): void {
         attributes: {
           [SENTRY_KIND]: 'client',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+          [SENTRY_OP]: DB,
           [DB_SYSTEM_NAME]: DB_SYSTEM_VALUE_MYSQL,
           [DB_QUERY_TEXT]: statement || undefined,
           [DB_QUERY_SUMMARY]: querySummary,

--- a/packages/server-utils/src/integrations/mysql2/mysql2-dc-subscriber.ts
+++ b/packages/server-utils/src/integrations/mysql2/mysql2-dc-subscriber.ts
@@ -5,15 +5,16 @@ import {
   DB_QUERY_SUMMARY,
   DB_QUERY_TEXT,
   DB_SYSTEM_NAME,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import {
   _INTERNAL_getSqlQuerySummary,
   _INTERNAL_sanitizeSqlQuery,
   getClient,
   hasSpanStreamingEnabled,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   startInactiveSpan,
 } from '@sentry/core';
@@ -116,7 +117,7 @@ function setupQueryChannel(tracingChannel: MySQL2TracingChannelFactory, channelN
         name,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+          [SENTRY_OP]: DB,
           [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MYSQL,
           [DB_QUERY_TEXT]: queryText,
           [DB_QUERY_SUMMARY]: querySummary,
@@ -139,7 +140,7 @@ function setupConnectChannel(tracingChannel: MySQL2TracingChannelFactory, channe
         name: spanName,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'db',
+          [SENTRY_OP]: DB,
           [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_VALUE_MYSQL,
           [DB_NAMESPACE]: data.database || undefined,
           [SERVER_ADDRESS]: data.serverAddress,

--- a/packages/server-utils/src/integrations/postgres-js.ts
+++ b/packages/server-utils/src/integrations/postgres-js.ts
@@ -6,7 +6,9 @@ import {
   DB_SYSTEM_NAME,
   ERROR_TYPE,
   SENTRY_KIND,
+  SENTRY_OP,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import type { IntegrationFn, PostgresConnectionContext, Span } from '@sentry/core';
 import {
   _INTERNAL_buildPostgresConnectionContext,
@@ -292,8 +294,8 @@ function instrumentPostgresJs(options: PostgresJsIntegrationOptions): void {
       // `sentry.kind: client` matches the mysql/pg channel subscribers.
       const span = startInactiveSpan({
         name,
-        op: 'db',
         attributes: {
+          [SENTRY_OP]: DB,
           [SENTRY_KIND]: 'client',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
           [DB_SYSTEM_NAME]: DB_SYSTEM_NAME_POSTGRES,

--- a/packages/server-utils/src/integrations/postgres.ts
+++ b/packages/server-utils/src/integrations/postgres.ts
@@ -6,9 +6,11 @@ import {
   DB_SYSTEM_NAME,
   DB_USER,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import type { IntegrationFn, Scope, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_getSqlQuerySummary,
@@ -43,7 +45,7 @@ const ATTR_PG_IDLE_TIMEOUT = 'db.postgresql.idle.timeout.millis';
 const ATTR_PG_MAX_CLIENT = 'db.postgresql.max.client';
 const DB_SYSTEM_POSTGRESQL = 'postgresql';
 
-// We set `op: 'db'` and the SQL description directly here (same as mysql
+// We set the `db` op and the SQL description directly here (same as mysql
 // orchestrion) rather than relying on the OTel pipeline's `inferDbSpanData`
 // processor, which only runs in the node SDK, so setting them here is what
 // makes the spans correct on the other runtimes
@@ -116,7 +118,7 @@ function instrumentPostgres(options: { ignoreConnectSpans?: boolean }): void {
  */
 function subscribeQueryLikeChannel(
   channelName: string,
-  getSpanOptions: (ctx: PgChannelContext) => { name: string; op: string; attributes: SpanAttributes },
+  getSpanOptions: (ctx: PgChannelContext) => { name: string; attributes: SpanAttributes },
   { deferStreamedResult = false }: { deferStreamedResult?: boolean } = {},
 ): void {
   bindTracingChannelToSpan(
@@ -175,7 +177,7 @@ function subscribeQueryLikeChannel(
   );
 }
 
-function querySpanOptions(ctx: PgChannelContext): { name: string; op: string; attributes: SpanAttributes } {
+function querySpanOptions(ctx: PgChannelContext): { name: string; attributes: SpanAttributes } {
   const params = (ctx.self as { connectionParameters?: PgConnectionParams } | undefined)?.connectionParameters ?? {};
   const queryConfig = extractQueryConfig(ctx.arguments);
   const client = getClient();
@@ -192,8 +194,8 @@ function querySpanOptions(ctx: PgChannelContext): { name: string; op: string; at
 
   return {
     name,
-    op: 'db',
     attributes: {
+      [SENTRY_OP]: DB,
       ...getConnectionAttributes(params),
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
       [DB_QUERY_TEXT]: queryConfig?.text || undefined,
@@ -203,15 +205,15 @@ function querySpanOptions(ctx: PgChannelContext): { name: string; op: string; at
   };
 }
 
-function connectSpanOptions(ctx: PgChannelContext): { name: string; op: string; attributes: SpanAttributes } {
+function connectSpanOptions(ctx: PgChannelContext): { name: string; attributes: SpanAttributes } {
   const params = (ctx.self as { connectionParameters?: PgConnectionParams } | undefined)?.connectionParameters ?? {};
   // No origin set -> defaults to 'manual'
-  return { name: SPAN_CONNECT, op: 'db', attributes: getConnectionAttributes(params) };
+  return { name: SPAN_CONNECT, attributes: { [SENTRY_OP]: DB, ...getConnectionAttributes(params) } };
 }
 
-function poolConnectSpanOptions(ctx: PgChannelContext): { name: string; op: string; attributes: SpanAttributes } {
+function poolConnectSpanOptions(ctx: PgChannelContext): { name: string; attributes: SpanAttributes } {
   const opts = (ctx.self as { options?: PgPoolOptions } | undefined)?.options ?? {};
-  return { name: SPAN_POOL_CONNECT, op: 'db', attributes: getPoolConnectionAttributes(opts) };
+  return { name: SPAN_POOL_CONNECT, attributes: { [SENTRY_OP]: DB, ...getPoolConnectionAttributes(opts) } };
 }
 
 function hasOnMethod(obj: object): obj is { on: (event: string, listener: (arg?: unknown) => void) => unknown } {

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -17,9 +17,11 @@ import {
   DB_SYSTEM_NAME,
   DB_USER,
   SENTRY_KIND,
+  SENTRY_OP,
   SERVER_ADDRESS,
   SERVER_PORT,
 } from '@sentry/conventions/attributes';
+import { DB } from '@sentry/conventions/op';
 import { CHANNELS } from '../orchestrion/channels';
 import { tediousModuleNames } from '../orchestrion/config/tedious';
 import { invokeOrchestrionInstrumentation } from '../orchestrion/instrumentation';
@@ -128,6 +130,7 @@ function subscribeQuery(channelName: string, operation: string): void {
     const sql = extractSql(request);
 
     const attributes: SpanAttributes = {
+      [SENTRY_OP]: DB,
       [SENTRY_KIND]: 'client',
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
       [DB_SYSTEM_NAME]: DB_SYSTEM_VALUE_MSSQL,
@@ -142,7 +145,6 @@ function subscribeQuery(channelName: string, operation: string): void {
 
     const span = startInactiveSpan({
       name: sql || getSpanName(operation, databaseName, sql, request.table),
-      op: 'db',
       attributes,
     });
 

--- a/packages/server-utils/src/integrations/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/integrations/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -16,11 +16,20 @@ import {
   GEN_AI_TOOL_CALL_ARGUMENTS,
   GEN_AI_TOOL_CALL_RESULT,
   GEN_AI_TOOL_DEFINITIONS,
+  GEN_AI_TOOL_DESCRIPTION,
   GEN_AI_TOOL_NAME,
   GEN_AI_USAGE_INPUT_TOKENS,
   GEN_AI_USAGE_OUTPUT_TOKENS,
   GEN_AI_USAGE_TOTAL_TOKENS,
+  SENTRY_OP,
 } from '@sentry/conventions/attributes';
+import {
+  GEN_AI_EMBEDDINGS,
+  GEN_AI_EXECUTE_TOOL,
+  GEN_AI_GENERATE_CONTENT,
+  GEN_AI_INVOKE_AGENT,
+  GEN_AI_RERANK,
+} from '@sentry/conventions/op';
 import type { Span, SpanAttributes } from '@sentry/core';
 import {
   _INTERNAL_skipAiProviderWrapping,
@@ -36,6 +45,7 @@ import {
   withScope,
 } from '@sentry/core';
 import type { TracingChannel } from 'node:diagnostics_channel';
+import { GEN_AI_TOOL_CALL_ID_ATTRIBUTE } from '../../ai/core/gen-ai-attributes';
 import type { GenAiOptions } from '../../ai/core/utils';
 import { getProviderMetadataAttributes } from '../../ai/vercel-ai';
 import { WORKERS_AI_INTEGRATION_NAME } from '../../ai/workers-ai/constants';
@@ -51,16 +61,18 @@ const AI_SDK_TELEMETRY_TRACING_CHANNEL = 'ai:telemetry';
 
 const ORIGIN = 'auto.vercelai.channel';
 
-// `@sentry/conventions` does not expose these yet, so we keep the literals here.
-const GEN_AI_TOOL_CALL_ID_ATTRIBUTE = 'gen_ai.tool.call.id';
-const GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE = 'gen_ai.tool.description';
-const GEN_AI_EMBEDDINGS_OPERATION = 'embeddings';
-const GEN_AI_RERANK_OPERATION = 'rerank';
-const GEN_AI_INVOKE_AGENT_OPERATION = 'invoke_agent';
-const GEN_AI_EXECUTE_TOOL_OPERATION = 'execute_tool';
-// The model-call op matches the Vercel AI OTel integration (`gen_ai.generate_content`) rather than
-// the generic `gen_ai.chat`, so v6 (OTel) and v7 (channel) produce the same spans.
-const GEN_AI_GENERATE_CONTENT_OPERATION = 'generate_content';
+// `gen_ai.operation.name` values, keyed to the span op they map to.
+const GEN_AI_OPERATION_SPAN_OPS = {
+  embeddings: GEN_AI_EMBEDDINGS,
+  rerank: GEN_AI_RERANK,
+  invoke_agent: GEN_AI_INVOKE_AGENT,
+  execute_tool: GEN_AI_EXECUTE_TOOL,
+  // The model-call op matches the Vercel AI OTel integration (`gen_ai.generate_content`) rather than
+  // the generic `gen_ai.chat`, so v6 (OTel) and v7 (channel) produce the same spans.
+  generate_content: GEN_AI_GENERATE_CONTENT,
+} as const;
+
+type GenAiOperation = keyof typeof GEN_AI_OPERATION_SPAN_OPS;
 
 // Subset of the `vercel.ai.*` passthrough attributes the OTel integration emits that we reproduce.
 const VERCEL_AI_OPERATION_ID_ATTRIBUTE = 'vercel.ai.operationId';
@@ -395,13 +407,13 @@ export function createSpanFromMessage(
     case 'embedMany': {
       // `embed` carries a single `value`; `embedMany` a `values` array — both map to the embeddings input.
       const input = type === 'embedMany' ? event.values : event.value;
-      return startGenAiSpan(GEN_AI_EMBEDDINGS_OPERATION, modelId, {
+      return startGenAiSpan('embeddings', modelId, {
         ...baseAttributes,
         ...(recordInputs && input !== undefined ? { [GEN_AI_EMBEDDINGS_INPUT]: stringify(input) } : {}),
       });
     }
     case 'rerank':
-      return startGenAiSpan(GEN_AI_RERANK_OPERATION, modelId, baseAttributes);
+      return startGenAiSpan('rerank', modelId, baseAttributes);
     default:
       // Unknown event type: opt out rather than open a span we can't shape correctly.
       return undefined;
@@ -409,11 +421,14 @@ export function createSpanFromMessage(
 }
 
 /** Start a `gen_ai.<operation>` span named `<operation> <suffix>` (or just `<operation>` when no suffix). */
-function startGenAiSpan(operation: string, suffix: string | undefined, attributes: SpanAttributes): Span {
+function startGenAiSpan(operation: GenAiOperation, suffix: string | undefined, attributes: SpanAttributes): Span {
   return startInactiveSpan({
     name: suffix ? `${operation} ${suffix}` : operation,
-    op: `gen_ai.${operation}`,
-    attributes: { [GEN_AI_OPERATION_NAME]: operation, ...attributes },
+    attributes: {
+      [SENTRY_OP]: GEN_AI_OPERATION_SPAN_OPS[operation],
+      [GEN_AI_OPERATION_NAME]: operation,
+      ...attributes,
+    },
   });
 }
 
@@ -429,7 +444,7 @@ function buildInvokeAgentSpan(
   if (callId) {
     operationIdByCallId.set(callId, { operationId, isStream });
   }
-  const span = startGenAiSpan(GEN_AI_INVOKE_AGENT_OPERATION, functionId, {
+  const span = startGenAiSpan('invoke_agent', functionId, {
     ...baseAttributes,
     [VERCEL_AI_OPERATION_ID_ATTRIBUTE]: operationId,
     [GEN_AI_RESPONSE_STREAMING]: isStream,
@@ -454,7 +469,7 @@ function buildModelCallSpan(
   const operationId = parent
     ? `${parent.operationId}.${parent.isStream ? 'doStream' : 'doGenerate'}`
     : 'ai.generateText.doGenerate';
-  return startGenAiSpan(GEN_AI_GENERATE_CONTENT_OPERATION, modelId, {
+  return startGenAiSpan('generate_content', modelId, {
     ...baseAttributes,
     [VERCEL_AI_OPERATION_ID_ATTRIBUTE]: operationId,
     ...(recordInputs ? buildInputMessageAttributes(event) : {}),
@@ -471,11 +486,11 @@ function buildToolSpan(event: Record<string, unknown>, recordInputs: boolean): S
   // Gated on `recordInputs` to match the OTel path (descriptions come from the recorded tools list).
   const description =
     recordInputs && toolName ? resolveToolDescription(asString(event.callId), toolName, event.tools) : undefined;
-  return startGenAiSpan(GEN_AI_EXECUTE_TOOL_OPERATION, toolName, {
+  return startGenAiSpan('execute_tool', toolName, {
     [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: ORIGIN,
     ...(toolName ? { [GEN_AI_TOOL_NAME]: toolName } : {}),
     ...(toolCallId ? { [GEN_AI_TOOL_CALL_ID_ATTRIBUTE]: toolCallId } : {}),
-    ...(description ? { [GEN_AI_TOOL_DESCRIPTION_ATTRIBUTE]: description } : {}),
+    ...(description ? { [GEN_AI_TOOL_DESCRIPTION]: description } : {}),
     ...(recordInputs && toolInput !== undefined ? { [GEN_AI_TOOL_CALL_ARGUMENTS]: stringify(toolInput) } : {}),
   });
 }

--- a/packages/server-utils/test/ai/lib/tracing/langchain-embeddings.test.ts
+++ b/packages/server-utils/test/ai/lib/tracing/langchain-embeddings.test.ts
@@ -7,8 +7,8 @@ import {
   GEN_AI_PROVIDER_NAME,
   GEN_AI_REQUEST_MODEL,
 } from '@sentry/conventions/attributes';
+import { GEN_AI_EMBEDDINGS } from '@sentry/conventions/op';
 import {
-  GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE,
   GEN_AI_REQUEST_DIMENSIONS_ATTRIBUTE,
   GEN_AI_REQUEST_ENCODING_FORMAT_ATTRIBUTE,
 } from '../../../../src/ai/core/gen-ai-attributes';
@@ -25,14 +25,14 @@ vi.mock('../../../../src/ai/core/utils', async importOriginal => {
   };
 });
 
-let capturedSpanConfig: { name: string; op: string; attributes: Record<string, unknown> } | undefined;
+let capturedSpanConfig: { name: string; attributes: Record<string, unknown> } | undefined;
 
 vi.mock('@sentry/core', async importOriginal => {
   const actual = (await importOriginal()) as typeof SentryCore;
   return {
     ...actual,
     startSpan: (
-      config: { name: string; op: string; attributes: Record<string, unknown> },
+      config: { name: string; attributes: Record<string, unknown> },
       callback: (span: unknown) => unknown,
     ) => {
       capturedSpanConfig = config;
@@ -81,7 +81,7 @@ describe('instrumentEmbeddingMethod', () => {
 
     expect(capturedSpanConfig).toBeDefined();
     expect(capturedSpanConfig!.name).toBe('embeddings text-embedding-3-small');
-    expect(capturedSpanConfig!.op).toBe(GEN_AI_EMBEDDINGS_OPERATION_ATTRIBUTE);
+    expect(capturedSpanConfig!.attributes['sentry.op']).toBe(GEN_AI_EMBEDDINGS);
     expect(capturedSpanConfig!.attributes[GEN_AI_OPERATION_NAME]).toBe('embeddings');
     expect(capturedSpanConfig!.attributes[GEN_AI_REQUEST_MODEL]).toBe('text-embedding-3-small');
     expect(capturedSpanConfig!.attributes[GEN_AI_PROVIDER_NAME]).toBe('openai');

--- a/packages/server-utils/test/integrations/postgres/postgres.test.ts
+++ b/packages/server-utils/test/integrations/postgres/postgres.test.ts
@@ -66,7 +66,7 @@ function installTestAsyncContextStrategy(): void {
 // `getActiveSpan`. We spy both: `getActiveSpan` to satisfy the
 // requireParentSpan gate, and `startInactiveSpan` to capture the span
 // options the subscriber builds (name + raw attributes) and to track the
-// span's lifecycle. The final `op: 'db'` / SQL description come from the
+// span's lifecycle. The final `db` op / SQL description come from the
 // SDK's `inferDbSpanData` processor, which isn't wired up here. That's
 // covered by the integration test.
 function makeSpan(): Span {
@@ -120,8 +120,8 @@ describe('postgresIntegration', () => {
     expect(startInactiveSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'SELECT * FROM "User"',
-        op: 'db',
         attributes: expect.objectContaining({
+          'sentry.op': 'db',
           'db.system.name': 'postgresql',
           'db.namespace': 'tests',
           'db.user': 'tim',
@@ -148,8 +148,8 @@ describe('postgresIntegration', () => {
     expect(startInactiveSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'SELECT * FROM "User" WHERE "email" = $1',
-        op: 'db',
         attributes: expect.objectContaining({
+          'sentry.op': 'db',
           'db.query.text': 'SELECT * FROM "User" WHERE "email" = $1',
           'db.postgresql.plan': 'select-user-by-email',
           'sentry.origin': 'auto.db.postgres',
@@ -179,8 +179,11 @@ describe('postgresIntegration', () => {
     expect(startInactiveSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'pg.connect',
-        op: 'db',
-        attributes: expect.objectContaining({ 'db.system.name': 'postgresql', 'db.namespace': 'tests' }),
+        attributes: expect.objectContaining({
+          'sentry.op': 'db',
+          'db.system.name': 'postgresql',
+          'db.namespace': 'tests',
+        }),
       }),
     );
     // Connect spans must NOT set an origin (so they default to 'manual').
@@ -207,8 +210,8 @@ describe('postgresIntegration', () => {
     expect(startInactiveSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'pg-pool.connect',
-        op: 'db',
         attributes: expect.objectContaining({
+          'sentry.op': 'db',
           'db.system.name': 'postgresql',
           'db.namespace': 'tests',
           'db.user': 'user',

--- a/packages/server-utils/test/orchestrion/firebase.test.ts
+++ b/packages/server-utils/test/orchestrion/firebase.test.ts
@@ -43,8 +43,8 @@ describe('startFirestoreSpan', () => {
     expect(startInactiveSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'addDoc cities',
-        op: 'db.query',
         attributes: expect.objectContaining({
+          'sentry.op': 'db.query',
           'sentry.origin': 'auto.firebase.firestore',
           'db.operation.name': 'addDoc',
           'db.collection.name': 'cities',
@@ -63,7 +63,10 @@ describe('startFirestoreSpan', () => {
     startFirestoreSpan('getDocs', makeReference('cities', 'collection'));
 
     expect(startInactiveSpanSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'getDocs cities', op: 'db.query' }),
+      expect.objectContaining({
+        name: 'getDocs cities',
+        attributes: expect.objectContaining({ 'sentry.op': 'db.query' }),
+      }),
     );
   });
 });

--- a/packages/solid/src/solidrouter.ts
+++ b/packages/solid/src/solidrouter.ts
@@ -7,13 +7,15 @@ import {
   startBrowserTracingNavigationSpan,
 } from '@sentry/browser';
 import {
-  SENTRY_SEGMENT_NAME_SOURCE,
   PARAMS_KEY_BASE,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
   URL_FULL,
   URL_PATH,
   URL_PATH_PARAMETER_KEY_BASE,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
+import { NAVIGATION } from '@sentry/conventions/op';
 import type { Client, Integration, Span } from '@sentry/core';
 import {
   getClient,
@@ -68,7 +70,7 @@ function handleNavigation(location: string): void {
       // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
       name: hasSpanStreamingEnabled(client) ? NAVIGATION_SPAN_NAME_FALLBACK : location,
       attributes: {
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        [SENTRY_OP]: NAVIGATION,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: `auto.navigation.${framework}.solidrouter`,
         [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
       },

--- a/packages/solid/src/tanstackrouter.ts
+++ b/packages/solid/src/tanstackrouter.ts
@@ -6,19 +6,20 @@ import {
   WINDOW,
 } from '@sentry/browser';
 import {
-  SENTRY_SEGMENT_NAME_SOURCE,
   PARAMS_KEY_BASE,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
   URL_FULL,
   URL_PATH,
   URL_PATH_PARAMETER_KEY_BASE,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 import type { Integration } from '@sentry/core';
 import {
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   filterCollectedUrl,
 } from '@sentry/core';
@@ -95,7 +96,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
               ? PAGELOAD_SPAN_NAME_FALLBACK
               : initialWindowLocation.pathname,
           attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+            [SENTRY_OP]: PAGELOAD,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.solid.tanstack_router',
             [SENTRY_SEGMENT_NAME_SOURCE]: routeMatch ? 'route' : 'url',
             ...(routeMatch && { [URL_TEMPLATE]: routeMatch.routeId }),
@@ -154,7 +155,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
             {
               name: routeMatch ? routeMatch.routeId : fallbackName,
               attributes: {
-                [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+                [SENTRY_OP]: NAVIGATION,
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.solid.tanstack_router',
                 [SENTRY_SEGMENT_NAME_SOURCE]: routeMatch ? 'route' : 'url',
                 ...(routeMatch && { [URL_TEMPLATE]: routeMatch.routeId }),

--- a/packages/sveltekit/src/client/svelte4BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte4BrowserTracing.ts
@@ -14,6 +14,7 @@ import {
   WINDOW,
 } from '@sentry/svelte';
 import { SENTRY_SEGMENT_NAME_SOURCE, SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD, ROUTER } from '@sentry/conventions/op';
 import type { Navigation, Page } from '@sveltejs/kit';
 // eslint-disable-next-line typescript/no-deprecated
 import { navigating, page } from '$app/stores';
@@ -46,8 +47,8 @@ function _instrumentPageload(client: Client, pageStore: Readable<Page>): void {
     // With span streaming, span names have to be low cardinality. The route id is only available
     // asynchronously, which updates the span name then.
     name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : initialPath,
-    op: 'pageload',
     attributes: {
+      [SENTRY_OP]: PAGELOAD,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',
       [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
     },
@@ -124,8 +125,8 @@ function _instrumentNavigations(client: Client, navigatingStore: Readable<Naviga
         name:
           parameterizedRouteDestination ||
           (hasSpanStreamingEnabled(client) ? NAVIGATION_SPAN_NAME_FALLBACK : rawRouteDestination || 'unknown'),
-        op: 'navigation',
         attributes: {
+          [SENTRY_OP]: NAVIGATION,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
           [SENTRY_SEGMENT_NAME_SOURCE]: parameterizedRouteDestination ? 'route' : 'url',
           ...(parameterizedRouteDestination && { [URL_TEMPLATE]: parameterizedRouteDestination }),
@@ -140,8 +141,7 @@ function _instrumentNavigations(client: Client, navigatingStore: Readable<Naviga
       // of its own, so it's the fallback.
       name: hasSpanStreamingEnabled(client) ? ROUTER_SPAN_NAME_FALLBACK : 'SvelteKit Route Change',
       attributes: {
-        // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
-        [SENTRY_OP]: 'router',
+        [SENTRY_OP]: ROUTER,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
         ...navigationInfo,
       },

--- a/packages/sveltekit/src/client/svelte5BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte5BrowserTracing.ts
@@ -14,6 +14,7 @@ import {
   WINDOW,
 } from '@sentry/svelte';
 import { SENTRY_SEGMENT_NAME_SOURCE, SENTRY_OP, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD, ROUTER } from '@sentry/conventions/op';
 import type { Navigation } from '@sveltejs/kit';
 import { getCurrentNavigation, onNavigationChange, onPageRouteChange } from './navigationState.svelte';
 
@@ -42,8 +43,8 @@ function _instrumentPageLoad(client: Client): void {
     // With span streaming, span names have to be low cardinality. The route id is only available
     // asynchronously, which updates the span name then.
     name: hasSpanStreamingEnabled(client) ? PAGELOAD_SPAN_NAME_FALLBACK : initialPath,
-    op: 'pageload',
     attributes: {
+      [SENTRY_OP]: PAGELOAD,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',
       [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
     },
@@ -104,8 +105,8 @@ function _instrumentNavigations(client: Client): void {
         name:
           parameterizedRouteDestination ||
           (hasSpanStreamingEnabled(client) ? NAVIGATION_SPAN_NAME_FALLBACK : rawRouteDestination || 'unknown'),
-        op: 'navigation',
         attributes: {
+          [SENTRY_OP]: NAVIGATION,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
           [SENTRY_SEGMENT_NAME_SOURCE]: parameterizedRouteDestination ? 'route' : 'url',
           ...(parameterizedRouteDestination && { [URL_TEMPLATE]: parameterizedRouteDestination }),
@@ -120,8 +121,7 @@ function _instrumentNavigations(client: Client): void {
       // of its own, so it's the fallback.
       name: hasSpanStreamingEnabled(client) ? ROUTER_SPAN_NAME_FALLBACK : 'SvelteKit Route Change',
       attributes: {
-        // TODO(conventions): Replace `'router'` with the `router` span op constant once it is released in `@sentry/conventions`.
-        [SENTRY_OP]: 'router',
+        [SENTRY_OP]: ROUTER,
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.ui.sveltekit',
         ...navigationInfo,
       },

--- a/packages/sveltekit/src/server-common/handle.ts
+++ b/packages/sveltekit/src/server-common/handle.ts
@@ -11,7 +11,6 @@ import {
   hasSpanStreamingEnabled,
   httpHeadersToSpanAttributes,
   HTTP_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   setHttpStatus,
   spanToJSON,
@@ -26,12 +25,14 @@ import type { Handle, ResolveOptions } from '@sveltejs/kit';
 import { DEBUG_BUILD } from '../common/debug-build';
 import { getTracePropagationData, sendErrorToSentry } from './utils';
 import {
-  SENTRY_SEGMENT_NAME_SOURCE,
   HTTP_REQUEST_METHOD,
   HTTP_ROUTE,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
   URL_FULL,
   URL_PATH,
 } from '@sentry/conventions/attributes';
+import { HTTP_SERVER } from '@sentry/conventions/op';
 
 export type SentryHandleOptions = {
   /**
@@ -190,7 +191,7 @@ async function instrumentHandle(
         }
 
         kitRootSpan.setAttributes({
-          [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
+          [SENTRY_OP]: HTTP_SERVER,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.sveltekit',
           [SENTRY_SEGMENT_NAME_SOURCE]: routeName ? 'route' : 'url',
           'sveltekit.tracing.original_name': originalName,
@@ -222,8 +223,8 @@ async function instrumentHandle(
       ? await resolveWithSentry()
       : await startSpan(
           {
-            op: 'http.server',
             attributes: {
+              [SENTRY_OP]: HTTP_SERVER,
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.sveltekit',
               [SENTRY_SEGMENT_NAME_SOURCE]: routeId ? 'route' : 'url',
               [HTTP_REQUEST_METHOD]: event.request.method,

--- a/packages/sveltekit/test/client/browserTracingIntegration.test.ts
+++ b/packages/sveltekit/test/client/browserTracingIntegration.test.ts
@@ -113,8 +113,8 @@ describe('browserTracingIntegration', () => {
     expect(startBrowserTracingPageLoadSpanSpy).toHaveBeenCalledTimes(1);
     expect(startBrowserTracingPageLoadSpanSpy).toHaveBeenCalledWith(fakeClient, {
       name: '/',
-      op: 'pageload',
       attributes: {
+        'sentry.op': 'pageload',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',
         [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
       },
@@ -217,8 +217,8 @@ describe('browserTracingIntegration', () => {
       fakeClient,
       {
         name: '/users/[id]',
-        op: 'navigation',
         attributes: {
+          'sentry.op': 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
           [SENTRY_SEGMENT_NAME_SOURCE]: 'route',
           [URL_TEMPLATE]: '/users/[id]',
@@ -361,8 +361,8 @@ describe('browserTracingIntegration', () => {
         fakeClient,
         {
           name: '/users/[id]',
-          op: 'navigation',
           attributes: {
+            'sentry.op': 'navigation',
             [SENTRY_SEGMENT_NAME_SOURCE]: 'route',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
             [URL_TEMPLATE]: '/users/[id]',

--- a/packages/sveltekit/test/client/svelte5BrowserTracing.test.ts
+++ b/packages/sveltekit/test/client/svelte5BrowserTracing.test.ts
@@ -81,8 +81,8 @@ describe('svelte5 browser tracing', () => {
 
       expect(startPageLoadSpanSpy).toHaveBeenCalledWith(client, {
         name: '/',
-        op: 'pageload',
         attributes: {
+          'sentry.op': 'pageload',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.sveltekit',
           [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
         },
@@ -122,8 +122,8 @@ describe('svelte5 browser tracing', () => {
         client,
         expect.objectContaining({
           name: '/users/[id]',
-          op: 'navigation',
           attributes: expect.objectContaining({
+            'sentry.op': 'navigation',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.sveltekit',
             [SENTRY_SEGMENT_NAME_SOURCE]: 'route',
             [URL_TEMPLATE]: '/users/[id]',

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -7,6 +7,7 @@ import {
   URL_PATH_PARAMETER_KEY_BASE,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
+import { NAVIGATION } from '@sentry/conventions/op';
 import type { Span, SpanAttributes, StartSpanOptions, TransactionSource } from '@sentry/core';
 import {
   getActiveSpan,
@@ -149,9 +150,9 @@ export function instrumentVueRouter(
       startNavigationSpanFn(
         {
           name: isUnparameterizedStreamedNavigation ? NAVIGATION_SPAN_NAME_FALLBACK : spanName,
-          op: 'navigation',
           attributes: {
             ...attributes,
+            [SENTRY_OP]: NAVIGATION,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue',
             [SENTRY_SEGMENT_NAME_SOURCE]: transactionSource,
           },

--- a/packages/vue/src/tanstackrouter.ts
+++ b/packages/vue/src/tanstackrouter.ts
@@ -6,19 +6,20 @@ import {
   WINDOW,
 } from '@sentry/browser';
 import {
-  SENTRY_SEGMENT_NAME_SOURCE,
   PARAMS_KEY_BASE,
+  SENTRY_OP,
+  SENTRY_SEGMENT_NAME_SOURCE,
   URL_FULL,
   URL_PATH,
   URL_PATH_PARAMETER_KEY_BASE,
   URL_TEMPLATE,
 } from '@sentry/conventions/attributes';
+import { NAVIGATION, PAGELOAD } from '@sentry/conventions/op';
 import type { Integration } from '@sentry/core';
 import {
   hasSpanStreamingEnabled,
   NAVIGATION_SPAN_NAME_FALLBACK,
   PAGELOAD_SPAN_NAME_FALLBACK,
-  SEMANTIC_ATTRIBUTE_SENTRY_OP,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   filterCollectedUrl,
 } from '@sentry/core';
@@ -101,7 +102,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
               ? PAGELOAD_SPAN_NAME_FALLBACK
               : initialWindowLocation.pathname,
           attributes: {
-            [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+            [SENTRY_OP]: PAGELOAD,
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.vue.tanstack_router',
             [SENTRY_SEGMENT_NAME_SOURCE]: routeMatch ? 'route' : 'url',
             ...(routeMatch && { [URL_TEMPLATE]: routeMatch.routeId }),
@@ -161,7 +162,7 @@ export function tanstackRouterBrowserTracingIntegration<R extends AnyRouter>(
             {
               name: routeMatch ? routeMatch.routeId : fallbackName,
               attributes: {
-                [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+                [SENTRY_OP]: NAVIGATION,
                 [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue.tanstack_router',
                 [SENTRY_SEGMENT_NAME_SOURCE]: routeMatch ? 'route' : 'url',
                 ...(routeMatch && { [URL_TEMPLATE]: routeMatch.routeId }),

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -126,11 +126,11 @@ describe('instrumentVueRouter()', () => {
         {
           name: transactionName,
           attributes: {
+            'sentry.op': 'navigation',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue',
             [SENTRY_SEGMENT_NAME_SOURCE]: transactionSource,
             ...getAttributesForRoute(to, transactionSource === 'route' ? transactionName : undefined),
           },
-          op: 'navigation',
         },
         expect.any(String),
       );
@@ -206,11 +206,11 @@ describe('instrumentVueRouter()', () => {
       {
         name: '/login',
         attributes: {
+          'sentry.op': 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue',
           [SENTRY_SEGMENT_NAME_SOURCE]: 'route',
           ...getAttributesForRoute(to, '/login'),
         },
-        op: 'navigation',
       },
       expect.any(String),
     );
@@ -237,11 +237,11 @@ describe('instrumentVueRouter()', () => {
       {
         name: 'login-screen',
         attributes: {
+          'sentry.op': 'navigation',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue',
           [SENTRY_SEGMENT_NAME_SOURCE]: 'custom',
           ...getAttributesForRoute(to),
         },
-        op: 'navigation',
       },
       expect.any(String),
     );
@@ -470,11 +470,11 @@ describe('instrumentVueRouter()', () => {
         {
           name: 'Navigation',
           attributes: {
+            'sentry.op': 'navigation',
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.vue',
             [SENTRY_SEGMENT_NAME_SOURCE]: 'url',
             ...getAttributesForRoute(to),
           },
-          op: 'navigation',
         },
         expect.any(String),
       );


### PR DESCRIPTION
replaces string literals with exported constants from conventions that have been released in the meantime.
