### PR TITLE
test(e2e): Port nextjs-15-t3 to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.client.config.ts
@@ -3,7 +3,6 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.edge.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.edge.config.ts
@@ -6,7 +6,6 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/sentry.server.config.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/tests/trpc-error.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/tests/trpc-error.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForError, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
 test('should capture error with trpc context', async ({ page }) => {
   const errorEventPromise = waitForError('nextjs-15-t3', errorEvent => {
@@ -35,14 +35,14 @@ test('should capture error with trpc context', async ({ page }) => {
   });
 });
 
-test('should create transaction with trpc input for error', async ({ page }) => {
-  const trpcTransactionPromise = waitForTransaction('nextjs-15-t3', async transactionEvent => {
-    return transactionEvent?.transaction === 'POST /api/trpc/[trpc]';
+test('should create span with trpc input for error', async ({ page }) => {
+  const trpcSpanPromise = waitForStreamedSpan('nextjs-15-t3', span => {
+    return span.name === 'POST /api/trpc/[trpc]' && getSpanOp(span) === 'http.server' && span.is_segment;
   });
 
   await page.goto('/');
   await page.click('#error-button');
 
-  const trpcTransaction = await trpcTransactionPromise;
-  expect(trpcTransaction).toBeDefined();
+  const trpcSpan = await trpcSpanPromise;
+  expect(trpcSpan).toBeDefined();
 });

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/tests/trpc-mutation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/tests/trpc-mutation.test.ts
@@ -1,16 +1,16 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('should create transaction with trpc input for mutation', async ({ page }) => {
-  const trpcTransactionPromise = waitForTransaction('nextjs-15-t3', async transactionEvent => {
-    return transactionEvent?.transaction === 'POST /api/trpc/[trpc]';
+test('should create span with trpc input for mutation', async ({ page }) => {
+  const trpcSpanPromise = waitForStreamedSpan('nextjs-15-t3', span => {
+    return span.name === 'POST /api/trpc/[trpc]' && getSpanOp(span) === 'http.server' && span.is_segment;
   });
 
   await page.goto('/');
   await page.locator('#createInput').fill('I love dogs');
   await page.click('#createButton');
 
-  const trpcTransaction = await trpcTransactionPromise;
+  const trpcSpan = await trpcSpanPromise;
 
-  expect(trpcTransaction).toBeDefined();
+  expect(trpcSpan).toBeDefined();
 });


### PR DESCRIPTION
Ports `nextjs-15-t3` to span streaming: removes the `traceLifecycle: 'static'` pins and rewrites the two tRPC route assertions onto streamed spans.

Ref #23802