### PR TITLE
test(e2e): Always run create-remix-app-v2 with orchestrion

### DIFF
--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
@@ -9,9 +9,7 @@
     "typecheck": "tsc",
     "clean": "npx rimraf node_modules pnpm-lock.yaml",
     "test:build": "pnpm install && pnpm build",
-    "test:assert": "pnpm playwright test",
-    "test:build:orchestrion": "INJECT_ORCHESTRION=true pnpm test:build",
-    "test:assert:orchestrion": "INJECT_ORCHESTRION=true pnpm test:assert && INJECT_ORCHESTRION=true TEST_ENV=development pnpm playwright test db"
+    "test:assert": "pnpm playwright test && TEST_ENV=development pnpm playwright test db"
   },
   "dependencies": {
     "@sentry/remix": "file:../../packed/sentry-remix-packed.tgz",
@@ -42,15 +40,6 @@
   },
   "resolutions": {
     "@types/react": "18.2.22"
-  },
-  "sentryTest": {
-    "variants": [
-      {
-        "build-command": "pnpm test:build:orchestrion",
-        "assert-command": "pnpm test:assert:orchestrion",
-        "label": "create-remix-app-v2 (orchestrion)"
-      }
-    ]
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/playwright.config.mjs
@@ -1,8 +1,6 @@
 import { getPlaywrightConfig } from '@sentry-internal/test-utils';
 import { fileURLToPath } from 'url';
 
-const injectOrchestrion = process.env.INJECT_ORCHESTRION === 'true';
-
 // `remix vite:dev` ignores PORT, so the port goes on the command. The dev server has no
 // bundle, so the SDK is loaded through `--import` the way `pnpm start` does it.
 const startCommand =
@@ -14,14 +12,12 @@ const config = getPlaywrightConfig(
   {
     startCommand,
   },
-  // The orchestrion variant exercises real MySQL/Redis. Boot them before the tests run,
-  // outside the webServer startup-timeout window. In the default variant no DB is needed.
-  injectOrchestrion
-    ? {
-        globalSetup: fileURLToPath(new URL('./global-setup.mjs', import.meta.url)),
-        globalTeardown: fileURLToPath(new URL('./global-teardown.mjs', import.meta.url)),
-      }
-    : {},
+  // The DB tests exercise real MySQL/Redis. Boot them before the tests run, outside the
+  // webServer startup-timeout window.
+  {
+    globalSetup: fileURLToPath(new URL('./global-setup.mjs', import.meta.url)),
+    globalTeardown: fileURLToPath(new URL('./global-teardown.mjs', import.meta.url)),
+  },
 );
 
 export default config;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/build-injection.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/build-injection.test.ts
@@ -7,10 +7,8 @@ import { expect, test } from '@playwright/test';
 // failed to load, the deps would stay external and the runtime `--import` hook would
 // inject the channels at runtime instead - the span tests would still pass. These
 // assertions inspect the built server bundle directly so a broken plugin can't hide
-// behind that runtime fallback. Only relevant in the orchestrion variant.
+// behind that runtime fallback.
 test.describe('orchestrion build-time injection', () => {
-  test.skip(process.env.INJECT_ORCHESTRION !== 'true', 'Only runs in the orchestrion variant');
-
   const serverBundle = readFileSync(path.join(process.cwd(), 'build/server/index.js'), 'utf8');
 
   test('force-bundles the instrumented deps instead of externalizing them', () => {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/db.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/db.test.ts
@@ -1,11 +1,9 @@
 import { expect, test } from '@playwright/test';
 import { waitForTransaction } from '@sentry-internal/test-utils';
 
-// These assertions only hold in the orchestrion variant (INJECT_ORCHESTRION=true), which
-// force-bundles + transforms mysql/ioredis and boots the databases via docker-compose.
+// Orchestrion force-bundles + transforms mysql/ioredis at build time, and the databases
+// are booted via docker-compose in the Playwright global setup.
 test.describe('orchestrion DB instrumentation', () => {
-  test.skip(process.env.INJECT_ORCHESTRION !== 'true', 'Only runs in the orchestrion variant');
-
   test('Instruments ioredis automatically via orchestrion', async ({ baseURL }) => {
     const transactionEventPromise = waitForTransaction('create-remix-app-v2', transactionEvent => {
       return (

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/vite.config.ts
@@ -4,19 +4,16 @@ import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
-const injectOrchestrion = process.env.INJECT_ORCHESTRION === 'true';
-
 export default defineConfig({
   plugins: [
     remix({
       ignoredRouteFiles: ['**/.*'],
     }),
     sentryRemixVitePlugin(),
-    // In the orchestrion variant, run the orchestrion code transform over the SSR
-    // server bundle and force-bundle the instrumented deps (mysql, ioredis,
-    // @remix-run/server-runtime, …) so their diagnostics-channel calls are injected
-    // at build time.
-    ...(injectOrchestrion ? [sentryOrchestrionPlugin()] : []),
+    // Run the orchestrion code transform over the SSR server bundle and force-bundle the
+    // instrumented deps (mysql, ioredis, @remix-run/server-runtime, …) so their
+    // diagnostics-channel calls are injected at build time.
+    sentryOrchestrionPlugin(),
     tsconfigPaths(),
   ],
 });


### PR DESCRIPTION
Orchestrion is always used now, so the `INJECT_ORCHESTRION` variant split in the `create-remix-app-v2` E2E app no longer earns its keep. The app previously ran as two CI jobs — a default one (orchestrion plugin off, DB + build-injection tests skipped) and an `INJECT_ORCHESTRION=true` variant (force-bundle/transform the instrumented deps at build time, boot real databases, run everything). That left the DB and build-time-injection coverage gated behind one of the two jobs and duplicated the app build for no added signal.

This collapses it into a single always-orchestrion run:

- Drop the `sentryTest.variants` block and the `test:build:orchestrion` / `test:assert:orchestrion` scripts, so the base `test:build`/`test:assert` are the whole story and CI runs one job instead of two.
- Add `sentryOrchestrionPlugin()` unconditionally in `vite.config.ts`.
- Always run the docker-compose MySQL/Redis global setup in `playwright.config.mjs`.
- Remove the `INJECT_ORCHESTRION` skip guards from `db.test.ts` and `build-injection.test.ts` so those suites merge into the regular run.

No coverage is lost: the two previously variant-only suites (runtime DB spans, and build-time diagnostics-channel injection into mysql/ioredis/`@remix-run/server-runtime`) now run on every invocation.

The `INJECT_ORCHESTRION` mentions under `dev-packages/node-integration-tests` are descriptive comments rather than variant switches, and are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SFugqE3KWYfwqEfqEbjLsB