### PR TITLE
ref(browser-utils): Move browser span-start APIs out of core

### DIFF
--- a/packages/browser-utils/src/ensureBrowserSpanStreaming.ts
+++ b/packages/browser-utils/src/ensureBrowserSpanStreaming.ts
@@ -1,0 +1,29 @@
+import type { Client } from '@sentry/core';
+import { getClient, hasSpanStreamingEnabled, spanStreamingIntegration } from '@sentry/core';
+
+/**
+ * The span streaming integration is only reachable from code that can actually start a span.
+ * `@sentry/browser`'s `init()` deliberately doesn't reference it, so error-only apps tree-shake the
+ * entire span streaming graph away without needing the `__SENTRY_TRACING__` flag. The guarded browser
+ * span-start APIs call this before starting a span.
+ */
+
+const clientsWithIntegration = new WeakSet<Client>();
+
+/**
+ * Lazily install the browser span streaming integration.
+ *
+ * Defaults to the current client; pass one explicitly from integration hooks, where the client being
+ * set up isn't necessarily the current one.
+ *
+ */
+export function ensureBrowserSpanStreaming(client: Client | undefined = getClient()): void {
+  // The `WeakSet` is an allocation optimization, not a semantic gate — `addIntegration()` is already
+  // idempotent by integration name, including against a user-supplied instance.
+  if (!client || clientsWithIntegration.has(client) || !hasSpanStreamingEnabled(client)) {
+    return;
+  }
+
+  clientsWithIntegration.add(client);
+  client.addIntegration(spanStreamingIntegration());
+}

