### PR TITLE
feat: Mirror SDK-set tags to scope attributes

### DIFF
--- a/packages/aws-serverless/src/sdk.ts
+++ b/packages/aws-serverless/src/sdk.ts
@@ -110,6 +110,7 @@ function setupTimeoutWarning(context: Context, options: WrapperOptions): NodeJS.
     return setTimeout(() => {
       withScope(scope => {
         scope.setTag('timeout', humanReadableTimeout);
+        scope.setAttribute('timeout', humanReadableTimeout);
         captureMessage(`Possible function timeout: ${context.functionName}`, 'warning');
       });
     }, timeoutWarningDelay);

--- a/packages/aws-serverless/test/sdk.test.ts
+++ b/packages/aws-serverless/test/sdk.test.ts
@@ -12,6 +12,7 @@ const mockInit = vi.fn();
 
 const mockScope = {
   setTag: vi.fn(),
+  setAttribute: vi.fn(),
   setContext: vi.fn(),
   addEventProcessor: vi.fn(),
   setTransactionName: vi.fn(),
@@ -121,6 +122,7 @@ describe('AWSLambda', () => {
       expect(mockWithScope).toBeCalledTimes(2);
       expect(mockCaptureMessage).toBeCalled();
       expect(mockScope.setTag).toBeCalledWith('timeout', '1s');
+      expect(mockScope.setAttribute).toBeCalledWith('timeout', '1s');
     });
 
     test('captureTimeoutWarning disabled', async () => {
@@ -137,6 +139,7 @@ describe('AWSLambda', () => {
       expect(mockWithScope).toBeCalledTimes(1);
       expect(mockCaptureMessage).not.toBeCalled();
       expect(mockScope.setTag).not.toBeCalledWith('timeout', '1s');
+      expect(mockScope.setAttribute).not.toBeCalledWith('timeout', '1s');
     });
 
     test('captureTimeoutWarning with configured timeoutWarningLimit', async () => {
@@ -146,7 +149,7 @@ describe('AWSLambda', () => {
        * If it would not work as expected, we'd exceed `setTimeout` used and never capture the warning.
        */
 
-      expect.assertions(2);
+      expect.assertions(3);
 
       const handler: Handler = (_event, _context, callback) => {
         setTimeout(() => {
@@ -167,6 +170,7 @@ describe('AWSLambda', () => {
 
       expect(mockCaptureMessage).toBeCalled();
       expect(mockScope.setTag).toBeCalledWith('timeout', '1m40s');
+      expect(mockScope.setAttribute).toBeCalledWith('timeout', '1m40s');
     });
 
     test('captureAllSettledReasons disabled (default)', async () => {
@@ -527,6 +531,7 @@ describe('AWSLambda', () => {
       expect(mockWithScope).toBeCalledTimes(2);
       expect(mockCaptureMessage).toBeCalled();
       expect(mockScope.setTag).toBeCalledWith('timeout', '1s');
+      expect(mockScope.setAttribute).toBeCalledWith('timeout', '1s');
     });
 
     test('marks streaming handler captured errors as unhandled', async () => {

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -99,6 +99,7 @@ export function init(options: BrowserOptions): Client | undefined {
     // @ts-expect-error `process.turbopack` is a magic string that will be replaced by Next.js
     if (process.turbopack) {
       getGlobalScope().setTag('turbopack', true);
+      getGlobalScope().setAttribute('turbopack', true);
     }
   } catch {
     // Noop

--- a/packages/react-router/src/client/sdk.ts
+++ b/packages/react-router/src/client/sdk.ts
@@ -1,7 +1,7 @@
 import type { BrowserOptions } from '@sentry/browser';
 import { init as browserInit } from '@sentry/browser';
 import type { Client } from '@sentry/core';
-import { applySdkMetadata, consoleSandbox, setTag } from '@sentry/core';
+import { applySdkMetadata, consoleSandbox, setAttribute, setTag } from '@sentry/core';
 
 const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 
@@ -30,6 +30,7 @@ export function init(options: BrowserOptions): Client | undefined {
   const client = browserInit(options);
 
   setTag('runtime', 'browser');
+  setAttribute('runtime', 'browser');
 
   return client;
 }

--- a/packages/react-router/src/server/sdk.ts
+++ b/packages/react-router/src/server/sdk.ts
@@ -1,5 +1,5 @@
 import type { Integration } from '@sentry/core';
-import { applySdkMetadata, debug, setTag } from '@sentry/core';
+import { applySdkMetadata, debug, setAttribute, setTag } from '@sentry/core';
 import type { NodeClient, NodeOptions } from '@sentry/node';
 import { getDefaultIntegrations as getNodeDefaultIntegrations, init as initNodeSdk } from '@sentry/node';
 import { DEBUG_BUILD } from '../common/debug-build';
@@ -34,6 +34,7 @@ export function init(options: NodeOptions): NodeClient | undefined {
   const client = initNodeSdk(opts);
 
   setTag('runtime', 'node');
+  setAttribute('runtime', 'node');
 
   DEBUG_BUILD && debug.log('SDK successfully initialized');
 

--- a/packages/react-router/test/client/sdk.test.ts
+++ b/packages/react-router/test/client/sdk.test.ts
@@ -6,6 +6,7 @@ import { init as reactRouterInit } from '../../src/client';
 
 const browserInit = vi.spyOn(SentryBrowser, 'init');
 const setTag = vi.spyOn(SentryCore, 'setTag');
+const setAttribute = vi.spyOn(SentryCore, 'setAttribute');
 const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 describe('React Router client SDK', () => {
@@ -48,6 +49,11 @@ describe('React Router client SDK', () => {
     it('sets the runtime tag to browser', () => {
       reactRouterInit({});
       expect(setTag).toHaveBeenCalledWith('runtime', 'browser');
+    });
+
+    it('sets the runtime attribute to browser', () => {
+      reactRouterInit({});
+      expect(setAttribute).toHaveBeenCalledWith('runtime', 'browser');
     });
 
     it('warns if BrowserTracing integration is present', () => {

--- a/packages/server-utils/src/integrations/vercel-ai/vercel-ai-dc-subscriber.ts
+++ b/packages/server-utils/src/integrations/vercel-ai/vercel-ai-dc-subscriber.ts
@@ -672,9 +672,11 @@ export function captureToolError(span: Span, data: VercelAiChannelMessage, error
     scope.setContext('trace', spanToTraceContext(span));
     if (toolName) {
       scope.setTag('vercel.ai.tool.name', toolName);
+      scope.setAttribute('vercel.ai.tool.name', toolName);
     }
     if (toolCallId) {
       scope.setTag('vercel.ai.tool.callId', toolCallId);
+      scope.setAttribute('vercel.ai.tool.callId', toolCallId);
     }
     scope.setLevel('error');
     captureException(


### PR DESCRIPTION
Duplicates tags the SDK sets itself onto scope attributes, so they also reach logs, metrics and streamed spans.