### PR TITLE
test(e2e): Port cloudflare-local-workers to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/src/index.ts
@@ -22,7 +22,6 @@ class MyDurableObjectBase extends DurableObject<Env> {
 
 export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
   (env: Env) => ({
-    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server
@@ -33,7 +32,6 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 
 export default Sentry.withSentry(
   (env: Env) => ({
-    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa', // dynamic sampling bias to keep transactions
     tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp } from '@sentry-internal/test-utils';
 
 /**
  * This must be the only test in here.
@@ -10,24 +10,43 @@ import { waitForTransaction } from '@sentry-internal/test-utils';
  * and masks bugs in our instrumentation - causing this test to pass when it
  * should fail.
  */
-test('Worker and Durable Object both send transactions when worker calls DO', async ({ baseURL }) => {
-  const workerTransactionPromise = waitForTransaction('cloudflare-local-workers', event => {
-    return event.transaction === 'GET /pass-to-object/storage/get' && event.contexts?.trace?.op === 'http.server';
-  });
-
-  const doTransactionPromise = waitForTransaction('cloudflare-local-workers', event => {
-    return event.transaction === 'GET /storage/get' && event.contexts?.trace?.op === 'http.server';
+test('Worker and Durable Object both send segment spans when worker calls DO', async ({ baseURL }) => {
+  // With span streaming, URL-sourced `http.server` spans are named by method only, so the worker
+  // and the Durable Object segment can only be told apart by `url.path`.
+  const spansPromise = collectStreamedSpans('cloudflare-local-workers', spans => {
+    return (
+      spans.some(
+        span =>
+          getSpanOp(span) === 'http.server' &&
+          span.is_segment &&
+          span.attributes['url.path']?.value === '/pass-to-object/storage/get',
+      ) &&
+      spans.some(
+        span =>
+          getSpanOp(span) === 'http.server' && span.is_segment && span.attributes['url.path']?.value === '/storage/get',
+      )
+    );
   });
 
   const response = await fetch(`${baseURL}/pass-to-object/storage/get`);
   expect(response.status).toBe(200);
 
-  const [workerTransaction, doTransaction] = await Promise.all([workerTransactionPromise, doTransactionPromise]);
+  const spans = await spansPromise;
+  const workerSpan = spans.find(
+    span =>
+      getSpanOp(span) === 'http.server' &&
+      span.is_segment &&
+      span.attributes['url.path']?.value === '/pass-to-object/storage/get',
+  )!;
+  const doSpan = spans.find(
+    span =>
+      getSpanOp(span) === 'http.server' && span.is_segment && span.attributes['url.path']?.value === '/storage/get',
+  )!;
 
-  expect(workerTransaction.transaction).toBe('GET /pass-to-object/storage/get');
-  expect(workerTransaction.contexts?.trace?.op).toBe('http.server');
+  expect(workerSpan.name).toBe('GET');
+  expect(workerSpan.attributes['sentry.segment.name.source']?.value).toBe('url');
 
-  expect(doTransaction.transaction).toBe('GET /storage/get');
-  expect(doTransaction.contexts?.trace?.op).toBe('http.server');
-  expect(doTransaction.spans?.some(span => span.op === 'db')).toBe(true);
+  expect(doSpan.name).toBe('GET');
+  expect(doSpan.attributes['sentry.segment.name.source']?.value).toBe('url');
+  expect(spans.some(span => getSpanOp(span) === 'db' && span.parent_span_id === doSpan.span_id)).toBe(true);
 });


### PR DESCRIPTION
Ports `cloudflare-local-workers` to span streaming.

Under streaming a URL-sourced `http.server` segment is named by method only, so the worker segment and the Durable Object segment are both called `GET`. The spec tells them apart by `url.path` and keeps asserting that both arrive. The `db` span check is done via `parent_span_id` of the DO segment. Both segments plus the child span are streamed in separate envelopes, so the test uses `collectStreamedSpans`.