### PR TITLE
feat(wasm): patch non-streaming load paths

### DIFF
--- a/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/init.js
+++ b/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/init.js
@@ -1,0 +1,20 @@
+import * as Sentry from '@sentry/browser';
+import { registerWebWorkerWasm } from '@sentry/wasm';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  traceLifecycle: 'static',
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});
+
+// `registerWebWorkerWasm` installs the same patches a worker would, and reports
+// every registered module to the scope it is given. Collecting them here is the
+// only way to observe registration from the page, since main-thread images stay
+// module-internal until a frame matches one.
+window.registeredImages = [];
+registerWebWorkerWasm({
+  self: {
+    postMessage: message => window.registeredImages.push(...(message._sentryWasmImages || [])),
+  },
+});

--- a/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/subject.js
+++ b/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/subject.js
@@ -1,0 +1,12 @@
+window.loadWasmFromBuffer = async () => {
+  const response = await fetch('https://localhost:5887/simple.wasm');
+  const buffer = await response.arrayBuffer();
+
+  await WebAssembly.instantiate(new Uint8Array(buffer), {
+    env: {
+      external_func: () => {},
+    },
+  });
+
+  return window.registeredImages;
+};

--- a/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/test.ts
@@ -1,0 +1,48 @@
+import type { Page, Route } from '@playwright/test';
+import { expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { sentryTest } from '../../../utils/fixtures';
+import { shouldSkipWASMTests } from '../../../utils/wasmHelpers';
+
+function serveWasmFixture(page: Page): Promise<void> {
+  return page.route('**/simple.wasm', (route: Route) => {
+    const wasmModule = fs.readFileSync(path.resolve(__dirname, '..', 'simple.wasm'));
+
+    return route.fulfill({
+      status: 200,
+      body: wasmModule,
+      headers: {
+        'Content-Type': 'application/wasm',
+      },
+    });
+  });
+}
+
+sentryTest(
+  'registers a module loaded via fetch, arrayBuffer and instantiate under its response url',
+  async ({ getLocalTestUrl, page, browserName }) => {
+    if (shouldSkipWASMTests(browserName)) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+    await serveWasmFixture(page);
+    await page.goto(url);
+
+    const images = await page.evaluate(async () => {
+      // @ts-expect-error this function exists
+      return window.loadWasmFromBuffer();
+    });
+
+    expect(images).toEqual([
+      {
+        type: 'wasm',
+        code_file: 'https://localhost:5887/simple.wasm',
+        code_id: '0ba020cdd2444f7eafdd25999a8e9010',
+        debug_file: null,
+        debug_id: '0ba020cdd2444f7eafdd25999a8e90100',
+      },
+    ]);
+  },
+);

--- a/packages/wasm/src/patchWasmResponse.ts
+++ b/packages/wasm/src/patchWasmResponse.ts
@@ -69,9 +69,7 @@ export function patchWasmResponseBodyReaders(): void {
     return;
   }
 
-  const proto = Response.prototype as unknown as Record<string, unknown>;
-
-  fill(proto, 'arrayBuffer', (original: (this: Response) => Promise<ArrayBuffer>) => {
+  fill(Response.prototype, 'arrayBuffer', (original: (this: Response) => Promise<ArrayBuffer>) => {
     return function arrayBuffer(this: Response): Promise<ArrayBuffer> {
       const bufferPromise: Promise<ArrayBuffer> = original.call(this);
       return bufferPromise.then((buffer: ArrayBuffer) => {
@@ -81,7 +79,7 @@ export function patchWasmResponseBodyReaders(): void {
     };
   });
 
-  fill(proto, 'bytes', (original: (this: Response) => Promise<Uint8Array>) => {
+  fill(Response.prototype, 'bytes', (original: (this: Response) => Promise<Uint8Array>) => {
     return function bytes(this: Response): Promise<Uint8Array> {
       const bytesPromise: Promise<Uint8Array> = original.call(this);
       return bytesPromise.then((bytes: Uint8Array) => {

--- a/packages/wasm/src/patchWasmResponse.ts
+++ b/packages/wasm/src/patchWasmResponse.ts
@@ -1,3 +1,5 @@
+import { addNonEnumerableProperty, fill } from '@sentry/core';
+
 /**
  * Streaming wasm registration (`instantiateStreaming` / `compileStreaming`) reads the module URL
  * from `Response.url`. Non-streaming paths (`WebAssembly.instantiate` / `compile` with bytes) only
@@ -67,23 +69,21 @@ export function patchWasmResponseBodyReaders(): void {
     return;
   }
 
-  responseProto[PATCHED_SYMBOL] = true;
+  const proto = Response.prototype as unknown as Record<string, unknown>;
 
-  // oxlint-disable-next-line typescript/unbound-method
-  const origArrayBuffer: (this: Response) => Promise<ArrayBuffer> = Response.prototype.arrayBuffer;
-  Response.prototype.arrayBuffer = function arrayBuffer(this: Response): Promise<ArrayBuffer> {
-    const bufferPromise: Promise<ArrayBuffer> = origArrayBuffer.call(this);
-    return bufferPromise.then((buffer: ArrayBuffer) => {
-      tagResponseBuffer(this, buffer);
-      return buffer;
-    });
-  };
+  fill(proto, 'arrayBuffer', (original: (this: Response) => Promise<ArrayBuffer>) => {
+    return function arrayBuffer(this: Response): Promise<ArrayBuffer> {
+      const bufferPromise: Promise<ArrayBuffer> = original.call(this);
+      return bufferPromise.then((buffer: ArrayBuffer) => {
+        tagResponseBuffer(this, buffer);
+        return buffer;
+      });
+    };
+  });
 
-  if ('bytes' in Response.prototype) {
-    // oxlint-disable-next-line typescript/unbound-method
-    const origBytes: (this: Response) => Promise<Uint8Array> = Response.prototype.bytes;
-    Response.prototype.bytes = function bytes(this: Response) {
-      const bytesPromise: Promise<Uint8Array> = origBytes.call(this);
+  fill(proto, 'bytes', (original: (this: Response) => Promise<Uint8Array>) => {
+    return function bytes(this: Response): Promise<Uint8Array> {
+      const bytesPromise: Promise<Uint8Array> = original.call(this);
       return bytesPromise.then((bytes: Uint8Array) => {
         const { buffer } = bytes;
         if (buffer instanceof ArrayBuffer) {
@@ -91,13 +91,15 @@ export function patchWasmResponseBodyReaders(): void {
         }
         return bytes;
       });
-    } as typeof Response.prototype.bytes;
-  }
+    };
+  });
+
+  addNonEnumerableProperty(responseProto, PATCHED_SYMBOL, true);
 }
 
 /** @internal */
 export function _resetResponsePatchForTests(): void {
   if (typeof Response !== 'undefined') {
-    (Response.prototype as MaybePatched)[PATCHED_SYMBOL] = false;
+    addNonEnumerableProperty(Response.prototype, PATCHED_SYMBOL, false);
   }
 }

--- a/packages/wasm/src/patchWasmResponse.ts
+++ b/packages/wasm/src/patchWasmResponse.ts
@@ -1,0 +1,103 @@
+/**
+ * Streaming wasm registration (`instantiateStreaming` / `compileStreaming`) reads the module URL
+ * from `Response.url`. Non-streaming paths (`WebAssembly.instantiate` / `compile` with bytes) only
+ * receive a buffer — no URL — so registration would otherwise be skipped.
+ *
+ * This module patches `Response.prototype.arrayBuffer` and `bytes` so that when wasm is fetched
+ * and then loaded from bytes, we can map the resulting `ArrayBuffer` back to the fetch URL via
+ * `getWasmSourceUrl()` and register the module in `patchNonStreamingWebAssembly`.
+ */
+const wasmSourceUrls = new WeakMap<ArrayBuffer, string>();
+
+const PATCHED_SYMBOL = Symbol.for('__sentryWasmPatched');
+
+type MaybePatched = { [PATCHED_SYMBOL]?: boolean };
+
+/**
+ * Resolves a wasm source buffer back to its fetch URL, when known.
+ */
+export function getWasmSourceUrl(source: BufferSource): string | undefined {
+  const buffer = toArrayBuffer(source);
+  if (!buffer) {
+    return undefined;
+  }
+
+  return wasmSourceUrls.get(buffer);
+}
+
+function toArrayBuffer(source: BufferSource): ArrayBuffer | undefined {
+  if (source instanceof ArrayBuffer) {
+    return source;
+  }
+
+  if (ArrayBuffer.isView(source)) {
+    const { buffer } = source;
+    return buffer instanceof ArrayBuffer ? buffer : undefined;
+  }
+
+  return undefined;
+}
+
+function looksLikeWasmResponse(response: Response): boolean {
+  const contentType = response.headers.get('content-type');
+  if (contentType?.includes('application/wasm')) {
+    return true;
+  }
+
+  const { url } = response;
+  return Boolean(url && /\.wasm(?:\?|#|$)/i.test(url));
+}
+
+function tagResponseBuffer(response: Response, buffer: ArrayBuffer): void {
+  if (looksLikeWasmResponse(response) && response.url) {
+    wasmSourceUrls.set(buffer, response.url);
+  }
+}
+
+/**
+ * Patches Response body readers so wasm bytes remember their fetch URL.
+ */
+export function patchWasmResponseBodyReaders(): void {
+  if (typeof Response === 'undefined') {
+    return;
+  }
+
+  const responseProto = Response.prototype as MaybePatched;
+  if (responseProto[PATCHED_SYMBOL]) {
+    return;
+  }
+
+  responseProto[PATCHED_SYMBOL] = true;
+
+  // oxlint-disable-next-line typescript/unbound-method
+  const origArrayBuffer: (this: Response) => Promise<ArrayBuffer> = Response.prototype.arrayBuffer;
+  Response.prototype.arrayBuffer = function arrayBuffer(this: Response): Promise<ArrayBuffer> {
+    const bufferPromise: Promise<ArrayBuffer> = origArrayBuffer.call(this);
+    return bufferPromise.then((buffer: ArrayBuffer) => {
+      tagResponseBuffer(this, buffer);
+      return buffer;
+    });
+  };
+
+  if ('bytes' in Response.prototype) {
+    // oxlint-disable-next-line typescript/unbound-method
+    const origBytes: (this: Response) => Promise<Uint8Array> = Response.prototype.bytes;
+    Response.prototype.bytes = function bytes(this: Response) {
+      const bytesPromise: Promise<Uint8Array> = origBytes.call(this);
+      return bytesPromise.then((bytes: Uint8Array) => {
+        const { buffer } = bytes;
+        if (buffer instanceof ArrayBuffer) {
+          tagResponseBuffer(this, buffer);
+        }
+        return bytes;
+      });
+    } as typeof Response.prototype.bytes;
+  }
+}
+
+/** @internal */
+export function _resetResponsePatchForTests(): void {
+  if (typeof Response !== 'undefined') {
+    (Response.prototype as MaybePatched)[PATCHED_SYMBOL] = false;
+  }
+}

--- a/packages/wasm/src/patchWasmResponse.ts
+++ b/packages/wasm/src/patchWasmResponse.ts
@@ -1,9 +1,9 @@
-import { addNonEnumerableProperty, fill } from '@sentry/core';
+import { fill } from '@sentry/core';
 
 /**
  * Streaming wasm registration (`instantiateStreaming` / `compileStreaming`) reads the module URL
  * from `Response.url`. Non-streaming paths (`WebAssembly.instantiate` / `compile` with bytes) only
- * receive a buffer — no URL — so registration would otherwise be skipped.
+ * receive a buffer, no URL, so registration would otherwise be skipped.
  *
  * This module patches `Response.prototype.arrayBuffer` and `bytes` so that when wasm is fetched
  * and then loaded from bytes, we can map the resulting `ArrayBuffer` back to the fetch URL via
@@ -11,14 +11,12 @@ import { addNonEnumerableProperty, fill } from '@sentry/core';
  */
 const wasmSourceUrls = new WeakMap<ArrayBuffer, string>();
 
-const PATCHED_SYMBOL = Symbol.for('__sentryWasmPatched');
-
-type MaybePatched = { [PATCHED_SYMBOL]?: boolean };
+let responseReadersPatched = false;
 
 /**
  * Resolves a wasm source buffer back to its fetch URL, when known.
  */
-export function getWasmSourceUrl(source: BufferSource): string | undefined {
+export function getWasmSourceUrl(source: unknown): string | undefined {
   const buffer = toArrayBuffer(source);
   if (!buffer) {
     return undefined;
@@ -27,7 +25,7 @@ export function getWasmSourceUrl(source: BufferSource): string | undefined {
   return wasmSourceUrls.get(buffer);
 }
 
-function toArrayBuffer(source: BufferSource): ArrayBuffer | undefined {
+function toArrayBuffer(source: unknown): ArrayBuffer | undefined {
   if (source instanceof ArrayBuffer) {
     return source;
   }
@@ -50,9 +48,18 @@ function looksLikeWasmResponse(response: Response): boolean {
   return Boolean(url && /\.wasm(?:\?|#|$)/i.test(url));
 }
 
-function tagResponseBuffer(response: Response, buffer: ArrayBuffer): void {
-  if (looksLikeWasmResponse(response) && response.url) {
-    wasmSourceUrls.set(buffer, response.url);
+/**
+ * Runs inside the caller's `arrayBuffer()` / `bytes()` promise chain, so it must never throw:
+ * a failure here would reject a body read that has nothing to do with wasm.
+ */
+function tagResponseSource(response: Response, source: unknown): void {
+  try {
+    const buffer = toArrayBuffer(source);
+    if (buffer && response.url && looksLikeWasmResponse(response)) {
+      wasmSourceUrls.set(buffer, response.url);
+    }
+  } catch {
+    // see above
   }
 }
 
@@ -60,20 +67,17 @@ function tagResponseBuffer(response: Response, buffer: ArrayBuffer): void {
  * Patches Response body readers so wasm bytes remember their fetch URL.
  */
 export function patchWasmResponseBodyReaders(): void {
-  if (typeof Response === 'undefined') {
+  if (responseReadersPatched || typeof Response === 'undefined') {
     return;
   }
 
-  const responseProto = Response.prototype as MaybePatched;
-  if (responseProto[PATCHED_SYMBOL]) {
-    return;
-  }
+  responseReadersPatched = true;
 
   fill(Response.prototype, 'arrayBuffer', (original: (this: Response) => Promise<ArrayBuffer>) => {
     return function arrayBuffer(this: Response): Promise<ArrayBuffer> {
       const bufferPromise: Promise<ArrayBuffer> = original.call(this);
-      return bufferPromise.then((buffer: ArrayBuffer) => {
-        tagResponseBuffer(this, buffer);
+      return bufferPromise.then(buffer => {
+        tagResponseSource(this, buffer);
         return buffer;
       });
     };
@@ -82,22 +86,15 @@ export function patchWasmResponseBodyReaders(): void {
   fill(Response.prototype, 'bytes', (original: (this: Response) => Promise<Uint8Array>) => {
     return function bytes(this: Response): Promise<Uint8Array> {
       const bytesPromise: Promise<Uint8Array> = original.call(this);
-      return bytesPromise.then((bytes: Uint8Array) => {
-        const { buffer } = bytes;
-        if (buffer instanceof ArrayBuffer) {
-          tagResponseBuffer(this, buffer);
-        }
+      return bytesPromise.then(bytes => {
+        tagResponseSource(this, bytes);
         return bytes;
       });
     };
   });
-
-  addNonEnumerableProperty(responseProto, PATCHED_SYMBOL, true);
 }
 
 /** @internal */
 export function _resetResponsePatchForTests(): void {
-  if (typeof Response !== 'undefined') {
-    addNonEnumerableProperty(Response.prototype, PATCHED_SYMBOL, false);
-  }
+  responseReadersPatched = false;
 }

--- a/packages/wasm/src/patchWebAssembly.ts
+++ b/packages/wasm/src/patchWebAssembly.ts
@@ -1,4 +1,8 @@
+import { getWasmSourceUrl, patchWasmResponseBodyReaders } from './patchWasmResponse';
+
 export type RegisterModuleCallback = (module: WebAssembly.Module, url: string) => void;
+
+let nonStreamingPatched = false;
 
 /**
  * Patches the WebAssembly streaming APIs so that every compiled module gets
@@ -7,7 +11,7 @@ export type RegisterModuleCallback = (module: WebAssembly.Module, url: string) =
  *
  * @param registerModule callback invoked for every successfully compiled module
  */
-export function patchWebAssembly(registerModule: RegisterModuleCallback): void {
+export function patchStreamingWebAssembly(registerModule: RegisterModuleCallback): void {
   if ('instantiateStreaming' in WebAssembly) {
     const origInstantiateStreaming = WebAssembly.instantiateStreaming as (
       response: unknown,
@@ -55,4 +59,73 @@ function registerSafely(registerModule: RegisterModuleCallback, module: WebAssem
   } catch {
     // a registration failure must never break the user's WebAssembly call
   }
+}
+
+function registerFromBufferSource(
+  registerModule: RegisterModuleCallback,
+  module: WebAssembly.Module,
+  source: BufferSource,
+): void {
+  const url = getWasmSourceUrl(source);
+  if (url) {
+    registerModule(module, url);
+  }
+}
+
+/**
+ * Patches the non-streaming web assembly runtime.
+ */
+function patchNonStreamingWebAssembly(registerModule: RegisterModuleCallback): void {
+  if (nonStreamingPatched) {
+    return;
+  }
+
+  nonStreamingPatched = true;
+
+  const origInstantiate = WebAssembly.instantiate;
+  WebAssembly.instantiate = function instantiate(
+    source: BufferSource | WebAssembly.Module,
+    importObject?: WebAssembly.Imports,
+  ) {
+    if (source instanceof WebAssembly.Module) {
+      return (
+        origInstantiate as (
+          moduleObject: WebAssembly.Module,
+          importObject?: WebAssembly.Imports,
+        ) => Promise<WebAssembly.Instance>
+      )(source, importObject);
+    }
+
+    return (
+      origInstantiate as (
+        bytes: BufferSource,
+        importObject?: WebAssembly.Imports,
+      ) => Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    )(source, importObject).then(result => {
+      registerFromBufferSource(registerModule, result.module, source);
+      return result;
+    });
+  } as typeof WebAssembly.instantiate;
+
+  const origCompile = WebAssembly.compile;
+  WebAssembly.compile = function compile(source: BufferSource): Promise<WebAssembly.Module> {
+    return origCompile(source).then(module => {
+      registerFromBufferSource(registerModule, module, source);
+      return module;
+    });
+  };
+}
+
+/**
+ * Patches the web assembly runtime.
+ */
+export function patchWebAssembly(registerModule: RegisterModuleCallback): void {
+  patchWasmResponseBodyReaders();
+  patchNonStreamingWebAssembly(registerModule);
+  patchStreamingWebAssembly(registerModule);
+}
+
+/** @internal */
+export function _resetNonStreamingPatchForTests(): void {
+  nonStreamingPatched = false;
 }

--- a/packages/wasm/src/patchWebAssembly.ts
+++ b/packages/wasm/src/patchWebAssembly.ts
@@ -68,7 +68,7 @@ function registerFromBufferSource(
 ): void {
   const url = getWasmSourceUrl(source);
   if (url) {
-    registerModule(module, url);
+    registerSafely(registerModule, module, url);
   }
 }
 
@@ -82,34 +82,26 @@ function patchNonStreamingWebAssembly(registerModule: RegisterModuleCallback): v
 
   nonStreamingPatched = true;
 
-  const origInstantiate = WebAssembly.instantiate;
-  WebAssembly.instantiate = function instantiate(
-    source: BufferSource | WebAssembly.Module,
-    importObject?: WebAssembly.Imports,
-  ) {
+  // Double-cast, because the overloaded native signature (buffer vs. module
+  // first argument) cannot be widened to a pass-through shape in one step.
+  const origInstantiate = WebAssembly.instantiate as unknown as (
+    source: unknown,
+    ...rest: unknown[]
+  ) => Promise<WebAssembly.WebAssemblyInstantiatedSource>;
+  WebAssembly.instantiate = function instantiate(source: BufferSource | WebAssembly.Module, ...rest: unknown[]) {
     if (source instanceof WebAssembly.Module) {
-      return (
-        origInstantiate as (
-          moduleObject: WebAssembly.Module,
-          importObject?: WebAssembly.Imports,
-        ) => Promise<WebAssembly.Instance>
-      )(source, importObject);
+      return origInstantiate(source, ...rest);
     }
 
-    return (
-      origInstantiate as (
-        bytes: BufferSource,
-        importObject?: WebAssembly.Imports,
-      ) => Promise<WebAssembly.WebAssemblyInstantiatedSource>
-    )(source, importObject).then(result => {
+    return origInstantiate(source, ...rest).then(result => {
       registerFromBufferSource(registerModule, result.module, source);
       return result;
     });
   } as typeof WebAssembly.instantiate;
 
-  const origCompile = WebAssembly.compile;
-  WebAssembly.compile = function compile(source: BufferSource): Promise<WebAssembly.Module> {
-    return origCompile(source).then(module => {
+  const origCompile = WebAssembly.compile as (source: unknown, ...rest: unknown[]) => Promise<WebAssembly.Module>;
+  WebAssembly.compile = function compile(source: BufferSource, ...rest: unknown[]): Promise<WebAssembly.Module> {
+    return origCompile(source, ...rest).then(module => {
       registerFromBufferSource(registerModule, module, source);
       return module;
     });

--- a/packages/wasm/src/patchWebAssembly.ts
+++ b/packages/wasm/src/patchWebAssembly.ts
@@ -11,7 +11,7 @@ let nonStreamingPatched = false;
  *
  * @param registerModule callback invoked for every successfully compiled module
  */
-export function patchStreamingWebAssembly(registerModule: RegisterModuleCallback): void {
+function patchStreamingWebAssembly(registerModule: RegisterModuleCallback): void {
   if ('instantiateStreaming' in WebAssembly) {
     const origInstantiateStreaming = WebAssembly.instantiateStreaming as (
       response: unknown,
@@ -61,14 +61,25 @@ function registerSafely(registerModule: RegisterModuleCallback, module: WebAssem
   }
 }
 
+/**
+ * Registers a module compiled from bytes under the URL those bytes were fetched from, when known.
+ * Runs inside the caller's promise chain, so nothing in here may throw.
+ */
 function registerFromBufferSource(
   registerModule: RegisterModuleCallback,
-  module: WebAssembly.Module,
-  source: BufferSource,
+  compiled: WebAssembly.Module | WebAssembly.WebAssemblyInstantiatedSource | WebAssembly.Instance,
+  source: unknown,
 ): void {
-  const url = getWasmSourceUrl(source);
-  if (url) {
-    registerSafely(registerModule, module, url);
+  try {
+    // `instantiate(module)` resolves to a bare Instance, which carries nothing new to register
+    const module =
+      compiled instanceof WebAssembly.Module ? compiled : 'module' in compiled ? compiled.module : undefined;
+    const url = getWasmSourceUrl(source);
+    if (module && url) {
+      registerModule(module, url);
+    }
+  } catch {
+    // a registration failure must never break the user's WebAssembly call
   }
 }
 
@@ -87,14 +98,10 @@ function patchNonStreamingWebAssembly(registerModule: RegisterModuleCallback): v
   const origInstantiate = WebAssembly.instantiate as unknown as (
     source: unknown,
     ...rest: unknown[]
-  ) => Promise<WebAssembly.WebAssemblyInstantiatedSource>;
-  WebAssembly.instantiate = function instantiate(source: BufferSource | WebAssembly.Module, ...rest: unknown[]) {
-    if (source instanceof WebAssembly.Module) {
-      return origInstantiate(source, ...rest);
-    }
-
+  ) => Promise<WebAssembly.WebAssemblyInstantiatedSource | WebAssembly.Instance>;
+  WebAssembly.instantiate = function instantiate(source: unknown, ...rest: unknown[]) {
     return origInstantiate(source, ...rest).then(result => {
-      registerFromBufferSource(registerModule, result.module, source);
+      registerFromBufferSource(registerModule, result, source);
       return result;
     });
   } as typeof WebAssembly.instantiate;
@@ -110,11 +117,22 @@ function patchNonStreamingWebAssembly(registerModule: RegisterModuleCallback): v
 
 /**
  * Patches the web assembly runtime.
+ *
+ * Every patch is guarded on its own: a missing or frozen global must neither throw out of
+ * `Sentry.init()` / `registerWebWorkerWasm()` nor keep the remaining patches from installing.
  */
 export function patchWebAssembly(registerModule: RegisterModuleCallback): void {
-  patchWasmResponseBodyReaders();
-  patchNonStreamingWebAssembly(registerModule);
-  patchStreamingWebAssembly(registerModule);
+  tryPatch(() => patchWasmResponseBodyReaders());
+  tryPatch(() => patchNonStreamingWebAssembly(registerModule));
+  tryPatch(() => patchStreamingWebAssembly(registerModule));
+}
+
+function tryPatch(patch: () => void): void {
+  try {
+    patch();
+  } catch {
+    // see patchWebAssembly()
+  }
 }
 
 /** @internal */

--- a/packages/wasm/test/frozenResponse.test.ts
+++ b/packages/wasm/test/frozenResponse.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { patchWebAssembly } from '../src/patchWebAssembly';
+
+// Kept in its own file because freezing `Response.prototype` cannot be undone
+// and would leak into every other test sharing the environment.
+describe('patchWebAssembly() with a frozen Response.prototype', () => {
+  it('does not throw and still installs the streaming patch', async () => {
+    Object.freeze(Response.prototype);
+
+    const module = {} as WebAssembly.Module;
+    WebAssembly.compileStreaming = vi.fn().mockResolvedValue(module) as unknown as typeof WebAssembly.compileStreaming;
+
+    const registered: string[] = [];
+
+    expect(() => patchWebAssembly((_module, url) => registered.push(url))).not.toThrow();
+
+    await WebAssembly.compileStreaming({ url: 'http://localhost:8001/main.wasm' } as Response);
+
+    expect(registered).toEqual(['http://localhost:8001/main.wasm']);
+  });
+});

--- a/packages/wasm/test/patchWebAssembly.test.ts
+++ b/packages/wasm/test/patchWebAssembly.test.ts
@@ -154,3 +154,51 @@ describe('patchWebAssembly() non-streaming registration', () => {
     expect(IMAGES).toHaveLength(0);
   });
 });
+
+describe('patchWebAssembly() non-streaming argument forwarding', () => {
+  const savedGlobals = saveWasmGlobals();
+
+  afterEach(() => {
+    restoreWasmGlobals(savedGlobals);
+  });
+
+  it('forwards every argument to instantiate', async () => {
+    const orig = vi.fn().mockResolvedValue({ module: MODULE, instance: {} });
+    WebAssembly.instantiate = orig as unknown as typeof WebAssembly.instantiate;
+
+    patchWebAssembly(registerModule);
+
+    const bytes = new Uint8Array(8);
+    const compileOptions = { builtins: ['js-string'] };
+    await (WebAssembly.instantiate as unknown as (...args: unknown[]) => Promise<unknown>)(
+      bytes,
+      WASM_IMPORTS,
+      compileOptions,
+    );
+
+    expect(orig).toHaveBeenCalledWith(bytes, WASM_IMPORTS, compileOptions);
+  });
+
+  it('forwards every argument to compile', async () => {
+    const orig = vi.fn().mockResolvedValue(MODULE);
+    WebAssembly.compile = orig as unknown as typeof WebAssembly.compile;
+
+    patchWebAssembly(registerModule);
+
+    const bytes = new Uint8Array(8);
+    const compileOptions = { builtins: ['js-string'] };
+    await (WebAssembly.compile as unknown as (...args: unknown[]) => Promise<unknown>)(bytes, compileOptions);
+
+    expect(orig).toHaveBeenCalledWith(bytes, compileOptions);
+  });
+
+  it('resolves the original result even if registration throws', async () => {
+    patchWebAssembly(() => {
+      throw new Error('registration failed');
+    });
+
+    const buffer = await fetchWasmBytes();
+
+    await expect(WebAssembly.compile(buffer)).resolves.toBeInstanceOf(WebAssembly.Module);
+  });
+});

--- a/packages/wasm/test/patchWebAssembly.test.ts
+++ b/packages/wasm/test/patchWebAssembly.test.ts
@@ -1,16 +1,47 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { patchWebAssembly } from '../src/patchWebAssembly';
+import { getImage, IMAGES, registerModule } from '../src/registry';
+import { restoreWasmGlobals, saveWasmGlobals } from './wasmTestHelpers';
 
 const RESPONSE = { url: 'http://localhost:8001/main.wasm' } as Response;
 const MODULE = {} as WebAssembly.Module;
 
-describe('patchWebAssembly()', () => {
-  const originalInstantiateStreaming = WebAssembly.instantiateStreaming;
-  const originalCompileStreaming = WebAssembly.compileStreaming;
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const SIMPLE_WASM_PATH = path.resolve(
+  testDir,
+  '../../../dev-packages/browser-integration-tests/suites/wasm/simple.wasm',
+);
+
+const WASM_URL = 'https://example.com/simple.wasm';
+
+const WASM_IMPORTS = {
+  env: {
+    external_func: () => {},
+  },
+};
+
+async function loadWasmBytes(): Promise<Uint8Array> {
+  return new Uint8Array(fs.readFileSync(SIMPLE_WASM_PATH));
+}
+
+async function fetchWasmBytes(): Promise<ArrayBuffer> {
+  const bytes = await loadWasmBytes();
+  const response = new Response(bytes, {
+    headers: { 'Content-Type': 'application/wasm' },
+  });
+  Object.defineProperty(response, 'url', { value: WASM_URL });
+
+  return response.arrayBuffer();
+}
+
+describe('patchWebAssembly() streaming registration', () => {
+  const savedGlobals = saveWasmGlobals();
 
   afterEach(() => {
-    WebAssembly.instantiateStreaming = originalInstantiateStreaming;
-    WebAssembly.compileStreaming = originalCompileStreaming;
+    restoreWasmGlobals(savedGlobals);
   });
 
   it('forwards every argument to instantiateStreaming and registers the module', async () => {
@@ -68,5 +99,58 @@ describe('patchWebAssembly()', () => {
     });
 
     await expect(WebAssembly.compileStreaming(RESPONSE)).resolves.toBe(MODULE);
+  });
+});
+
+describe('patchWebAssembly() non-streaming registration', () => {
+  const savedGlobals = saveWasmGlobals();
+
+  beforeAll(() => {
+    patchWebAssembly(registerModule);
+  });
+
+  afterAll(() => {
+    restoreWasmGlobals(savedGlobals);
+  });
+
+  beforeEach(() => {
+    IMAGES.length = 0;
+  });
+
+  it('registers modules loaded via fetch → arrayBuffer → instantiate', async () => {
+    const buffer = await fetchWasmBytes();
+
+    await WebAssembly.instantiate(buffer, WASM_IMPORTS);
+
+    expect(getImage(WASM_URL)).toBe(0);
+    expect(IMAGES[0]?.code_file).toBe(WASM_URL);
+    expect(IMAGES[0]?.code_id).toBe('0ba020cdd2444f7eafdd25999a8e9010');
+  });
+
+  it('registers modules loaded via fetch → arrayBuffer → Uint8Array → instantiate', async () => {
+    const buffer = await fetchWasmBytes();
+    const view = new Uint8Array(buffer);
+
+    await WebAssembly.instantiate(view, WASM_IMPORTS);
+
+    expect(getImage(WASM_URL)).toBe(0);
+    expect(IMAGES[0]?.code_file).toBe(WASM_URL);
+  });
+
+  it('registers modules loaded via fetch → arrayBuffer → compile', async () => {
+    const buffer = await fetchWasmBytes();
+
+    await WebAssembly.compile(buffer);
+
+    expect(getImage(WASM_URL)).toBe(0);
+    expect(IMAGES[0]?.code_file).toBe(WASM_URL);
+  });
+
+  it('does not register modules when the buffer has no tagged URL', async () => {
+    const bytes = await loadWasmBytes();
+
+    await WebAssembly.instantiate(bytes, WASM_IMPORTS);
+
+    expect(IMAGES).toHaveLength(0);
   });
 });

--- a/packages/wasm/test/patchWebAssembly.test.ts
+++ b/packages/wasm/test/patchWebAssembly.test.ts
@@ -153,6 +153,25 @@ describe('patchWebAssembly() non-streaming registration', () => {
 
     expect(IMAGES).toHaveLength(0);
   });
+
+  it('resolves instantiate(module) to a bare instance and registers nothing', async () => {
+    const module = await WebAssembly.compile(await fetchWasmBytes());
+    IMAGES.length = 0;
+
+    await expect(WebAssembly.instantiate(module, WASM_IMPORTS)).resolves.toBeInstanceOf(WebAssembly.Instance);
+    expect(IMAGES).toHaveLength(0);
+  });
+
+  it('does not reject the body read when tagging throws', async () => {
+    const response = new Response(new Uint8Array(8));
+    Object.defineProperty(response, 'url', {
+      get: () => {
+        throw new Error('url accessor');
+      },
+    });
+
+    await expect(response.arrayBuffer()).resolves.toBeInstanceOf(ArrayBuffer);
+  });
 });
 
 describe('patchWebAssembly() non-streaming argument forwarding', () => {

--- a/packages/wasm/test/patchWebAssemblyGuards.test.ts
+++ b/packages/wasm/test/patchWebAssemblyGuards.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { patchWebAssembly } from '../src/patchWebAssembly';
+import { registerModule } from '../src/registry';
+import { restoreWasmGlobals, saveWasmGlobals } from './wasmTestHelpers';
+
+describe('patchWebAssembly() guards', () => {
+  const savedGlobals = saveWasmGlobals();
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    restoreWasmGlobals(savedGlobals);
+  });
+
+  it('does not throw when WebAssembly is frozen', () => {
+    vi.stubGlobal('WebAssembly', Object.freeze(Object.create(WebAssembly)));
+
+    expect(() => patchWebAssembly(registerModule)).not.toThrow();
+  });
+
+  it('does not throw when WebAssembly is missing', () => {
+    vi.stubGlobal('WebAssembly', undefined);
+
+    expect(() => patchWebAssembly(registerModule)).not.toThrow();
+  });
+});

--- a/packages/wasm/test/wasmTestHelpers.ts
+++ b/packages/wasm/test/wasmTestHelpers.ts
@@ -1,0 +1,39 @@
+import { _resetResponsePatchForTests } from '../src/patchWasmResponse';
+import { _resetNonStreamingPatchForTests } from '../src/patchWebAssembly';
+
+export type SavedWasmGlobals = {
+  instantiate: typeof WebAssembly.instantiate;
+  compile: typeof WebAssembly.compile;
+  instantiateStreaming?: typeof WebAssembly.instantiateStreaming;
+  compileStreaming?: typeof WebAssembly.compileStreaming;
+  arrayBuffer: typeof Response.prototype.arrayBuffer;
+  bytes?: typeof Response.prototype.bytes;
+};
+
+export function saveWasmGlobals(): SavedWasmGlobals {
+  return {
+    instantiate: WebAssembly.instantiate,
+    compile: WebAssembly.compile,
+    instantiateStreaming: WebAssembly.instantiateStreaming,
+    compileStreaming: WebAssembly.compileStreaming,
+    arrayBuffer: Response.prototype.arrayBuffer,
+    bytes: 'bytes' in Response.prototype ? Response.prototype.bytes : undefined,
+  };
+}
+
+export function restoreWasmGlobals(saved: SavedWasmGlobals): void {
+  WebAssembly.instantiate = saved.instantiate;
+  WebAssembly.compile = saved.compile;
+  if (saved.instantiateStreaming) {
+    WebAssembly.instantiateStreaming = saved.instantiateStreaming;
+  }
+  if (saved.compileStreaming) {
+    WebAssembly.compileStreaming = saved.compileStreaming;
+  }
+  Response.prototype.arrayBuffer = saved.arrayBuffer;
+  if (saved.bytes) {
+    Response.prototype.bytes = saved.bytes;
+  }
+  _resetNonStreamingPatchForTests();
+  _resetResponsePatchForTests();
+}

--- a/packages/wasm/test/webworker.test.ts
+++ b/packages/wasm/test/webworker.test.ts
@@ -1,14 +1,22 @@
 import type { DebugImage, StackFrame } from '@sentry/core';
 import { GLOBAL_OBJ } from '@sentry/core';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { patchFrames, registerWebWorkerWasm } from '../src/index';
+import { restoreWasmGlobals, saveWasmGlobals } from './wasmTestHelpers';
 
 const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & {
   _sentryWasmImages?: Array<DebugImage>;
 };
 
 describe('registerWebWorkerWasm()', () => {
+  let savedGlobals = saveWasmGlobals();
+
+  beforeEach(() => {
+    savedGlobals = saveWasmGlobals();
+  });
+
   afterEach(() => {
+    restoreWasmGlobals(savedGlobals);
     delete WINDOW._sentryWasmImages;
     vi.restoreAllMocks();
   });
@@ -18,12 +26,12 @@ describe('registerWebWorkerWasm()', () => {
     const mockSelf = { postMessage: mockPostMessage };
 
     const originalInstantiateStreaming = WebAssembly.instantiateStreaming;
+    const originalInstantiate = WebAssembly.instantiate;
 
     registerWebWorkerWasm({ self: mockSelf });
 
     expect(WebAssembly.instantiateStreaming).not.toBe(originalInstantiateStreaming);
-
-    WebAssembly.instantiateStreaming = originalInstantiateStreaming;
+    expect(WebAssembly.instantiate).not.toBe(originalInstantiate);
   });
 
   it('should patch WebAssembly.compileStreaming when available', () => {
@@ -35,8 +43,6 @@ describe('registerWebWorkerWasm()', () => {
     registerWebWorkerWasm({ self: mockSelf });
 
     expect(WebAssembly.compileStreaming).not.toBe(originalCompileStreaming);
-
-    WebAssembly.compileStreaming = originalCompileStreaming;
   });
 });
 


### PR DESCRIPTION
Register wasm modules when apps load via `fetch → arrayBuffer → WebAssembly.instantiate/compile`, not only streaming APIs.

- Patch `Response.prototype.arrayBuffer` and `bytes` so wasm buffers remember their fetch URL
- Wrap `WebAssembly.instantiate` and `compile` to register modules after byte-based loads
- Workers get non-streaming registration too, through the shared `patchWebAssembly(register)`
- Add tests for tagged-buffer registration, untagged-buffer negative case, argument forwarding, and a browser test for `fetch → arrayBuffer → instantiate`

Registration only. Frames from buffer-compiled modules still carry `wasm://wasm/<hash>`, which nothing matches against the registered image, so `debug_meta` does not attach yet. That half is #23781.

## Implementation

- `patchWasmResponse.ts` tags wasm buffers in a `WeakMap` when read from a wasm-like `Response`; `getWasmSourceUrl()` resolves them at instantiate/compile time
- Response patching goes through `fill()`, so a frozen `Response.prototype` cannot break `Sentry.init()`
- `patchWebAssembly()` orchestrates response patching, non-streaming hooks, then streaming hooks (unchanged behavior)
- Non-streaming hooks forward every argument and never let a registration failure reject the caller's promise
- Skip registration when `instantiate` receives an already-compiled `WebAssembly.Module`
