### PR TITLE
test(v10/nextjs): Drop nextjs-16-cf-workers canary variant

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -45,12 +45,6 @@
         "build-command": "pnpm test:build-latest",
         "label": "nextjs-16-cf-workers (latest)"
       }
-    ],
-    "optionalVariants": [
-      {
-        "build-command": "pnpm test:build-canary",
-        "label": "nextjs-16-cf-workers (canary)"
-      }
     ]
   }
 }


### PR DESCRIPTION
Backport of: #23540