### PR TITLE
test(e2e): Port cloudflare-workersentrypoint to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/src/index.ts
@@ -63,7 +63,6 @@ class MyDurableObjectBase extends DurableObject<Env> {
 
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
-    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server
@@ -108,7 +107,6 @@ class MyWorker extends WorkerEntrypoint {
 
 export default Sentry.withSentry(
   env => ({
-    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/tests/index.test.ts
@@ -1,5 +1,11 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForRequest, waitForTransaction } from '@sentry-internal/test-utils';
+import {
+  getSpanOp,
+  waitForError,
+  waitForRequest,
+  waitForStreamedSpan,
+  waitForStreamedSpans,
+} from '@sentry-internal/test-utils';
 import { SDK_VERSION } from '@sentry/cloudflare';
 import { WebSocket } from 'ws';
 
@@ -7,6 +13,22 @@ test('Index page', async ({ baseURL }) => {
   const result = await fetch(baseURL!);
   expect(result.status).toBe(200);
   await expect(result.text()).resolves.toBe('Hello World!');
+});
+
+test('Sends a streamed span for a basic request', async ({ baseURL }) => {
+  const spanPromise = waitForStreamedSpan('cloudflare-workersentrypoint', span => {
+    return getSpanOp(span) === 'http.server' && span.is_segment;
+  });
+
+  await fetch(baseURL!);
+
+  const span = await spanPromise;
+
+  // The root path is a low-cardinality route, so the span keeps the full `GET /` name under streaming.
+  expect(span.name).toBe('GET /');
+  expect(span.trace_id).toMatch(/[a-f0-9]{32}/);
+  expect(span.status).toBe('ok');
+  expect(span.attributes['sentry.segment.name.source']?.value).toBe('route');
 });
 
 test("worker's withSentry", async ({ baseURL }) => {
@@ -78,24 +100,21 @@ test('sends user-agent header with SDK name and version in envelope requests', a
 
   const request = await requestPromise;
 
-  expect(request.rawProxyRequestHeaders).toMatchObject({
-    'user-agent': `sentry.javascript.cloudflare/${SDK_VERSION}`,
-  });
+  expect(request.rawProxyRequestHeaders['user-agent']).toBe(`sentry.javascript.cloudflare/${SDK_VERSION}`);
 });
 
-test('Storage operations create spans in Durable Object transactions', async ({ baseURL }) => {
-  const transactionWaiter = waitForTransaction('cloudflare-workersentrypoint', event => {
-    return event.spans?.some(span => span.op === 'db' && span.description === 'durable_object_storage_put') ?? false;
+test('Storage operations create spans in Durable Object', async ({ baseURL }) => {
+  const spansPromise = waitForStreamedSpans('cloudflare-workersentrypoint', spans => {
+    return spans.some(span => span.name === 'durable_object_storage_put' && getSpanOp(span) === 'db');
   });
 
   const response = await fetch(`${baseURL}/pass-to-object/storage/put`);
   expect(response.status).toBe(200);
 
-  const transaction = await transactionWaiter;
-  const putSpan = transaction.spans?.find(span => span.description === 'durable_object_storage_put');
+  const spans = await spansPromise;
+  const putSpan = spans.find(span => span.name === 'durable_object_storage_put' && getSpanOp(span) === 'db');
 
   expect(putSpan).toBeDefined();
-  expect(putSpan?.op).toBe('db');
-  expect(putSpan?.data?.['db.system.name']).toBe('cloudflare.durable_object.storage');
-  expect(putSpan?.data?.['db.operation.name']).toBe('put');
+  expect(putSpan?.attributes['db.system.name']?.value).toBe('cloudflare.durable_object.storage');
+  expect(putSpan?.attributes['db.operation.name']?.value).toBe('put');
 });


### PR DESCRIPTION
Ports `cloudflare-workersentrypoint` to span streaming: the `traceLifecycle: 'static'` pin is removed from both `Sentry.init` sites and the spec asserts on streamed spans.

The spec mirrors the `cloudflare-workers` port: the storage test reads the `db` span from a streamed envelope, and a basic-request test pins the `GET /` segment name (root path is a `route` source, so it is kept as-is under streaming).