### PR TITLE
feat(sveltekit): Register a route provider backed by reported route ids

### DIFF
--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -1,5 +1,7 @@
 import type { Integration } from '@sentry/core';
+import { setRouteProvider } from '@sentry/core';
 import { browserTracingIntegration as originalBrowserTracingIntegration } from '@sentry/svelte';
+import { routeProvider } from './routeCache';
 // The `sentrySvelteKit()` Vite plugin redirects this to the Svelte 4 or Svelte 5 variant per Kit
 // version; without the plugin it resolves via `exports` to the Svelte 4 variant, so builds don't break.
 import { instrumentSvelteKitTracing } from '@sentry/sveltekit/browser-tracing-variant';
@@ -20,6 +22,10 @@ export function browserTracingIntegration(
 
   return {
     ...integration,
+    setup: client => {
+      setRouteProvider(routeProvider, client);
+      integration.setup?.(client);
+    },
     afterAllSetup: client => {
       integration.afterAllSetup(client);
       instrumentSvelteKitTracing(client, options);

--- a/packages/sveltekit/src/client/routeCache.ts
+++ b/packages/sveltekit/src/client/routeCache.ts
@@ -1,0 +1,15 @@
+import { createCachedRouteProvider } from '@sentry/core';
+
+// SvelteKit has no public route matcher, and `page.route.id` is not available synchronously, so the
+// provider answers from route ids the instrumentation has already seen rather than by matching.
+export const routeProvider = createCachedRouteProvider();
+
+/**
+ * Records the parameterized route id SvelteKit reported for a path.
+ *
+ * Called from both the Kit 2 and Kit 3 instrumentation, since `page.route.id` is the only place the
+ * route id is available.
+ */
+export function recordRouteId(pathname: string | undefined, routeId: string | null | undefined): void {
+  routeProvider.record(pathname, routeId);
+}

--- a/packages/sveltekit/src/client/svelte4BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte4BrowserTracing.ts
@@ -19,6 +19,7 @@ import type { Navigation, Page } from '@sveltejs/kit';
 // eslint-disable-next-line typescript/no-deprecated
 import { navigating, page } from '$app/stores';
 import type { Readable } from 'svelte/store';
+import { recordRouteId } from './routeCache';
 
 /**
  * SvelteKit 2 / Svelte 4 browser tracing (`$app/stores`). Selected at build time, so it's only
@@ -64,6 +65,8 @@ function _instrumentPageload(client: Client, pageStore: Readable<Page>): void {
 
     const routeId = pageState.route?.id;
 
+    recordRouteId(pageState.url?.pathname, routeId);
+
     if (routeId) {
       pageloadSpan.updateName(routeId);
       pageloadSpan.setAttributes({ [SENTRY_SEGMENT_NAME_SOURCE]: 'route', [URL_TEMPLATE]: routeId });
@@ -106,6 +109,8 @@ function _instrumentNavigations(client: Client, navigatingStore: Readable<Naviga
 
     const parameterizedRouteOrigin = from?.route.id;
     const parameterizedRouteDestination = to?.route.id;
+
+    recordRouteId(to?.url.pathname, parameterizedRouteDestination);
 
     if (routingSpan) {
       // If a routing span is still open from a previous navigation, we finish it.

--- a/packages/sveltekit/src/client/svelte5BrowserTracing.ts
+++ b/packages/sveltekit/src/client/svelte5BrowserTracing.ts
@@ -17,6 +17,7 @@ import { SENTRY_SEGMENT_NAME_SOURCE, SENTRY_OP, URL_TEMPLATE } from '@sentry/con
 import { NAVIGATION, PAGELOAD, ROUTER } from '@sentry/conventions/op';
 import type { Navigation } from '@sveltejs/kit';
 import { getCurrentNavigation, onNavigationChange, onPageRouteChange } from './navigationState.svelte';
+import { recordRouteId } from './routeCache';
 
 /**
  * SvelteKit 3 / Svelte 5 browser tracing (`$app/state` runes). Selected at build time, so it's only
@@ -57,6 +58,8 @@ function _instrumentPageLoad(client: Client): void {
   // `page.route.id` isn't available synchronously when we set up (during `Sentry.init`), so we react
   // to it and upgrade the pageload span from `url` to the parameterized `route` once it resolves.
   onPageRouteChange(routeId => {
+    recordRouteId(WINDOW.location?.pathname, routeId);
+
     if (routeId) {
       pageLoadSpan.updateName(routeId);
       pageLoadSpan.setAttributes({ [SENTRY_SEGMENT_NAME_SOURCE]: 'route', [URL_TEMPLATE]: routeId });
@@ -89,6 +92,8 @@ function _instrumentNavigations(client: Client): void {
 
     const parameterizedRouteOrigin = from?.route.id;
     const parameterizedRouteDestination = to?.route.id;
+
+    recordRouteId(to?.url.pathname, parameterizedRouteDestination);
 
     routingSpan?.end();
 


### PR DESCRIPTION
Registers a route provider for SvelteKit, for both the Kit 2 and Kit 3 variants.

SvelteKit has no public route matcher and `page.route.id` is not available synchronously, so this is a cache-backed provider: it answers from route ids the instrumentation has already reported rather than by matching. Both variants already read the route id to rename the span, so they record it on the way through.

Part of #23556
