### PR TITLE
test(e2e): Migrate nuxt-5 to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.client.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.client.config.ts
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/nuxt';
 import { /* usePinia,*/ useRuntimeConfig } from '#imports';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: useRuntimeConfig().public.sentry.dsn,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/sentry.server.config.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nuxt';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1.0, //  Capture 100% of the transactions
   tunnel: 'http://localhost:3031/', // proxy server

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/server/api/db-test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/server/api/db-test.ts
@@ -61,6 +61,11 @@ export default defineHandler(async event => {
     }
 
     case 'error': {
+      // A successful query runs first so the captured error carries a query breadcrumb: with span
+      // streaming there is no transaction event left to read breadcrumbs off.
+      await db.exec('CREATE TABLE IF NOT EXISTS logs (id INTEGER PRIMARY KEY, message TEXT, level TEXT)');
+      await db.exec(`INSERT INTO logs (message, level) VALUES ('Test log', 'INFO')`);
+
       const stmt = db.prepare('SELECT * FROM nonexistent_table WHERE invalid_column = ?');
       await stmt.get(1);
       return { success: false, message: 'Should have thrown an error' };

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/cache.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/cache.test.ts
@@ -1,33 +1,37 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/nuxt';
+import { collectStreamedSpans } from '@sentry-internal/test-utils';
 
 test.describe('Cache Instrumentation', () => {
   const SEMANTIC_ATTRIBUTE_CACHE_KEY = 'cache.key';
   const SEMANTIC_ATTRIBUTE_CACHE_HIT = 'cache.hit';
 
+  async function collectCacheSpans() {
+    const spans = await collectStreamedSpans('nuxt-5', spans =>
+      spans.some(span => span.is_segment && span.attributes['url.path']?.value === '/api/cache-test'),
+    );
+    const rootSpan = spans.find(span => span.is_segment && span.attributes['url.path']?.value === '/api/cache-test');
+
+    return spans.filter(
+      span => span.trace_id === rootSpan?.trace_id && span.attributes['sentry.origin']?.value === 'auto.cache.nuxt',
+    );
+  }
+
   test('instruments cachedFunction and cachedEventHandler calls and creates spans with correct attributes', async ({
     request,
   }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction?.includes('GET /api/cache-test') ?? false;
-    });
+    const cacheSpansPromise = collectCacheSpans();
 
     const response = await request.get('/api/cache-test');
     expect(response.status()).toBe(200);
 
-    const transaction = await transactionPromise;
+    const allCacheSpans = await cacheSpansPromise;
+    expect(allCacheSpans.length).toBeGreaterThan(0);
 
     // Helper to find spans by operation
-    const findSpansByMethod = (method: string) => {
-      return transaction.spans?.filter(span => span.data?.['db.operation.name'] === method) || [];
-    };
+    const findSpansByMethod = (method: string) =>
+      allCacheSpans.filter(span => span.attributes['db.operation.name']?.value === method);
 
-    // Test that we have cache operations from cachedFunction and cachedEventHandler
-    const allCacheSpans = transaction.spans?.filter(
-      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nuxt',
-    );
-    expect(allCacheSpans?.length).toBeGreaterThan(0);
+    const getCacheKey = (span: (typeof allCacheSpans)[number]) => span.attributes[SEMANTIC_ATTRIBUTE_CACHE_KEY]?.value;
 
     // Test getItem spans for cachedFunction - should have both cache miss and cache hit
     const getItemSpans = findSpansByMethod('getItem');
@@ -36,34 +40,34 @@ test.describe('Cache Instrumentation', () => {
     // Find cache miss (first call to getCachedUser('123'))
     const cacheMissSpan = getItemSpans.find(
       span =>
-        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
-        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123') &&
-        !span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT],
+        typeof getCacheKey(span) === 'string' &&
+        (getCacheKey(span) as string).includes('user:123') &&
+        !span.attributes[SEMANTIC_ATTRIBUTE_CACHE_HIT]?.value,
     );
     if (cacheMissSpan) {
-      expect(cacheMissSpan.data).toMatchObject({
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: false,
-        'db.operation.name': 'getItem',
-        'db.collection.name': expect.stringMatching(/^(cache)?$/),
+      expect(cacheMissSpan.attributes).toMatchObject({
+        'sentry.op': { type: 'string', value: 'cache.get' },
+        'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: false },
+        'db.operation.name': { type: 'string', value: 'getItem' },
+        'db.collection.name': { type: 'string', value: expect.stringMatching(/^(cache)?$/) },
       });
     }
 
     // Find cache hit (second call to getCachedUser('123'))
     const cacheHitSpan = getItemSpans.find(
       span =>
-        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
-        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123') &&
-        span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT],
+        typeof getCacheKey(span) === 'string' &&
+        (getCacheKey(span) as string).includes('user:123') &&
+        span.attributes[SEMANTIC_ATTRIBUTE_CACHE_HIT]?.value,
     );
     if (cacheHitSpan) {
-      expect(cacheHitSpan.data).toMatchObject({
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
-        'db.operation.name': 'getItem',
-        'db.collection.name': expect.stringMatching(/^(cache)?$/),
+      expect(cacheHitSpan.attributes).toMatchObject({
+        'sentry.op': { type: 'string', value: 'cache.get' },
+        'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+        [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
+        'db.operation.name': { type: 'string', value: 'getItem' },
+        'db.collection.name': { type: 'string', value: expect.stringMatching(/^(cache)?$/) },
       });
     }
 
@@ -72,42 +76,33 @@ test.describe('Cache Instrumentation', () => {
     expect(setItemSpans.length).toBeGreaterThan(0);
 
     const cacheSetSpan = setItemSpans.find(
-      span =>
-        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
-        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('user:123'),
+      span => typeof getCacheKey(span) === 'string' && (getCacheKey(span) as string).includes('user:123'),
     );
     if (cacheSetSpan) {
-      expect(cacheSetSpan.data).toMatchObject({
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.put',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-        'db.operation.name': 'setItem',
-        'db.collection.name': expect.stringMatching(/^(cache)?$/),
+      expect(cacheSetSpan.attributes).toMatchObject({
+        'sentry.op': { type: 'string', value: 'cache.put' },
+        'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+        'db.operation.name': { type: 'string', value: 'setItem' },
+        'db.collection.name': { type: 'string', value: expect.stringMatching(/^(cache)?$/) },
       });
     }
 
     // Test that we have spans for different cached functions
     const dataKeySpans = getItemSpans.filter(
-      span =>
-        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
-        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('data:test-key'),
+      span => typeof getCacheKey(span) === 'string' && (getCacheKey(span) as string).includes('data:test-key'),
     );
     expect(dataKeySpans.length).toBeGreaterThan(0);
 
     // Test that we have spans for cachedEventHandler
     const cachedHandlerSpans = getItemSpans.filter(
-      span =>
-        typeof span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === 'string' &&
-        span.data[SEMANTIC_ATTRIBUTE_CACHE_KEY].includes('cachedHandler'),
+      span => typeof getCacheKey(span) === 'string' && (getCacheKey(span) as string).includes('cachedHandler'),
     );
     expect(cachedHandlerSpans.length).toBeGreaterThan(0);
 
-    // Verify all cache spans have OK status
-    allCacheSpans?.forEach(span => {
+    // Verify all cache spans have OK status and are nested under the request's root span
+    allCacheSpans.forEach(span => {
       expect(span.status).toBe('ok');
-    });
-
-    // Verify cache spans are properly nested under the transaction
-    allCacheSpans?.forEach(span => {
+      expect(span.is_segment).toBe(false);
       expect(span.parent_span_id).toBeDefined();
     });
   });
@@ -117,41 +112,38 @@ test.describe('Cache Instrumentation', () => {
     const uniqueUser = `test-${Date.now()}`;
     const uniqueData = `data-${Date.now()}`;
 
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction?.includes('GET /api/cache-test') ?? false;
-    });
+    const cacheSpansPromise = collectCacheSpans();
 
     await request.get(`/api/cache-test?user=${uniqueUser}&data=${uniqueData}`);
-    const transaction1 = await transactionPromise;
 
     // Get all cache-related spans
-    const allCacheSpans = transaction1.spans?.filter(
-      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nuxt',
-    );
+    const allCacheSpans = await cacheSpansPromise;
 
     // We should have cache operations
-    expect(allCacheSpans?.length).toBeGreaterThan(0);
+    expect(allCacheSpans.length).toBeGreaterThan(0);
 
     // Get all getItem operations
-    const allGetItemSpans = allCacheSpans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'cache.get');
+    const allGetItemSpans = allCacheSpans.filter(span => span.attributes['sentry.op']?.value === 'cache.get');
 
     // Get all setItem operations
-    const allSetItemSpans = allCacheSpans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_OP] === 'cache.put');
+    const allSetItemSpans = allCacheSpans.filter(span => span.attributes['sentry.op']?.value === 'cache.put');
 
     // We should have both get and set operations
-    expect(allGetItemSpans?.length).toBeGreaterThan(0);
-    expect(allSetItemSpans?.length).toBeGreaterThan(0);
+    expect(allGetItemSpans.length).toBeGreaterThan(0);
+    expect(allSetItemSpans.length).toBeGreaterThan(0);
 
     // Check for cache misses (cache.hit = false)
-    const cacheMissSpans = allGetItemSpans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT] === false);
+    const cacheMissSpans = allGetItemSpans.filter(
+      span => span.attributes[SEMANTIC_ATTRIBUTE_CACHE_HIT]?.value === false,
+    );
 
     // Check for cache hits (cache.hit = true)
-    const cacheHitSpans = allGetItemSpans?.filter(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_HIT] === true);
+    const cacheHitSpans = allGetItemSpans.filter(span => span.attributes[SEMANTIC_ATTRIBUTE_CACHE_HIT]?.value === true);
 
     // We should have at least one cache miss (first calls to getCachedUser and getCachedData)
-    expect(cacheMissSpans?.length).toBeGreaterThanOrEqual(1);
+    expect(cacheMissSpans.length).toBeGreaterThanOrEqual(1);
 
     // We should have at least one cache hit (second calls to getCachedUser and getCachedData)
-    expect(cacheHitSpans?.length).toBeGreaterThanOrEqual(1);
+    expect(cacheHitSpans.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/cache.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/cache.test.ts
@@ -47,6 +47,7 @@ test.describe('Cache Instrumentation', () => {
     if (cacheMissSpan) {
       expect(cacheMissSpan.attributes).toMatchObject({
         'sentry.op': { type: 'string', value: 'cache.get' },
+        'cache.operation': { type: 'string', value: 'get' },
         'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
         [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: false },
         'db.operation.name': { type: 'string', value: 'getItem' },
@@ -64,6 +65,7 @@ test.describe('Cache Instrumentation', () => {
     if (cacheHitSpan) {
       expect(cacheHitSpan.attributes).toMatchObject({
         'sentry.op': { type: 'string', value: 'cache.get' },
+        'cache.operation': { type: 'string', value: 'get' },
         'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
         [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
         'db.operation.name': { type: 'string', value: 'getItem' },
@@ -81,6 +83,7 @@ test.describe('Cache Instrumentation', () => {
     if (cacheSetSpan) {
       expect(cacheSetSpan.attributes).toMatchObject({
         'sentry.op': { type: 'string', value: 'cache.put' },
+        'cache.operation': { type: 'string', value: 'put' },
         'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
         'db.operation.name': { type: 'string', value: 'setItem' },
         'db.collection.name': { type: 'string', value: expect.stringMatching(/^(cache)?$/) },

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/database-multi.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/database-multi.test.ts
@@ -1,156 +1,155 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp } from '@sentry-internal/test-utils';
+
+async function collectDbSpans() {
+  const spans = await collectStreamedSpans('nuxt-5', spans =>
+    spans.some(span => span.is_segment && span.attributes['url.path']?.value === '/api/db-multi-test'),
+  );
+  const rootSpan = spans.find(span => span.is_segment && span.attributes['url.path']?.value === '/api/db-multi-test');
+
+  return spans.filter(span => span.trace_id === rootSpan?.trace_id && getSpanOp(span) === 'db.query');
+}
 
 test.describe('multiple database instances', () => {
   test('instruments default database instance', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-multi-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-multi-test?method=default-db');
 
-    const transaction = await transactionPromise;
+    const dbSpans = await dbSpansPromise;
+    expect(dbSpans.length).toBeGreaterThan(0);
 
-    const dbSpans = transaction.spans?.filter(span => span.op === 'db.query');
-
-    expect(dbSpans).toBeDefined();
-    expect(dbSpans!.length).toBeGreaterThan(0);
-
-    // Check that we have the SELECT span
-    const selectSpan = dbSpans?.find(span => span.description?.includes('SELECT * FROM default_table'));
+    const selectSpan = dbSpans.find(span => span.name === 'SELECT default_table');
     expect(selectSpan).toBeDefined();
-    expect(selectSpan?.op).toBe('db.query');
-    expect(selectSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(selectSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(selectSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT default_table' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM default_table WHERE id = ?' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'db.namespace': { type: 'string', value: 'db.sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('instruments named database instance (users)', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-multi-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-multi-test?method=users-db');
 
-    const transaction = await transactionPromise;
+    const dbSpans = await dbSpansPromise;
+    expect(dbSpans.length).toBeGreaterThan(0);
 
-    const dbSpans = transaction.spans?.filter(span => span.op === 'db.query');
-
-    expect(dbSpans).toBeDefined();
-    expect(dbSpans!.length).toBeGreaterThan(0);
-
-    // Check that we have the SELECT span from users database
-    const selectSpan = dbSpans?.find(span => span.description?.includes('SELECT * FROM user_profiles'));
+    const selectSpan = dbSpans.find(span => span.name === 'SELECT user_profiles');
     expect(selectSpan).toBeDefined();
-    expect(selectSpan?.op).toBe('db.query');
-    expect(selectSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(selectSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(selectSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT user_profiles' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM user_profiles WHERE id = ?' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'db.namespace': { type: 'string', value: 'users_db.sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('instruments named database instance (analytics)', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-multi-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-multi-test?method=analytics-db');
 
-    const transaction = await transactionPromise;
+    const dbSpans = await dbSpansPromise;
+    expect(dbSpans.length).toBeGreaterThan(0);
 
-    const dbSpans = transaction.spans?.filter(span => span.op === 'db.query');
-
-    expect(dbSpans).toBeDefined();
-    expect(dbSpans!.length).toBeGreaterThan(0);
-
-    // Check that we have the SELECT span from analytics database
-    const selectSpan = dbSpans?.find(span => span.description?.includes('SELECT * FROM events'));
+    const selectSpan = dbSpans.find(span => span.name === 'SELECT events');
     expect(selectSpan).toBeDefined();
-    expect(selectSpan?.op).toBe('db.query');
-    expect(selectSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(selectSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(selectSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT events' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM events WHERE id = ?' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'db.namespace': { type: 'string', value: 'analytics_db.sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('instruments multiple database instances in single request', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-multi-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-multi-test?method=multiple-dbs');
 
-    const transaction = await transactionPromise;
+    const dbSpans = await dbSpansPromise;
+    expect(dbSpans.length).toBeGreaterThan(0);
 
-    const dbSpans = transaction.spans?.filter(span => span.op === 'db.query');
+    const sessionSpan = dbSpans.find(span => span.name === 'SELECT sessions');
+    const accountSpan = dbSpans.find(span => span.name === 'SELECT accounts');
+    const metricSpan = dbSpans.find(span => span.name === 'SELECT metrics');
 
-    expect(dbSpans).toBeDefined();
-    expect(dbSpans!.length).toBeGreaterThan(0);
+    // Each instance keeps its own namespace, while the span name stays low cardinality
+    expect(sessionSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT sessions' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM sessions WHERE id = ?' },
+      'db.namespace': { type: 'string', value: 'db.sqlite' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
+    expect(accountSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT accounts' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM accounts WHERE id = ?' },
+      'db.namespace': { type: 'string', value: 'users_db.sqlite' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
+    expect(metricSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT metrics' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM metrics WHERE id = ?' },
+      'db.namespace': { type: 'string', value: 'analytics_db.sqlite' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
 
-    // Check that we have spans from all three databases
-    const sessionSpan = dbSpans?.find(span => span.description?.includes('SELECT * FROM sessions'));
-    const accountSpan = dbSpans?.find(span => span.description?.includes('SELECT * FROM accounts'));
-    const metricSpan = dbSpans?.find(span => span.description?.includes('SELECT * FROM metrics'));
-
-    expect(sessionSpan).toBeDefined();
-    expect(sessionSpan?.op).toBe('db.query');
-    expect(sessionSpan?.data?.['db.system.name']).toBe('sqlite');
-
-    expect(accountSpan).toBeDefined();
-    expect(accountSpan?.op).toBe('db.query');
-    expect(accountSpan?.data?.['db.system.name']).toBe('sqlite');
-
-    expect(metricSpan).toBeDefined();
-    expect(metricSpan?.op).toBe('db.query');
-    expect(metricSpan?.data?.['db.system.name']).toBe('sqlite');
-
-    // All should have the same origin
-    expect(sessionSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
-    expect(accountSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
-    expect(metricSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    // All spans belong to the same trace as the request's root span
+    const traceIds = new Set(dbSpans.map(span => span.trace_id));
+    expect(traceIds.size).toBe(1);
   });
 
   test('instruments SQL template tag across multiple databases', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-multi-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-multi-test?method=sql-template-multi');
 
-    const transaction = await transactionPromise;
+    const dbSpans = await dbSpansPromise;
+    expect(dbSpans.length).toBeGreaterThan(0);
 
-    const dbSpans = transaction.spans?.filter(span => span.op === 'db.query');
-
-    expect(dbSpans).toBeDefined();
-    expect(dbSpans!.length).toBeGreaterThan(0);
-
-    // Check that we have INSERT spans from both databases
-    const logsInsertSpan = dbSpans?.find(span => span.description?.includes('INSERT INTO logs'));
-    const auditLogsInsertSpan = dbSpans?.find(span => span.description?.includes('INSERT INTO audit_logs'));
+    const logsInsertSpan = dbSpans.find(span => span.name === 'INSERT logs');
+    const auditLogsInsertSpan = dbSpans.find(span => span.name === 'INSERT audit_logs');
 
     expect(logsInsertSpan).toBeDefined();
-    expect(logsInsertSpan?.op).toBe('db.query');
-    expect(logsInsertSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(logsInsertSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(logsInsertSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'INSERT logs' },
+      'db.query.text': { type: 'string', value: 'INSERT INTO logs (message) VALUES (?)' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'db.namespace': { type: 'string', value: 'db.sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
 
     expect(auditLogsInsertSpan).toBeDefined();
-    expect(auditLogsInsertSpan?.op).toBe('db.query');
-    expect(auditLogsInsertSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(auditLogsInsertSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(auditLogsInsertSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'INSERT audit_logs' },
+      'db.query.text': { type: 'string', value: 'INSERT INTO audit_logs (action) VALUES (?)' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'db.namespace': { type: 'string', value: 'users_db.sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('creates correct span count for multiple database operations', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-multi-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-multi-test?method=multiple-dbs');
 
-    const transaction = await transactionPromise;
-
-    const dbSpans = transaction.spans?.filter(span => span.op === 'db.query');
+    const dbSpans = await dbSpansPromise;
 
     // We should have multiple spans:
     // - 3 CREATE TABLE (exec) spans
     // - 3 INSERT (exec) spans
     // - 3 SELECT (prepare + get) spans
     // Total should be at least 9 spans
-    expect(dbSpans).toBeDefined();
-    expect(dbSpans!.length).toBeGreaterThanOrEqual(9);
+    expect(dbSpans.length).toBeGreaterThanOrEqual(9);
   });
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/database.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/database.test.ts
@@ -1,129 +1,128 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp, waitForError } from '@sentry-internal/test-utils';
+
+async function collectDbSpans() {
+  const spans = await collectStreamedSpans('nuxt-5', spans =>
+    spans.some(span => span.is_segment && span.attributes['url.path']?.value === '/api/db-test'),
+  );
+  const rootSpan = spans.find(span => span.is_segment && span.attributes['url.path']?.value === '/api/db-test');
+
+  return spans.filter(span => span.trace_id === rootSpan?.trace_id && getSpanOp(span) === 'db.query');
+}
 
 test.describe('database integration', () => {
   test('captures db.prepare().get() span', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=prepare-get');
 
-    const transaction = await transactionPromise;
-
-    const dbSpan = transaction.spans?.find(span => span.op === 'db.query' && span.description?.includes('SELECT'));
+    const dbSpan = (await dbSpansPromise).find(span => span.name === 'SELECT users');
 
     expect(dbSpan).toBeDefined();
-    expect(dbSpan?.op).toBe('db.query');
-    expect(dbSpan?.description).toBe('SELECT * FROM users WHERE id = ?');
-    expect(dbSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(dbSpan?.data?.['db.query.text']).toBe('SELECT * FROM users WHERE id = ?');
-    expect(dbSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(dbSpan?.status).toBe('ok');
+    expect(dbSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT users' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM users WHERE id = ?' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'db.namespace': { type: 'string', value: 'db.sqlite' },
+      'sentry.op': { type: 'string', value: 'db.query' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('captures db.prepare().all() span', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=prepare-all');
 
-    const transaction = await transactionPromise;
-
-    const dbSpan = transaction.spans?.find(
-      span => span.op === 'db.query' && span.description?.includes('SELECT * FROM products'),
-    );
+    const dbSpan = (await dbSpansPromise).find(span => span.name === 'SELECT products');
 
     expect(dbSpan).toBeDefined();
-    expect(dbSpan?.op).toBe('db.query');
-    expect(dbSpan?.description).toBe('SELECT * FROM products WHERE price > ?');
-    expect(dbSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(dbSpan?.data?.['db.query.text']).toBe('SELECT * FROM products WHERE price > ?');
-    expect(dbSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(dbSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT products' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM products WHERE price > ?' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('captures db.prepare().run() span', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=prepare-run');
 
-    const transaction = await transactionPromise;
-
-    const dbSpan = transaction.spans?.find(
-      span => span.op === 'db.query' && span.description?.includes('INSERT INTO orders'),
-    );
+    const dbSpan = (await dbSpansPromise).find(span => span.name === 'INSERT orders');
 
     expect(dbSpan).toBeDefined();
-    expect(dbSpan?.op).toBe('db.query');
-    expect(dbSpan?.description).toBe('INSERT INTO orders (customer, amount) VALUES (?, ?)');
-    expect(dbSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(dbSpan?.data?.['db.query.text']).toBe('INSERT INTO orders (customer, amount) VALUES (?, ?)');
-    expect(dbSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(dbSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'INSERT orders' },
+      'db.query.text': { type: 'string', value: 'INSERT INTO orders (customer, amount) VALUES (?, ?)' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('captures db.prepare().bind().all() span', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=prepare-bind');
 
-    const transaction = await transactionPromise;
-
-    const dbSpan = transaction.spans?.find(
-      span => span.op === 'db.query' && span.description?.includes('SELECT * FROM items'),
-    );
+    const dbSpan = (await dbSpansPromise).find(span => span.name === 'SELECT items');
 
     expect(dbSpan).toBeDefined();
-    expect(dbSpan?.op).toBe('db.query');
-    expect(dbSpan?.description).toBe('SELECT * FROM items WHERE category = ?');
-    expect(dbSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(dbSpan?.data?.['db.query.text']).toBe('SELECT * FROM items WHERE category = ?');
-    expect(dbSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(dbSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT items' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM items WHERE category = ?' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('captures db.sql template tag span', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=sql');
 
-    const transaction = await transactionPromise;
-
-    const dbSpan = transaction.spans?.find(
-      span => span.op === 'db.query' && span.description?.includes('INSERT INTO messages'),
-    );
+    const dbSpan = (await dbSpansPromise).find(span => span.name === 'INSERT messages');
 
     expect(dbSpan).toBeDefined();
-    expect(dbSpan?.op).toBe('db.query');
-    expect(dbSpan?.description).toContain('INSERT INTO messages');
-    expect(dbSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(dbSpan?.data?.['db.query.text']).toContain('INSERT INTO messages');
-    expect(dbSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    expect(dbSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'INSERT messages' },
+      'db.query.text': {
+        type: 'string',
+        value: 'INSERT INTO messages (content, created_at) VALUES (?, ?)',
+      },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('captures db.exec() span', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=exec');
 
-    const transaction = await transactionPromise;
+    const dbSpans = await dbSpansPromise;
+    const insertSpan = dbSpans.find(span => span.name === 'INSERT logs');
 
-    const dbSpan = transaction.spans?.find(
-      span => span.op === 'db.query' && span.description?.includes('INSERT INTO logs'),
-    );
+    expect(insertSpan).toBeDefined();
+    expect(insertSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'INSERT logs' },
+      'db.query.text': { type: 'string', value: `INSERT INTO logs (message, level) VALUES ('Test log', 'INFO')` },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
 
-    expect(dbSpan).toBeDefined();
-    expect(dbSpan?.op).toBe('db.query');
-    expect(dbSpan?.description).toBe(`INSERT INTO logs (message, level) VALUES ('Test log', 'INFO')`);
-    expect(dbSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(dbSpan?.data?.['db.query.text']).toBe(`INSERT INTO logs (message, level) VALUES ('Test log', 'INFO')`);
-    expect(dbSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
+    // DDL statements are summarized as `{operation} {table}` as well, with the statement on the attribute
+    expect(dbSpans.find(span => span.name === 'DROP TABLE logs')?.attributes).toMatchObject({
+      'db.query.text': { type: 'string', value: 'DROP TABLE IF EXISTS logs' },
+    });
+    expect(dbSpans.find(span => span.name === 'CREATE TABLE logs')?.attributes).toMatchObject({
+      'db.query.text': {
+        type: 'string',
+        value: 'CREATE TABLE logs (id INTEGER PRIMARY KEY, message TEXT, level TEXT)',
+      },
+    });
   });
 
   test('captures database error and marks span as failed', async ({ request }) => {
@@ -133,15 +132,13 @@ test.describe('database integration', () => {
       );
     });
 
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=error').catch(() => {
       // Expected to fail
     });
 
-    const [error, transaction] = await Promise.all([errorPromise, transactionPromise]);
+    const [error, dbSpans] = await Promise.all([errorPromise, dbSpansPromise]);
 
     const dbException = error.exception?.values?.find(value => value.mechanism?.type === 'auto.db.nuxt');
 
@@ -152,50 +149,46 @@ test.describe('database integration', () => {
       type: 'auto.db.nuxt',
     });
 
-    const dbSpan = transaction.spans?.find(
-      span => span.op === 'db.query' && span.description?.includes('SELECT * FROM nonexistent_table'),
-    );
+    const dbSpan = dbSpans.find(span => span.name === 'SELECT nonexistent_table');
 
     expect(dbSpan).toBeDefined();
-    expect(dbSpan?.op).toBe('db.query');
-    expect(dbSpan?.description).toBe('SELECT * FROM nonexistent_table WHERE invalid_column = ?');
-    expect(dbSpan?.data?.['db.system.name']).toBe('sqlite');
-    expect(dbSpan?.data?.['db.query.text']).toBe('SELECT * FROM nonexistent_table WHERE invalid_column = ?');
-    expect(dbSpan?.data?.['sentry.origin']).toBe('auto.db.nuxt');
-    expect(dbSpan?.status).toBe('internal_error');
+    expect(dbSpan?.status).toBe('error');
+    expect(dbSpan?.attributes).toMatchObject({
+      'db.query.summary': { type: 'string', value: 'SELECT nonexistent_table' },
+      'db.query.text': { type: 'string', value: 'SELECT * FROM nonexistent_table WHERE invalid_column = ?' },
+      'db.system.name': { type: 'string', value: 'sqlite' },
+      'sentry.origin': { type: 'string', value: 'auto.db.nuxt' },
+    });
   });
 
   test('captures breadcrumb for db.exec() queries', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
+    const errorPromise = waitForError('nuxt-5', errorEvent => {
+      return !!errorEvent?.exception?.values?.some(value => value.mechanism?.type === 'auto.db.nuxt');
     });
 
-    await request.get('/api/db-test?method=exec');
+    await request.get('/api/db-test?method=error').catch(() => {
+      // Expected to fail
+    });
 
-    const transaction = await transactionPromise;
+    const error = await errorPromise;
 
-    const dbBreadcrumb = transaction.breadcrumbs?.find(
+    const dbBreadcrumb = error.breadcrumbs?.find(
       breadcrumb => breadcrumb.category === 'query' && breadcrumb.message?.includes('INSERT INTO logs'),
     );
 
     expect(dbBreadcrumb).toBeDefined();
-    expect(dbBreadcrumb?.category).toBe('query');
     expect(dbBreadcrumb?.message).toBe(`INSERT INTO logs (message, level) VALUES ('Test log', 'INFO')`);
     expect(dbBreadcrumb?.data?.['db.query.text']).toBe(`INSERT INTO logs (message, level) VALUES ('Test log', 'INFO')`);
   });
 
   test('multiple database operations in single request create multiple spans', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/db-test';
-    });
+    const dbSpansPromise = collectDbSpans();
 
     await request.get('/api/db-test?method=prepare-get');
 
-    const transaction = await transactionPromise;
+    const dbSpans = await dbSpansPromise;
 
-    const dbSpans = transaction.spans?.filter(span => span.op === 'db.query');
-
-    expect(dbSpans).toBeDefined();
-    expect(dbSpans!.length).toBeGreaterThanOrEqual(1);
+    expect(dbSpans.length).toBeGreaterThanOrEqual(1);
+    expect(dbSpans.every(span => !span.is_segment)).toBe(true);
   });
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/environment.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/environment.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForError, waitForStreamedSpan } from '@sentry-internal/test-utils';
 import { isDevMode } from './isDevMode';
 
 test.describe('environment detection', async () => {
@@ -21,19 +21,19 @@ test.describe('environment detection', async () => {
     }
   });
 
-  test('sets correct environment for client-side transactions', async ({ page }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', async transactionEvent => {
-      return transactionEvent.transaction === '/test-param/:param()';
+  test('sets correct environment for client-side spans', async ({ page }) => {
+    const pageloadSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+      return span.is_segment && span.name === '/test-param/:param()';
     });
 
     await page.goto(`/test-param/1234`);
 
-    const transaction = await transactionPromise;
+    const pageloadSpan = await pageloadSpanPromise;
 
     if (isDevMode) {
-      expect(transaction.environment).toBe('development');
+      expect(pageloadSpan.attributes['sentry.environment']?.value).toBe('development');
     } else {
-      expect(transaction.environment).toBe('production');
+      expect(pageloadSpan.attributes['sentry.environment']?.value).toBe('production');
     }
   });
 
@@ -56,22 +56,22 @@ test.describe('environment detection', async () => {
     }
   });
 
-  test('sets correct environment for server-side transactions', async ({ page }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', async transactionEvent => {
-      return transactionEvent.transaction === 'GET /api/nitro-fetch';
+  test('sets correct environment for server-side spans', async ({ page }) => {
+    const serverSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+      return span.is_segment && span.attributes['url.path']?.value === '/api/nitro-fetch';
     });
 
     await page.goto(`/fetch-server-routes`, isDevMode ? { waitUntil: 'networkidle' } : {});
     await page.getByText('Fetch Nitro $fetch', { exact: true }).click();
 
-    const transaction = await transactionPromise;
+    const serverSpan = await serverSpanPromise;
 
-    expect(transaction.contexts.trace.op).toBe('http.server');
+    expect(getSpanOp(serverSpan)).toBe('http.server');
 
     if (isDevMode) {
-      expect(transaction.environment).toBe('development');
+      expect(serverSpan.attributes['sentry.environment']?.value).toBe('development');
     } else {
-      expect(transaction.environment).toBe('production');
+      expect(serverSpan.attributes['sentry.environment']?.value).toBe('production');
     }
   });
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/middleware.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/middleware.test.ts
@@ -1,12 +1,18 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction, waitForError } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp, waitForError } from '@sentry-internal/test-utils';
 
-// TODO: Skipped for Nuxt 5 as the SDK is not yet updated for that
+async function collectRequestSpans() {
+  const spans = await collectStreamedSpans('nuxt-5', spans =>
+    spans.some(span => span.is_segment && span.attributes['url.path']?.value === '/api/middleware-test'),
+  );
+  const rootSpan = spans.find(span => span.is_segment && span.attributes['url.path']?.value === '/api/middleware-test');
+
+  return spans.filter(span => span.trace_id === rootSpan?.trace_id);
+}
+
 test.describe('Server Middleware Instrumentation', () => {
   test('should create separate spans for each server middleware', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
+    const spansPromise = collectRequestSpans();
 
     // Make request to the API endpoint that will trigger all server middleware
     const response = await request.get('/api/middleware-test');
@@ -15,22 +21,23 @@ test.describe('Server Middleware Instrumentation', () => {
     const responseData = await response.json();
     expect(responseData.message).toBe('Server middleware test endpoint');
 
-    const serverTxnEvent = await serverTxnEventPromise;
+    const spans = await spansPromise;
 
     // Verify that we have spans for each middleware
-    const middlewareSpans = serverTxnEvent.spans?.filter(span => span.op === 'middleware') || [];
+    const middlewareSpans = spans.filter(span => getSpanOp(span) === 'middleware');
 
     // 3 simple + 2 hooks (middleware+handler) + 3 array hooks (2 middleware + 1 handler)
     expect(middlewareSpans).toHaveLength(8);
 
     // Check for specific middleware spans
-    const firstMiddlewareSpan = middlewareSpans.find(span => span.data?.['nuxt.middleware.name'] === '01.first');
-    const secondMiddlewareSpan = middlewareSpans.find(span => span.data?.['nuxt.middleware.name'] === '02.second');
-    const authMiddlewareSpan = middlewareSpans.find(span => span.data?.['nuxt.middleware.name'] === '03.auth');
-    const hooksOnRequestSpan = middlewareSpans.find(span => span.data?.['nuxt.middleware.name'] === '04.hooks');
-    const arrayHooksHandlerSpan = middlewareSpans.find(
-      span => span.data?.['nuxt.middleware.name'] === '05.array-hooks',
-    );
+    const findSpanByName = (name: string) =>
+      middlewareSpans.find(span => span.attributes['nuxt.middleware.name']?.value === name);
+
+    const firstMiddlewareSpan = findSpanByName('01.first');
+    const secondMiddlewareSpan = findSpanByName('02.second');
+    const authMiddlewareSpan = findSpanByName('03.auth');
+    const hooksOnRequestSpan = findSpanByName('04.hooks');
+    const arrayHooksHandlerSpan = findSpanByName('05.array-hooks');
 
     expect(firstMiddlewareSpan).toBeDefined();
     expect(secondMiddlewareSpan).toBeDefined();
@@ -42,12 +49,12 @@ test.describe('Server Middleware Instrumentation', () => {
     [firstMiddlewareSpan, secondMiddlewareSpan, authMiddlewareSpan].forEach(span => {
       expect(span).toEqual(
         expect.objectContaining({
-          op: 'middleware',
-          data: expect.objectContaining({
-            'sentry.op': 'middleware',
-            'sentry.origin': 'auto.middleware.nuxt',
-            'http.request.method': 'GET',
-            'http.route': '/api/middleware-test',
+          is_segment: false,
+          attributes: expect.objectContaining({
+            'sentry.op': { type: 'string', value: 'middleware' },
+            'sentry.origin': { type: 'string', value: 'auto.middleware.nuxt' },
+            'http.request.method': { type: 'string', value: 'GET' },
+            'http.route': { type: 'string', value: '/api/middleware-test' },
           }),
           parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
           span_id: expect.stringMatching(/[a-f0-9]{16}/),
@@ -69,25 +76,24 @@ test.describe('Server Middleware Instrumentation', () => {
   });
 
   test('middleware spans should have proper parent-child relationship', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
+    const spansPromise = collectRequestSpans();
 
     await request.get('/api/middleware-test');
-    const serverTxnEvent = await serverTxnEventPromise;
+    const spans = await spansPromise;
 
-    const middlewareSpans = serverTxnEvent.spans?.filter(span => span.op === 'middleware') || [];
+    const segmentSpan = spans.find(
+      span => span.is_segment && span.attributes['url.path']?.value === '/api/middleware-test',
+    );
+    const middlewareSpans = spans.filter(span => getSpanOp(span) === 'middleware');
 
-    // All middleware spans should be children of the main transaction
+    // All middleware spans should be children of the request's segment span
     middlewareSpans.forEach(span => {
-      expect(span.parent_span_id).toBe(serverTxnEvent.contexts?.trace?.span_id);
+      expect(span.parent_span_id).toBe(segmentSpan?.span_id);
     });
   });
 
   test('should capture errors thrown in middleware and associate them with the span', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
+    const spansPromise = collectRequestSpans();
 
     const errorEventPromise = waitForError('nuxt-5', errorEvent => {
       return errorEvent?.exception?.values?.[0]?.value === 'Auth middleware error';
@@ -99,19 +105,19 @@ test.describe('Server Middleware Instrumentation', () => {
     // The request should fail due to the middleware error
     expect(response.status()).toBe(500);
 
-    const [serverTxnEvent, errorEvent] = await Promise.all([serverTxnEventPromise, errorEventPromise]);
+    const [spans, errorEvent] = await Promise.all([spansPromise, errorEventPromise]);
 
     // Find the auth middleware span
-    const authMiddlewareSpan = serverTxnEvent.spans?.find(
-      span => span.op === 'middleware' && span.data?.['nuxt.middleware.name'] === '03.auth',
+    const authMiddlewareSpan = spans.find(
+      span => getSpanOp(span) === 'middleware' && span.attributes['nuxt.middleware.name']?.value === '03.auth',
     );
 
     expect(authMiddlewareSpan).toBeDefined();
 
     // Verify the span has error status
-    expect(authMiddlewareSpan?.status).toBe('internal_error');
+    expect(authMiddlewareSpan?.status).toBe('error');
 
-    // Verify the error event is associated with the correct transaction
+    // Verify the error event is associated with the correct request
     expect(errorEvent.transaction).toContain('GET /api/middleware-test');
 
     // Verify the error has the correct mechanism
@@ -128,95 +134,98 @@ test.describe('Server Middleware Instrumentation', () => {
   });
 
   test('should create spans for middleware and handler hooks', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
+    const spansPromise = collectRequestSpans();
 
     // Make request to trigger middleware with hooks
     const response = await request.get('/api/middleware-test');
     expect(response.status()).toBe(200);
 
-    const serverTxnEvent = await serverTxnEventPromise;
-    const middlewareSpans = serverTxnEvent.spans?.filter(span => span.op === 'middleware') || [];
+    const spans = await spansPromise;
+    const middlewareSpans = spans.filter(span => getSpanOp(span) === 'middleware');
 
     // Find spans for the hooks middleware
-    const hooksSpans = middlewareSpans.filter(span => span.data?.['nuxt.middleware.name'] === '04.hooks');
+    const hooksSpans = middlewareSpans.filter(span => span.attributes['nuxt.middleware.name']?.value === '04.hooks');
 
     // Should have spans for middleware and handler (h3 v2 no longer has onBeforeResponse)
     expect(hooksSpans).toHaveLength(2);
 
     // Find specific hook spans
-    const middlewareSpan = hooksSpans.find(span => span.data?.['nuxt.middleware.hook.name'] === 'middleware');
-    const handlerSpan = hooksSpans.find(span => span.data?.['nuxt.middleware.hook.name'] === 'handler');
+    const findSpanByHook = (hook: string) =>
+      hooksSpans.find(span => span.attributes['nuxt.middleware.hook.name']?.value === hook);
+
+    const middlewareSpan = findSpanByHook('middleware');
+    const handlerSpan = findSpanByHook('handler');
 
     expect(middlewareSpan).toBeDefined();
     expect(handlerSpan).toBeDefined();
 
     // Verify span names include hook types
-    expect(middlewareSpan?.description).toBe('04.hooks.middleware');
-    expect(handlerSpan?.description).toBe('04.hooks');
+    expect(middlewareSpan?.name).toBe('04.hooks.middleware');
+    expect(handlerSpan?.name).toBe('04.hooks');
 
     // Verify all spans have correct middleware name (without hook suffix)
     [middlewareSpan, handlerSpan].forEach(span => {
-      expect(span?.data?.['nuxt.middleware.name']).toBe('04.hooks');
+      expect(span?.attributes['nuxt.middleware.name']?.value).toBe('04.hooks');
     });
 
     // Verify hook-specific attributes
-    expect(middlewareSpan?.data?.['nuxt.middleware.hook.name']).toBe('middleware');
-    expect(handlerSpan?.data?.['nuxt.middleware.hook.name']).toBe('handler');
+    expect(middlewareSpan?.attributes['nuxt.middleware.hook.name']?.value).toBe('middleware');
+    expect(handlerSpan?.attributes['nuxt.middleware.hook.name']?.value).toBe('handler');
 
     // Verify middleware has index (middleware is always an array in h3 v2)
-    expect(middlewareSpan?.data?.['nuxt.middleware.hook.index']).toBe(0);
-    expect(handlerSpan?.data).not.toHaveProperty('nuxt.middleware.hook.index');
+    expect(middlewareSpan?.attributes['nuxt.middleware.hook.index']?.value).toBe(0);
+    expect(handlerSpan?.attributes['nuxt.middleware.hook.index']).toBeUndefined();
   });
 
   test('should create spans with index attributes for array middleware', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
+    const spansPromise = collectRequestSpans();
 
     // Make request to trigger middleware with array hooks
     const response = await request.get('/api/middleware-test');
     expect(response.status()).toBe(200);
 
-    const serverTxnEvent = await serverTxnEventPromise;
-    const middlewareSpans = serverTxnEvent.spans?.filter(span => span.op === 'middleware') || [];
+    const spans = await spansPromise;
+    const middlewareSpans = spans.filter(span => getSpanOp(span) === 'middleware');
 
     // Find spans for the array hooks middleware
-    const arrayHooksSpans = middlewareSpans.filter(span => span.data?.['nuxt.middleware.name'] === '05.array-hooks');
+    const arrayHooksSpans = middlewareSpans.filter(
+      span => span.attributes['nuxt.middleware.name']?.value === '05.array-hooks',
+    );
 
     // Should have spans for 2 middleware + 1 handler = 3 spans (h3 v2 no longer has onBeforeResponse)
     expect(arrayHooksSpans).toHaveLength(3);
 
     // Find middleware array spans
     const middlewareArraySpans = arrayHooksSpans.filter(
-      span => span.data?.['nuxt.middleware.hook.name'] === 'middleware',
+      span => span.attributes['nuxt.middleware.hook.name']?.value === 'middleware',
     );
     expect(middlewareArraySpans).toHaveLength(2);
 
     // Find handler span
-    const handlerSpan = arrayHooksSpans.find(span => span.data?.['nuxt.middleware.hook.name'] === 'handler');
+    const handlerSpan = arrayHooksSpans.find(span => span.attributes['nuxt.middleware.hook.name']?.value === 'handler');
     expect(handlerSpan).toBeDefined();
 
     // Verify index attributes for middleware array
-    const middleware0Span = middlewareArraySpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 0);
-    const middleware1Span = middlewareArraySpans.find(span => span.data?.['nuxt.middleware.hook.index'] === 1);
+    const middleware0Span = middlewareArraySpans.find(
+      span => span.attributes['nuxt.middleware.hook.index']?.value === 0,
+    );
+    const middleware1Span = middlewareArraySpans.find(
+      span => span.attributes['nuxt.middleware.hook.index']?.value === 1,
+    );
 
     expect(middleware0Span).toBeDefined();
     expect(middleware1Span).toBeDefined();
 
     // Verify span names for array middleware handlers
-    expect(middleware0Span?.description).toBe('05.array-hooks.middleware');
-    expect(middleware1Span?.description).toBe('05.array-hooks.middleware');
+    expect(middleware0Span?.name).toBe('05.array-hooks.middleware');
+    expect(middleware1Span?.name).toBe('05.array-hooks.middleware');
 
     // Verify handler has no index
-    expect(handlerSpan?.data).not.toHaveProperty('nuxt.middleware.hook.index');
+    expect(handlerSpan?.attributes['nuxt.middleware.hook.index']).toBeUndefined();
   });
 
   test('should handle errors in middleware hooks', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
+    const spansPromise = collectRequestSpans();
 
     const errorEventPromise = waitForError('nuxt-5', errorEvent => {
       return errorEvent?.exception?.values?.[0]?.value === 'OnRequest hook error';
@@ -226,25 +235,23 @@ test.describe('Server Middleware Instrumentation', () => {
     const response = await request.get('/api/middleware-test?throwOnRequestError=true');
     expect(response.status()).toBe(500);
 
-    const [serverTxnEvent, errorEvent] = await Promise.all([serverTxnEventPromise, errorEventPromise]);
+    const [spans, errorEvent] = await Promise.all([spansPromise, errorEventPromise]);
 
     // Find the middleware span that should have error status
-    const middlewareSpan = serverTxnEvent.spans?.find(
+    const middlewareSpan = spans.find(
       span =>
-        span.op === 'middleware' &&
-        span.data?.['nuxt.middleware.name'] === '04.hooks' &&
-        span.data?.['nuxt.middleware.hook.name'] === 'middleware',
+        getSpanOp(span) === 'middleware' &&
+        span.attributes['nuxt.middleware.name']?.value === '04.hooks' &&
+        span.attributes['nuxt.middleware.hook.name']?.value === 'middleware',
     );
 
     expect(middlewareSpan).toBeDefined();
-    expect(middlewareSpan?.status).toBe('internal_error');
+    expect(middlewareSpan?.status).toBe('error');
     expect(errorEvent.exception?.values?.[0]?.value).toBe('OnRequest hook error');
   });
 
   test('should handle errors in array middleware with proper index attribution', async ({ request }) => {
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/middleware-test') ?? false;
-    });
+    const spansPromise = collectRequestSpans();
 
     const errorEventPromise = waitForError('nuxt-5', errorEvent => {
       return errorEvent?.exception?.values?.[0]?.value === 'OnRequest[1] hook error';
@@ -254,31 +261,28 @@ test.describe('Server Middleware Instrumentation', () => {
     const response = await request.get('/api/middleware-test?throwOnRequest1Error=true');
     expect(response.status()).toBe(500);
 
-    const [serverTxnEvent, errorEvent] = await Promise.all([serverTxnEventPromise, errorEventPromise]);
+    const [spans, errorEvent] = await Promise.all([spansPromise, errorEventPromise]);
+
+    const findArrayHookSpan = (index: number) =>
+      spans.find(
+        span =>
+          getSpanOp(span) === 'middleware' &&
+          span.attributes['nuxt.middleware.name']?.value === '05.array-hooks' &&
+          span.attributes['nuxt.middleware.hook.name']?.value === 'middleware' &&
+          span.attributes['nuxt.middleware.hook.index']?.value === index,
+      );
 
     // Find the second middleware span that should have error status
-    const middleware1Span = serverTxnEvent.spans?.find(
-      span =>
-        span.op === 'middleware' &&
-        span.data?.['nuxt.middleware.name'] === '05.array-hooks' &&
-        span.data?.['nuxt.middleware.hook.name'] === 'middleware' &&
-        span.data?.['nuxt.middleware.hook.index'] === 1,
-    );
+    const middleware1Span = findArrayHookSpan(1);
 
     expect(middleware1Span).toBeDefined();
-    expect(middleware1Span?.status).toBe('internal_error');
+    expect(middleware1Span?.status).toBe('error');
     expect(errorEvent.exception?.values?.[0]?.value).toBe('OnRequest[1] hook error');
 
     // Verify the first middleware handler still executed successfully
-    const middleware0Span = serverTxnEvent.spans?.find(
-      span =>
-        span.op === 'middleware' &&
-        span.data?.['nuxt.middleware.name'] === '05.array-hooks' &&
-        span.data?.['nuxt.middleware.hook.name'] === 'middleware' &&
-        span.data?.['nuxt.middleware.hook.index'] === 0,
-    );
+    const middleware0Span = findArrayHookSpan(0);
 
     expect(middleware0Span).toBeDefined();
-    expect(middleware0Span?.status).not.toBe('internal_error');
+    expect(middleware0Span?.status).not.toBe('error');
   });
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage-aliases.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage-aliases.test.ts
@@ -38,13 +38,14 @@ test.describe('Storage Instrumentation - Aliases', () => {
     expect(setSpan).toBeDefined();
     expect(setSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.put' },
+      'cache.operation': { type: 'string', value: 'put' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:user') },
       'db.operation.name': { type: 'string', value: 'setItem' },
       'db.collection.name': { type: 'string', value: 'test-storage' },
       'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(setSpan?.name).toBe(prefixKey('alias:user'));
+    expect(setSpan?.name).toBe('cache.put');
 
     // Test get (alias for getItem)
     expect(findSpansByMethod('getItem').length).toBeGreaterThanOrEqual(1);
@@ -52,6 +53,7 @@ test.describe('Storage Instrumentation - Aliases', () => {
     expect(getSpan).toBeDefined();
     expect(getSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.get' },
+      'cache.operation': { type: 'string', value: 'get' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:user') },
       [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
@@ -59,7 +61,7 @@ test.describe('Storage Instrumentation - Aliases', () => {
       'db.collection.name': { type: 'string', value: 'test-storage' },
       'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(getSpan?.name).toBe(prefixKey('alias:user'));
+    expect(getSpan?.name).toBe('cache.get');
 
     // Test has (alias for hasItem)
     expect(findSpansByMethod('hasItem').length).toBeGreaterThanOrEqual(1);
@@ -67,6 +69,7 @@ test.describe('Storage Instrumentation - Aliases', () => {
     expect(hasSpan).toBeDefined();
     expect(hasSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.get' },
+      'cache.operation': { type: 'string', value: 'get' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:user') },
       [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
@@ -82,25 +85,27 @@ test.describe('Storage Instrumentation - Aliases', () => {
     expect(delSpan).toBeDefined();
     expect(delSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.remove' },
+      'cache.operation': { type: 'string', value: 'remove' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:temp1') },
       'db.operation.name': { type: 'string', value: 'removeItem' },
       'db.collection.name': { type: 'string', value: 'test-storage' },
       'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(delSpan?.name).toBe(prefixKey('alias:temp1'));
+    expect(delSpan?.name).toBe('cache.remove');
 
     const removeSpan = findByKey('removeItem', prefixKey('alias:temp2'));
     expect(removeSpan).toBeDefined();
     expect(removeSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.remove' },
+      'cache.operation': { type: 'string', value: 'remove' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:temp2') },
       'db.operation.name': { type: 'string', value: 'removeItem' },
       'db.collection.name': { type: 'string', value: 'test-storage' },
       'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(removeSpan?.name).toBe(prefixKey('alias:temp2'));
+    expect(removeSpan?.name).toBe('cache.remove');
 
     // Verify all spans have OK status
     expect(allStorageSpans.length).toBeGreaterThan(0);

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage-aliases.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage-aliases.test.ts
@@ -1,6 +1,16 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/nuxt';
+import { collectStreamedSpans } from '@sentry-internal/test-utils';
+
+async function collectStorageSpans(route: string) {
+  const spans = await collectStreamedSpans('nuxt-5', spans =>
+    spans.some(span => span.is_segment && span.attributes['url.path']?.value === route),
+  );
+  const rootSpan = spans.find(span => span.is_segment && span.attributes['url.path']?.value === route);
+
+  return spans.filter(
+    span => span.trace_id === rootSpan?.trace_id && span.attributes['sentry.origin']?.value === 'auto.cache.nuxt',
+  );
+}
 
 test.describe('Storage Instrumentation - Aliases', () => {
   const prefixKey = (key: string) => `test-storage:${key}`;
@@ -8,100 +18,93 @@ test.describe('Storage Instrumentation - Aliases', () => {
   const SEMANTIC_ATTRIBUTE_CACHE_HIT = 'cache.hit';
 
   test('instruments storage alias methods (get, set, has, del, remove) and creates spans', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction?.includes('GET /api/storage-aliases-test') ?? false;
-    });
+    const storageSpansPromise = collectStorageSpans('/api/storage-aliases-test');
 
     const response = await request.get('/api/storage-aliases-test');
     expect(response.status()).toBe(200);
 
-    const transaction = await transactionPromise;
+    const allStorageSpans = await storageSpansPromise;
 
     // Helper to find spans by operation
-    const findSpansByMethod = (method: string) => {
-      return transaction.spans?.filter(span => span.data?.['db.operation.name'] === method) || [];
-    };
+    const findSpansByMethod = (method: string) =>
+      allStorageSpans.filter(span => span.attributes['db.operation.name']?.value === method);
+
+    const findByKey = (method: string, key: string) =>
+      findSpansByMethod(method).find(span => span.attributes[SEMANTIC_ATTRIBUTE_CACHE_KEY]?.value === key);
 
     // Test set (alias for setItem)
-    const setSpans = findSpansByMethod('setItem');
-    expect(setSpans.length).toBeGreaterThanOrEqual(1);
-    const setSpan = setSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:user'));
+    expect(findSpansByMethod('setItem').length).toBeGreaterThanOrEqual(1);
+    const setSpan = findByKey('setItem', prefixKey('alias:user'));
     expect(setSpan).toBeDefined();
-    expect(setSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.put',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:user'),
-      'db.operation.name': 'setItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(setSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.put' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:user') },
+      'db.operation.name': { type: 'string', value: 'setItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(setSpan?.description).toBe(prefixKey('alias:user'));
+    expect(setSpan?.name).toBe(prefixKey('alias:user'));
 
     // Test get (alias for getItem)
-    const getSpans = findSpansByMethod('getItem');
-    expect(getSpans.length).toBeGreaterThanOrEqual(1);
-    const getSpan = getSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:user'));
+    expect(findSpansByMethod('getItem').length).toBeGreaterThanOrEqual(1);
+    const getSpan = findByKey('getItem', prefixKey('alias:user'));
     expect(getSpan).toBeDefined();
-    expect(getSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:user'),
-      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
-      'db.operation.name': 'getItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(getSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.get' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:user') },
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
+      'db.operation.name': { type: 'string', value: 'getItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(getSpan?.description).toBe(prefixKey('alias:user'));
+    expect(getSpan?.name).toBe(prefixKey('alias:user'));
 
     // Test has (alias for hasItem)
-    const hasSpans = findSpansByMethod('hasItem');
-    expect(hasSpans.length).toBeGreaterThanOrEqual(1);
-    const hasSpan = hasSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:user'));
+    expect(findSpansByMethod('hasItem').length).toBeGreaterThanOrEqual(1);
+    const hasSpan = findByKey('hasItem', prefixKey('alias:user'));
     expect(hasSpan).toBeDefined();
-    expect(hasSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:user'),
-      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
-      'db.operation.name': 'hasItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(hasSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.get' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:user') },
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
+      'db.operation.name': { type: 'string', value: 'hasItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
 
     // Test del and remove (both aliases for removeItem)
-    const removeSpans = findSpansByMethod('removeItem');
-    expect(removeSpans.length).toBeGreaterThanOrEqual(2); // Should have both del and remove calls
+    expect(findSpansByMethod('removeItem').length).toBeGreaterThanOrEqual(2); // Should have both del and remove calls
 
-    const delSpan = removeSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:temp1'));
+    const delSpan = findByKey('removeItem', prefixKey('alias:temp1'));
     expect(delSpan).toBeDefined();
-    expect(delSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.remove',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:temp1'),
-      'db.operation.name': 'removeItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(delSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.remove' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:temp1') },
+      'db.operation.name': { type: 'string', value: 'removeItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(delSpan?.description).toBe(prefixKey('alias:temp1'));
+    expect(delSpan?.name).toBe(prefixKey('alias:temp1'));
 
-    const removeSpan = removeSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('alias:temp2'));
+    const removeSpan = findByKey('removeItem', prefixKey('alias:temp2'));
     expect(removeSpan).toBeDefined();
-    expect(removeSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.remove',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('alias:temp2'),
-      'db.operation.name': 'removeItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(removeSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.remove' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('alias:temp2') },
+      'db.operation.name': { type: 'string', value: 'removeItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(removeSpan?.description).toBe(prefixKey('alias:temp2'));
+    expect(removeSpan?.name).toBe(prefixKey('alias:temp2'));
 
     // Verify all spans have OK status
-    const allStorageSpans = transaction.spans?.filter(
-      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nuxt',
-    );
-    expect(allStorageSpans?.length).toBeGreaterThan(0);
-    allStorageSpans?.forEach(span => {
+    expect(allStorageSpans.length).toBeGreaterThan(0);
+    allStorageSpans.forEach(span => {
       expect(span.status).toBe('ok');
     });
   });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage.test.ts
@@ -38,6 +38,7 @@ test.describe('Storage Instrumentation', () => {
     expect(setItemSpan).toBeDefined();
     expect(setItemSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.put' },
+      'cache.operation': { type: 'string', value: 'put' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('user:123') },
       'db.operation.name': { type: 'string', value: 'setItem' },
@@ -45,7 +46,7 @@ test.describe('Storage Instrumentation', () => {
       'db.system.name': { type: 'string', value: 'memory' },
     });
 
-    expect(setItemSpan?.name).toBe(prefixKey('user:123'));
+    expect(setItemSpan?.name).toBe('cache.put');
 
     // Test setItemRaw spans
     expect(findSpansByMethod('setItemRaw').length).toBeGreaterThanOrEqual(1);
@@ -54,6 +55,7 @@ test.describe('Storage Instrumentation', () => {
     expect(setItemRawSpan).toBeDefined();
     expect(setItemRawSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.put' },
+      'cache.operation': { type: 'string', value: 'put' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('raw:data') },
       'db.operation.name': { type: 'string', value: 'setItemRaw' },
@@ -67,6 +69,7 @@ test.describe('Storage Instrumentation', () => {
     expect(hasItemSpan).toBeDefined();
     expect(hasItemSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.get' },
+      'cache.operation': { type: 'string', value: 'get' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('user:123') },
       [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
@@ -81,6 +84,7 @@ test.describe('Storage Instrumentation', () => {
     expect(getItemSpan).toBeDefined();
     expect(getItemSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.get' },
+      'cache.operation': { type: 'string', value: 'get' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('user:123') },
       [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
@@ -88,7 +92,7 @@ test.describe('Storage Instrumentation', () => {
       'db.collection.name': { type: 'string', value: 'test-storage' },
       'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(getItemSpan?.name).toBe(prefixKey('user:123'));
+    expect(getItemSpan?.name).toBe('cache.get');
 
     // Test getItemRaw spans - should have cache hit attribute
     expect(findSpansByMethod('getItemRaw').length).toBeGreaterThanOrEqual(1);
@@ -96,6 +100,7 @@ test.describe('Storage Instrumentation', () => {
     expect(getItemRawSpan).toBeDefined();
     expect(getItemRawSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.get' },
+      'cache.operation': { type: 'string', value: 'get' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('raw:data') },
       [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
@@ -109,6 +114,7 @@ test.describe('Storage Instrumentation', () => {
     expect(getKeysSpans.length).toBeGreaterThanOrEqual(1);
     expect(getKeysSpans[0]?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.get' },
+      'cache.operation': { type: 'string', value: 'get' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       'db.operation.name': { type: 'string', value: 'getKeys' },
       'db.collection.name': { type: 'string', value: 'test-storage' },
@@ -121,6 +127,7 @@ test.describe('Storage Instrumentation', () => {
     expect(removeItemSpan).toBeDefined();
     expect(removeItemSpan?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.remove' },
+      'cache.operation': { type: 'string', value: 'remove' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('batch:1') },
       'db.operation.name': { type: 'string', value: 'removeItem' },
@@ -133,6 +140,7 @@ test.describe('Storage Instrumentation', () => {
     expect(clearSpans.length).toBeGreaterThanOrEqual(1);
     expect(clearSpans[0]?.attributes).toMatchObject({
       'sentry.op': { type: 'string', value: 'cache.remove' },
+      'cache.operation': { type: 'string', value: 'remove' },
       'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
       'db.operation.name': { type: 'string', value: 'clear' },
       'db.collection.name': { type: 'string', value: 'test-storage' },

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/storage.test.ts
@@ -1,6 +1,16 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/nuxt';
+import { collectStreamedSpans } from '@sentry-internal/test-utils';
+
+async function collectStorageSpans(route: string) {
+  const spans = await collectStreamedSpans('nuxt-5', spans =>
+    spans.some(span => span.is_segment && span.attributes['url.path']?.value === route),
+  );
+  const rootSpan = spans.find(span => span.is_segment && span.attributes['url.path']?.value === route);
+
+  return spans.filter(
+    span => span.trace_id === rootSpan?.trace_id && span.attributes['sentry.origin']?.value === 'auto.cache.nuxt',
+  );
+}
 
 test.describe('Storage Instrumentation', () => {
   const prefixKey = (key: string) => `test-storage:${key}`;
@@ -8,143 +18,130 @@ test.describe('Storage Instrumentation', () => {
   const SEMANTIC_ATTRIBUTE_CACHE_HIT = 'cache.hit';
 
   test('instruments all storage operations and creates spans with correct attributes', async ({ request }) => {
-    const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-      return transactionEvent.transaction?.includes('GET /api/storage-test') ?? false;
-    });
+    const storageSpansPromise = collectStorageSpans('/api/storage-test');
 
     const response = await request.get('/api/storage-test');
     expect(response.status()).toBe(200);
 
-    const transaction = await transactionPromise;
+    const allStorageSpans = await storageSpansPromise;
 
     // Helper to find spans by operation
-    const findSpansByMethod = (method: string) => {
-      return transaction.spans?.filter(span => span.data?.['db.operation.name'] === method) || [];
-    };
+    const findSpansByMethod = (method: string) =>
+      allStorageSpans.filter(span => span.attributes['db.operation.name']?.value === method);
+
+    const findSpanByCacheKey = (method: string, key: string) =>
+      findSpansByMethod(method).find(span => span.attributes[SEMANTIC_ATTRIBUTE_CACHE_KEY]?.value === key);
 
     // Test setItem spans
-    const setItemSpans = findSpansByMethod('setItem');
-    expect(setItemSpans.length).toBeGreaterThanOrEqual(1);
-    const setItemSpan = setItemSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('user:123'));
+    expect(findSpansByMethod('setItem').length).toBeGreaterThanOrEqual(1);
+    const setItemSpan = findSpanByCacheKey('setItem', prefixKey('user:123'));
     expect(setItemSpan).toBeDefined();
-    expect(setItemSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.put',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('user:123'),
-      'db.operation.name': 'setItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(setItemSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.put' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('user:123') },
+      'db.operation.name': { type: 'string', value: 'setItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(setItemSpan?.description).toBe(prefixKey('user:123'));
+
+    expect(setItemSpan?.name).toBe(prefixKey('user:123'));
 
     // Test setItemRaw spans
-    const setItemRawSpans = findSpansByMethod('setItemRaw');
-    expect(setItemRawSpans.length).toBeGreaterThanOrEqual(1);
-    const setItemRawSpan = setItemRawSpans.find(
-      span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('raw:data'),
-    );
+    expect(findSpansByMethod('setItemRaw').length).toBeGreaterThanOrEqual(1);
+    const setItemRawSpan = findSpanByCacheKey('setItemRaw', prefixKey('raw:data'));
+
     expect(setItemRawSpan).toBeDefined();
-    expect(setItemRawSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.put',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('raw:data'),
-      'db.operation.name': 'setItemRaw',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(setItemRawSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.put' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('raw:data') },
+      'db.operation.name': { type: 'string', value: 'setItemRaw' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
 
     // Test hasItem spans - should have cache hit attribute
-    const hasItemSpans = findSpansByMethod('hasItem');
-    expect(hasItemSpans.length).toBeGreaterThanOrEqual(1);
-    const hasItemSpan = hasItemSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('user:123'));
+    expect(findSpansByMethod('hasItem').length).toBeGreaterThanOrEqual(1);
+    const hasItemSpan = findSpanByCacheKey('hasItem', prefixKey('user:123'));
     expect(hasItemSpan).toBeDefined();
-    expect(hasItemSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('user:123'),
-      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
-      'db.operation.name': 'hasItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(hasItemSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.get' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('user:123') },
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
+      'db.operation.name': { type: 'string', value: 'hasItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
 
     // Test getItem spans - should have cache hit attribute
-    const getItemSpans = findSpansByMethod('getItem');
-    expect(getItemSpans.length).toBeGreaterThanOrEqual(1);
-    const getItemSpan = getItemSpans.find(span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('user:123'));
+    expect(findSpansByMethod('getItem').length).toBeGreaterThanOrEqual(1);
+    const getItemSpan = findSpanByCacheKey('getItem', prefixKey('user:123'));
     expect(getItemSpan).toBeDefined();
-    expect(getItemSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('user:123'),
-      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
-      'db.operation.name': 'getItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(getItemSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.get' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('user:123') },
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
+      'db.operation.name': { type: 'string', value: 'getItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
-    expect(getItemSpan?.description).toBe(prefixKey('user:123'));
+    expect(getItemSpan?.name).toBe(prefixKey('user:123'));
 
     // Test getItemRaw spans - should have cache hit attribute
-    const getItemRawSpans = findSpansByMethod('getItemRaw');
-    expect(getItemRawSpans.length).toBeGreaterThanOrEqual(1);
-    const getItemRawSpan = getItemRawSpans.find(
-      span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('raw:data'),
-    );
+    expect(findSpansByMethod('getItemRaw').length).toBeGreaterThanOrEqual(1);
+    const getItemRawSpan = findSpanByCacheKey('getItemRaw', prefixKey('raw:data'));
     expect(getItemRawSpan).toBeDefined();
-    expect(getItemRawSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('raw:data'),
-      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: true,
-      'db.operation.name': 'getItemRaw',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(getItemRawSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.get' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('raw:data') },
+      [SEMANTIC_ATTRIBUTE_CACHE_HIT]: { type: 'boolean', value: true },
+      'db.operation.name': { type: 'string', value: 'getItemRaw' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
 
     // Test getKeys spans
     const getKeysSpans = findSpansByMethod('getKeys');
     expect(getKeysSpans.length).toBeGreaterThanOrEqual(1);
-    expect(getKeysSpans[0]?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.get',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      'db.operation.name': 'getKeys',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(getKeysSpans[0]?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.get' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      'db.operation.name': { type: 'string', value: 'getKeys' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
 
     // Test removeItem spans
-    const removeItemSpans = findSpansByMethod('removeItem');
-    expect(removeItemSpans.length).toBeGreaterThanOrEqual(1);
-    const removeItemSpan = removeItemSpans.find(
-      span => span.data?.[SEMANTIC_ATTRIBUTE_CACHE_KEY] === prefixKey('batch:1'),
-    );
+    expect(findSpansByMethod('removeItem').length).toBeGreaterThanOrEqual(1);
+    const removeItemSpan = findSpanByCacheKey('removeItem', prefixKey('batch:1'));
     expect(removeItemSpan).toBeDefined();
-    expect(removeItemSpan?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.remove',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: prefixKey('batch:1'),
-      'db.operation.name': 'removeItem',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(removeItemSpan?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.remove' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      [SEMANTIC_ATTRIBUTE_CACHE_KEY]: { type: 'string', value: prefixKey('batch:1') },
+      'db.operation.name': { type: 'string', value: 'removeItem' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
 
     // Test clear spans
     const clearSpans = findSpansByMethod('clear');
     expect(clearSpans.length).toBeGreaterThanOrEqual(1);
-    expect(clearSpans[0]?.data).toMatchObject({
-      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'cache.remove',
-      [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.cache.nuxt',
-      'db.operation.name': 'clear',
-      'db.collection.name': 'test-storage',
-      'db.system.name': 'memory',
+    expect(clearSpans[0]?.attributes).toMatchObject({
+      'sentry.op': { type: 'string', value: 'cache.remove' },
+      'sentry.origin': { type: 'string', value: 'auto.cache.nuxt' },
+      'db.operation.name': { type: 'string', value: 'clear' },
+      'db.collection.name': { type: 'string', value: 'test-storage' },
+      'db.system.name': { type: 'string', value: 'memory' },
     });
 
     // Verify all spans have OK status
-    const allStorageSpans = transaction.spans?.filter(
-      span => span.data?.[SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN] === 'auto.cache.nuxt',
-    );
-    expect(allStorageSpans?.length).toBeGreaterThan(0);
-    allStorageSpans?.forEach(span => {
+    expect(allStorageSpans.length).toBeGreaterThan(0);
+    allStorageSpans.forEach(span => {
       expect(span.status).toBe('ok');
     });
   });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.cached-html.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.cached-html.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
 test.describe('Rendering Modes with Cached HTML', () => {
   test('changes tracing meta tags with multiple requests on Client-Side only page', async ({ page }) => {
@@ -29,6 +29,20 @@ test.describe('Rendering Modes with Cached HTML', () => {
   });
 });
 
+// Cached pages have exact-match routes, so the server segment is selected by `url.path` instead of
+// its name (route matching may or may not rename exact-match segments under span streaming).
+function waitForServerSegment(routePath: string) {
+  return waitForStreamedSpan('nuxt-5', span => {
+    return span.is_segment && getSpanOp(span) === 'http.server' && span.attributes['url.path']?.value === routePath;
+  });
+}
+
+function waitForPageloadSegment(routePath: string) {
+  return waitForStreamedSpan('nuxt-5', span => {
+    return span.is_segment && getSpanOp(span) === 'pageload' && span.attributes['url.path']?.value === routePath;
+  });
+}
+
 /**
  * Tests that tracing meta-tags change with multiple requests on ISR-cached pages
  * This utility handles the common pattern of:
@@ -47,18 +61,13 @@ export async function testChangingTracingMetaTagsOnISRPage(
   expectedPageText: string,
 ): Promise<void> {
   // === 1. Request ===
-  const clientTxnEventPromise1 = waitForTransaction('nuxt-5', txnEvent => {
-    return txnEvent.transaction === routePath;
-  });
+  const clientSpanPromise1 = waitForPageloadSegment(routePath);
+  const serverSpanPromise1 = waitForServerSegment(routePath);
 
-  const serverTxnEventPromise1 = waitForTransaction('nuxt-5', txnEvent => {
-    return txnEvent.transaction?.includes(`GET ${routePath}`) ?? false;
-  });
-
-  const [_1, clientTxnEvent1, serverTxnEvent1] = await Promise.all([
+  const [_1, clientSpan1, serverSpan1] = await Promise.all([
     page.goto(routePath),
-    clientTxnEventPromise1,
-    serverTxnEventPromise1,
+    clientSpanPromise1,
+    serverSpanPromise1,
     expect(page.getByText(expectedPageText, { exact: true })).toBeVisible(),
   ]);
 
@@ -68,18 +77,13 @@ export async function testChangingTracingMetaTagsOnISRPage(
 
   // === 2. Request ===
 
-  const clientTxnEventPromise2 = waitForTransaction('nuxt-5', txnEvent => {
-    return txnEvent.transaction === routePath;
-  });
+  const clientSpanPromise2 = waitForPageloadSegment(routePath);
+  const serverSpanPromise2 = waitForServerSegment(routePath);
 
-  const serverTxnEventPromise2 = waitForTransaction('nuxt-5', txnEvent => {
-    return txnEvent.transaction?.includes(`GET ${routePath}`) ?? false;
-  });
-
-  const [_2, clientTxnEvent2, serverTxnEvent2] = await Promise.all([
+  const [_2, clientSpan2, serverSpan2] = await Promise.all([
     page.goto(routePath),
-    clientTxnEventPromise2,
-    serverTxnEventPromise2,
+    clientSpanPromise2,
+    serverSpanPromise2,
     expect(page.getByText(expectedPageText, { exact: true })).toBeVisible(),
   ]);
 
@@ -87,30 +91,30 @@ export async function testChangingTracingMetaTagsOnISRPage(
   const sentryTraceMetaTagContent2 = await page.locator('meta[name="sentry-trace"]').getAttribute('content');
   const [htmlMetaTraceId2] = sentryTraceMetaTagContent2?.split('-') || [];
 
-  const serverTxnEvent1TraceId = serverTxnEvent1.contexts?.trace?.trace_id;
-  const serverTxnEvent2TraceId = serverTxnEvent2.contexts?.trace?.trace_id;
+  const serverSpan1TraceId = serverSpan1.trace_id;
+  const serverSpan2TraceId = serverSpan2.trace_id;
 
   await test.step('Test distributed trace from 1. request', () => {
-    expect(baggageMetaTagContent1).toContain(`sentry-trace_id=${serverTxnEvent1TraceId}`);
+    expect(baggageMetaTagContent1).toContain(`sentry-trace_id=${serverSpan1TraceId}`);
 
-    expect(clientTxnEvent1.contexts?.trace?.trace_id).toBe(serverTxnEvent1TraceId);
-    expect(clientTxnEvent1.contexts?.trace?.parent_span_id).toBe(serverTxnEvent1.contexts?.trace?.span_id);
-    expect(serverTxnEvent1.contexts?.trace?.trace_id).toBe(htmlMetaTraceId1);
+    expect(clientSpan1.trace_id).toBe(serverSpan1TraceId);
+    expect(clientSpan1.parent_span_id).toBe(serverSpan1.span_id);
+    expect(serverSpan1TraceId).toBe(htmlMetaTraceId1);
   });
 
   await test.step('Test distributed trace from 2. request', () => {
-    expect(baggageMetaTagContent2).toContain(`sentry-trace_id=${serverTxnEvent2TraceId}`);
+    expect(baggageMetaTagContent2).toContain(`sentry-trace_id=${serverSpan2TraceId}`);
 
-    expect(clientTxnEvent2.contexts?.trace?.trace_id).toBe(serverTxnEvent2TraceId);
-    expect(clientTxnEvent2.contexts?.trace?.parent_span_id).toBe(serverTxnEvent2.contexts?.trace?.span_id);
-    expect(serverTxnEvent2.contexts?.trace?.trace_id).toBe(htmlMetaTraceId2);
+    expect(clientSpan2.trace_id).toBe(serverSpan2TraceId);
+    expect(clientSpan2.parent_span_id).toBe(serverSpan2.span_id);
+    expect(serverSpan2TraceId).toBe(htmlMetaTraceId2);
   });
 
   await test.step('Test that trace IDs from subsequent requests are different', () => {
-    // Different trace IDs for the server transactions
-    expect(serverTxnEvent1TraceId).toBeDefined();
-    expect(serverTxnEvent1TraceId).not.toBe(serverTxnEvent2TraceId);
-    expect(serverTxnEvent1TraceId).not.toBe(htmlMetaTraceId2);
+    // Different trace IDs for the server root spans
+    expect(serverSpan1TraceId).toBeDefined();
+    expect(serverSpan1TraceId).not.toBe(serverSpan2TraceId);
+    expect(serverSpan1TraceId).not.toBe(htmlMetaTraceId2);
   });
 }
 
@@ -119,13 +123,11 @@ export async function testChangingTracingMetaTagsOnISRPage(
  * This utility handles the common pattern of:
  * 1. Making two requests to a cached page
  * 2. Verifying no tracing meta-tags are present
- * 3. Verifying only the first request creates a server transaction
- * 4. Verifying traces are not distributed
+ * 3. Verifying traces are not distributed (each pageload starts its own trace)
  *
  * @param page - Playwright page object
  * @param routePath - The route path to test (e.g., '/rendering-modes/swr-cached-page')
  * @param expectedPageText - The text to verify is visible on the page (e.g., 'SWR Cached Page')
- * @returns Object containing transaction events for additional custom assertions
  */
 export async function testExcludeTracingMetaTagsOnCachedPage(
   page: Page,
@@ -133,19 +135,15 @@ export async function testExcludeTracingMetaTagsOnCachedPage(
   expectedPageText: string,
 ): Promise<void> {
   // === 1. Request ===
-  const clientTxnEventPromise1 = waitForTransaction('nuxt-5', txnEvent => {
-    return txnEvent.transaction === routePath;
-  });
+  const clientSpanPromise1 = waitForPageloadSegment(routePath);
 
-  // Only the 1. request creates a server transaction
-  const serverTxnEventPromise1 = waitForTransaction('nuxt-5', txnEvent => {
-    return txnEvent.transaction?.includes(`GET ${routePath}`) ?? false;
-  });
+  // Only the 1. request creates a server root span
+  const serverSpanPromise1 = waitForServerSegment(routePath);
 
-  const [_1, clientTxnEvent1, serverTxnEvent1] = await Promise.all([
+  const [_1, clientSpan1, serverSpan1] = await Promise.all([
     page.goto(routePath),
-    clientTxnEventPromise1,
-    serverTxnEventPromise1,
+    clientSpanPromise1,
+    serverSpanPromise1,
     expect(page.getByText(expectedPageText, { exact: true })).toBeVisible(),
   ]);
 
@@ -155,54 +153,37 @@ export async function testExcludeTracingMetaTagsOnCachedPage(
 
   // === 2. Request ===
 
-  await page.goto(routePath);
+  const clientSpanPromise2 = waitForPageloadSegment(routePath);
 
-  const clientTxnEventPromise2 = waitForTransaction('nuxt-5', txnEvent => {
-    return txnEvent.transaction === routePath;
-  });
-
-  let serverTxnEvent2 = undefined;
-  const serverTxnEventPromise2 = Promise.race([
-    waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes(`GET ${routePath}`) ?? false;
-    }),
-    new Promise((_, reject) => setTimeout(() => reject(new Error('No second server transaction expected')), 2000)),
-  ]);
-
-  try {
-    serverTxnEvent2 = await serverTxnEventPromise2;
-    throw new Error('Second server transaction should not have been sent');
-  } catch (error) {
-    expect(error.message).toBe('No second server transaction expected');
-  }
-
-  const [clientTxnEvent2] = await Promise.all([
-    clientTxnEventPromise2,
+  const [_2, clientSpan2] = await Promise.all([
+    page.goto(routePath),
+    clientSpanPromise2,
     expect(page.getByText(expectedPageText, { exact: true })).toBeVisible(),
   ]);
 
-  const clientTxnEvent1TraceId = clientTxnEvent1.contexts?.trace?.trace_id;
-  const clientTxnEvent2TraceId = clientTxnEvent2.contexts?.trace?.trace_id;
+  const clientSpan1TraceId = clientSpan1.trace_id;
+  const clientSpan2TraceId = clientSpan2.trace_id;
 
-  const serverTxnEvent1TraceId = serverTxnEvent1.contexts?.trace?.trace_id;
-  const serverTxnEvent2TraceId = serverTxnEvent2?.contexts?.trace?.trace_id;
+  const serverSpan1TraceId = serverSpan1.trace_id;
 
   await test.step('No baggage and sentry-trace meta-tags are present on second request', async () => {
     expect(await page.locator('meta[name="baggage"]').count()).toBe(0);
     expect(await page.locator('meta[name="sentry-trace"]').count()).toBe(0);
   });
 
-  await test.step('1. Server Transaction and all Client Transactions are defined', () => {
-    expect(serverTxnEvent1TraceId).toBeDefined();
-    expect(clientTxnEvent1TraceId).toBeDefined();
-    expect(clientTxnEvent2TraceId).toBeDefined();
-    expect(serverTxnEvent2).toBeUndefined();
-    expect(serverTxnEvent2TraceId).toBeUndefined();
+  await test.step('1. server root span and all client root spans are defined', () => {
+    expect(serverSpan1TraceId).toBeDefined();
+    expect(clientSpan1TraceId).toBeDefined();
+    expect(clientSpan2TraceId).toBeDefined();
   });
 
   await test.step('Trace is not distributed', () => {
     // Cannot create distributed trace as HTML Meta Tags are not added (caching leads to multiple usages of the same server trace id)
-    expect(clientTxnEvent1TraceId).not.toBe(clientTxnEvent2TraceId);
-    expect(clientTxnEvent1TraceId).not.toBe(serverTxnEvent1TraceId);
+    expect(clientSpan1TraceId).not.toBe(clientSpan2TraceId);
+    expect(clientSpan1TraceId).not.toBe(serverSpan1TraceId);
+    expect(clientSpan2TraceId).not.toBe(serverSpan1TraceId);
+    // Without meta tags the pageloads have no parent and start their own traces
+    expect(clientSpan1.parent_span_id).toBeUndefined();
+    expect(clientSpan2.parent_span_id).toBeUndefined();
   });
 }

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.client.test.ts
@@ -1,96 +1,72 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
-import type { Span } from '@sentry/nuxt';
+import { collectStreamedSpans, getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
 test('sends a pageload root span with a parameterized URL', async ({ page }) => {
-  const transactionPromise = waitForTransaction('nuxt-5', async transactionEvent => {
-    return transactionEvent.transaction === '/test-param/:param()';
+  const pageloadSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto(`/test-param/1234`);
 
-  const rootSpan = await transactionPromise;
+  const pageloadSpan = await pageloadSpanPromise;
 
-  expect(rootSpan).toMatchObject({
-    contexts: {
-      trace: {
-        data: {
-          'sentry.segment.name.source': 'route',
-          'sentry.origin': 'auto.pageload.vue',
-          'sentry.op': 'pageload',
-          'params.param': '1234',
-          'url.template': '/test-param/:param()',
-          'url.path': '/test-param/1234',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/test-param\/1234$/),
-        },
-        op: 'pageload',
-        origin: 'auto.pageload.vue',
-      },
-    },
-    transaction: '/test-param/:param()',
-    transaction_info: {
-      source: 'route',
-    },
+  expect(pageloadSpan.name).toBe('/test-param/:param()');
+  expect(pageloadSpan.status).toBe('ok');
+  expect(pageloadSpan.attributes).toMatchObject({
+    'sentry.segment.name.source': { type: 'string', value: 'route' },
+    'sentry.origin': { type: 'string', value: 'auto.pageload.vue' },
+    'sentry.op': { type: 'string', value: 'pageload' },
+    'params.param': { type: 'string', value: '1234' },
+    'url.template': { type: 'string', value: '/test-param/:param()' },
+    'url.path': { type: 'string', value: '/test-param/1234' },
+    'url.full': { type: 'string', value: expect.stringMatching(/^https?:\/\/localhost:\d+\/test-param\/1234$/) },
   });
 });
 
 test('sends a navigation root span with a parameterized URL', async ({ page }) => {
-  const transactionPromise = waitForTransaction('nuxt-5', async transactionEvent => {
-    return (
-      transactionEvent.contexts?.trace?.op === 'navigation' && transactionEvent.transaction === '/test-param/:param()'
-    );
+  const navigationSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+    return getSpanOp(span) === 'navigation' && span.is_segment && span.name === '/test-param/:param()';
   });
 
   await page.goto(`/`);
   await page.getByText('Fetch Param').click();
 
-  const rootSpan = await transactionPromise;
+  const navigationSpan = await navigationSpanPromise;
 
-  expect(rootSpan).toMatchObject({
-    contexts: {
-      trace: {
-        data: {
-          'sentry.segment.name.source': 'route',
-          'sentry.origin': 'auto.navigation.vue',
-          'sentry.op': 'navigation',
-          'params.param': '1234',
-          'url.template': '/test-param/:param()',
-          'url.path': '/test-param/1234',
-          'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/test-param\/1234$/),
-        },
-        op: 'navigation',
-        origin: 'auto.navigation.vue',
-      },
-    },
-    transaction: '/test-param/:param()',
-    transaction_info: {
-      source: 'route',
-    },
+  expect(navigationSpan.name).toBe('/test-param/:param()');
+  expect(navigationSpan.attributes).toMatchObject({
+    'sentry.segment.name.source': { type: 'string', value: 'route' },
+    'sentry.origin': { type: 'string', value: 'auto.navigation.vue' },
+    'sentry.op': { type: 'string', value: 'navigation' },
+    'params.param': { type: 'string', value: '1234' },
+    'url.template': { type: 'string', value: '/test-param/:param()' },
+    'url.path': { type: 'string', value: '/test-param/1234' },
+    'url.full': { type: 'string', value: expect.stringMatching(/^https?:\/\/localhost:\d+\/test-param\/1234$/) },
   });
 });
 
 // fixme: note that this test only works because we explictly enabled Vue’s Options API in the nuxt config
 test('sends component tracking spans when `trackComponents` is enabled', async ({ page }) => {
-  const transactionPromise = waitForTransaction('nuxt-5', async transactionEvent => {
-    return transactionEvent.transaction === '/client-error';
-  });
+  const spansPromise = collectStreamedSpans('nuxt-5', spans =>
+    spans.some(span => span.name === '/client-error' && span.is_segment && getSpanOp(span) === 'pageload'),
+  );
 
   await page.goto(`/client-error`);
 
-  const rootSpan = await transactionPromise;
-  const errorButtonSpan = rootSpan.spans.find((span: Span) => span.description === 'Vue <ErrorButton>');
+  const spans = await spansPromise;
+  const errorButtonSpan = spans.find(span => span.name === 'Vue <ErrorButton>');
 
-  const expected = {
-    data: { 'sentry.origin': 'auto.ui.vue', 'sentry.op': 'ui.mount' },
-    description: 'Vue <ErrorButton>',
-    op: 'ui.mount',
+  expect(errorButtonSpan).toMatchObject({
+    name: 'Vue <ErrorButton>',
+    is_segment: false,
     parent_span_id: expect.stringMatching(/[a-f0-9]{16}/),
     span_id: expect.stringMatching(/[a-f0-9]{16}/),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
     trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-    origin: 'auto.ui.vue',
-  };
-
-  expect(errorButtonSpan).toMatchObject(expected);
+    start_timestamp: expect.any(Number),
+    end_timestamp: expect.any(Number),
+    attributes: expect.objectContaining({
+      'sentry.op': { type: 'string', value: 'ui.mount' },
+      'sentry.origin': { type: 'string', value: 'auto.ui.vue' },
+    }),
+  });
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.server.test.ts
@@ -1,64 +1,63 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
-import { SEMANTIC_ATTRIBUTE_SENTRY_OP, SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/nuxt';
+import { collectStreamedSpans, getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('sends a server action transaction on pageload', async ({ page }) => {
-  const transactionPromise = waitForTransaction('nuxt-5', transactionEvent => {
-    return transactionEvent.transaction.includes('GET /test-param/');
+test('sends a server root span on pageload', async ({ page }) => {
+  const serverSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+    return span.is_segment && span.name.includes('GET /test-param/');
   });
 
   await page.goto('/test-param/1234');
 
-  const transaction = await transactionPromise;
+  const serverSpan = await serverSpanPromise;
 
-  expect(transaction.contexts.trace).toEqual(
-    expect.objectContaining({
-      data: expect.objectContaining({
-        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.server',
-        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.http_server',
-      }),
-    }),
-  );
+  expect(getSpanOp(serverSpan)).toBe('http.server');
+  expect(serverSpan.attributes['sentry.origin']?.value).toBe('auto.http.http_server');
 });
 
-test('does not send transactions for build asset folder "_nuxt"', async ({ page }) => {
+test('does not send spans for build asset folder "_nuxt"', async ({ page }) => {
   let buildAssetFolderOccurred = false;
 
-  waitForTransaction('nuxt-5', transactionEvent => {
-    if (transactionEvent.transaction?.match(/^GET \/_nuxt\//)) {
+  waitForStreamedSpan('nuxt-5', span => {
+    if (span.is_segment && /^GET \/_nuxt\//.test(span.name)) {
       buildAssetFolderOccurred = true;
     }
     return false; // expects to return a boolean (but not relevant here)
   });
 
-  const transactionEventPromise = waitForTransaction('nuxt-5', transactionEvent => {
-    return transactionEvent.transaction.includes('GET /test-param/');
+  const serverSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+    return span.is_segment && span.name.includes('GET /test-param/');
   });
 
   await page.goto('/test-param/1234');
 
-  const transactionEvent = await transactionEventPromise;
+  const serverSpan = await serverSpanPromise;
 
   expect(buildAssetFolderOccurred).toBe(false);
 
-  expect(transactionEvent.transaction).toBe('GET /test-param/:param()');
+  expect(serverSpan.name).toBe('GET /test-param/:param()');
+  expect(serverSpan.attributes['sentry.segment.name.source']?.value).toBe('route');
 });
 
 // TODO: Make test work with Nuxt 5
 test.skip('captures server API calls made with Nitro $fetch', async ({ page }) => {
-  const transactionPromise = waitForTransaction('nuxt-5', async transactionEvent => {
-    return transactionEvent.transaction === 'GET /api/nitro-fetch';
-  });
+  const spansPromise = collectStreamedSpans('nuxt-5', spans =>
+    spans.some(span => span.is_segment && span.attributes['url.path']?.value === '/api/nitro-fetch'),
+  );
 
   await page.goto(`/fetch-server-routes`);
   await page.getByText('Fetch Nitro $fetch', { exact: true }).click();
 
-  const httpServerFetchSpan = await transactionPromise;
-  const httpClientSpan = httpServerFetchSpan.spans.find(span => span.description === 'GET https://example.com/');
+  const spans = await spansPromise;
 
-  expect(httpServerFetchSpan.transaction).toEqual('GET /api/nitro-fetch');
-  expect(httpServerFetchSpan.contexts.trace.op).toEqual('http.server');
+  const httpServerSpan = spans.find(
+    span => span.is_segment && span.attributes['url.path']?.value === '/api/nitro-fetch',
+  );
+  const httpClientSpan = spans.find(
+    span => span.trace_id === httpServerSpan?.trace_id && span.attributes['url.full']?.value === 'https://example.com/',
+  );
 
-  expect(httpClientSpan.parent_span_id).toEqual(httpServerFetchSpan.contexts.trace.span_id);
-  expect(httpClientSpan.op).toEqual('http.client');
+  expect(getSpanOp(httpServerSpan!)).toEqual('http.server');
+
+  expect(httpClientSpan?.parent_span_id).toEqual(httpServerSpan?.span_id);
+  expect(getSpanOp(httpClientSpan!)).toEqual('http.client');
 });

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/tests/tracing.test.ts
@@ -1,22 +1,23 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
 test.describe('distributed tracing', () => {
   const PARAM = 's0me-param';
+  const API_PATH = `/api/user/${PARAM}`;
 
   test('capture a distributed pageload trace', async ({ page }) => {
-    const clientTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction === '/test-param/:param()';
+    const clientSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+      return getSpanOp(span) === 'pageload' && span.is_segment;
     });
 
-    const serverTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /test-param/') ?? false;
+    const serverSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+      return span.is_segment && span.name.includes('GET /test-param/');
     });
 
-    const [_, clientTxnEvent, serverTxnEvent] = await Promise.all([
+    const [_, clientSpan, serverSpan] = await Promise.all([
       page.goto(`/test-param/${PARAM}`),
-      clientTxnEventPromise,
-      serverTxnEventPromise,
+      clientSpanPromise,
+      serverSpanPromise,
       expect(page.getByText(`Param: ${PARAM}`)).toBeVisible(),
     ]);
 
@@ -24,7 +25,7 @@ test.describe('distributed tracing', () => {
 
     // URL-encoded for parametrized 'GET /test-param/s0me-param' -> `GET /test-param/:param`
     expect(baggageMetaTagContent).toContain(`sentry-transaction=GET%20%2Ftest-param%2F%3Aparam`);
-    expect(baggageMetaTagContent).toContain(`sentry-trace_id=${serverTxnEvent.contexts?.trace?.trace_id}`);
+    expect(baggageMetaTagContent).toContain(`sentry-trace_id=${serverSpan.trace_id}`);
     expect(baggageMetaTagContent).toContain('sentry-sampled=true');
     expect(baggageMetaTagContent).toContain('sentry-sample_rate=1');
 
@@ -33,125 +34,115 @@ test.describe('distributed tracing', () => {
 
     expect(metaSampled).toBe('1');
 
-    expect(clientTxnEvent).toMatchObject({
-      transaction: '/test-param/:param()',
-      transaction_info: { source: 'route' },
-      type: 'transaction',
-      contexts: {
-        trace: {
-          op: 'pageload',
-          origin: 'auto.pageload.vue',
-          trace_id: metaTraceId,
-          parent_span_id: metaParentSpanId,
-        },
-      },
+    expect(clientSpan).toMatchObject({
+      name: '/test-param/:param()',
+      is_segment: true,
+      trace_id: metaTraceId,
+      parent_span_id: metaParentSpanId,
+      attributes: expect.objectContaining({
+        'sentry.op': { type: 'string', value: 'pageload' },
+        'sentry.origin': { type: 'string', value: 'auto.pageload.vue' },
+        'sentry.segment.name.source': { type: 'string', value: 'route' },
+      }),
     });
 
-    expect(serverTxnEvent).toMatchObject({
-      transaction: `GET /test-param/:param()`, // parametrized route
-      transaction_info: { source: 'route' },
-      type: 'transaction',
-      contexts: {
-        trace: {
-          op: 'http.server',
-          origin: 'auto.http.http_server',
-        },
-      },
+    expect(serverSpan).toMatchObject({
+      name: 'GET /test-param/:param()', // parametrized
+      is_segment: true,
+      attributes: expect.objectContaining({
+        'sentry.op': { type: 'string', value: 'http.server' },
+        'sentry.origin': { type: 'string', value: 'auto.http.http_server' },
+        'sentry.segment.name.source': { type: 'string', value: 'route' },
+      }),
     });
 
     // connected trace
-    expect(clientTxnEvent.contexts?.trace?.trace_id).toBeDefined();
-    expect(clientTxnEvent.contexts?.trace?.parent_span_id).toBeDefined();
-
-    expect(clientTxnEvent.contexts?.trace?.trace_id).toBe(serverTxnEvent.contexts?.trace?.trace_id);
-    expect(clientTxnEvent.contexts?.trace?.parent_span_id).toBe(serverTxnEvent.contexts?.trace?.span_id);
-    expect(serverTxnEvent.contexts?.trace?.trace_id).toBe(metaTraceId);
+    expect(clientSpan.trace_id).toBe(serverSpan.trace_id);
+    expect(clientSpan.parent_span_id).toBe(serverSpan.span_id);
+    expect(serverSpan.trace_id).toBe(metaTraceId);
   });
 
   test('capture a distributed trace from a client-side API request with parametrized routes', async ({ page }) => {
-    const clientTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction === '/test-param/user/:userId()';
+    // The `http.client` span ends after the pageload segment, so it can be flushed in a later
+    // envelope. Accumulate until both spans have arrived.
+    const clientSpansPromise = collectStreamedSpans('nuxt-5', spans => {
+      return (
+        spans.some(span => span.name === '/test-param/user/:userId()' && span.is_segment) &&
+        spans.some(
+          span => getSpanOp(span) === 'http.client' && `${span.attributes['url.full']?.value}`.includes(API_PATH),
+        )
+      );
     });
-    const ssrTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /test-param/user') ?? false;
+    const ssrSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+      return span.is_segment && span.name.includes('GET /test-param/user');
     });
-    const serverReqTxnEventPromise = waitForTransaction('nuxt-5', txnEvent => {
-      return txnEvent.transaction?.includes('GET /api/user/') ?? false;
+    const serverReqSpanPromise = waitForStreamedSpan('nuxt-5', span => {
+      return span.is_segment && span.name.includes('GET /api/user/');
     });
 
     // Navigate to the page which will trigger an API call from the client-side
     await page.goto(`/test-param/user/${PARAM}`);
 
-    const [clientTxnEvent, ssrTxnEvent, serverReqTxnEvent] = await Promise.all([
-      clientTxnEventPromise,
-      ssrTxnEventPromise,
-      serverReqTxnEventPromise,
+    const [clientSpans, ssrSpan, serverReqSpan] = await Promise.all([
+      clientSpansPromise,
+      ssrSpanPromise,
+      serverReqSpanPromise,
     ]);
 
-    const httpClientSpan = clientTxnEvent?.spans?.find(span => span.description === `GET /api/user/${PARAM}`);
-
-    expect(clientTxnEvent).toEqual(
-      expect.objectContaining({
-        type: 'transaction',
-        transaction: '/test-param/user/:userId()', // parametrized route
-        transaction_info: { source: 'route' },
-        contexts: expect.objectContaining({
-          trace: expect.objectContaining({
-            op: 'pageload',
-            origin: 'auto.pageload.vue',
-          }),
-        }),
-      }),
+    const pageloadSpan = clientSpans.find(span => span.name === '/test-param/user/:userId()' && span.is_segment);
+    const httpClientSpan = clientSpans.find(
+      span => getSpanOp(span) === 'http.client' && `${span.attributes['url.full']?.value}`.includes(API_PATH),
     );
+
+    expect(pageloadSpan).toMatchObject({
+      name: '/test-param/user/:userId()',
+      is_segment: true,
+      attributes: expect.objectContaining({
+        'sentry.op': { type: 'string', value: 'pageload' },
+        'sentry.origin': { type: 'string', value: 'auto.pageload.vue' },
+        'sentry.segment.name.source': { type: 'string', value: 'route' },
+      }),
+    });
 
     expect(httpClientSpan).toBeDefined();
-    expect(httpClientSpan).toEqual(
-      expect.objectContaining({
-        description: `GET /api/user/${PARAM}`, // fixme: parametrize
-        parent_span_id: clientTxnEvent.contexts?.trace?.span_id, // pageload span is parent
-        data: expect.objectContaining({
-          'url.full': expect.stringContaining(`/api/user/${PARAM}`),
-          type: 'fetch',
-          'sentry.op': 'http.client',
-          'sentry.origin': 'auto.http.browser',
-          'http.request.method': 'GET',
-        }),
+    expect(httpClientSpan).toMatchObject({
+      // A relative fetch has no domain of its own, so it resolves against the page origin.
+      name: 'GET localhost',
+      parent_span_id: pageloadSpan?.span_id, // pageload span is parent
+      attributes: expect.objectContaining({
+        type: { type: 'string', value: 'fetch' },
+        'sentry.op': { type: 'string', value: 'http.client' },
+        'sentry.origin': { type: 'string', value: 'auto.http.browser' },
+        'http.request.method': { type: 'string', value: 'GET' },
+        'url.full': { type: 'string', value: expect.stringContaining(API_PATH) },
+        'url.domain': { type: 'string', value: 'localhost' },
       }),
-    );
+    });
 
-    expect(ssrTxnEvent).toEqual(
-      expect.objectContaining({
-        type: 'transaction',
-        transaction: `GET /test-param/user/:userId()`, // parametrized route
-        transaction_info: { source: 'route' },
-        contexts: expect.objectContaining({
-          trace: expect.objectContaining({
-            op: 'http.server',
-            origin: 'auto.http.http_server',
-          }),
-        }),
+    expect(ssrSpan).toMatchObject({
+      name: 'GET /test-param/user/:userId()', // parametrized route
+      is_segment: true,
+      attributes: expect.objectContaining({
+        'sentry.op': { type: 'string', value: 'http.server' },
+        'sentry.origin': { type: 'string', value: 'auto.http.http_server' },
+        'sentry.segment.name.source': { type: 'string', value: 'route' },
       }),
-    );
+    });
 
-    expect(serverReqTxnEvent).toEqual(
-      expect.objectContaining({
-        type: 'transaction',
-        transaction: `GET /api/user/:userId`, // parametrized route
-        transaction_info: { source: 'route' },
-        contexts: expect.objectContaining({
-          trace: expect.objectContaining({
-            op: 'http.server',
-            origin: 'auto.http.http_server',
-            parent_span_id: httpClientSpan?.span_id, // http.client span is parent
-          }),
-        }),
+    expect(serverReqSpan).toMatchObject({
+      name: 'GET /api/user/:userId', // parametrized route
+      is_segment: true,
+      parent_span_id: httpClientSpan?.span_id, // http.client span is parent
+      attributes: expect.objectContaining({
+        'sentry.op': { type: 'string', value: 'http.server' },
+        'sentry.origin': { type: 'string', value: 'auto.http.http_server' },
       }),
-    );
+    });
 
-    // All 3 transactions and the http.client span should share the same trace_id
-    expect(clientTxnEvent.contexts?.trace?.trace_id).toBeDefined();
-    expect(clientTxnEvent.contexts?.trace?.trace_id).toBe(httpClientSpan?.trace_id);
-    expect(clientTxnEvent.contexts?.trace?.trace_id).toBe(ssrTxnEvent.contexts?.trace?.trace_id);
-    expect(clientTxnEvent.contexts?.trace?.trace_id).toBe(serverReqTxnEvent.contexts?.trace?.trace_id);
+    // All 3 root spans and the http.client span should share the same trace_id
+    expect(pageloadSpan?.trace_id).toBeDefined();
+    expect(pageloadSpan?.trace_id).toBe(httpClientSpan?.trace_id);
+    expect(pageloadSpan?.trace_id).toBe(ssrSpan.trace_id);
+    expect(pageloadSpan?.trace_id).toBe(serverReqSpan.trace_id);
   });
 });


### PR DESCRIPTION
Reference https://github.com/getsentry/sentry-javascript/issues/23804

Two changes beyond the mechanical port. The shared cached-html helper (used by the pre-rendered test; the SWR tests were already skipped) asserted that a second request sends no server root span — that only passed because the listener registered after `page.goto`. Streaming's buffered flush exposed the span, so the helper now checks the actual contract: no tracing meta tags, and each pageload starts its own trace. Also, `db-test.ts` runs a successful query before the failing one, so the error carries a query breadcrumb — there is no transaction event to read breadcrumbs off anymore.