### PR TITLE
fix(v10/nextjs): Register Vercel AI span processors on Next.js

### DIFF
--- a/packages/core/src/tracing/vercel-ai/index.ts
+++ b/packages/core/src/tracing/vercel-ai/index.ts
@@ -513,10 +513,20 @@ function processGenerateSpan(span: Span, name: string, attributes: SpanAttribute
   }
 }
 
+const CLIENTS_WITH_VERCEL_AI_PROCESSORS = new WeakSet<Client>();
+
 /**
  * Add event processors to the given client to process Vercel AI spans.
+ *
+ * Idempotent: both the integration and the Next.js SDK register these, and duplicate hooks would
+ * process every span twice.
  */
 export function addVercelAiProcessors(client: Client): void {
+  if (CLIENTS_WITH_VERCEL_AI_PROCESSORS.has(client)) {
+    return;
+  }
+  CLIENTS_WITH_VERCEL_AI_PROCESSORS.add(client);
+
   client.on('spanStart', onVercelAiSpanStart);
   // Note: We cannot do this on `spanEnd`, because the span cannot be mutated anymore at this point
   client.addEventProcessor(Object.assign(vercelAiEventProcessor, { id: 'VercelAiEventProcessor' }));

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -4,6 +4,7 @@
 import { HTTP_TARGET, URL_QUERY } from '@sentry/conventions/attributes';
 import type { EventProcessor } from '@sentry/core';
 import {
+  addVercelAiProcessors,
   applySdkMetadata,
   debug,
   getClient,
@@ -209,6 +210,14 @@ export function init(options: NodeOptions): NodeClient | undefined {
   applySdkMetadata(opts, 'nextjs', ['nextjs', cloudflareConfig ? 'cloudflare' : 'node']);
 
   const client = nodeInit(opts);
+
+  // Next.js bundles `ai`, so the integration can neither patch the module nor detect it via `Modules`
+  // (which only sees the app's own `package.json`, missing workspace and transitive deps). Register
+  // the processors here instead — after init, so an explicitly constructed `vercelAIIntegration()`
+  // can't override the default back to the broken behavior.
+  if (client?.getIntegrationByName('VercelAI')) {
+    addVercelAiProcessors(client);
+  }
 
   client?.on('beforeSampling', ({ spanAttributes }, samplingDecision) => {
     // There are situations where the Next.js Node.js server forwards requests for the Edge Runtime server (e.g. in


### PR DESCRIPTION
- On Next.js, Vercel AI spans arrive unprocessed — raw `ai.generateText` / `ai.toolCall`, no `gen_ai` op
- Next.js bundles `ai`, so it is never patched, and the `Modules` fallback misses workspace and transitive deps
- Registered in `init` rather than on the default integration, which a user-supplied `vercelAIIntegration()` would replace
- No e2e: reproducing needs `ai` hidden from `Modules`, and this gating is gone in v11
- Telemetry still needs per-call `experimental_telemetry: { isEnabled: true }`; docs to follow

Ref: https://linear.app/getsentry/issue/TET-2891/vercel-ai-sdk-v6-instrumentation-is-broken-on-nextjs