### PR TITLE
test(e2e): Port Solid E2E test apps to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solid-static/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/solid-static/.gitignore
@@ -1,0 +1,29 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
+!*.d.ts

--- a/dev-packages/e2e-tests/test-applications/solid-static/README.md
+++ b/dev-packages/e2e-tests/test-applications/solid-static/README.md
@@ -1,0 +1,40 @@
+## Usage
+
+Those templates dependencies are maintained via [pnpm](https://pnpm.io) via `pnpm up -Lri`.
+
+This is the reason you see a `pnpm-lock.yaml`. That being said, any package manager will work. This file can be safely
+be removed once you clone a template.
+
+```bash
+$ npm install # or pnpm install or yarn install
+```
+
+## Exploring the template
+
+This template's goal is to showcase the routing features of Solid. It also showcase how the router and Suspense work
+together to parallelize data fetching tied to a route via the `.data.ts` pattern.
+
+You can learn more about it on the [`@solidjs/router` repository](https://github.com/solidjs/solid-router)
+
+### Learn more on the [Solid Website](https://solidjs.com) and come chat with us on our [Discord](https://discord.com/invite/solidjs)
+
+## Available Scripts
+
+In the project directory, you can run:
+
+### `npm run dev` or `npm start`
+
+Runs the app in the development mode.<br> Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+The page will reload if you make edits.<br>
+
+### `npm run build`
+
+Builds the app for production to the `dist` folder.<br> It correctly bundles Solid in production mode and optimizes the
+build for the best performance.
+
+The build is minified and the filenames include the hashes.<br> Your app is ready to be deployed!
+
+## Deployment
+
+You can deploy the `dist` folder to any static host provider (netlify, surge, now, etc.)

--- a/dev-packages/e2e-tests/test-applications/solid-static/index.html
+++ b/dev-packages/e2e-tests/test-applications/solid-static/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>Solid App</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+
+    <script src="/src/index.tsx" type="module"></script>
+  </body>
+</html>

--- a/dev-packages/e2e-tests/test-applications/solid-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/solid-static/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "solid-static",
+  "version": "0.0.0",
+  "description": "",
+  "scripts": {
+    "build": "vite build",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml dist",
+    "dev": "vite",
+    "preview": "vite preview",
+    "start": "vite",
+    "test:prod": "TEST_ENV=production playwright test",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm test:prod"
+  },
+  "license": "MIT",
+  "devDependencies": {
+    "@playwright/test": "~1.56.0",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "autoprefixer": "^10.4.17",
+    "postcss": "^8.4.33",
+    "solid-devtools": "^0.29.2",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.4.11",
+    "vite-plugin-solid": "^2.11.6"
+  },
+  "dependencies": {
+    "solid-js": "^1.8.18",
+    "@sentry/solid": "file:../../packed/sentry-solid-packed.tgz"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/solid-static/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/solid-static/playwright.config.mjs
@@ -1,0 +1,8 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: 'pnpm preview --port 3030',
+  port: 3030,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/solid-static/postcss.config.js
+++ b/dev-packages/e2e-tests/test-applications/solid-static/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/dev-packages/e2e-tests/test-applications/solid-static/src/app.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid-static/src/app.tsx
@@ -1,0 +1,72 @@
+import * as Sentry from '@sentry/solid';
+import { ErrorBoundary, createSignal, onMount } from 'solid-js';
+
+const SentryErrorBoundary = Sentry.withSentryErrorBoundary(ErrorBoundary);
+
+const [count, setCount] = createSignal(1);
+const [caughtError, setCaughtError] = createSignal(false);
+
+export default function App() {
+  return (
+    <SampleErrorBoundary>
+      {caughtError() && <Throw error={`Error ${count()} thrown from Sentry ErrorBoundary in Solid E2E test app`} />}
+      <section class="bg-gray-100 text-gray-700 p-8">
+        <div class="flex flex-col items-start space-x-2">
+          <button
+            class="border rounded-lg px-2 mb-2 border-red-500 text-red-500 cursor-pointer"
+            id="caughtErrorBtn"
+            onClick={() => setCaughtError(true)}
+          >
+            Throw caught error
+          </button>
+        </div>
+        <div class="flex flex-col items-start space-x-2">
+          <button
+            class="border rounded-lg px-2 mb-2 border-red-500 text-red-500 cursor-pointer"
+            id="errorBtn"
+            onClick={() => {
+              throw new Error('Error thrown from Solid E2E test app');
+            }}
+          >
+            Throw uncaught error
+          </button>
+        </div>
+      </section>
+    </SampleErrorBoundary>
+  );
+}
+
+function Throw(props) {
+  onMount(() => {
+    throw new Error(props.error);
+  });
+  return null;
+}
+
+function SampleErrorBoundary(props) {
+  return (
+    <SentryErrorBoundary
+      fallback={(error, reset) => (
+        <section class="bg-gray-100 text-gray-700 p-8">
+          <h1 class="text-2xl font-bold">Error Boundary Fallback</h1>
+          <div class="flex items-center space-x-2 mb-4">
+            <code>{error.message}</code>
+          </div>
+          <button
+            id="errorBoundaryResetBtn"
+            class="border rounded-lg px-2 border-gray-900"
+            onClick={() => {
+              setCount(count() + 1);
+              setCaughtError(false);
+              reset();
+            }}
+          >
+            Reset
+          </button>
+        </section>
+      )}
+    >
+      {props.children}
+    </SentryErrorBoundary>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/solid-static/src/index.css
+++ b/dev-packages/e2e-tests/test-applications/solid-static/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dev-packages/e2e-tests/test-applications/solid-static/src/index.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid-static/src/index.tsx
@@ -5,6 +5,7 @@ import App from './app';
 import './index.css';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   debug: true,
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/solid-static/src/pageroot.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid-static/src/pageroot.tsx
@@ -1,0 +1,28 @@
+import { A } from '@solidjs/router';
+
+export default function PageRoot(props) {
+  return (
+    <>
+      <nav class="bg-gray-200 text-gray-900 px-4">
+        <ul class="flex items-center">
+          <li class="py-2 px-4">
+            <A href="/" class="no-underline hover:underline">
+              Home
+            </A>
+          </li>
+          <li>
+            <A href="/error-boundary-example" class="no-underline hover:underline">
+              Error Boundary Example
+            </A>
+          </li>
+          <li class="py-2 px-4">
+            <A href="/error" class="no-underline hover:underline">
+              Error
+            </A>
+          </li>
+        </ul>
+      </nav>
+      <main>{props.children}</main>
+    </>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/solid-static/src/routes.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-static/src/routes.ts
@@ -1,0 +1,23 @@
+import { lazy } from 'solid-js';
+
+import ErrorBoundaryExample from './pages/errorboundaryexample';
+import Home from './pages/home';
+
+export const routes = [
+  {
+    path: '/',
+    component: Home,
+  },
+  {
+    path: '/user/:id',
+    component: lazy(() => import('./pages/user')),
+  },
+  {
+    path: '/error-boundary-example',
+    component: ErrorBoundaryExample,
+  },
+  {
+    path: '**',
+    component: lazy(() => import('./errors/404')),
+  },
+];

--- a/dev-packages/e2e-tests/test-applications/solid-static/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/solid-static/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'solid-static',
+});

--- a/dev-packages/e2e-tests/test-applications/solid-static/tailwind.config.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-static/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/solid-static/tests/errorboundary.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-static/tests/errorboundary.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test('captures an exception', async ({ page }) => {
+  const errorEventPromise = waitForError('solid-static', errorEvent => {
+    return (
+      !errorEvent.type &&
+      errorEvent.exception?.values?.[0]?.value === 'Error 1 thrown from Sentry ErrorBoundary in Solid E2E test app'
+    );
+  });
+
+  const [, , errorEvent] = await Promise.all([
+    page.goto('/'),
+    page.locator('#caughtErrorBtn').click(),
+    errorEventPromise,
+  ]);
+
+  expect(errorEvent).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'Error 1 thrown from Sentry ErrorBoundary in Solid E2E test app',
+          mechanism: {
+            type: 'auto.function.solid.error_boundary',
+            handled: true,
+          },
+        },
+      ],
+    },
+    transaction: '/',
+  });
+});
+
+test('captures a second exception after resetting the boundary', async ({ page }) => {
+  const firstErrorEventPromise = waitForError('solid-static', errorEvent => {
+    return (
+      !errorEvent.type &&
+      errorEvent.exception?.values?.[0]?.value === 'Error 1 thrown from Sentry ErrorBoundary in Solid E2E test app'
+    );
+  });
+
+  const [, , firstErrorEvent] = await Promise.all([
+    page.goto('/'),
+    page.locator('#caughtErrorBtn').click(),
+    firstErrorEventPromise,
+  ]);
+
+  expect(firstErrorEvent).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'Error 1 thrown from Sentry ErrorBoundary in Solid E2E test app',
+          mechanism: {
+            type: 'auto.function.solid.error_boundary',
+            handled: true,
+          },
+        },
+      ],
+    },
+    transaction: '/',
+  });
+
+  const secondErrorEventPromise = waitForError('solid-static', errorEvent => {
+    return (
+      !errorEvent.type &&
+      errorEvent.exception?.values?.[0]?.value === 'Error 2 thrown from Sentry ErrorBoundary in Solid E2E test app'
+    );
+  });
+
+  const [, , secondErrorEvent] = await Promise.all([
+    page.locator('#errorBoundaryResetBtn').click(),
+    page.locator('#caughtErrorBtn').click(),
+    await secondErrorEventPromise,
+  ]);
+
+  expect(secondErrorEvent).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'Error 2 thrown from Sentry ErrorBoundary in Solid E2E test app',
+          mechanism: {
+            type: 'auto.function.solid.error_boundary',
+            handled: true,
+          },
+        },
+      ],
+    },
+    transaction: '/',
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/solid-static/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-static/tests/errors.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test('sends an error', async ({ page }) => {
+  const errorPromise = waitForError('solid-static', async errorEvent => {
+    return !errorEvent.type && errorEvent.exception?.values?.[0]?.value === 'Error thrown from Solid E2E test app';
+  });
+
+  await Promise.all([page.goto(`/`), page.locator('#errorBtn').click()]);
+
+  const error = await errorPromise;
+
+  expect(error).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'Error thrown from Solid E2E test app',
+          mechanism: {
+            type: 'auto.browser.global_handlers.onerror',
+            handled: false,
+          },
+        },
+      ],
+    },
+    transaction: '/',
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/solid-static/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-static/tests/performance.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('sends a pageload transaction', async ({ page }) => {
+  const transactionPromise = waitForTransaction('solid-static', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  });
+
+  const [, pageloadTransaction] = await Promise.all([page.goto('/'), transactionPromise]);
+
+  expect(pageloadTransaction).toMatchObject({
+    contexts: {
+      trace: {
+        op: 'pageload',
+        origin: 'auto.pageload.browser',
+      },
+    },
+    transaction: '/',
+    transaction_info: {
+      source: 'url',
+    },
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/solid-static/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/solid-static/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["vite/client"],
+    "noEmit": true,
+    "isolatedModules": true
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/solid-static/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-static/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import solidPlugin from 'vite-plugin-solid';
+
+export default defineConfig({
+  plugins: [solidPlugin()],
+  build: {
+    target: 'esnext',
+  },
+  envPrefix: 'PUBLIC_',
+});

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/src/main.tsx
@@ -97,7 +97,6 @@ declare module '@tanstack/solid-router' {
 declare const __APP_DSN__: string;
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: __APP_DSN__,
   debug: true,
   environment: 'qa', // dynamic sampling bias to keep transactions

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/tests/routing-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/tests/routing-instrumentation.test.ts
@@ -1,250 +1,183 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('sends a pageload transaction with a parameterized URL', async ({ page }) => {
-  const transactionPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('sends a pageload span with a parameterized URL', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto(`/posts/456`);
 
-  const rootSpan = await transactionPromise;
+  const pageloadSpan = await pageloadSpanPromise;
 
-  expect(rootSpan).toMatchObject({
-    contexts: {
-      trace: {
-        data: {
-          'sentry.segment.name.source': 'route',
-          'sentry.origin': 'auto.pageload.solid.tanstack_router',
-          'sentry.op': 'pageload',
-          'url.path.parameter.postId': '456',
-          'url.template': '/posts/$postId',
-          'url.path': '/posts/456',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/456$/),
-        },
-        op: 'pageload',
-        origin: 'auto.pageload.solid.tanstack_router',
-      },
-    },
-    transaction: '/posts/$postId',
-    transaction_info: {
-      source: 'route',
-    },
+  expect(pageloadSpan.name).toBe('/posts/$postId');
+  expect(pageloadSpan.attributes).toMatchObject({
+    'sentry.segment.name.source': { value: 'route', type: 'string' },
+    'sentry.origin': { value: 'auto.pageload.solid.tanstack_router', type: 'string' },
+    'sentry.op': { value: 'pageload', type: 'string' },
+    'url.path.parameter.postId': { value: '456', type: 'string' },
+    'url.template': { value: '/posts/$postId', type: 'string' },
+    'url.path': { value: '/posts/456', type: 'string' },
+    'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/456$/), type: 'string' },
   });
 });
 
-test('sends a navigation transaction with a parameterized URL', async ({ page }) => {
-  const pageloadTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('sends a navigation span with a parameterized URL', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const navigationTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return (
-      !!transactionEvent?.transaction &&
-      transactionEvent.transaction === '/posts/$postId' &&
-      transactionEvent.contexts?.trace?.op === 'navigation'
-    );
+  const navigationSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'navigation' && span.is_segment && span.name === '/posts/$postId';
   });
 
   await page.goto(`/`);
-  await pageloadTxnPromise;
+  await pageloadSpanPromise;
 
   await page.waitForTimeout(5000);
   await page.locator('#nav-link').click();
 
-  const navigationTxn = await navigationTxnPromise;
+  const navigationSpan = await navigationSpanPromise;
 
-  expect(navigationTxn).toMatchObject({
-    contexts: {
-      trace: {
-        data: {
-          'sentry.segment.name.source': 'route',
-          'sentry.origin': 'auto.navigation.solid.tanstack_router',
-          'sentry.op': 'navigation',
-          'url.path.parameter.postId': '2',
-          'url.template': '/posts/$postId',
-          'url.path': '/posts/2',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/2$/),
-        },
-        op: 'navigation',
-        origin: 'auto.navigation.solid.tanstack_router',
-      },
-    },
-    transaction: '/posts/$postId',
-    transaction_info: {
-      source: 'route',
-    },
+  expect(navigationSpan.name).toBe('/posts/$postId');
+  expect(navigationSpan.attributes).toMatchObject({
+    'sentry.segment.name.source': { value: 'route', type: 'string' },
+    'sentry.origin': { value: 'auto.navigation.solid.tanstack_router', type: 'string' },
+    'sentry.op': { value: 'navigation', type: 'string' },
+    'url.path.parameter.postId': { value: '2', type: 'string' },
+    'url.template': { value: '/posts/$postId', type: 'string' },
+    'url.path': { value: '/posts/2', type: 'string' },
+    'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/2$/), type: 'string' },
   });
 });
 
-test('sends a pageload transaction named after the resolved route when a redirect is thrown on initial load', async ({
+test('sends a pageload span named after the resolved route when a redirect is thrown on initial load', async ({
   page,
 }) => {
-  const pageloadTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.transaction === '/posts/$postId';
+  const pageloadSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment && span.name === '/posts/$postId';
   });
 
   await page.goto(`/redirect`);
 
-  const pageloadTxn = await pageloadTxnPromise;
+  const pageloadSpan = await pageloadSpanPromise;
 
-  expect(pageloadTxn).toMatchObject({
-    contexts: {
-      trace: {
-        data: {
-          'sentry.segment.name.source': 'route',
-          'sentry.origin': 'auto.pageload.solid.tanstack_router',
-          'sentry.op': 'pageload',
-          'url.path.parameter.postId': '1',
-          'url.template': '/posts/$postId',
-          'url.path': '/posts/1',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/1$/),
-        },
-        op: 'pageload',
-        origin: 'auto.pageload.solid.tanstack_router',
-      },
-    },
-    transaction: '/posts/$postId',
-    transaction_info: {
-      source: 'route',
-    },
+  expect(pageloadSpan.name).toBe('/posts/$postId');
+  expect(pageloadSpan.attributes).toMatchObject({
+    'sentry.segment.name.source': { value: 'route', type: 'string' },
+    'sentry.origin': { value: 'auto.pageload.solid.tanstack_router', type: 'string' },
+    'sentry.op': { value: 'pageload', type: 'string' },
+    'url.path.parameter.postId': { value: '1', type: 'string' },
+    'url.template': { value: '/posts/$postId', type: 'string' },
+    'url.path': { value: '/posts/1', type: 'string' },
+    'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/1$/), type: 'string' },
   });
 });
 
-test('sends a navigation transaction when a redirect is thrown in beforeLoad', async ({ page }) => {
-  const pageloadTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('sends a navigation span when a redirect is thrown in beforeLoad', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const navigationTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return (
-      !!transactionEvent?.transaction &&
-      transactionEvent.transaction === '/posts/$postId' &&
-      transactionEvent.contexts?.trace?.op === 'navigation'
-    );
+  const navigationSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'navigation' && span.is_segment && span.name === '/posts/$postId';
   });
 
   await page.goto(`/`);
-  await pageloadTxnPromise;
+  await pageloadSpanPromise;
 
   await page.locator('#redirect-link').click();
 
-  const navigationTxn = await navigationTxnPromise;
+  const navigationSpan = await navigationSpanPromise;
 
-  expect(navigationTxn).toMatchObject({
-    contexts: {
-      trace: {
-        data: {
-          'sentry.segment.name.source': 'route',
-          'sentry.origin': 'auto.navigation.solid.tanstack_router',
-          'sentry.op': 'navigation',
-          'url.path.parameter.postId': '1',
-          'url.template': '/posts/$postId',
-          'url.path': '/posts/1',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/1$/),
-        },
-        op: 'navigation',
-        origin: 'auto.navigation.solid.tanstack_router',
-      },
-    },
-    transaction: '/posts/$postId',
-    transaction_info: {
-      source: 'route',
-    },
+  expect(navigationSpan.name).toBe('/posts/$postId');
+  expect(navigationSpan.attributes).toMatchObject({
+    'sentry.segment.name.source': { value: 'route', type: 'string' },
+    'sentry.origin': { value: 'auto.navigation.solid.tanstack_router', type: 'string' },
+    'sentry.op': { value: 'navigation', type: 'string' },
+    'url.path.parameter.postId': { value: '1', type: 'string' },
+    'url.template': { value: '/posts/$postId', type: 'string' },
+    'url.path': { value: '/posts/1', type: 'string' },
+    'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/1$/), type: 'string' },
   });
 });
 
-test('sends a navigation transaction for a normal navigation that happens after a redirect', async ({ page }) => {
-  const pageloadTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('sends a navigation span for a normal navigation that happens after a redirect', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto(`/`);
-  await pageloadTxnPromise;
+  await pageloadSpanPromise;
 
-  const redirectTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return transactionEvent.contexts?.trace?.op === 'navigation' && transactionEvent.transaction === '/posts/$postId';
+  const redirectSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'navigation' && span.is_segment && span.name === '/posts/$postId';
   });
   await page.locator('#redirect-link').click();
-  await redirectTxnPromise;
+  await redirectSpanPromise;
 
-  const navigationTxnPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
+  const navigationSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
     return (
-      transactionEvent.contexts?.trace?.op === 'navigation' &&
-      transactionEvent.contexts?.trace?.data?.['url.path.parameter.postId'] === '2'
+      getSpanOp(span) === 'navigation' && span.is_segment && span.attributes['url.path.parameter.postId']?.value === '2'
     );
   });
 
   await page.locator('#nav-link').click();
 
-  const navigationTxn = await navigationTxnPromise;
+  const navigationSpan = await navigationSpanPromise;
 
-  expect(navigationTxn).toMatchObject({
-    contexts: {
-      trace: {
-        data: {
-          'sentry.segment.name.source': 'route',
-          'sentry.origin': 'auto.navigation.solid.tanstack_router',
-          'sentry.op': 'navigation',
-          'url.path.parameter.postId': '2',
-          'url.template': '/posts/$postId',
-          'url.path': '/posts/2',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/2$/),
-        },
-        op: 'navigation',
-        origin: 'auto.navigation.solid.tanstack_router',
-      },
-    },
-    transaction: '/posts/$postId',
-    transaction_info: {
-      source: 'route',
-    },
+  expect(navigationSpan.name).toBe('/posts/$postId');
+  expect(navigationSpan.attributes).toMatchObject({
+    'sentry.segment.name.source': { value: 'route', type: 'string' },
+    'sentry.origin': { value: 'auto.navigation.solid.tanstack_router', type: 'string' },
+    'sentry.op': { value: 'navigation', type: 'string' },
+    'url.path.parameter.postId': { value: '2', type: 'string' },
+    'url.template': { value: '/posts/$postId', type: 'string' },
+    'url.path': { value: '/posts/2', type: 'string' },
+    'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/posts\/2$/), type: 'string' },
   });
 });
 
-test('sends pageload transaction with web vitals measurements', async ({ page }) => {
-  const transactionPromise = waitForTransaction('solid-tanstack-router', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('sends a pageload span with web vital attributes and a standalone LCP span', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
+  });
+
+  const lcpSpanPromise = waitForStreamedSpan('solid-tanstack-router', span => {
+    return getSpanOp(span) === 'ui.webvital.lcp';
   });
 
   await page.goto(`/`);
 
-  const transaction = await transactionPromise;
+  const pageloadSpan = await pageloadSpanPromise;
 
-  expect(transaction).toMatchObject({
-    contexts: {
-      trace: {
-        op: 'pageload',
-        origin: 'auto.pageload.solid.tanstack_router',
-        data: {
-          'sentry.segment.name.source': 'route',
-          'url.template': '/',
-          'url.path': '/',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
-        },
-      },
-    },
-    transaction: '/',
-    transaction_info: {
-      source: 'route',
-    },
-    measurements: expect.objectContaining({
-      ttfb: expect.objectContaining({
-        value: expect.any(Number),
-        unit: 'millisecond',
-      }),
-      lcp: expect.objectContaining({
-        value: expect.any(Number),
-        unit: 'millisecond',
-      }),
-      fp: expect.objectContaining({
-        value: expect.any(Number),
-        unit: 'millisecond',
-      }),
-      fcp: expect.objectContaining({
-        value: expect.any(Number),
-        unit: 'millisecond',
-      }),
-    }),
+  // LCP is only reported once the page is hidden or a navigation happens
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+
+  const lcpSpan = await lcpSpanPromise;
+
+  const webVitalNumber = { value: expect.any(Number), type: expect.stringMatching(/^(integer|double)$/) };
+
+  expect(pageloadSpan.name).toBe('/');
+  expect(pageloadSpan.attributes).toMatchObject({
+    'sentry.op': { value: 'pageload', type: 'string' },
+    'sentry.origin': { value: 'auto.pageload.solid.tanstack_router', type: 'string' },
+    'sentry.segment.name.source': { value: 'route', type: 'string' },
+    'url.template': { value: '/', type: 'string' },
+    'url.path': { value: '/', type: 'string' },
+    'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/$/), type: 'string' },
+    'browser.web_vital.ttfb.value': webVitalNumber,
+    'browser.web_vital.fp.value': webVitalNumber,
+    'browser.web_vital.fcp.value': webVitalNumber,
+  });
+
+  expect(lcpSpan.attributes).toMatchObject({
+    'sentry.op': { value: 'ui.webvital.lcp', type: 'string' },
+    'sentry.origin': { value: 'auto.http.browser.lcp', type: 'string' },
+    'sentry.pageload.span_id': { value: pageloadSpan.span_id, type: 'string' },
+    'browser.web_vital.lcp.value': webVitalNumber,
   });
 });

--- a/dev-packages/e2e-tests/test-applications/solid/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid/tests/performance.test.ts
@@ -1,23 +1,17 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('sends a pageload transaction', async ({ page }) => {
-  const transactionPromise = waitForTransaction('solid', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('sends a pageload span', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('solid', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const [, pageloadTransaction] = await Promise.all([page.goto('/'), transactionPromise]);
+  const [, pageloadSpan] = await Promise.all([page.goto('/'), pageloadSpanPromise]);
 
-  expect(pageloadTransaction).toMatchObject({
-    contexts: {
-      trace: {
-        op: 'pageload',
-        origin: 'auto.pageload.browser',
-      },
-    },
-    transaction: '/',
-    transaction_info: {
-      source: 'url',
-    },
+  expect(pageloadSpan.name).toBe('Pageload');
+  expect(pageloadSpan.attributes).toMatchObject({
+    'sentry.op': { value: 'pageload', type: 'string' },
+    'sentry.origin': { value: 'auto.pageload.browser', type: 'string' },
+    'sentry.segment.name.source': { value: 'url', type: 'string' },
   });
 });


### PR DESCRIPTION
Ports `solid` and `solid-tanstack-router` to span streaming and adds `solid-static`, a verbatim copy of `solid` that keeps `traceLifecycle: 'static'` and the transaction-based specs, so the static trace lifecycle stays covered.

Under streaming, the plain `solid` pageload span is named `Pageload` with `sentry.segment.name.source: url`, since `browserTracingIntegration` has no route information. The error specs are unchanged: the scope's transaction name stays the URL path, so error events still carry `transaction: '/'`.

The web vitals spec in `solid-tanstack-router` now asserts `browser.web_vital.{ttfb,fp,fcp}.value` attributes on the pageload span and a standalone `ui.webvital.lcp` span, since measurements do not exist on streamed spans and LCP is reported as its own span on page hide.

Closes: #23814
