### PR TITLE
feat(aws)!: Use `queue` Span OP for AWS SQS & SNS messaging

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -779,6 +779,7 @@ These changes are not caught by TypeScript. If you filter, group, or alert on sp
 | Redis commands / connect              | `db.redis`, `db.redis.connect`                                                                                                                      | `db.query`, `db`                                  |
 | Nuxt & Nitro storage (unstorage)      | `cache.has_item`, `cache.get_item`, `cache.get_items`, `cache.get_keys`, `cache.set_item`, `cache.set_items`, `cache.remove_item`, `cache.clear`, … | `cache.get`, `cache.put`, `cache.remove`          |
 | Kafka, AMQP & OTel-inferred messaging | `message`, `message.produce`, `message.consume`                                                                                                     | `queue.publish`, `queue.receive`, `queue.process` |
+| AWS SQS & SNS messaging commands      | `rpc`                                                                                                                                               | `queue.publish`, `queue.receive`                  |
 
 **RPC & Gen AI:**
 
@@ -879,7 +880,7 @@ Only the Express, Koa and Hapi integrations resolve a route template for `router
 
 Messaging span names now read `<operation type> <destination>` in every integration. The amqplib, kafkajs and NestJS BullMQ integrations used their own word order or verb, so their names change: `my-queue process` became `process my-queue`, amqplib's `publish` became `send`, and the kafkajs batch span's `poll` became `receive`. Cloudflare Queues and the kafkajs producer already matched the conventions, so their names are the same in both trace lifecycles. The operation name an integration reports upstream stays on `messaging.operation.name`.
 
-AWS SQS and SNS span names follow the messaging conventions too, so the operation comes first (`my-queue receive` becomes `receive my-queue`, `my-topic send` becomes `send my-topic`). A streamed SNS `Publish` to a platform endpoint is named `send`, because the endpoint ARN it used to carry ends in a per-device id (`endpoint/GCM/myapp/<uuid> send`). The full ARN remains on `messaging.destination.name`.
+AWS SQS `SendMessage`, `SendMessageBatch` and `ReceiveMessage`, and SNS `Publish`, are messaging spans (e.g. `queue.publish`) rather than `rpc` ones now. Every other command on those clients, such as `DeleteMessage`, stays `rpc`. Their names follow the messaging conventions too, so the operation comes first (`my-queue receive` becomes `receive my-queue`, `my-topic send` becomes `send my-topic`). A streamed SNS `Publish` to a platform endpoint is named `send`, because the endpoint ARN it used to carry ends in a per-device id (`endpoint/GCM/myapp/<uuid> send`). The full ARN remains on `messaging.destination.name`.
 
 An amqplib span's destination is the exchange it uses, or the routing key when it uses the default exchange. RabbitMQ binds every queue to the default exchange under a key equal to the queue's own name, so `sendToQueue` spans are named after their queue (`send my-queue`) instead of dropping the destination. `messaging.destination.name` reports the same value, and the routing key remains on `messaging.rabbitmq.destination.routing_key` in full.
 

--- a/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration-streamed/test.ts
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration-streamed/test.ts
@@ -122,6 +122,7 @@ function assertAwsServiceSpans(spanCcontainer: SerializedStreamedSpanContainer):
   expectSpan('SQS SendMessage', {
     name: 'send my-queue',
     attributes: expect.objectContaining({
+      'sentry.op': { value: 'queue.publish', type: 'string' },
       'rpc.method': { value: 'SendMessage', type: 'string' },
       'rpc.service': { value: 'SQS', type: 'string' },
       'messaging.system': { value: 'aws_sqs', type: 'string' },
@@ -136,6 +137,7 @@ function assertAwsServiceSpans(spanCcontainer: SerializedStreamedSpanContainer):
   expectSpan('SQS ReceiveMessage', {
     name: 'receive my-queue',
     attributes: expect.objectContaining({
+      'sentry.op': { value: 'queue.receive', type: 'string' },
       'rpc.method': { value: 'ReceiveMessage', type: 'string' },
       'messaging.system': { value: 'aws_sqs', type: 'string' },
       'messaging.operation.type': { value: 'receive', type: 'string' },
@@ -151,6 +153,7 @@ function assertAwsServiceSpans(spanCcontainer: SerializedStreamedSpanContainer):
       'rpc.method': { value: 'Publish', type: 'string' },
       'rpc.service': { value: 'SNS', type: 'string' },
       'messaging.system': { value: 'aws.sns', type: 'string' },
+      'sentry.op': { value: 'queue.publish', type: 'string' },
       'messaging.destination': { value: 'my-topic', type: 'string' },
       'aws.sns.topic.arn': { value: 'arn:aws:sns:us-east-1:123456789012:my-topic', type: 'string' },
       'sentry.kind': { value: 'producer', type: 'string' },
@@ -163,6 +166,7 @@ function assertAwsServiceSpans(spanCcontainer: SerializedStreamedSpanContainer):
     attributes: expect.objectContaining({
       'rpc.method': { value: 'Publish', type: 'string' },
       'rpc.service': { value: 'SNS', type: 'string' },
+      'sentry.op': { value: 'queue.publish', type: 'string' },
       'messaging.destination': { value: 'endpoint/GCM/myapp/5e3e9847-3183-3f18-a7e8-671c3a57d4b3', type: 'string' },
       'messaging.destination.name': {
         value: 'arn:aws:sns:us-east-1:123456789012:endpoint/GCM/myapp/5e3e9847-3183-3f18-a7e8-671c3a57d4b3',

--- a/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/test.ts
+++ b/dev-packages/node-integration-tests/suites/aws-serverless/aws-integration/test.ts
@@ -109,7 +109,7 @@ function assertAwsServiceSpans(transaction: TransactionEvent): void {
   // SQS - SendMessage (producer)
   expectSpan('SQS SendMessage', {
     description: 'my-queue send',
-    op: 'rpc',
+    op: 'queue.publish',
     origin: ORIGIN,
     data: expect.objectContaining({
       'rpc.method': 'SendMessage',
@@ -125,7 +125,7 @@ function assertAwsServiceSpans(transaction: TransactionEvent): void {
   // SQS - ReceiveMessage (consumer)
   expectSpan('SQS ReceiveMessage', {
     description: 'my-queue receive',
-    op: 'rpc',
+    op: 'queue.receive',
     origin: ORIGIN,
     data: expect.objectContaining({
       'rpc.method': 'ReceiveMessage',
@@ -139,7 +139,7 @@ function assertAwsServiceSpans(transaction: TransactionEvent): void {
   // SNS - Publish (producer)
   expectSpan('SNS Publish', {
     description: 'my-topic send',
-    op: 'rpc',
+    op: 'queue.publish',
     origin: ORIGIN,
     data: expect.objectContaining({
       'rpc.method': 'Publish',
@@ -154,6 +154,7 @@ function assertAwsServiceSpans(transaction: TransactionEvent): void {
   // Without span streaming the name keeps the raw ARN suffix, including the per-device id.
   expectSpan('SNS Publish (platform endpoint)', {
     description: 'endpoint/GCM/myapp/5e3e9847-3183-3f18-a7e8-671c3a57d4b3 send',
+    op: 'queue.publish',
     data: expect.objectContaining({
       'rpc.method': 'Publish',
       'rpc.service': 'SNS',

--- a/packages/server-utils/src/integrations/aws-sdk/services/sns.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/services/sns.ts
@@ -8,6 +8,7 @@ import {
   MESSAGING_SYSTEM,
   SENTRY_KIND,
 } from '@sentry/conventions/attributes';
+import { QUEUE_PUBLISH } from '@sentry/conventions/op';
 import { ATTR_MESSAGING_DESTINATION_KIND, MESSAGING_DESTINATION_KIND_VALUE_TOPIC } from '../constants';
 import type { NormalizedRequest, NormalizedResponse } from '../types';
 import { injectPropagationContext } from './MessageAttributes';
@@ -31,12 +32,15 @@ function buildSpanName(operation: string, destination: string | undefined, isStr
 export class SnsServiceExtension implements ServiceExtension {
   public requestPreSpanHook(request: NormalizedRequest): RequestMetadata {
     let spanName = `SNS ${request.commandName}`;
+    let spanOp: string | undefined;
+
     const spanAttributes: Record<string, unknown> = {
       [MESSAGING_SYSTEM]: 'aws.sns',
       [SENTRY_KIND]: 'client',
     };
 
     if (request.commandName === 'Publish') {
+      spanOp = QUEUE_PUBLISH;
       spanAttributes[SENTRY_KIND] = 'producer';
 
       spanAttributes[ATTR_MESSAGING_DESTINATION_KIND] = MESSAGING_DESTINATION_KIND_VALUE_TOPIC;
@@ -67,6 +71,7 @@ export class SnsServiceExtension implements ServiceExtension {
     return {
       spanAttributes,
       spanName,
+      spanOp,
     };
   }
 

--- a/packages/server-utils/src/integrations/aws-sdk/services/sqs.ts
+++ b/packages/server-utils/src/integrations/aws-sdk/services/sqs.ts
@@ -9,6 +9,7 @@ import {
   SENTRY_KIND,
   URL_FULL,
 } from '@sentry/conventions/attributes';
+import { QUEUE_PUBLISH, QUEUE_RECEIVE } from '@sentry/conventions/op';
 import type { SQS } from '../aws-sdk.types';
 import type { CommandInput, NormalizedRequest, NormalizedResponse } from '../types';
 import {
@@ -23,6 +24,7 @@ export class SqsServiceExtension implements ServiceExtension {
     const queueUrl = extractQueueUrl(request.commandInput);
     const queueName = extractQueueNameFromUrl(queueUrl);
     let operation: string | undefined;
+    let spanOp: string | undefined;
 
     const spanAttributes: Record<string, unknown> = {
       [MESSAGING_SYSTEM]: 'aws_sqs',
@@ -36,6 +38,7 @@ export class SqsServiceExtension implements ServiceExtension {
       case 'ReceiveMessage':
         {
           operation = 'receive';
+          spanOp = QUEUE_RECEIVE;
           spanAttributes[SENTRY_KIND] = 'consumer';
 
           request.commandInput.MessageAttributeNames = addPropagationFieldsToAttributeNames(
@@ -47,6 +50,7 @@ export class SqsServiceExtension implements ServiceExtension {
       case 'SendMessage':
       case 'SendMessageBatch':
         operation = 'send';
+        spanOp = QUEUE_PUBLISH;
         spanAttributes[SENTRY_KIND] = 'producer';
         break;
     }
@@ -61,6 +65,8 @@ export class SqsServiceExtension implements ServiceExtension {
     return {
       spanAttributes,
       spanName: buildSpanName(operation, queueName, isStreamed),
+      // Fallback to `rpc` if there's no messaging operation
+      spanOp,
     };
   }
 

--- a/packages/server-utils/test/integrations/aws-sdk-sns.test.ts
+++ b/packages/server-utils/test/integrations/aws-sdk-sns.test.ts
@@ -57,6 +57,21 @@ describe('SnsServiceExtension span naming', () => {
     });
   });
 
+  it.each([
+    ['Publish', 'queue.publish'],
+    ['CreateTopic', undefined],
+  ])('gives a %s span the %o op', (commandName, expected) => {
+    setUpClient('stream');
+
+    const metadata = new SnsServiceExtension().requestPreSpanHook({
+      serviceName: 'SNS',
+      commandName,
+      commandInput: { TopicArn: TOPIC_ARN },
+    });
+
+    expect(metadata.spanOp).toBe(expected);
+  });
+
   it('reports the operation type it names the span after', () => {
     setUpClient('stream');
 

--- a/packages/server-utils/test/integrations/aws-sdk-sqs.test.ts
+++ b/packages/server-utils/test/integrations/aws-sdk-sqs.test.ts
@@ -44,11 +44,24 @@ describe('SqsServiceExtension span naming', () => {
       expect(spanAttributes?.['messaging.destination.name']).toBeUndefined();
     });
 
-    // The aws-sdk house style (`SQS.DeleteMessage`) still names these.
-    it('leaves a command with no messaging operation unnamed', () => {
+    // The aws-sdk house style (`SQS.DeleteMessage`) still names these, and they are not queue spans.
+    it('leaves a command with no messaging operation unnamed and on the default op', () => {
       setUpClient('stream');
 
-      expect(preSpanHook('DeleteMessage', { QueueUrl: QUEUE_URL }).spanName).toBeUndefined();
+      const { spanName, spanOp } = preSpanHook('DeleteMessage', { QueueUrl: QUEUE_URL });
+
+      expect(spanName).toBeUndefined();
+      expect(spanOp).toBeUndefined();
+    });
+
+    it.each([
+      ['ReceiveMessage', 'queue.receive'],
+      ['SendMessage', 'queue.publish'],
+      ['SendMessageBatch', 'queue.publish'],
+    ])('gives a %s span the %s op', (commandName, expected) => {
+      setUpClient('stream');
+
+      expect(preSpanHook(commandName, { QueueUrl: QUEUE_URL }).spanOp).toBe(expected);
     });
 
     it.each([


### PR DESCRIPTION
Follow-up to this PR: 
- https://github.com/getsentry/sentry-javascript/pull/23652