### PR TITLE
fix(core): Match wrapped Facebook Mobile browser errors in `DEFAULT_IGNORE_ERRORS`

### DIFF
--- a/packages/core/src/integrations/eventFilters.ts
+++ b/packages/core/src/integrations/eventFilters.ts
@@ -20,7 +20,8 @@ const DEFAULT_IGNORE_ERRORS = [
   /vv\(\)\.getRestrictions is not a function/, // Error thrown by GTM, seemingly not affecting end-users
   /Can't find variable: _AutofillCallbackHandler/, // Unactionable error in instagram webview https://developers.facebook.com/community/threads/320013549791141/
   /Object Not Found Matching Id:\d+, MethodName:simulateEvent/, // unactionable error from CEFSharp, a .NET library that embeds chromium in .NET apps
-  /^Java exception was raised during method invocation$/, // error from Facebook Mobile browser (https://github.com/getsentry/sentry-javascript/issues/15065)
+  /Java exception was raised during method invocation$/, // error from Facebook Mobile browser (https://github.com/getsentry/sentry-javascript/issues/15065, https://github.com/getsentry/sentry-javascript/issues/23733)
+  /Java object is gone$/, // error from Facebook Mobile browser (https://github.com/getsentry/sentry-javascript/issues/15065, https://github.com/getsentry/sentry-javascript/issues/23733)
 ];
 
 /** Options for the EventFilters integration */

--- a/packages/core/test/lib/integrations/eventFilters.test.ts
+++ b/packages/core/test/lib/integrations/eventFilters.test.ts
@@ -373,6 +373,28 @@ const FB_MOBILE_BROWSER_EVENT: Event = {
   },
 };
 
+const FB_MOBILE_BROWSER_POST_MESSAGE_EVENT: Event = {
+  exception: {
+    values: [
+      {
+        type: 'Error',
+        value: 'Error invoking postMessage: Java exception was raised during method invocation',
+      },
+    ],
+  },
+};
+
+const FB_MOBILE_BROWSER_JAVA_OBJECT_GONE_EVENT: Event = {
+  exception: {
+    values: [
+      {
+        type: 'Error',
+        value: 'Error invoking postMessage: Java object is gone',
+      },
+    ],
+  },
+};
+
 const MALFORMED_EVENT: Event = {
   exception: {
     values: [
@@ -495,6 +517,16 @@ describe('EventFilters', () => {
     it('uses default filters (FB Mobile Browser)', () => {
       const eventProcessor = createEventFiltersEventProcessor(integrationFn);
       expect(eventProcessor(FB_MOBILE_BROWSER_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters (FB Mobile Browser, wrapped in postMessage error)', () => {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
+      expect(eventProcessor(FB_MOBILE_BROWSER_POST_MESSAGE_EVENT, {})).toBe(null);
+    });
+
+    it('uses default filters (FB Mobile Browser, Java object is gone)', () => {
+      const eventProcessor = createEventFiltersEventProcessor(integrationFn);
+      expect(eventProcessor(FB_MOBILE_BROWSER_JAVA_OBJECT_GONE_EVENT, {})).toBe(null);
     });
 
     it("uses default filters (undefined is not an object (evaluating 'a.L'))", () => {


### PR DESCRIPTION
## What
Drops the `^` anchor on the Facebook Mobile browser pattern in `DEFAULT_IGNORE_ERRORS` and adds the sibling `Java object is gone` error.

## Why
the Android WebView bridge wraps these errors as `Error invoking postMessage: Java exception was raised during method invocation`, so the start-anchored regex never matched. Only the end anchor is kept so the message still has to end with the known text and can't over-match unrelated errors.

Fixes #23733