### PR TITLE
fix(repo): Align nx cache outputs with actual build outputs

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -88,5 +88,18 @@
   },
   "astro": {
     "external": true
+  },
+  "nx": {
+    "targets": {
+      "build:transpile": {
+        "outputs": [
+          "{projectRoot}/build/esm",
+          "{projectRoot}/build/cjs",
+          "{projectRoot}/build/npm/esm",
+          "{projectRoot}/build/npm/cjs",
+          "{projectRoot}/build/import-hook.mjs"
+        ]
+      }
+    }
   }
 }

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -108,7 +108,8 @@
           "{projectRoot}/build/npm/cjs",
           "{projectRoot}/build/npm/run-lambda-handler.mjs",
           "{projectRoot}/build/npm/run-lambda-handler.mjs.map",
-          "{projectRoot}/build/lambda-extension"
+          "{projectRoot}/build/lambda-extension",
+          "{projectRoot}/build/import-hook.mjs"
         ],
         "cache": true
       },

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -69,7 +69,7 @@
       },
       "build:types": {
         "outputs": [
-          "{projectRoot}/build-types"
+          "{projectRoot}/build/esm/**/*.d.ts"
         ]
       }
     }

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -64,7 +64,8 @@
     "targets": {
       "build:transpile": {
         "outputs": [
-          "{projectRoot}/build"
+          "{projectRoot}/build",
+          "!{projectRoot}/build/esm/**/*.d.ts"
         ]
       },
       "build:types": {

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -79,5 +79,18 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "nx": {
+    "targets": {
+      "build:transpile": {
+        "outputs": [
+          "{projectRoot}/build/esm",
+          "{projectRoot}/build/cjs",
+          "{projectRoot}/build/npm/esm",
+          "{projectRoot}/build/npm/cjs",
+          "{projectRoot}/build/import-hook.mjs"
+        ]
+      }
+    }
+  }
 }

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -95,7 +95,8 @@
         ],
         "outputs": [
           "{projectRoot}/build/types",
-          "{projectRoot}/*.d.ts"
+          "{projectRoot}/*.d.ts",
+          "{projectRoot}/*.d.ts.map"
         ],
         "cache": true
       }

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -100,5 +100,18 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "nx": {
+    "targets": {
+      "build:transpile": {
+        "outputs": [
+          "{projectRoot}/build/esm",
+          "{projectRoot}/build/cjs",
+          "{projectRoot}/build/npm/esm",
+          "{projectRoot}/build/npm/cjs",
+          "{projectRoot}/build/import-hook.mjs"
+        ]
+      }
+    }
+  }
 }

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -87,5 +87,18 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "nx": {
+    "targets": {
+      "build:transpile": {
+        "outputs": [
+          "{projectRoot}/build/esm",
+          "{projectRoot}/build/cjs",
+          "{projectRoot}/build/npm/esm",
+          "{projectRoot}/build/npm/cjs",
+          "{projectRoot}/build/import-hook.mjs"
+        ]
+      }
+    }
+  }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -89,5 +89,16 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "nx": {
+    "targets": {
+      "build:types": {
+        "outputs": [
+          "{projectRoot}/build/types",
+          "{projectRoot}/*.d.ts",
+          "{projectRoot}/*.d.ts.map"
+        ]
+      }
+    }
+  }
 }

--- a/scripts/ci-print-build-artifact-paths.mjs
+++ b/scripts/ci-print-build-artifact-paths.mjs
@@ -61,6 +61,12 @@ for (const node of Object.values(graph.nodes)) {
     }
 
     for (const output of outputs) {
+      // Negated outputs only narrow a target's Nx cache ownership to keep parallel targets'
+      // outputs disjoint; they are not files to exclude from the uploaded artifact — those files
+      // are emitted and owned by another target and must still be uploaded via its output.
+      if (output.startsWith('!')) {
+        continue;
+      }
       const rel = output.replace(/\{projectRoot\}/g, root).replace(/\\/g, '/');
       const prefix = `${kind}/${pkg}/`;
       if (!rel.startsWith(prefix)) {


### PR DESCRIPTION
Audits every cached nx target's `outputs` against what each package's build command actually emits, and fixes the mismatches. When a target produces a file that isn't listed in its `outputs`, nx never stores it in the cache — so a later cache *hit* restores an incomplete `build/`, silently missing files until a full rebuild.

**`build:transpile`** — the `makeOrchestrionLoader('./build')` helper emits `build/import-hook.mjs`, but only some of its callers declared it. Added it for the remaining server SDKs: astro, aws-serverless, google-cloud-serverless, remix, tanstackstart-react. (node and nextjs already declared it.)

**`build:types`** — several packages run a second `tsc` for subpath exports that writes declarations outside `build/types`, uncaptured by any cached target:
- **vue** — had no override at all; its `tsconfig.router-types.json` emits `tanstackrouter.d.ts` + `.d.ts.map` at the package root. Added an override mirroring `solid` (`build/types`, `*.d.ts`, `*.d.ts.map`).
- **nestjs** — its setup-types config has `declarationMap: true`, so it also emits `*.d.ts.map` at root, which the override was missing.
- **deno** — declared `build-types`, a directory that is never produced; its `tsc` actually writes declarations into `build/esm`. Repointed to `build/esm/**/*.d.ts` (recursive, since deno's `src` is nested).

_Root cause:_ these `outputs` lists were maintained by hand as build steps were added (extra `tsc` passes, the orchestrion import-hook), so per-package emitters drifted out of sync with the declarations.

Verified against the rollup/tsconfig configs rather than on-disk `build/` dirs, since some of those are stale (e.g. leftover `packages/node-core/`, `packages/tanstackstart/` with no `package.json`). The other cached targets — `build:bundle` (`build/bundles`), `build:tarball` (`*.tgz`), `build:layer` (`build/aws`), `lint` (no outputs), `test:unit` (`coverage`) — were checked and already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFugqE3KWYfwqEfqEbjLsB