### PR TITLE
test(e2e): Port cloudflare-vercelai-v7 to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/src/index.ts
@@ -4,7 +4,6 @@ import { MockLanguageModelV3 } from 'ai/test';
 
 export default Sentry.withSentry(
   (env: Env) => ({
-    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     environment: 'qa',
     tunnel: 'http://localhost:3031/',

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/tests/index.test.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/tests/index.test.ts
@@ -2,7 +2,6 @@ import { expect, test } from '@playwright/test';
 import { getSpanOp, waitForStreamedSpans } from '@sentry-internal/test-utils';
 
 test('captures Vercel AI v7 spans with nodejs_compat using tracing channels', async ({ baseURL }) => {
-  // gen_ai spans are extracted into a separate span v2 envelope item
   const genAiSpansPromise = waitForStreamedSpans('cloudflare-vercelai-v7-compat', spans =>
     spans.some(span => getSpanOp(span) === 'gen_ai.invoke_agent'),
   );
@@ -13,30 +12,44 @@ test('captures Vercel AI v7 spans with nodejs_compat using tracing channels', as
 
   const genAiSpans = await genAiSpansPromise;
 
-  expect(genAiSpans).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: 'invoke_agent',
-        attributes: expect.objectContaining({
-          'gen_ai.operation.name': { value: 'invoke_agent', type: 'string' },
-          'gen_ai.usage.input_tokens': { value: 10, type: 'integer' },
-          'gen_ai.usage.output_tokens': { value: 20, type: 'integer' },
-          'gen_ai.usage.total_tokens': { value: 30, type: 'integer' },
-          'sentry.op': { value: 'gen_ai.invoke_agent', type: 'string' },
-          'sentry.origin': { value: 'auto.vercelai.channel', type: 'string' },
-        }),
-      }),
-      expect.objectContaining({
-        name: 'generate_content mock-model-id',
-        attributes: expect.objectContaining({
-          'gen_ai.operation.name': { value: 'generate_content', type: 'string' },
-          'gen_ai.usage.input_tokens': { value: 10, type: 'integer' },
-          'gen_ai.usage.output_tokens': { value: 20, type: 'integer' },
-          'gen_ai.usage.total_tokens': { value: 30, type: 'integer' },
-          'sentry.op': { value: 'gen_ai.generate_content', type: 'string' },
-          'sentry.origin': { value: 'auto.vercelai.channel', type: 'string' },
-        }),
-      }),
-    ]),
-  );
+  const invokeAgentSpan = genAiSpans.find(span => getSpanOp(span) === 'gen_ai.invoke_agent');
+  const generateContentSpan = genAiSpans.find(span => getSpanOp(span) === 'gen_ai.generate_content');
+
+  expect(invokeAgentSpan).toEqual({
+    trace_id: expect.stringMatching(/^[a-f0-9]{32}$/),
+    parent_span_id: expect.stringMatching(/^[a-f0-9]{16}$/),
+    span_id: expect.stringMatching(/^[a-f0-9]{16}$/),
+    name: 'invoke_agent',
+    start_timestamp: expect.any(Number),
+    end_timestamp: expect.any(Number),
+    status: 'ok',
+    is_segment: false,
+    attributes: expect.objectContaining({
+      'gen_ai.operation.name': { value: 'invoke_agent', type: 'string' },
+      'gen_ai.usage.input_tokens': { value: 10, type: 'integer' },
+      'gen_ai.usage.output_tokens': { value: 20, type: 'integer' },
+      'gen_ai.usage.total_tokens': { value: 30, type: 'integer' },
+      'sentry.op': { value: 'gen_ai.invoke_agent', type: 'string' },
+      'sentry.origin': { value: 'auto.vercelai.channel', type: 'string' },
+    }),
+  });
+
+  expect(generateContentSpan).toEqual({
+    trace_id: invokeAgentSpan!.trace_id,
+    parent_span_id: invokeAgentSpan!.span_id,
+    span_id: expect.stringMatching(/^[a-f0-9]{16}$/),
+    name: 'generate_content mock-model-id',
+    start_timestamp: expect.any(Number),
+    end_timestamp: expect.any(Number),
+    status: 'ok',
+    is_segment: false,
+    attributes: expect.objectContaining({
+      'gen_ai.operation.name': { value: 'generate_content', type: 'string' },
+      'gen_ai.usage.input_tokens': { value: 10, type: 'integer' },
+      'gen_ai.usage.output_tokens': { value: 20, type: 'integer' },
+      'gen_ai.usage.total_tokens': { value: 30, type: 'integer' },
+      'sentry.op': { value: 'gen_ai.generate_content', type: 'string' },
+      'sentry.origin': { value: 'auto.vercelai.channel', type: 'string' },
+    }),
+  });
 });


### PR DESCRIPTION
Ports `cloudflare-vercelai-v7` to span streaming. The spec already asserted on streamed spans, so this only removes the static pin and a comment that described gen_ai extraction as a special case.