### PR TITLE
feat(remix)!: Move the Vite plugin to `@sentry/remix/vite`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1260,6 +1260,18 @@ Affected SDKs: `@sentry/react-router`.
 + import { sentryOnBuildEnd } from '@sentry/react-router/vite';
 ```
 
+### Remix: Vite plugin moved to `@sentry/remix/vite`
+
+Affected SDKs: `@sentry/remix`.
+
+`sentryRemixVitePlugin` is no longer available from the main `@sentry/remix` entry point. Import it from the dedicated subpath instead:
+
+```diff
+// vite.config.ts
+- import { sentryRemixVitePlugin } from '@sentry/remix';
++ import { sentryRemixVitePlugin } from '@sentry/remix/vite';
+```
+
 ## 3. Removed APIs
 
 ### `@sentry/core` / All SDKs

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/vite.config.ts
@@ -1,6 +1,6 @@
 import { installGlobals } from '@remix-run/node';
 import { vitePlugin as remix } from '@remix-run/dev';
-import { sentryRemixVitePlugin } from '@sentry/remix';
+import { sentryRemixVitePlugin } from '@sentry/remix/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/vite.config.ts
@@ -1,6 +1,6 @@
 import { installGlobals } from '@remix-run/node';
 import { vitePlugin as remix } from '@remix-run/dev';
-import { sentryRemixVitePlugin } from '@sentry/remix';
+import { sentryRemixVitePlugin } from '@sentry/remix/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/vite.config.ts
@@ -1,5 +1,5 @@
 import { vitePlugin as remix } from '@remix-run/dev';
-import { sentryRemixVitePlugin } from '@sentry/remix';
+import { sentryRemixVitePlugin } from '@sentry/remix/vite';
 import { sentryOrchestrionPlugin } from '@sentry/server-utils/orchestrion/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/vite.config.ts
@@ -1,5 +1,5 @@
 import { vitePlugin as remix } from '@remix-run/dev';
-import { sentryRemixVitePlugin } from '@sentry/remix';
+import { sentryRemixVitePlugin } from '@sentry/remix/vite';
 import { hydrogen } from '@shopify/hydrogen/vite';
 import { oxygen } from '@shopify/mini-oxygen/vite';
 import { defineConfig } from 'vite';

--- a/dev-packages/e2e-tests/test-applications/remix-server-timing/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/remix-server-timing/vite.config.ts
@@ -1,5 +1,5 @@
 import { vitePlugin as remix } from '@remix-run/dev';
-import { sentryRemixVitePlugin } from '@sentry/remix';
+import { sentryRemixVitePlugin } from '@sentry/remix/vite';
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -42,6 +42,11 @@
       "types": "./build/types/cloudflare/index.d.ts",
       "default": "./build/esm/cloudflare/index.js"
     },
+    "./vite": {
+      "types": "./build/types/vite/index.d.ts",
+      "import": "./build/esm/vite/index.js",
+      "require": "./build/cjs/vite/index.js"
+    },
     "./import": {
       "import": {
         "default": "./build/import-hook.mjs"

--- a/packages/remix/rollup.npm.config.mjs
+++ b/packages/remix/rollup.npm.config.mjs
@@ -13,6 +13,7 @@ export default [
         'src/client/index.ts',
         'src/server/index.ts',
         'src/cloudflare/index.ts',
+        'src/vite/index.ts',
       ],
       packageSpecificConfig: {
         external: ['react-router', 'react-router-dom', 'react', 'react/jsx-runtime'],

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -1,7 +1,6 @@
 export * from './server';
 export { captureRemixErrorBoundaryError, withSentry, ErrorBoundary, browserTracingIntegration } from './client';
 
-export { sentryRemixVitePlugin } from './config/vite';
 export { createRemixRouteManifest } from './config/createRemixRouteManifest';
 export type { CreateRemixRouteManifestOptions } from './config/createRemixRouteManifest';
 

--- a/packages/remix/src/vite/index.ts
+++ b/packages/remix/src/vite/index.ts
@@ -1,0 +1,32 @@
+import type { Plugin } from 'vite';
+import { makeRouteManifestPlugin } from './routeManifestPlugin';
+import type { SentryRemixVitePluginOptions } from './types';
+
+export type { SentryRemixVitePluginOptions };
+
+/**
+ * Sentry Vite plugins for Remix.
+ *
+ * Add these to your Vite configuration to inject the Remix route manifest, so client-side
+ * transactions are parameterized.
+ *
+ * @example
+ * ```typescript
+ * // vite.config.ts
+ * import { vitePlugin as remix } from '@remix-run/dev';
+ * import { sentryRemixVitePlugin } from '@sentry/remix/vite';
+ * import { defineConfig } from 'vite';
+ *
+ * export default defineConfig({
+ *   plugins: [
+ *     remix(),
+ *     sentryRemixVitePlugin({
+ *       appDirPath: './app',
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function sentryRemixVitePlugin(options: SentryRemixVitePluginOptions = {}): Plugin[] {
+  return [makeRouteManifestPlugin(options)];
+}

--- a/packages/remix/src/vite/routeManifestPlugin.ts
+++ b/packages/remix/src/vite/routeManifestPlugin.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import type { Plugin } from 'vite';
-import { createRemixRouteManifest } from './createRemixRouteManifest';
+import { createRemixRouteManifest } from '../config/createRemixRouteManifest';
+import type { SentryRemixVitePluginOptions } from './types';
 
 /**
  * Escapes a JSON string for safe embedding in HTML script tags.
@@ -12,45 +13,13 @@ function escapeJsonForHtml(jsonString: string): string {
     .replace(/<!--/g, '<\\!--'); // Escape <!-- to prevent HTML comment injection
 }
 
-export type SentryRemixVitePluginOptions = {
-  /**
-   * Path to the app directory (where routes folder is located).
-   * Can be relative to project root or absolute.
-   * Defaults to 'app' in the project root.
-   *
-   * @example './app'
-   * @example '/absolute/path/to/app'
-   */
-  appDirPath?: string;
-};
-
 // Global variable key used to store the route manifest
 const MANIFEST_GLOBAL_KEY = '_sentryRemixRouteManifest' as const;
 
 /**
  * Vite plugin to inject Remix route manifest for Sentry client-side route parameterization.
- *
- * @param options - Plugin configuration options
- * @returns Vite plugin
- *
- * @example
- * ```typescript
- * // vite.config.ts
- * import { defineConfig } from 'vite';
- * import { vitePlugin as remix } from '@remix-run/dev';
- * import { sentryRemixVitePlugin } from '@sentry/remix';
- *
- * export default defineConfig({
- *   plugins: [
- *     remix(),
- *     sentryRemixVitePlugin({
- *       appDirPath: './app',
- *     }),
- *   ],
- * });
- * ```
  */
-export function sentryRemixVitePlugin(options: SentryRemixVitePluginOptions = {}): Plugin {
+export function makeRouteManifestPlugin(options: Pick<SentryRemixVitePluginOptions, 'appDirPath'> = {}): Plugin {
   let routeManifestJson: string = '';
   let isDevMode = false;
 

--- a/packages/remix/src/vite/types.ts
+++ b/packages/remix/src/vite/types.ts
@@ -1,0 +1,11 @@
+export type SentryRemixVitePluginOptions = {
+  /**
+   * Path to the app directory (where routes folder is located).
+   * Can be relative to project root or absolute.
+   * Defaults to 'app' in the project root.
+   *
+   * @example './app'
+   * @example '/absolute/path/to/app'
+   */
+  appDirPath?: string;
+};

--- a/packages/remix/test/vite/routeManifestPlugin.test.ts
+++ b/packages/remix/test/vite/routeManifestPlugin.test.ts
@@ -3,9 +3,9 @@ import * as os from 'os';
 import * as path from 'path';
 import type { Plugin, ResolvedConfig } from 'vite';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { sentryRemixVitePlugin } from '../../src/config/vite';
+import { makeRouteManifestPlugin } from '../../src/vite/routeManifestPlugin';
 
-describe('sentryRemixVitePlugin', () => {
+describe('makeRouteManifestPlugin', () => {
   let tempDir: string;
   let appDir: string;
   let routesDir: string;
@@ -35,7 +35,7 @@ describe('sentryRemixVitePlugin', () => {
 
   describe('plugin configuration', () => {
     it('should return a valid Vite plugin with correct name', () => {
-      const plugin = sentryRemixVitePlugin();
+      const plugin = makeRouteManifestPlugin();
 
       expect(plugin).toBeDefined();
       expect(plugin.name).toBe('sentry-remix-route-manifest');
@@ -43,13 +43,13 @@ describe('sentryRemixVitePlugin', () => {
     });
 
     it('should accept custom appDirPath option', () => {
-      const plugin = sentryRemixVitePlugin({ appDirPath: '/custom/path' });
+      const plugin = makeRouteManifestPlugin({ appDirPath: '/custom/path' });
 
       expect(plugin).toBeDefined();
     });
 
     it('should work with no options', () => {
-      const plugin = sentryRemixVitePlugin();
+      const plugin = makeRouteManifestPlugin();
 
       expect(plugin).toBeDefined();
     });
@@ -62,7 +62,7 @@ describe('sentryRemixVitePlugin', () => {
       fs.writeFileSync(path.join(routesDir, 'about.tsx'), '// about');
       fs.writeFileSync(path.join(routesDir, 'users.$id.tsx'), '// users');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
       };
 
@@ -83,7 +83,7 @@ describe('sentryRemixVitePlugin', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
       fs.writeFileSync(path.join(routesDir, 'users.$id.tsx'), '// users');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
       };
 
@@ -101,7 +101,7 @@ describe('sentryRemixVitePlugin', () => {
     });
 
     it('should handle errors gracefully and set empty manifest', () => {
-      const plugin = sentryRemixVitePlugin({ appDirPath: '/nonexistent/path' }) as Plugin & {
+      const plugin = makeRouteManifestPlugin({ appDirPath: '/nonexistent/path' }) as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
       };
 
@@ -124,7 +124,7 @@ describe('sentryRemixVitePlugin', () => {
       fs.mkdirSync(customRoutesDir, { recursive: true });
       fs.writeFileSync(path.join(customRoutesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin({ appDirPath: customAppDir }) as Plugin & {
+      const plugin = makeRouteManifestPlugin({ appDirPath: customAppDir }) as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
       };
 
@@ -144,7 +144,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should inject manifest into HTML with <head> tag', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -172,7 +172,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should handle HTML without <head> tag by creating one', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -198,7 +198,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should handle HTML with uppercase <HEAD> tag', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -223,7 +223,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should handle minimal HTML by wrapping it', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -251,7 +251,7 @@ describe('sentryRemixVitePlugin', () => {
       // Create a route that might have special characters
       fs.writeFileSync(path.join(routesDir, 'test.tsx'), '// test');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -280,7 +280,7 @@ describe('sentryRemixVitePlugin', () => {
       // without proper escaping
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// test');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -323,7 +323,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should inject manifest into entry.client.tsx file', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -349,7 +349,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should inject manifest into entry-client.ts file', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -373,7 +373,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should not inject into non-entry files', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -396,7 +396,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should inject manifest into entry.server.tsx for server-side transaction naming', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -422,7 +422,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should handle files with "entry.client" in path', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -446,7 +446,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should not double-inject if transformIndexHtml already ran', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -474,7 +474,7 @@ describe('sentryRemixVitePlugin', () => {
       fs.writeFileSync(path.join(routesDir, 'about.tsx'), '// about');
       fs.writeFileSync(path.join(routesDir, 'users.$id.tsx'), '// users');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -514,7 +514,7 @@ describe('sentryRemixVitePlugin', () => {
       fs.mkdirSync(usersDir);
       fs.writeFileSync(path.join(usersDir, '$id.tsx'), '// user');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transformIndexHtml: {
           order: string;
@@ -552,7 +552,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should inject manifest into entry-server.ts file', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -576,7 +576,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should handle files with "entry.server" in path', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };
@@ -600,7 +600,7 @@ describe('sentryRemixVitePlugin', () => {
     it('should inject manifest into Hydrogen/Cloudflare server.ts files', () => {
       fs.writeFileSync(path.join(routesDir, 'index.tsx'), '// index');
 
-      const plugin = sentryRemixVitePlugin() as Plugin & {
+      const plugin = makeRouteManifestPlugin() as Plugin & {
         configResolved: (config: ResolvedConfig) => void;
         transform: (code: string, id: string) => { code: string; map: null } | null;
       };


### PR DESCRIPTION
- `sentryRemixVitePlugin` moves from the main `@sentry/remix` entry to a dedicated `@sentry/remix/vite` subpath, matching `@sentry/sveltekit` and `@sentry/react-router`.
- It was exported from `index.server.ts`, the package's CJS `main`, so anything the plugin imports lands in the module graph of every Remix server process. Splitting the entry keeps build-time-only dependencies off the runtime path.
- It now returns an array so further plugins can be added without another breaking change — #23988 stacks on this to auto-wire the orchestrion transform.

Refs #23986