### PR TITLE
test(e2e): Port cloudflare-workers-workflow-legacy to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/src/index.ts
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/src/index.ts
@@ -38,7 +38,6 @@ class RetryTestWorkflowBase extends WorkflowEntrypoint<Env, WorkflowParams> {
 
 export const RetryTestWorkflow = Sentry.instrumentWorkflowWithSentry(
   (env: Env) => ({
-    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     tunnel: 'http://localhost:3031/',
   }),
@@ -47,7 +46,6 @@ export const RetryTestWorkflow = Sentry.instrumentWorkflowWithSentry(
 
 export default Sentry.withSentry(
   (env: Env) => ({
-    traceLifecycle: 'static',
     dsn: env.E2E_TEST_DSN,
     tunnel: 'http://localhost:3031/',
     // Do not cache this client, as locally there is only one instance


### PR DESCRIPTION
Ports `cloudflare-workers-workflow-legacy` to span streaming. Its spec only asserts on error events, so removing the static pin from the workflow and the worker `Sentry.init` is the whole change.

Fixes #23803.