### PR TITLE
docs: Use `db.query.text` in the v11 `beforeSendSpan` example

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -388,7 +388,7 @@ Sentry.init({
   beforeSendSpan: span => {
     if (span.attributes['sentry.op'] === 'db.query') {
       span.name = scrub(span.name);
-      span.attributes['db.statement'] = scrub(span.attributes['db.statement']);
+      span.attributes['db.query.text'] = scrub(span.attributes['db.query.text']);
     }
     return span;
   },


### PR DESCRIPTION
The "after" snippet of the `beforeSendSpan` example in the v11 migration guide still scrubs `db.statement`. v11 renamed that attribute to `db.query.text`, as the attribute table further down in the same guide says, so copying the example would silently scrub nothing.

Docs only, no code change.