### PR TITLE
test(cloudflare): De-flake Workflow auto-instrumentation test

### DIFF
--- a/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workflow/test.ts
+++ b/dev-packages/cloudflare-integration-tests/suites/vite-autoinstrument/workflow/test.ts
@@ -4,8 +4,12 @@ import { createRunner } from '../../../runner';
 
 // The worker is built by the Sentry Vite plugin (auto-instrumentation on). The
 // runner detects `vite.config.mts`, runs `vite build`, and serves the generated
-// output — so a workflow-step transaction only arrives if the build-time
-// transform wrapped `MyWorkflow` with `instrumentWorkflowWithSentry`.
+// output — so these transactions only arrive if the build-time transform wrapped
+// `MyWorkflow` with `instrumentWorkflowWithSentry` and the default export with
+// `withSentry`.
+//
+// The workflow step and the triggering request are separate executions whose
+// envelopes race, so both are expected `unordered`.
 it('auto-instruments a Workflow class', async ({ signal }) => {
   const runner = createRunner(__dirname)
     .expect(envelope => {
@@ -14,6 +18,13 @@ it('auto-instruments a Workflow class', async ({ signal }) => {
       expect(transactionEvent.contexts?.trace?.op).toBe('function');
       expect(transactionEvent.contexts?.trace?.origin).toBe('auto.faas.cloudflare.workflow');
     })
+    .expect(envelope => {
+      const transactionEvent = envelope[1]?.[0]?.[1] as TransactionEvent;
+      expect(transactionEvent.transaction).toBe('GET /workflow/trigger');
+      expect(transactionEvent.contexts?.trace?.op).toBe('http.server');
+      expect(transactionEvent.contexts?.trace?.origin).toBe('auto.http.cloudflare');
+    })
+    .unordered()
     .start(signal);
 
   await runner.makeRequest('get', '/workflow/trigger');


### PR DESCRIPTION
The scenario emits two transactions (`step-one` and `GET /workflow/trigger`) from separate executions, but the test expected one envelope in ordered mode — so it asserted against whichever won the race. Now expects both, unordered.

- Matches every other `vite-autoinstrument` multi-transaction suite.
- Also asserts the request transaction, previously unchecked.
- Reproduced the CI failure locally before and after.

Fixes #23242