### PR TITLE
test(e2e): Port nextjs-16-userfeedback to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/instrumentation-client.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/instrumentation-client.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.edge.config.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/sentry.server.config.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server


### PR DESCRIPTION
Removes the `traceLifecycle: 'static'` pins from `nextjs-16-userfeedback`. Its specs assert on feedback and error envelopes, which streaming does not change, so no spec rewrite is needed.

Ref #23802