### PR TITLE
test(e2e): Run DB driver tests against the dev server for the remaining frameworks

### DIFF
--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
@@ -11,7 +11,7 @@
     "test:build": "pnpm install && pnpm build",
     "test:assert": "pnpm playwright test",
     "test:build:orchestrion": "INJECT_ORCHESTRION=true pnpm test:build",
-    "test:assert:orchestrion": "INJECT_ORCHESTRION=true pnpm test:assert"
+    "test:assert:orchestrion": "INJECT_ORCHESTRION=true pnpm test:assert && INJECT_ORCHESTRION=true TEST_ENV=development pnpm playwright test db"
   },
   "dependencies": {
     "@sentry/remix": "file:../../packed/sentry-remix-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/playwright.config.mjs
@@ -3,9 +3,16 @@ import { fileURLToPath } from 'url';
 
 const injectOrchestrion = process.env.INJECT_ORCHESTRION === 'true';
 
+// `remix vite:dev` ignores PORT, so the port goes on the command. The dev server has no
+// bundle, so the SDK is loaded through `--import` the way `pnpm start` does it.
+const startCommand =
+  process.env.TEST_ENV === 'development'
+    ? `NODE_OPTIONS='--import=./instrument.server.cjs' pnpm dev --port 3030`
+    : `pnpm start`;
+
 const config = getPlaywrightConfig(
   {
-    startCommand: `pnpm start`,
+    startCommand,
   },
   // The orchestrion variant exercises real MySQL/Redis. Boot them before the tests run,
   // outside the webServer startup-timeout window. In the default variant no DB is needed.

--- a/dev-packages/e2e-tests/test-applications/solidstart/instrument.server.mjs
+++ b/dev-packages/e2e-tests/test-applications/solidstart/instrument.server.mjs
@@ -1,0 +1,12 @@
+// Dev-server counterpart of `src/instrument.server.ts`. `vinxi dev` produces no build output, so
+// there is no `.output/server/instrument.server.mjs` to `--import`; this file is loaded directly.
+import * as Sentry from '@sentry/solidstart';
+
+Sentry.init({
+  traceLifecycle: 'static',
+  dsn: process.env.E2E_TEST_DSN,
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  tracesSampleRate: 1.0, //  Capture 100% of the transactions
+  tunnel: 'http://localhost:3031/', // proxy server
+  debug: !!process.env.DEBUG,
+});

--- a/dev-packages/e2e-tests/test-applications/solidstart/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart/package.json
@@ -4,11 +4,13 @@
   "scripts": {
     "clean": "pnpx rimraf node_modules pnpm-lock.yaml .vinxi .output",
     "build": "vinxi build",
+    "dev": "vinxi dev",
     "preview": "HOST=localhost PORT=3030 vinxi start",
     "start:import": "HOST=localhost PORT=3030 node --import ./.output/server/instrument.server.mjs .output/server/index.mjs",
     "test:prod": "TEST_ENV=production playwright test",
     "test:build": "pnpm install && pnpm build",
-    "test:assert": "pnpm test:prod"
+    "test:assert": "pnpm test:prod && pnpm test:dev",
+    "test:dev": "TEST_ENV=development playwright test db"
   },
   "type": "module",
   "dependencies": {

--- a/dev-packages/e2e-tests/test-applications/solidstart/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/solidstart/playwright.config.mjs
@@ -1,7 +1,14 @@
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
 
+// `vinxi dev` ignores PORT, so the port goes on the command, and the SDK comes from the app's own
+// instrumentation file rather than the build output the production command uses.
+const startCommand =
+  process.env.TEST_ENV === 'development'
+    ? `NODE_OPTIONS='--import ./instrument.server.mjs' pnpm dev --port 3030`
+    : 'pnpm start:import';
+
 const config = getPlaywrightConfig({
-  startCommand: 'pnpm start:import',
+  startCommand,
   port: 3030,
 });
 

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build && cp instrument.server.mjs .output/server",
+    "dev": "vite dev",
     "start": "node --import ./.output/server/instrument.server.mjs .output/server/index.mjs",
     "test": "playwright test",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
@@ -14,7 +15,7 @@
     "test:build:tunnel-custom": "pnpm install && E2E_TEST_CUSTOM_TUNNEL_ROUTE=1 pnpm build",
     "test:build:tunnel-object": "pnpm install && E2E_TEST_TUNNEL_ROUTE_MODE=object E2E_TEST_DSN=http://public@localhost:3031/1337 pnpm build",
     "test:build-latest": "pnpm add @tanstack/react-start@latest @tanstack/react-router@latest && pnpm install && pnpm build",
-    "test:assert:proxy": "pnpm test",
+    "test:assert:proxy": "pnpm test && TEST_ENV=development pnpm playwright test db-drivers",
     "test:assert": "pnpm test:assert:proxy",
     "test:assert:tunnel-generated": "E2E_TEST_TUNNEL_ROUTE_MODE=dynamic E2E_TEST_DSN=http://public@localhost:3031/1337 pnpm test",
     "test:assert:tunnel-streamed": "E2E_TEST_TUNNEL_ROUTE_MODE=dynamic E2E_TEST_DSN=http://public@localhost:3031/1337 E2E_TEST_STREAMED_SPANS=1 pnpm test",

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/playwright.config.mjs
@@ -5,8 +5,15 @@ import { getPlaywrightConfig } from '@sentry-internal/test-utils';
 const usesManagedTunnelRoute =
   (process.env.E2E_TEST_TUNNEL_ROUTE_MODE ?? 'off') !== 'off' || process.env.E2E_TEST_CUSTOM_TUNNEL_ROUTE === '1';
 
+// The dev server has no build output, so `--import` points at the app's own instrumentation file.
+// `vite dev` ignores PORT, so the port goes on the command.
+const startCommand =
+  process.env.TEST_ENV === 'development'
+    ? `NODE_OPTIONS='--import ./instrument.server.mjs' pnpm dev --port 3000`
+    : `pnpm start`;
+
 const config = getPlaywrightConfig({
-  startCommand: `pnpm start`,
+  startCommand,
   port: 3000,
 });
 

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/db-drivers.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/tests/db-drivers.test.ts
@@ -6,9 +6,9 @@ const usesManagedTunnelRoute =
 
 test.skip(usesManagedTunnelRoute, 'Default e2e suites run only in the proxy variant');
 
-// `sentryTanstackStart()` auto-wires the orchestrion build-time transform, which injects
-// `diagnostics_channel` publishers into these drivers as Vite bundles the server. That only
-// happens in the production build, which is what the e2e app runs.
+// Same spans in both runs, from two injectors: the orchestrion build-time transform that
+// `sentryTanstackStart()` auto-wires into the server bundle, and the runtime hook in `vite dev`,
+// where the drivers stay external on Node's own loader.
 test('Instruments ioredis automatically', async ({ baseURL }) => {
   const transactionEventPromise = waitForTransaction('tanstackstart-react', transactionEvent => {
     return (


### PR DESCRIPTION
Remix, Solid Start and TanStack Start only ran their orchestrion DB tests against the production server. This adds dev versions to the e2e suites.

nuxt-4 stays out until the Nitro init-order defect from #23835 is fixed.