### PR TITLE
test(e2e): Skip the redirect in the react-router-7 double-instrumentation check

### DIFF
--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/performance.server.test.ts
@@ -135,6 +135,12 @@ test.describe('server - instrumentation API performance', () => {
       'Dev server emits extra http.server segments for module requests',
     );
 
+    // Navigate to `/performance/` with the trailing slash: `/performance` is answered with a 301 to
+    // it, and that redirect is a second request with a second `http.server` segment. It should not
+    // be sent at all — `ignoreStatusCodes` covers 301 — but that option is only applied to
+    // transactions, so span streaming emits it. Going straight to the final URL keeps this test
+    // about double-instrumentation instead of failing on the redirect.
+    //
     // A streamed server segment is named after the method alone until a route is matched, so a
     // duplicate shows up as a bare `GET`. Collect the origin and path alongside the name — they are
     // what says which instrumentation emitted the extra segment, and for which request.
@@ -152,7 +158,7 @@ test.describe('server - instrumentation API performance', () => {
       return false;
     });
 
-    await page.goto(`/performance`);
+    await page.goto(`/performance/`);
     // Give any (erroneous) duplicate span time to arrive before asserting.
     await page.waitForTimeout(3000);
 
@@ -160,7 +166,7 @@ test.describe('server - instrumentation API performance', () => {
       {
         name: 'GET /performance',
         origin: 'auto.http.react_router.instrumentation_api',
-        urlPath: expect.stringContaining('/performance'),
+        urlPath: '/performance/',
       },
     ]);
   });

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/tests/performance/performance.server.test.ts
@@ -135,11 +135,18 @@ test.describe('server - instrumentation API performance', () => {
       'Dev server emits extra http.server segments for module requests',
     );
 
-    const httpServerSpanNames: string[] = [];
+    // A streamed server segment is named after the method alone until a route is matched, so a
+    // duplicate shows up as a bare `GET`. Collect the origin and path alongside the name — they are
+    // what says which instrumentation emitted the extra segment, and for which request.
+    const httpServerSegments: Array<Record<string, unknown>> = [];
     void waitForStreamedSpans(APP_NAME, spans => {
       for (const span of spans) {
         if (getSpanOp(span) === 'http.server' && span.is_segment) {
-          httpServerSpanNames.push(span.name);
+          httpServerSegments.push({
+            name: span.name,
+            origin: span.attributes['sentry.origin']?.value,
+            urlPath: span.attributes['url.path']?.value,
+          });
         }
       }
       return false;
@@ -149,7 +156,13 @@ test.describe('server - instrumentation API performance', () => {
     // Give any (erroneous) duplicate span time to arrive before asserting.
     await page.waitForTimeout(3000);
 
-    expect(httpServerSpanNames).toEqual(['GET /performance']);
+    expect(httpServerSegments).toEqual([
+      {
+        name: 'GET /performance',
+        origin: 'auto.http.react_router.instrumentation_api',
+        urlPath: expect.stringContaining('/performance'),
+      },
+    ]);
   });
 
   test('resolves a real http.route on routes without a loader/action', async ({ page }) => {


### PR DESCRIPTION
This is a "workaround" to fix an e2e test fail triggered by switching it to span streaming: For our React router 7 e2e tests, `/performance` redirects with status 301 to `/performance/`, so `page.goto('/performance')` makes two requests and the redirect gets its own `http.server` segment. 

In static trace lifecycle, the 301 segment should never be sent: `ignoreStatusCodes` drops 301 by default. But in span streaming, we can no longer ignore spans based on response status codes. 

To fix the test, it now goes straight to `/performance/`, so there is no redirect and it stays about what it is named after. 

#23956 tracks deprecating the related `ignoreStatusCodes` option