### PR TITLE
ref: Remove redundant `forceTransaction: true` usages

### DIFF
--- a/packages/aws-serverless/src/requestSpanOptions.ts
+++ b/packages/aws-serverless/src/requestSpanOptions.ts
@@ -46,7 +46,6 @@ export function getRequestSpanOptions(event: unknown, context: Context, requestI
   // The span is started within the surrounding `continueTrace`, so it continues the incoming trace.
   return {
     name: context.functionName,
-    forceTransaction: true,
     attributes: {
       [SENTRY_OP]: FUNCTION_AWS,
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.aws_lambda',

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -521,7 +521,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
             ...startSpanOptions,
             // Navigation starts a new trace and is NOT parented under any active interaction (e.g. ui.action.click)
             parentSpan: null,
-            forceTransaction: true,
           },
           true,
           navigationOptions?.url,

--- a/packages/nestjs/src/integrations/helpers.ts
+++ b/packages/nestjs/src/integrations/helpers.ts
@@ -130,7 +130,6 @@ const PROCESS_OPERATION = 'process';
 export function getBullMQProcessSpanOptions(queueName: string | undefined): {
   name: string;
   attributes: Record<string, string | undefined>;
-  forceTransaction: boolean;
 } {
   const client = getClient();
   const isStreamed = !!client && hasSpanStreamingEnabled(client);
@@ -151,7 +150,6 @@ export function getBullMQProcessSpanOptions(queueName: string | undefined): {
       [MESSAGING_OPERATION_TYPE]: PROCESS_OPERATION,
       [MESSAGING_DESTINATION_NAME]: queueName,
     },
-    forceTransaction: true,
   };
 }
 

--- a/packages/react-router/src/server/createServerInstrumentation.ts
+++ b/packages/react-router/src/server/createServerInstrumentation.ts
@@ -103,7 +103,6 @@ export function createSentryServerInstrumentation(
             await startSpan(
               {
                 name: unparameterizedName,
-                forceTransaction: true,
                 attributes: {
                   [SENTRY_OP]: HTTP_SERVER,
                   [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.react_router.instrumentation_api',

--- a/packages/react-router/test/server/createServerInstrumentation.test.ts
+++ b/packages/react-router/test/server/createServerInstrumentation.test.ts
@@ -165,11 +165,10 @@ describe('createSentryServerInstrumentation', () => {
 
     await hooks.request(mockHandleRequest, { request: mockRequest, context: undefined });
 
-    // Should create a new root span with forceTransaction
+    // Should create a new root span
     expect(core.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'GET /api/users',
-        forceTransaction: true,
         attributes: expect.objectContaining({
           'sentry.op': 'http.server',
           'sentry.origin': 'auto.http.react_router.instrumentation_api',


### PR DESCRIPTION
## What

Removes `forceTransaction: true` from four spans that are already root spans, so the option had no effect.

- `aws-serverless`: the `function.aws` invocation span
- `browser`: the navigation span, which already passes `parentSpan: null`
- `nestjs`: the BullMQ process span, since queue jobs run outside a request
- `react-router`: the server request span, on the branch that only runs when there is no root span

The remaining usages are:

- MCP server spans: without the flag every MCP request nests under the HTTP transaction (`POST /messages` and `/ GET /sse`, and the `mcp.server` transaction that the Insights views read is gone.
- Next.js server actions: `withServerActionInstrumentation` forks an isolation scope and sets the transaction name, the `extra` data and the request headers on it. With no transaction in that scope, all of it is dropped.
- nestjs event spans: the transaction still arrives, promoted through `sentry.parent_span_already_sent`, but only because the handler outlives the request. A synchronous handler would nest instead.

## Why

Less to read, and the flag now marks only the spans that truly need it.