### PR TITLE
fix(orchestrion): Stop force-bundling instrumented deps in dev servers

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-7/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-7/package.json
@@ -9,7 +9,9 @@
     "astro": "astro",
     "start": "node ./dist/server/entry.mjs",
     "test:build": "pnpm install && pnpm build",
-    "test:assert": "TEST_ENV=production playwright test"
+    "test:assert": "pnpm test:prod && pnpm test:dev",
+    "test:prod": "TEST_ENV=production playwright test",
+    "test:dev": "TEST_ENV=development playwright test db"
   },
   "//": "Need to use ioredis 5.10.1 because that's the last version before they support tracing channels",
   "dependencies": {

--- a/dev-packages/e2e-tests/test-applications/astro-7/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/astro-7/playwright.config.mjs
@@ -6,8 +6,9 @@ if (!testEnv) {
   throw new Error('No test env defined');
 }
 
+// `astro dev` ignores PORT, so the port goes on the command.
 const config = getPlaywrightConfig({
-  startCommand: 'pnpm start',
+  startCommand: testEnv === 'development' ? 'pnpm dev --port 3030' : 'pnpm start',
 });
 
 export default {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/db.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/db.server.test.ts
@@ -2,14 +2,9 @@ import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 import { APP_NAME } from '../constants';
 
-// Orchestrion injects `diagnostics_channel` publishers at build time, so these spans only exist in the
-// bundled server build. `react-router dev` serves an unbundled SSR pipeline where the transform never
-// runs, so the assertions are meaningless there — skip them in the dev run.
-const isDev = process.env.TEST_ENV === 'development';
-
-test.describe('server - orchestrion build-time db instrumentation', () => {
-  test.skip(isDev, 'orchestrion only injects into the bundled server build, not the dev server');
-
+// Same spans in both runs, from two injectors: the build-time transform in the server bundle, and
+// the runtime hook in `react-router dev`, where the drivers stay on Node's own loader.
+test.describe('server - orchestrion db instrumentation', () => {
   test('instruments ioredis automatically via orchestrion', async ({ page }) => {
     const transactionEventPromise = waitForTransaction(APP_NAME, transactionEvent => {
       return (

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
@@ -12,7 +12,8 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test:prod": "TEST_ENV=production playwright test",
     "test:build": "pnpm install && pnpm build",
-    "test:assert": "pnpm test:prod"
+    "test:assert": "pnpm test:prod && pnpm test:dev",
+    "test:dev": "TEST_ENV=development playwright test db"
   },
   "//": "Need to use ioredis 5.10.1 because that's the last version before they support tracing channels",
   "dependencies": {

--- a/packages/nuxt/src/vite/orchestrion.ts
+++ b/packages/nuxt/src/vite/orchestrion.ts
@@ -26,6 +26,12 @@ export function setupOrchestrion(nuxt: Nuxt, hasServerConfig: boolean, buildTime
       return;
     }
 
+    // `nuxt dev` has no bundle to transform, and inlining the CommonJS drivers into Nitro's dev
+    // server breaks them (`ioredis` throws `(0, lodash_1.defaults) is not a function`).
+    if (nuxt.options?.dev) {
+      return;
+    }
+
     // On Cloudflare (workerd) the SDK is initialized through `sentryCloudflareNitroPlugin` (no
     // server config file), so the transform must still run there — detected via the Nitro preset.
     // Nitro normalizes preset names, so match any `cloudflare*` spelling.

--- a/packages/nuxt/test/vite/orchestrion.test.ts
+++ b/packages/nuxt/test/vite/orchestrion.test.ts
@@ -3,11 +3,11 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
 
 const mockSentryOrchestrionPlugin = vi.fn(() => ({ name: 'sentry-orchestrion-plugin' }));
 
-function createMockNuxt(options: { _prepare?: boolean } = {}) {
+function createMockNuxt(options: { _prepare?: boolean; dev?: boolean } = {}) {
   const hooks: Record<string, Array<(...args: any[]) => void | Promise<void>>> = {};
 
   return {
-    options: { _prepare: options._prepare ?? false },
+    options: { _prepare: options._prepare ?? false, dev: options.dev ?? false },
     hook: (name: string, callback: (...args: any[]) => void | Promise<void>) => {
       hooks[name] = hooks[name] || [];
       hooks[name].push(callback);
@@ -112,6 +112,19 @@ describe('setupOrchestrion', () => {
     setupOrchestrion(mockNuxt as unknown as Nuxt, true, false);
     await mockNuxt.triggerHook('nitro:config', nitroConfig);
 
+    expect(mockSentryOrchestrionPlugin).not.toHaveBeenCalled();
+    expect(nitroConfig).toEqual({});
+  });
+
+  it('does not change Nitro configuration in dev mode', async () => {
+    const { setupOrchestrion } = await import('../../src/vite/orchestrion');
+    const mockNuxt = createMockNuxt({ dev: true });
+    const nitroConfig = {};
+
+    setupOrchestrion(mockNuxt as unknown as Nuxt, true);
+    await mockNuxt.triggerHook('nitro:config', nitroConfig);
+
+    // Nothing to transform in dev, and inlining the CommonJS drivers there breaks them.
     expect(mockSentryOrchestrionPlugin).not.toHaveBeenCalled();
     expect(nitroConfig).toEqual({});
   });

--- a/packages/server-utils/src/orchestrion/bundler/vite.ts
+++ b/packages/server-utils/src/orchestrion/bundler/vite.ts
@@ -1,5 +1,5 @@
 import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/vite';
-import type { Plugin, ResolvedConfig } from 'vite';
+import type { ConfigEnv, Plugin, ResolvedConfig } from 'vite';
 
 export type { Plugin as VitePlugin } from 'vite';
 import { instrumentedModuleNames } from '../config';
@@ -83,7 +83,14 @@ export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
       // calls never land in a browser (`client`) bundle (where they'd throw `X is not a function`).
       return environment.config.consumer === 'server';
     },
-    config(): { ssr: { noExternal: string[] } } {
+    config(_config: unknown, env?: ConfigEnv): { ssr: { noExternal: string[] } } | null {
+      // Vite's dev SSR runner has no CommonJS interop, so an inlined `ioredis`/`mysql` throws
+      // `exports is not defined` on first import. Left external they stay on Node's loader, where
+      // the runtime hook `Sentry.init()` registers injects the same publishers.
+      if (env?.command === 'serve') {
+        return null;
+      }
+
       // Force-bundle every instrumented package so the code transform actually
       // sees its source. Vite externalizes dependencies in SSR builds by
       // default, leaving them as bare `require()`/`import` calls resolved from
@@ -104,6 +111,11 @@ export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
       };
     },
     configResolved(config: ResolvedConfig): void {
+      // Nothing is force-bundled in `serve`, so an externalized module is expected there.
+      if (config.command === 'serve') {
+        return;
+      }
+
       // Explicit `ssr.external` string entries take priority over `noExternal`
       // in Vite, so they defeat the force-bundling above. (`ssr.external: true`
       // does not — `noExternal` entries still win there.)

--- a/packages/server-utils/test/orchestrion/bundler.test.ts
+++ b/packages/server-utils/test/orchestrion/bundler.test.ts
@@ -175,14 +175,24 @@ describe('sentryOrchestrionWebpackPlugin', () => {
 });
 
 describe('sentryOrchestrionPlugin (vite)', () => {
-  function runConfigResolved(ssrExternal: string[] | true | undefined): ReturnType<typeof vi.fn> {
+  function runConfigResolved(
+    ssrExternal: string[] | true | undefined,
+    command: 'build' | 'serve' = 'build',
+  ): ReturnType<typeof vi.fn> {
     const warn = vi.fn();
     const plugin = vitePlugin();
     (plugin.configResolved as (config: unknown) => void)({
+      command,
       ssr: { external: ssrExternal },
       logger: { warn },
     } as unknown as ResolvedConfig);
     return warn;
+  }
+
+  function runConfig(command: 'build' | 'serve'): { ssr: { noExternal: string[] } } | null {
+    const plugin = vitePlugin();
+    const config = plugin.config as (config: unknown, env: unknown) => { ssr: { noExternal: string[] } } | null;
+    return config.call(plugin, {}, { command, mode: 'production' });
   }
 
   it('warns when instrumented modules are listed in ssr.external', () => {
@@ -200,14 +210,22 @@ describe('sentryOrchestrionPlugin (vite)', () => {
   });
 
   it('force-bundles the orchestrion helper package alongside instrumented modules', () => {
-    const plugin = vitePlugin();
-    const config = (plugin.config as () => { ssr: { noExternal: string[] } })();
+    const config = runConfig('build');
 
     // Left external, Vite 5's CommonJS interop turns the snippet's `require`
     // into a default import of the named-exports-only ESM entry — a link-time
     // crash at server startup.
-    expect(config.ssr.noExternal).toContain('@sentry/server-utils');
-    expect(config.ssr.noExternal).toContain('mysql');
+    expect(config?.ssr.noExternal).toContain('@sentry/server-utils');
+    expect(config?.ssr.noExternal).toContain('mysql');
+  });
+
+  it('does not force-bundle instrumented modules on the dev server', () => {
+    // Inlined in dev, the CommonJS drivers throw `exports is not defined` on import.
+    expect(runConfig('serve')).toBeNull();
+  });
+
+  it('does not warn about externalized instrumented modules on the dev server', () => {
+    expect(runConfigResolved(['mysql', 'lodash'], 'serve')).not.toHaveBeenCalled();
   });
 
   it('gates the transform on the ssr flag (Vite 5 ignores applyToEnvironment)', () => {


### PR DESCRIPTION
The Vite plugin's `ssr.noExternal` and the Nuxt module's Nitro `externals.inline` force-bundle instrumented packages unconditionally. That's right for a build, but in a dev server it breaks the drivers (`exports is not defined` on Vite, `(0, lodash_1.defaults) is not a function` on Nitro) and takes them off Node's module loader, where the runtime hook `Sentry.init()` registers would have instrumented them instead.

Gate both on the build. Dev falls through to the runtime hook and emits the same spans.

astro-7 and sveltekit-2 gain a dev pass over their DB tests; the react-router-7 dev skip is removed.

Nuxt still records no DB spans in dev — Nitro hoists `ioredis`/`mysql` above `Sentry.init()` in the generated `--import` entry. Tracked in #23876; this only removes the crash there.

Fixes #22857