### PR TITLE
test(e2e): Fix failing e2e tests after db span name adjustments

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-16/tests/db-page.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/tests/db-page.test.ts
@@ -15,8 +15,6 @@ test('Instruments DB calls made during server-side rendering of a page', async (
 
   // One page render produces spans from both injection paths: pg (externalized → runtime module
   // hook) and ioredis (bundle-safe allowlisted → build-time loader).
-  // The postgres span name is low cardinality under span streaming (just the operation); the query
-  // itself is asserted below via `db.query.text`. The redis span names still carry their full text.
   expect(spans).toContainEqual(
     expect.objectContaining({
       name: 'SELECT',
@@ -31,7 +29,7 @@ test('Instruments DB calls made during server-side rendering of a page', async (
   );
   expect(spans).toContainEqual(
     expect.objectContaining({
-      name: 'set page-key [1 other arguments]',
+      name: 'set localhost:6379',
       status: 'ok',
       attributes: expect.objectContaining({
         'sentry.op': { value: 'db.query', type: 'string' },
@@ -44,7 +42,7 @@ test('Instruments DB calls made during server-side rendering of a page', async (
   );
   expect(spans).toContainEqual(
     expect.objectContaining({
-      name: 'get page-key',
+      name: 'get localhost:6379',
       status: 'ok',
       attributes: expect.objectContaining({
         'sentry.op': { value: 'db.query', type: 'string' },

--- a/dev-packages/e2e-tests/test-applications/solidstart/instrument.server.mjs
+++ b/dev-packages/e2e-tests/test-applications/solidstart/instrument.server.mjs
@@ -3,7 +3,6 @@
 import * as Sentry from '@sentry/solidstart';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   environment: 'qa', // dynamic sampling bias to keep transactions
   tracesSampleRate: 1.0, //  Capture 100% of the transactions

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/db.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/db.test.ts
@@ -28,7 +28,7 @@ test('Instruments ioredis automatically via build-time orchestrion', async ({ ba
   expect(redisSpans).toHaveLength(2);
   expect(redisSpans).toContainEqual(
     expect.objectContaining({
-      name: 'set test-key [1 other arguments]',
+      name: 'set localhost:6379',
       status: 'ok',
       attributes: expect.objectContaining({
         'sentry.op': { type: 'string', value: 'db.query' },
@@ -41,7 +41,7 @@ test('Instruments ioredis automatically via build-time orchestrion', async ({ ba
   );
   expect(redisSpans).toContainEqual(
     expect.objectContaining({
-      name: 'get test-key',
+      name: 'get localhost:6379',
       status: 'ok',
       attributes: expect.objectContaining({
         'sentry.op': { type: 'string', value: 'db.query' },


### PR DESCRIPTION
Looks like we ran into some timing issues with merging PRs. #23741 changed redis span names to be low cardinality when span streaming is enabled, and some e2e tests were converted to span streaming at the same time. However, the e2e tests didn't take these changes into account. 

Partially my bad because I wasn't aware that we test redis spans in so many e2e tests. Good to have them though!

Partially ... merge queues?