### PR TITLE
test(e2e): Assert Next.js Cloudflare worker bundle stays free of orchestrion bundler plugins

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/worker-bundle.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/tests/worker-bundle.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { isDevMode } from './isDevMode';
+
+/**
+ * The orchestrion bundler plugins are build-time-only, and their module-scope side effects break
+ * on Workers (an unawaited `WebAssembly.compile()` crashed every cold start, issue #22794). The
+ * worker bundle OpenNext produces must therefore never contain them: importing `@sentry/nextjs`
+ * on the server has to keep the plugin graph out of the deployed artifact.
+ */
+test('worker bundle does not contain the orchestrion bundler plugins', () => {
+  test.skip(isDevMode, 'requires the production worker build');
+
+  const openNextDir = path.resolve(__dirname, '..', '.open-next');
+  expect(fs.existsSync(path.join(openNextDir, 'worker.js'))).toBe(true);
+
+  // `assets` holds the static client files; everything else is code the worker can run.
+  const serverFiles = collectJsFiles(openNextDir).filter(
+    filePath => !filePath.startsWith(path.join(openNextDir, 'assets')),
+  );
+  expect(serverFiles.length).toBeGreaterThan(0);
+
+  const markers = ['code-transformer-bundler-plugins', '__codeTransformerWebpackDiagnostics'];
+  const leaks = serverFiles.filter(filePath => {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return markers.some(marker => content.includes(marker));
+  });
+
+  expect(leaks.map(filePath => path.relative(openNextDir, filePath))).toEqual([]);
+});
+
+function collectJsFiles(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return collectJsFiles(fullPath);
+    }
+    return /\.(js|mjs|cjs)$/.test(entry.name) ? [fullPath] : [];
+  });
+}


### PR DESCRIPTION


Adds one test to the `nextjs-16-cf-workers` e2e app. After the OpenNext build, it scans every script in `.open-next/` (except static assets) and fails if the orchestrion bundler plugins show up, naming the offending files.

The plugins are build-time-only, but they used to get compiled into the worker bundle, where an unawaited `WebAssembly.compile()` crashed every cold start. The bundle check is deterministic, unlike waiting for an error to not appear.

The below issue is fixed in https://github.com/getsentry/sentry-javascript/pull/23906 already, this PR is just adding the verification.
Closes https://github.com/getsentry/sentry-javascript/issues/22794

