### PR TITLE
feat(node): Deprecate `ignoreStatusCodes` in http integrations

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -483,11 +483,11 @@ Sentry.init({
 
 #### `ignoreStatusCodes` is deprecated
 
-The `ignoreStatusCodes` option is deprecated on `httpIntegration` and `httpServerSpansIntegration` (Node and the SDKs built on it) as well as on `denoHttpIntegration` and `denoServeIntegration`. It will be removed in v12, without replacement.
+The `ignoreStatusCodes` option is deprecated on `httpIntegration` and `httpServerSpansIntegration` (Node and the SDKs built on it) as well as on `denoHttpIntegration` and `denoServeIntegration`. It will be removed in v12, without a direct replacement.
 
-The filter runs on the finished transaction event, which span streaming no longer produces. Child spans are sent as they end, long before the response status code is known, so a request's spans can no longer be dropped once the status turns out to be uninteresting. The option therefore only has an effect with `traceLifecycle: 'static'`.
+The filter runs on the finished transaction event, which is no longer supported span streaming. Child spans are sent as they end, before the response status code is known, so a request's spans can no longer be dropped once the status turns out to be uninteresting. The option therefore only has an effect with `traceLifecycle: 'static'`.
 
-There is no status-code-based equivalent under span streaming. To keep specific requests out of Sentry, decide before they are instrumented via `ignoreIncomingRequests`, which matches on the incoming request instead of on the response:
+To keep specific requests out of Sentry, decide before they are instrumented: Use `tracesSampler`, or ignore the request via `ignoreIncomingRequests`, which matches on the incoming request instead of on the response:
 
 ```js
 Sentry.init({

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -481,6 +481,24 @@ Sentry.init({
 
 `ignoreSpans` itself is unchanged in shape, but it now takes effect when a span **starts** rather than when the transaction is sent. Matched spans are never recorded at all, which means a matched non-segment span's children are re-parented to its parent instead of being dropped.
 
+#### `ignoreStatusCodes` is deprecated
+
+The `ignoreStatusCodes` option is deprecated on `httpIntegration` and `httpServerSpansIntegration` (Node and the SDKs built on it) as well as on `denoHttpIntegration` and `denoServeIntegration`. It will be removed in v12, without replacement.
+
+The filter runs on the finished transaction event, which span streaming no longer produces. Child spans are sent as they end, long before the response status code is known, so a request's spans can no longer be dropped once the status turns out to be uninteresting. The option therefore only has an effect with `traceLifecycle: 'static'`.
+
+There is no status-code-based equivalent under span streaming. To keep specific requests out of Sentry, decide before they are instrumented via `ignoreIncomingRequests`, which matches on the incoming request instead of on the response:
+
+```js
+Sentry.init({
+  integrations: [
+    Sentry.httpIntegration({
+      ignoreIncomingRequests: urlPath => urlPath.startsWith('/admin'),
+    }),
+  ],
+});
+```
+
 #### Opting out of span streaming
 
 To keep the previous transaction-based model, set `traceLifecycle: 'static'`:
@@ -656,7 +674,8 @@ Sentry.init({
 
 This filter runs on transaction events (`processEvent`), so it only takes effect when `traceLifecycle` is `'static'`.
 The default `'stream'` lifecycle does not produce transaction events, and typical Deno apps are unaffected. Node's
-`httpIntegration` has the same limitation.
+`httpIntegration` has the same limitation. For that reason, [`ignoreStatusCodes` is deprecated](#ignorestatuscodes-is-deprecated)
+and will be removed in v12.
 
 Transactions that are kept now also carry the HTTP status in the top-level `response` context, as in the other server
 SDKs.
@@ -1423,6 +1442,8 @@ Sentry.httpIntegration({
   },
 });
 ```
+
+Note that `ignoreStatusCodes` is itself [deprecated](#ignorestatuscodes-is-deprecated) and will be removed in v12.
 
 ### `@sentry/cloudflare`
 

--- a/packages/deno/src/integrations/deno-serve.ts
+++ b/packages/deno/src/integrations/deno-serve.ts
@@ -31,9 +31,9 @@ export type DenoServeIntegrationOptions = {
    * @default `[[401, 404], [301, 303], [305, 399]]`
    *
    * @deprecated This option only has an effect if `traceLifecycle` is set to `'static'`. With span streaming
-   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, long before the
+   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, before the
    * response status code is known, so a request's spans cannot be dropped retroactively. `ignoreStatusCodes` will be
-   * removed in v12 of the SDK, without replacement.
+   * removed in v12 of the SDK.
    */
   ignoreStatusCodes?: (number | [number, number])[];
 };

--- a/packages/deno/src/integrations/deno-serve.ts
+++ b/packages/deno/src/integrations/deno-serve.ts
@@ -29,6 +29,11 @@ export type DenoServeIntegrationOptions = {
    * produce transaction events, so the filter does not run.
    *
    * @default `[[401, 404], [301, 303], [305, 399]]`
+   *
+   * @deprecated This option only has an effect if `traceLifecycle` is set to `'static'`. With span streaming
+   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, long before the
+   * response status code is known, so a request's spans cannot be dropped retroactively. `ignoreStatusCodes` will be
+   * removed in v12 of the SDK, without replacement.
    */
   ignoreStatusCodes?: (number | [number, number])[];
 };
@@ -88,6 +93,7 @@ const instrumentedDenoServe = (serve: typeof Deno.serve): typeof Deno.serve =>
   });
 
 const _denoServeIntegration = ((options: DenoServeIntegrationOptions = {}) => {
+  // oxlint-disable-next-line typescript/no-deprecated
   const ignoreStatusCodes = options.ignoreStatusCodes ?? DEFAULT_IGNORE_STATUS_CODES;
 
   return {

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -109,9 +109,9 @@ export interface DenoHttpIntegrationOptions {
    * @default `[[401, 404], [301, 303], [305, 399]]`
    *
    * @deprecated This option only has an effect if `traceLifecycle` is set to `'static'`. With span streaming
-   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, long before the
+   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, before the
    * response status code is known, so a request's spans cannot be dropped retroactively. `ignoreStatusCodes` will be
-   * removed in v12 of the SDK, without replacement.
+   * removed in v12 of the SDK.
    */
   ignoreStatusCodes?: (number | [number, number])[];
 

--- a/packages/deno/src/integrations/http.ts
+++ b/packages/deno/src/integrations/http.ts
@@ -107,6 +107,11 @@ export interface DenoHttpIntegrationOptions {
    * limitation.
    *
    * @default `[[401, 404], [301, 303], [305, 399]]`
+   *
+   * @deprecated This option only has an effect if `traceLifecycle` is set to `'static'`. With span streaming
+   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, long before the
+   * response status code is known, so a request's spans cannot be dropped retroactively. `ignoreStatusCodes` will be
+   * removed in v12 of the SDK, without replacement.
    */
   ignoreStatusCodes?: (number | [number, number])[];
 
@@ -146,6 +151,7 @@ export interface DenoHttpIntegrationOptions {
 const _denoHttpIntegration = ((options: DenoHttpIntegrationOptions = {}) => {
   const breadcrumbs = options.breadcrumbs ?? true;
   const tracePropagation = options.tracePropagation ?? true;
+  // oxlint-disable-next-line typescript/no-deprecated
   const ignoreStatusCodes = options.ignoreStatusCodes ?? DEFAULT_IGNORE_STATUS_CODES;
 
   return {

--- a/packages/node/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node/src/integrations/http/httpServerSpansIntegration.ts
@@ -89,7 +89,7 @@ export interface HttpServerSpansIntegrationOptions {
    * @default `[[401, 404], [301, 303], [305, 399]]`
    *
    * @deprecated This option only has an effect if `traceLifecycle` is set to `'static'`. With span streaming
-   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, long before the
+   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, before the
    * response status code is known, so a request's spans cannot be dropped retroactively. `ignoreStatusCodes` will be
    * removed in v12 of the SDK, without replacement.
    */

--- a/packages/node/src/integrations/http/httpServerSpansIntegration.ts
+++ b/packages/node/src/integrations/http/httpServerSpansIntegration.ts
@@ -84,7 +84,14 @@ export interface HttpServerSpansIntegrationOptions {
    * By default, spans with some 3xx and 4xx status codes are ignored (see @default).
    * Expects an array of status codes or a range of status codes, e.g. [[300,399], 404] would ignore 3xx and 404 status codes.
    *
+   * Important: This option is ignored by default! It only has an effect if `traceLifecycle` is set to `'static'`.
+   *
    * @default `[[401, 404], [301, 303], [305, 399]]`
+   *
+   * @deprecated This option only has an effect if `traceLifecycle` is set to `'static'`. With span streaming
+   * (`traceLifecycle: 'stream'`, the default), the SDK ignores it: child spans are sent as they end, long before the
+   * response status code is known, so a request's spans cannot be dropped retroactively. `ignoreStatusCodes` will be
+   * removed in v12 of the SDK, without replacement.
    */
   ignoreStatusCodes?: (number | [number, number])[];
 
@@ -98,6 +105,7 @@ export interface HttpServerSpansIntegrationOptions {
 const _httpServerSpansIntegration = ((options: HttpServerSpansIntegrationOptions = {}) => {
   const ignoreStaticAssets = options.ignoreStaticAssets ?? true;
   const ignoreIncomingRequests = options.ignoreIncomingRequests;
+  // oxlint-disable-next-line typescript/no-deprecated
   const ignoreStatusCodes = options.ignoreStatusCodes ?? DEFAULT_IGNORE_STATUS_CODES;
 
   const { onSpanCreated } = options;


### PR DESCRIPTION
This PR deprecates `ignoreStatusCodes` on 

- Node `httpIntegration` / `httpServerSpansIntegration`
- Deno's `denoHttpIntegration` / `denoServeIntegration`

both scheduled for removal in v12 without replacement.

The option filters finished transaction events by response status code, which span streaming no longer supports. Child spans are sent as they end, potentially before the response status is known, so a request's spans can't be dropped retroactively. 

`ignoreIncomingRequests` is the nearest alternative for keeping requests out of Sentry, but it matches on the request rather than on the response, so the migration note is explicit that it isn't fully equivalent.

Fixes #23956