--- a/packages/browser-utils/src/index.ts
+++ b/packages/browser-utils/src/index.ts
@@ -9,6 +9,8 @@ export {
 
 export { addPerformanceEntries, startTrackingLongTasks, startTrackingLongAnimationFrames } from './performance/entries';
 
+export { startSpan, startInactiveSpan, startSpanManual } from './spanApi';
+
 export {
   addWebVitalsToSpan,
   // eslint-disable-next-line typescript/no-deprecated

--- a/packages/browser-utils/src/performance/interactions.ts
+++ b/packages/browser-utils/src/performance/interactions.ts
@@ -18,6 +18,7 @@ import {
 } from '@sentry/core';
 import { startIdleSpan } from '@sentry/core/browser';
 import { DEBUG_BUILD } from '../debug-build';
+import { ensureBrowserSpanStreaming } from '../ensureBrowserSpanStreaming';
 import { htmlTreeAsString } from '../htmlTreeAsString';
 import { addPerformanceInstrumentationHandler } from '../instrumentation/performanceObserver';
 import { isBotUserAgent } from '../isBotUserAgent';
@@ -65,6 +66,10 @@ const _interactionsIntegration = ((options: InteractionsOptions = {}) => {
       if (isBotUserAgent()) {
         return;
       }
+
+      // Interaction spans are started through `startIdleSpan`, which - unlike the guarded `startSpan`
+      // APIs - does not install span streaming itself, so we ensure it here.
+      ensureBrowserSpanStreaming(client);
 
       const latestRoute: RouteInfo = { name: undefined, source: undefined };
       // The pageload/navigation span that is currently in progress, if any. Clicks that happen while one

--- a/packages/browser-utils/src/performance/utils.ts
+++ b/packages/browser-utils/src/performance/utils.ts
@@ -1,6 +1,6 @@
 import type { SentrySpan, Span, SpanTimeInput, StartSpanOptions } from '@sentry/core';
 import { spanToStaticSpanJSON, withActiveSpan } from '@sentry/core';
-import { startInactiveSpan } from '@sentry/core/browser';
+import { startInactiveSpan } from '../spanApi';
 import { WINDOW } from '../types';
 
 /**

--- a/packages/browser-utils/src/spanApi.ts
+++ b/packages/browser-utils/src/spanApi.ts
@@ -1,14 +1,14 @@
-import type { Client } from '../client';
-import { getClient } from '../currentScopes';
-import { spanStreamingIntegration } from '../integrations/spanStreaming';
-import type { Span } from '../types/span';
-import type { StartSpanOptions } from '../types/startSpanOptions';
-import { hasSpanStreamingEnabled } from './spans/hasSpanStreamingEnabled';
+import type { Span, StartSpanOptions } from '@sentry/core';
+/* oxlint-disable sdk/no-unguarded-span-apis -- This module IS the guarded browser variant: each wrapper
+   installs `spanStreamingIntegration` via `ensureBrowserSpanStreaming` before delegating to the
+   plain core API, which is exactly what browser-facing code is meant to go through. */
 import {
   startInactiveSpan as coreStartInactiveSpan,
   startSpan as coreStartSpan,
   startSpanManual as coreStartSpanManual,
-} from './trace';
+} from '@sentry/core';
+/* oxlint-enable sdk/no-unguarded-span-apis */
+import { ensureBrowserSpanStreaming } from './ensureBrowserSpanStreaming';
 
 /**
  * Browser variants of the span-start APIs.
@@ -19,34 +19,13 @@ import {
  * the `__SENTRY_TRACING__` flag.
  */
 
-const clientsWithIntegration = new WeakSet<Client>();
-
-/**
- * Lazily install the browser span streaming integration.
- *
- * Defaults to the current client; pass one explicitly from integration hooks, where the client being
- * set up isn't necessarily the current one.
- *
- * @internal
- */
-export function _INTERNAL_ensureBrowserSpanStreaming(client: Client | undefined = getClient()): void {
-  // The `WeakSet` is an allocation optimization, not a semantic gate — `addIntegration()` is already
-  // idempotent by integration name, including against a user-supplied instance.
-  if (!client || clientsWithIntegration.has(client) || !hasSpanStreamingEnabled(client)) {
-    return;
-  }
-
-  clientsWithIntegration.add(client);
-  client.addIntegration(spanStreamingIntegration());
-}
-
 /**
  * Wraps a function with a span and finishes the span after the function is done.
  *
  * See {@link startSpan} in `@sentry/core` for details.
  */
 export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) => T): T {
-  _INTERNAL_ensureBrowserSpanStreaming();
+  ensureBrowserSpanStreaming();
   return coreStartSpan(options, callback);
 }
 
@@ -56,7 +35,7 @@ export function startSpan<T>(options: StartSpanOptions, callback: (span: Span) =
  * See {@link startSpanManual} in `@sentry/core` for details.
  */
 export function startSpanManual<T>(options: StartSpanOptions, callback: (span: Span, finish: () => void) => T): T {
-  _INTERNAL_ensureBrowserSpanStreaming();
+  ensureBrowserSpanStreaming();
   return coreStartSpanManual(options, callback);
 }
 
@@ -66,6 +45,6 @@ export function startSpanManual<T>(options: StartSpanOptions, callback: (span: S
  * See {@link startInactiveSpan} in `@sentry/core` for details.
  */
 export function startInactiveSpan(options: StartSpanOptions): Span {
-  _INTERNAL_ensureBrowserSpanStreaming();
+  ensureBrowserSpanStreaming();
   return coreStartInactiveSpan(options);
 }

--- a/packages/browser-utils/src/web-vitals/spans.ts
+++ b/packages/browser-utils/src/web-vitals/spans.ts
@@ -13,7 +13,7 @@ import {
   spanToJSON,
   timestampInSeconds,
 } from '@sentry/core';
-import { startInactiveSpan } from '@sentry/core/browser';
+import { startInactiveSpan } from '../spanApi';
 import { DEBUG_BUILD } from '../debug-build';
 import { htmlTreeAsString } from '../htmlTreeAsString';
 import { WINDOW } from '../types';

--- a/packages/browser-utils/test/web-vitals/spans.test.ts
+++ b/packages/browser-utils/test/web-vitals/spans.test.ts
@@ -1,5 +1,5 @@
 import * as SentryCore from '@sentry/core';
-import * as SentryCoreBrowser from '@sentry/core/browser';
+import * as SpanApi from '../../src/spanApi';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { htmlTreeAsString } from '../../src/htmlTreeAsString';
 import * as inpModule from '../../src/web-vitals/inp';
@@ -27,9 +27,9 @@ vi.mock('@sentry/core', async () => {
   };
 });
 
-// `startInactiveSpan` comes from `@sentry/core/browser`, not the root entry - see `browserSpanApi.ts`.
-vi.mock('@sentry/core/browser', async () => {
-  const actual = await vi.importActual('@sentry/core/browser');
+// `startInactiveSpan` is the guarded browser variant from `../../src/spanApi`, not the root entry.
+vi.mock('../../src/spanApi', async () => {
+  const actual = await vi.importActual('../../src/spanApi');
   return {
     ...actual,
     startInactiveSpan: vi.fn(),
@@ -71,7 +71,7 @@ describe('_emitWebVitalSpan', () => {
 
   beforeEach(() => {
     vi.mocked(SentryCore.getCurrentScope).mockReturnValue(mockScope as any);
-    vi.mocked(SentryCoreBrowser.startInactiveSpan).mockReturnValue(mockSpan as any);
+    vi.mocked(SpanApi.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
     // A root span is its own root, which is what the web vital spans are parented to.
     vi.mocked(SentryCore.getRootSpan).mockImplementation(span => span);
@@ -92,7 +92,7 @@ describe('_emitWebVitalSpan', () => {
       startTime: 1.5,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith({
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith({
       name: 'Test Vital',
       attributes: {
         'sentry.origin': 'auto.http.browser.lcp',
@@ -107,7 +107,7 @@ describe('_emitWebVitalSpan', () => {
     });
 
     // No standalone flag
-    expect(SentryCoreBrowser.startInactiveSpan).not.toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).not.toHaveBeenCalledWith(
       expect.objectContaining({ experimental: expect.anything() }),
     );
 
@@ -129,7 +129,7 @@ describe('_emitWebVitalSpan', () => {
       parentSpan,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
           'sentry.segment.name': 'Pageload',
@@ -150,7 +150,7 @@ describe('_emitWebVitalSpan', () => {
       standalone: true,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({ experimental: { standalone: true } }),
     );
   });
@@ -170,7 +170,7 @@ describe('_emitWebVitalSpan', () => {
       standalone: true,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
           'sentry.replay_id': 'replay-123',
@@ -195,7 +195,7 @@ describe('_emitWebVitalSpan', () => {
       standalone: true,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({ 'sentry._internal.replay_is_buffering': true }),
       }),
@@ -216,7 +216,7 @@ describe('_emitWebVitalSpan', () => {
       startTime: 1.5,
     });
 
-    const attributes = vi.mocked(SentryCoreBrowser.startInactiveSpan).mock.calls[0]![0].attributes!;
+    const attributes = vi.mocked(SpanApi.startInactiveSpan).mock.calls[0]![0].attributes!;
     expect(attributes['sentry.replay_id']).toBeUndefined();
   });
 
@@ -238,7 +238,7 @@ describe('_emitWebVitalSpan', () => {
       startTime: 1.0,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
           'sentry.pageload.span_id': 'abc123',
@@ -264,7 +264,7 @@ describe('_emitWebVitalSpan', () => {
       startTime: 1.0,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.not.objectContaining({
           'sentry.pageload.span_id': expect.anything(),
@@ -284,7 +284,7 @@ describe('_emitWebVitalSpan', () => {
       startTime: 1.0,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
           'browser.web_vital.cls.report_event': 'pagehide',
@@ -304,7 +304,7 @@ describe('_emitWebVitalSpan', () => {
       startTime: 1.0,
     });
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
           'custom.attr': 'value',
@@ -314,7 +314,7 @@ describe('_emitWebVitalSpan', () => {
   });
 
   it('handles when startInactiveSpan returns undefined', () => {
-    vi.mocked(SentryCoreBrowser.startInactiveSpan).mockReturnValue(undefined as any);
+    vi.mocked(SpanApi.startInactiveSpan).mockReturnValue(undefined as any);
 
     expect(() => {
       _emitWebVitalSpan({
@@ -344,7 +344,7 @@ describe('_sendLcpSpan', () => {
     vi.mocked(SentryCore.getCurrentScope).mockReturnValue(mockScope as any);
     vi.mocked(SentryCore.browserPerformanceTimeOrigin).mockReturnValue(1000);
     vi.mocked(htmlTreeAsString).mockImplementation((node: any) => `<${node?.tagName || 'div'}>`);
-    vi.mocked(SentryCoreBrowser.startInactiveSpan).mockReturnValue(mockSpan as any);
+    vi.mocked(SpanApi.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({
       // The web vital span takes its segment name off the pageload span it is parented to.
       name: 'test-route',
@@ -371,7 +371,7 @@ describe('_sendLcpSpan', () => {
 
     _sendLcpSpan(250, mockEntry, mockPageloadSpan as any, 'pagehide');
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: '<img>',
         attributes: expect.objectContaining({
@@ -401,7 +401,7 @@ describe('_sendLcpSpan', () => {
   it('sends a streamed LCP span without entry data', () => {
     _sendLcpSpan(250, undefined);
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Largest contentful paint',
         startTime: 1, // timeOrigin: 1000 / 1000
@@ -413,7 +413,7 @@ describe('_sendLcpSpan', () => {
     _sendLcpSpan(0, undefined);
     _sendLcpSpan(MAX_PLAUSIBLE_LCP_DURATION + 1, undefined);
 
-    expect(SentryCoreBrowser.startInactiveSpan).not.toHaveBeenCalled();
+    expect(SpanApi.startInactiveSpan).not.toHaveBeenCalled();
   });
 });
 
@@ -433,7 +433,7 @@ describe('_sendClsSpan', () => {
     vi.mocked(SentryCore.browserPerformanceTimeOrigin).mockReturnValue(1000);
     vi.mocked(SentryCore.timestampInSeconds).mockReturnValue(1.5);
     vi.mocked(htmlTreeAsString).mockImplementation((node: any) => `<${node?.tagName || 'div'}>`);
-    vi.mocked(SentryCoreBrowser.startInactiveSpan).mockReturnValue(mockSpan as any);
+    vi.mocked(SpanApi.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({
       // The web vital span takes its segment name off the pageload span it is parented to.
       name: 'test-route',
@@ -471,7 +471,7 @@ describe('_sendClsSpan', () => {
 
     _sendClsSpan(0.1, mockEntry, mockPageloadSpan as any, 'navigation');
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: '<div>',
         attributes: expect.objectContaining({
@@ -493,7 +493,7 @@ describe('_sendClsSpan', () => {
     _sendClsSpan(0, undefined);
 
     expect(SentryCore.timestampInSeconds).toHaveBeenCalled();
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Layout shift',
         startTime: 1.5,
@@ -517,7 +517,7 @@ describe('_sendInpSpan', () => {
     vi.mocked(SentryCore.getCurrentScope).mockReturnValue(mockScope as any);
     vi.mocked(SentryCore.browserPerformanceTimeOrigin).mockReturnValue(1000);
     vi.mocked(htmlTreeAsString).mockReturnValue('<button>');
-    vi.mocked(SentryCoreBrowser.startInactiveSpan).mockReturnValue(mockSpan as any);
+    vi.mocked(SpanApi.startInactiveSpan).mockReturnValue(mockSpan as any);
     vi.mocked(SentryCore.getActiveSpan).mockReturnValue(undefined);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
     // A root span is its own root, which is what the web vital spans are parented to.
@@ -542,7 +542,7 @@ describe('_sendInpSpan', () => {
     _sendInpSpan(120, mockEntry);
 
     // startTime = (1000 + 500) / 1000 = 1.5
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: '<button>',
         startTime: 1.5,
@@ -573,7 +573,7 @@ describe('_sendInpSpan', () => {
 
     _sendInpSpan(80, mockEntry);
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         attributes: expect.objectContaining({
           'sentry.op': 'ui.interaction.press',
@@ -605,7 +605,7 @@ describe('_sendInpSpan', () => {
 
     expect(inpModule.getCachedInteractionContext).toHaveBeenCalledWith(42);
 
-    expect(SentryCoreBrowser.startInactiveSpan).toHaveBeenCalledWith(
+    expect(SpanApi.startInactiveSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'body > CachedButton',
         attributes: expect.objectContaining({
@@ -637,7 +637,7 @@ describe('trackInpAsSpan', () => {
     vi.mocked(SentryCore.browserPerformanceTimeOrigin).mockReturnValue(1000);
     vi.mocked(SentryCore.getCurrentScope).mockReturnValue(mockScope as any);
     vi.mocked(SentryCore.getActiveSpan).mockReturnValue(undefined);
-    vi.mocked(SentryCoreBrowser.startInactiveSpan).mockReturnValue({ end: vi.fn() } as any);
+    vi.mocked(SpanApi.startInactiveSpan).mockReturnValue({ end: vi.fn() } as any);
     vi.mocked(SentryCore.spanToJSON).mockReturnValue({ attributes: {} } as any);
     // A root span is its own root, which is what the web vital spans are parented to.
     vi.mocked(SentryCore.getRootSpan).mockImplementation(span => span);
@@ -657,7 +657,7 @@ describe('trackInpAsSpan', () => {
     trackInpAsSpan(streamingClient);
     inpCallback({ metric: validMetric });
 
-    const call = vi.mocked(SentryCoreBrowser.startInactiveSpan).mock.calls[0]![0];
+    const call = vi.mocked(SpanApi.startInactiveSpan).mock.calls[0]![0];
     expect(call.experimental).toBeUndefined();
     expect(call.attributes?.['sentry.op']).toBe('ui.interaction.click');
   });
@@ -667,25 +667,25 @@ describe('trackInpAsSpan', () => {
     trackInpAsSpan(staticClient);
     inpCallback({ metric: validMetric });
 
-    const call = vi.mocked(SentryCoreBrowser.startInactiveSpan).mock.calls[0]![0];
+    const call = vi.mocked(SpanApi.startInactiveSpan).mock.calls[0]![0];
     expect(call.experimental).toEqual({ standalone: true });
   });
 
   it('ignores INP metrics without a value', () => {
     trackInpAsSpan(streamingClient);
     inpCallback({ metric: { value: null, entries: [] } });
-    expect(SentryCoreBrowser.startInactiveSpan).not.toHaveBeenCalled();
+    expect(SpanApi.startInactiveSpan).not.toHaveBeenCalled();
   });
 
   it('ignores implausibly long INP durations', () => {
     trackInpAsSpan(streamingClient);
     inpCallback({ metric: { value: (inpModule.MAX_PLAUSIBLE_INP_DURATION + 1) * 1000, entries: validMetric.entries } });
-    expect(SentryCoreBrowser.startInactiveSpan).not.toHaveBeenCalled();
+    expect(SpanApi.startInactiveSpan).not.toHaveBeenCalled();
   });
 
   it('ignores INP metrics without a matching interaction entry', () => {
     trackInpAsSpan(streamingClient);
     inpCallback({ metric: { value: 120, entries: [{ name: 'scroll', duration: 120 }] } });
-    expect(SentryCoreBrowser.startInactiveSpan).not.toHaveBeenCalled();
+    expect(SpanApi.startInactiveSpan).not.toHaveBeenCalled();
   });
 });

--- a/packages/browser/src/index.bundle.tracing.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.logs.metrics.ts
@@ -17,7 +17,7 @@ export {
   spanStreamingIntegration,
 } from '@sentry/core';
 
-export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/core/browser';
+export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/browser-utils';
 export {
   browserTracingIntegration,
   startBrowserTracingNavigationSpan,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.logs.metrics.ts
@@ -17,7 +17,7 @@ export {
   metrics,
   spanStreamingIntegration,
 } from '@sentry/core';
-export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/core/browser';
+export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/browser-utils';
 
 export {
   browserTracingIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -22,7 +22,7 @@ export {
   setMeasurement,
   spanStreamingIntegration,
 } from '@sentry/core';
-export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/core/browser';
+export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/browser-utils';
 
 export {
   browserTracingIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.logs.metrics.ts
@@ -16,7 +16,7 @@ export {
   withActiveSpan,
   spanStreamingIntegration,
 } from '@sentry/core';
-export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/core/browser';
+export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/browser-utils';
 
 export {
   browserTracingIntegration,

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -22,7 +22,7 @@ export {
   setMeasurement,
   spanStreamingIntegration,
 } from '@sentry/core';
-export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/core/browser';
+export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/browser-utils';
 
 export {
   browserTracingIntegration,

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -23,7 +23,7 @@ export {
   setMeasurement,
   spanStreamingIntegration,
 } from '@sentry/core';
-export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/core/browser';
+export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/browser-utils';
 
 export {
   browserTracingIntegration,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -71,7 +71,7 @@ export {
   metrics,
   spanStreamingIntegration,
 } from '@sentry/core';
-export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/core/browser';
+export { startSpan, startInactiveSpan, startSpanManual } from '@sentry/browser-utils';
 export type { Span, FeatureFlagsIntegration } from '@sentry/core';
 export { makeBrowserOfflineTransport } from './transports/offline';
 export { browserProfilingIntegration } from './profiling/integration';

--- a/packages/browser/src/integrations/fetchStreamPerformance.ts
+++ b/packages/browser/src/integrations/fetchStreamPerformance.ts
@@ -13,7 +13,7 @@ import {
   stripDataUrlContent,
   filterCollectedUrl,
 } from '@sentry/core';
-import { startInactiveSpan } from '@sentry/core/browser';
+import { startInactiveSpan } from '@sentry/browser-utils';
 import { WINDOW } from '../helpers';
 
 const responseToStreamSpan = new WeakMap<object, Span>();

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -22,17 +22,19 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_IDLE_SPAN_FINISH_REASON,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
   spanIsSampled,
+  spanStreamingIntegration,
   spanToJSON,
   timestampInSeconds,
   TRACING_DEFAULTS,
   browserPerformanceTimeOrigin,
 } from '@sentry/core';
-import { _INTERNAL_ensureBrowserSpanStreaming, startIdleSpan, startInactiveSpan } from '@sentry/core/browser';
+import { startIdleSpan } from '@sentry/core/browser';
 import {
   addHistoryInstrumentationHandler,
   addPerformanceEntries,
   getLocationHref,
   isBotUserAgent,
+  startInactiveSpan,
   startTrackingLongAnimationFrames,
   startTrackingLongTasks,
 } from '@sentry/browser-utils';
@@ -564,10 +566,12 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         return;
       }
 
-      // Technically, every startSpan call already ensures that `spanStreamingIntegration` is installed,
-      // but we do it here anyway for the edge case that users disabled pageload and navigation spans and
-      // purely rely on manual startSpan calls.
-      _INTERNAL_ensureBrowserSpanStreaming(client);
+      // The pageload/navigation idle span is started through the unguarded `startIdleSpan`, so - unlike
+      // the guarded `startSpan` APIs - nothing installs span streaming for it. We ensure it here.
+      // `addIntegration` is idempotent by name, so this is safe even if a span already installed it.
+      if (hasSpanStreamingEnabled(client)) {
+        client.addIntegration(spanStreamingIntegration());
+      }
 
       // Auto-register webVitalsIntegration if the user hasn't added one. We do this in
       // afterAllSetup so that a user-provided webVitalsIntegration - which may be ordered after

--- a/packages/browser/src/tracing/request.ts
+++ b/packages/browser/src/tracing/request.ts
@@ -22,7 +22,7 @@ import {
   stripUrlQueryAndFragment,
   timestampInSeconds,
 } from '@sentry/core';
-import { startInactiveSpan } from '@sentry/core/browser';
+import { startInactiveSpan } from '@sentry/browser-utils';
 import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, XhrHint } from '@sentry/browser-utils';
 import { filterCollectedUrl, filterCollectedUrlQuery } from '@sentry/core';
 import {

--- a/packages/browser/test/integrations/fetchStreamPerformance.test.ts
+++ b/packages/browser/test/integrations/fetchStreamPerformance.test.ts
@@ -1,6 +1,6 @@
 import type { Client, HandlerDataFetch } from '@sentry/core';
 import * as utils from '@sentry/core';
-import * as coreBrowser from '@sentry/core/browser';
+import * as browserUtils from '@sentry/browser-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fetchStreamPerformanceIntegration } from '../../src/integrations/fetchStreamPerformance';
 
@@ -24,7 +24,7 @@ describe('fetchStreamPerformanceIntegration', () => {
     });
     vi.spyOn(utils, 'addFetchEndInstrumentationHandler').mockImplementation(() => () => {});
     const startInactiveSpanSpy = vi
-      .spyOn(coreBrowser, 'startInactiveSpan')
+      .spyOn(browserUtils, 'startInactiveSpan')
       .mockReturnValue(new utils.SentryNonRecordingSpan());
 
     fetchStreamPerformanceIntegration().setup?.({

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -18,7 +18,7 @@ import {
   browserPerformanceTimeOrigin,
   getSpanDescendants,
 } from '@sentry/core';
-import { startInactiveSpan } from '@sentry/core/browser';
+import { startInactiveSpan } from '@sentry/browser-utils';
 import { JSDOM } from 'jsdom';
 import { TextDecoder, TextEncoder } from 'util';
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/packages/browser/test/tracing/request.test.ts
+++ b/packages/browser/test/tracing/request.test.ts
@@ -1,6 +1,5 @@
 import type { Client } from '@sentry/core';
 import * as utils from '@sentry/core';
-import * as coreBrowser from '@sentry/core/browser';
 import * as browserUtils from '@sentry/browser-utils';
 import { HTTP_REQUEST_METHOD } from '@sentry/conventions/attributes';
 import type { MockInstance } from 'vitest';
@@ -345,7 +344,7 @@ describe('instrumentOutgoingRequests', () => {
       vi.spyOn(utils, 'getActiveSpan').mockReturnValue(activeSpan);
       vi.spyOn(utils, 'hasSpansEnabled').mockReturnValue(true);
       vi.spyOn(utils, 'hasSpanStreamingEnabled').mockReturnValue(true);
-      vi.spyOn(coreBrowser, 'startInactiveSpan').mockReturnValue(ignoredSpan);
+      vi.spyOn(browserUtils, 'startInactiveSpan').mockReturnValue(ignoredSpan);
       const getTraceDataSpy = vi.spyOn(utils, 'getTraceData').mockReturnValue({
         'sentry-trace': '12345678901234567890123456789012-1234567890123456-1',
       });

--- a/packages/browser/test/tracing/spanStreamingSetup.test.ts
+++ b/packages/browser/test/tracing/spanStreamingSetup.test.ts
@@ -1,6 +1,6 @@
 import type { Client } from '@sentry/core';
 import { createTransport, getMainCarrier, resolvedSyncPromise } from '@sentry/core';
-import { startIdleSpan, startInactiveSpan, startSpan, startSpanManual } from '@sentry/core/browser';
+import { startInactiveSpan, startSpan, startSpanManual } from '@sentry/browser-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BrowserOptions } from '../../src';
 import { browserTracingIntegration, init } from '../../src';
@@ -46,7 +46,6 @@ describe('span streaming wiring', () => {
   it.each([
     ['startSpan', () => startSpan({ name: 'test' }, () => {})],
     ['startInactiveSpan', () => startInactiveSpan({ name: 'test' }).end()],
-    ['startIdleSpan', () => startIdleSpan({ name: 'test' })],
     ['startSpanManual', () => startSpanManual({ name: 'test' }, () => {})],
   ])('installs the integration when the first span is started via %s', (_, startTestSpan) => {
     const client = initSdk();

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -4,13 +4,6 @@
  * @module
  */
 
-export {
-  startSpan,
-  startInactiveSpan,
-  startSpanManual,
-  _INTERNAL_ensureBrowserSpanStreaming,
-} from './tracing/browserSpanApi';
-
 export { startIdleSpan } from './tracing/idleSpan';
 
 export type { XhrBreadcrumbData, XhrBreadcrumbHint } from './types/breadcrumb';

--- a/packages/core/src/tracing/idleSpan.ts
+++ b/packages/core/src/tracing/idleSpan.ts
@@ -16,7 +16,6 @@ import {
   spanToStaticSpanJSON,
 } from '../utils/spanUtils';
 import { timestampInSeconds } from '../utils/time';
-import { _INTERNAL_ensureBrowserSpanStreaming } from './browserSpanApi';
 import { SentryNonRecordingSpan, spanIsNonRecordingSpan } from './sentryNonRecordingSpan';
 import { SentrySpan } from './sentrySpan';
 import { SPAN_STATUS_ERROR, SPAN_STATUS_OK } from './spanstatus';
@@ -91,7 +90,6 @@ interface IdleSpanOptions {
  */
 export function startIdleSpan(startSpanOptions: StartSpanOptions, options: Partial<IdleSpanOptions> = {}): Span {
   const client = getClient();
-  _INTERNAL_ensureBrowserSpanStreaming(client);
 
   // Activities store a list of active spans
   const activities = new Map<string, boolean>();

--- a/packages/core/test/exports.test.ts
+++ b/packages/core/test/exports.test.ts
@@ -3,38 +3,32 @@ import * as browserEntry from '../src/browser';
 import * as rootEntry from '../src/index';
 import { spanStreamingIntegration } from '../src/integrations/spanStreaming';
 import * as serverEntry from '../src/server';
-import * as browserSpanApi from '../src/tracing/browserSpanApi';
 import {
   startInactiveSpan as plainStartInactiveSpan,
   startSpan as plainStartSpan,
   startSpanManual as plainStartSpanManual,
 } from '../src/tracing/trace';
 
-// The span-start APIs exist in two variants under the same name: the plain ones (`./tracing/trace`)
-// and the browser ones (`./tracing/browserSpanApi`) that install `spanStreamingIntegration` before
-// starting the span. The isomorphic root entry disambiguates to the plain variant with explicit
-// re-exports — if someone adds another `export *` that also carries one of these names, or drops the
-// explicit re-export, the root entry silently flips to the wrong variant (or fails to link). The
-// browser entry serves the guarded variant, and the server entry is disjoint from the isomorphic
-// surface, so it deliberately does not re-export these APIs at all.
+// The isomorphic span-start APIs (`startSpan`, `startInactiveSpan`, `startSpanManual`) live only on the
+// root entry, which serves the plain variant from `./tracing/trace`. The guarded browser variant - the
+// one that installs `spanStreamingIntegration` before starting a span - lives in `@sentry/browser-utils`,
+// not here, so none of core's platform entries re-export these APIs. If someone adds another `export *`
+// that carries one of these names, the root entry could silently flip to a different variant (or fail to
+// link), which is what this guards against.
 describe('entry point resolution', () => {
   const cases = [
-    ['startSpan', plainStartSpan, browserSpanApi.startSpan],
-    ['startInactiveSpan', plainStartInactiveSpan, browserSpanApi.startInactiveSpan],
-    ['startSpanManual', plainStartSpanManual, browserSpanApi.startSpanManual],
+    ['startSpan', plainStartSpan],
+    ['startInactiveSpan', plainStartInactiveSpan],
+    ['startSpanManual', plainStartSpanManual],
   ] as const;
 
   it.each(cases)('`%s`: the root entry serves the plain variant', (name, plain) => {
     expect(rootEntry[name]).toBe(plain);
   });
 
-  it.each(cases)('`%s`: the browser entry serves the browser variant', (name, plain, browser) => {
-    expect(browserEntry[name]).toBe(browser);
-    expect(browserEntry[name]).not.toBe(plain);
-  });
-
-  it.each(cases)('`%s`: the server entry does not re-export the isomorphic API', name => {
+  it.each(cases)('`%s`: the platform entries do not re-export the isomorphic API', name => {
     expect(serverEntry).not.toHaveProperty(name);
+    expect(browserEntry).not.toHaveProperty(name);
   });
 
   // `spanStreamingIntegration` is isomorphic and lives only on the root entry. The platform entries

--- a/packages/effect/src/client/tracer.ts
+++ b/packages/effect/src/client/tracer.ts
@@ -1,4 +1,4 @@
-import { startInactiveSpan } from '@sentry/core/browser';
+import { startInactiveSpan } from '@sentry/browser';
 import { makeSentryTracer } from '../tracer';
 
 /**

--- a/packages/effect/test/layer.test.ts
+++ b/packages/effect/test/layer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as sentryCore from '@sentry/core';
-import * as sentryCoreBrowser from '@sentry/core/browser';
+import * as sentryBrowser from '@sentry/browser';
 import { getClient, getMainCarrier, SDK_VERSION } from '@sentry/core';
 import { Effect, Layer, Logger } from 'effect';
 import * as References from 'effect/References';
@@ -25,7 +25,7 @@ describe.each([
       SentryEffectTracer: sentryClient.SentryEffectTracer,
       SentryEffectLogger: sentryClient.SentryEffectLogger,
       SentryEffectMetricsLayer: sentryClient.SentryEffectMetricsLayer,
-      startInactiveSpan: sentryCoreBrowser as { startInactiveSpan: typeof sentryCore.startInactiveSpan },
+      startInactiveSpan: sentryBrowser as { startInactiveSpan: typeof sentryCore.startInactiveSpan },
     },
   ],
   [

--- a/packages/effect/test/tracer.test.ts
+++ b/packages/effect/test/tracer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@effect/vitest';
 import * as sentryCore from '@sentry/core';
-import * as sentryCoreBrowser from '@sentry/core/browser';
+import * as sentryBrowser from '@sentry/browser';
 import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
 import { Effect } from 'effect';
 import { afterEach, vi } from 'vitest';
@@ -8,10 +8,10 @@ import { SentryEffectTracer as clientTracer } from '../src/client/tracer';
 import { SentryEffectTracer as serverTracer } from '../src/server/tracer';
 
 // The two variants differ only in which module they start spans through, so spying on `spanApi` also
-// asserts that wiring: the client tracer must go through `@sentry/core/browser` (which installs
+// asserts that wiring: the client tracer must go through `@sentry/browser` (which installs
 // `spanStreamingIntegration`) and the server tracer through the plain `@sentry/core`.
 const VARIANTS = [
-  { variant: 'client', tracer: clientTracer, spanApi: sentryCoreBrowser as SpanApi },
+  { variant: 'client', tracer: clientTracer, spanApi: sentryBrowser as SpanApi },
   { variant: 'server', tracer: serverTracer, spanApi: sentryCore as SpanApi },
 ];
 

--- a/packages/react-router/src/client/createClientInstrumentation.ts
+++ b/packages/react-router/src/client/createClientInstrumentation.ts
@@ -15,7 +15,7 @@ import {
   updateSpanName,
   filterCollectedUrl,
 } from '@sentry/core';
-import { startSpan } from '@sentry/core/browser';
+import { startSpan } from '@sentry/browser';
 import type { ClientInstrumentation } from 'react-router';
 import { DEBUG_BUILD } from '../common/debug-build';
 import { captureInstrumentationError, getPathFromRequest, getPattern, normalizeRoutePath } from '../common/utils';

--- a/packages/react-router/test/client/createClientInstrumentation.test.ts
+++ b/packages/react-router/test/client/createClientInstrumentation.test.ts
@@ -1,20 +1,11 @@
 import * as browser from '@sentry/browser';
 import * as core from '@sentry/core';
-import * as coreBrowser from '@sentry/core/browser';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createSentryClientInstrumentation,
   isClientInstrumentationApiUsed,
   isNavigateHookInvoked,
 } from '../../src/client/createClientInstrumentation';
-
-vi.mock('@sentry/core/browser', async () => {
-  const actual = await vi.importActual('@sentry/core/browser');
-  return {
-    ...actual,
-    startSpan: vi.fn(),
-  };
-});
 
 vi.mock('@sentry/core', async () => {
   const actual = await vi.importActual('@sentry/core');
@@ -33,6 +24,7 @@ vi.mock('@sentry/core', async () => {
 });
 
 vi.mock('@sentry/browser', () => ({
+  startSpan: vi.fn(),
   startBrowserTracingNavigationSpan: vi.fn().mockReturnValue({ setStatus: vi.fn() }),
   getAbsoluteUrl: vi.fn((urlOrPath: string) => {
     try {
@@ -205,7 +197,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockCallFetch = vi.fn().mockResolvedValue({ status: 'success', error: undefined });
     const mockInstrument = vi.fn();
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
 
     const instrumentation = createSentryClientInstrumentation();
     instrumentation.router?.({ instrument: mockInstrument });
@@ -219,7 +211,7 @@ describe('createSentryClientInstrumentation', () => {
       fetcherKey: 'fetcher-1',
     });
 
-    expect(coreBrowser.startSpan).toHaveBeenCalledWith(
+    expect(browser.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Fetcher fetcher-1',
         attributes: expect.objectContaining({
@@ -237,7 +229,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockCallLoader = vi.fn().mockResolvedValue({ status: 'success', error: undefined });
     const mockInstrument = vi.fn();
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
 
     const instrumentation = createSentryClientInstrumentation();
     // Route has id, index, path as required properties
@@ -259,7 +251,7 @@ describe('createSentryClientInstrumentation', () => {
       context: undefined,
     });
 
-    expect(coreBrowser.startSpan).toHaveBeenCalledWith(
+    expect(browser.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: '/users/:id',
         attributes: expect.objectContaining({
@@ -277,7 +269,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockCallAction = vi.fn().mockResolvedValue({ status: 'success', error: undefined });
     const mockInstrument = vi.fn();
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
 
     const instrumentation = createSentryClientInstrumentation();
     instrumentation.route?.({
@@ -297,7 +289,7 @@ describe('createSentryClientInstrumentation', () => {
       context: undefined,
     });
 
-    expect(coreBrowser.startSpan).toHaveBeenCalledWith(
+    expect(browser.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: '/users/:id',
         attributes: expect.objectContaining({
@@ -345,7 +337,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockInstrument = vi.fn();
     const mockSpan = { setStatus: vi.fn() };
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn(mockSpan));
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn(mockSpan));
 
     const instrumentation = createSentryClientInstrumentation();
     instrumentation.route?.({
@@ -379,7 +371,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockInstrument = vi.fn();
     const mockSpan = { setStatus: vi.fn() };
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn(mockSpan));
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn(mockSpan));
 
     const instrumentation = createSentryClientInstrumentation({ captureErrors: false });
     instrumentation.route?.({
@@ -592,7 +584,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockCallLoader = vi.fn().mockResolvedValue({ status: 'success', error: undefined });
     const mockInstrument = vi.fn();
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
 
     const instrumentation = createSentryClientInstrumentation();
     instrumentation.route?.({
@@ -612,7 +604,7 @@ describe('createSentryClientInstrumentation', () => {
       context: undefined,
     });
 
-    expect(coreBrowser.startSpan).toHaveBeenCalledWith(
+    expect(browser.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: '/users/123',
       }),
@@ -624,7 +616,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockCallMiddleware = vi.fn().mockResolvedValue({ status: 'success', error: undefined });
     const mockInstrument = vi.fn();
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
 
     const instrumentation = createSentryClientInstrumentation();
     instrumentation.route?.({
@@ -643,7 +635,7 @@ describe('createSentryClientInstrumentation', () => {
       context: undefined,
     });
 
-    expect(coreBrowser.startSpan).toHaveBeenCalledWith(
+    expect(browser.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'middleware test-route',
         attributes: expect.objectContaining({
@@ -663,7 +655,7 @@ describe('createSentryClientInstrumentation', () => {
     const mockCallLazy = vi.fn().mockResolvedValue({ status: 'success', error: undefined });
     const mockInstrument = vi.fn();
 
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn());
 
     const instrumentation = createSentryClientInstrumentation();
     instrumentation.route?.({
@@ -677,7 +669,7 @@ describe('createSentryClientInstrumentation', () => {
 
     await hooks.lazy(mockCallLazy, undefined);
 
-    expect(coreBrowser.startSpan).toHaveBeenCalledWith(
+    expect(browser.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Lazy Route Load',
         attributes: expect.objectContaining({
@@ -905,7 +897,7 @@ describe('isNavigateHookInvoked', () => {
 describe('navigation root parameterization', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (coreBrowser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn({ setStatus: vi.fn() }));
+    (browser.startSpan as any).mockImplementation((_opts: any, fn: any) => fn({ setStatus: vi.fn() }));
   });
 
   it('renames the active navigation/pageload root span with the route pattern from the loader hook', async () => {

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -1,7 +1,7 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/browser';
 import type { Span } from '@sentry/core';
 import { debug } from '@sentry/core';
-import { startInactiveSpan } from '@sentry/core/browser';
+import { startInactiveSpan } from '@sentry/browser';
 import { SENTRY_OP } from '@sentry/conventions/attributes';
 import { UI_MOUNT, UI_UPDATE } from '@sentry/conventions/op';
 import { afterUpdate, beforeUpdate, onMount } from 'svelte';

--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -4,7 +4,7 @@ import {
   objectify,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
 } from '@sentry/core';
-import { startSpan } from '@sentry/core/browser';
+import { startSpan } from '@sentry/svelte';
 import { SENTRY_SEGMENT_NAME_SOURCE, CODE_FUNCTION_NAME, SENTRY_OP } from '@sentry/conventions/attributes';
 import { FUNCTION } from '@sentry/conventions/op';
 import { captureException } from '@sentry/svelte';

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -10,8 +10,8 @@ const mockCaptureException = vi.spyOn(SentrySvelte, 'captureException').mockImpl
 
 const mockStartSpan = vi.fn();
 
-vi.mock('@sentry/core/browser', async () => {
-  const original = (await vi.importActual('@sentry/core/browser')) as any;
+vi.mock('@sentry/svelte', async () => {
+  const original = (await vi.importActual('@sentry/svelte')) as any;
   return {
     ...original,
     startSpan: (...args: unknown[]) => {


### PR DESCRIPTION
Stacked on top of #23762 — review/merge that first.

Follow-up to the core entrypoint split: the guarded browser span-start APIs do not belong in `@sentry/core`. They exist purely so that `spanStreamingIntegration` is reachable only from code that starts a span, which is a browser-SDK concern, so this moves them down into `@sentry/browser-utils` (which already sits below `@sentry/browser` and the framework SDKs).

What moves out of `@sentry/core/browser`:

- `startSpan` / `startInactiveSpan` / `startSpanManual` — the guarded wrappers that install span streaming before delegating to the plain core APIs — now live in `@sentry/browser-utils`. Everything they need is already public on `@sentry/core`.
- `ensureBrowserSpanStreaming` (previously `_INTERNAL_ensureBrowserSpanStreaming`) moves too, and is now **package-private** to `@sentry/browser-utils`. Its only callers are the wrappers and `interactionsIntegration`.

`startIdleSpan` stays in `@sentry/core/browser`, and no longer installs span streaming itself. That responsibility now sits with its callers: `interactionsIntegration` ensures it in `setup()`, and `browserTracingIntegration` continues to ensure it in `afterAllSetup` (guaranteeing the pageload segment streams with browser tracing alone).

_Decisions_

- This is not a breaking change: `@sentry/core/browser` is introduced by #23762 and unreleased, and `@sentry/browser` still re-exports the wrappers unchanged. The framework SDKs (effect, react-router, svelte, sveltekit) were repointed to packages they already depend on (`@sentry/browser` / `@sentry/svelte`), so no new dependencies were added.
- The wrapper module is the single place that legitimately imports the *plain* core span APIs in browser-facing code, so it carries a scoped `no-unguarded-span-apis` suppression — it is itself the guarded variant the rule steers callers toward.
- `browserTracingIntegration` can no longer reach the now-private gate, so it installs span streaming inline via core’\s public `hasSpanStreamingEnabled` + `spanStreamingIntegration`. This is a small, idempotent duplication of the gate logic; the alternative was keeping `ensureBrowserSpanStreaming` exported, which we chose not to do.
- The `XhrBreadcrumbData` / `XhrBreadcrumbHint` / `BrowserClientReplayOptions` types stay in `@sentry/core`: `XhrBreadcrumbHint` is referenced by core’\s own `Client` signatures (moving it would invert the dependency), and `BrowserClientReplayOptions` was deliberately parked in core to avoid a browser↔replay cycle.