### PR TITLE
fix(browser)!: stop tagging DOMException.code on events

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -567,6 +567,12 @@ Sentry.init({
 });
 ```
 
+### `DOMException.code` is no longer set as a tag
+
+Affected SDKs: All SDKs running in the browser.
+
+Events created from a `DOMException` no longer carry a `DOMException.code` tag. The `code` property is deprecated and has been replaced by `DOMException.name`, which is already available as the exception type. If you have searches or alert rules keyed on the tag, switch them to `error.type`.
+
 ### `attachStacktrace` defaults to `true`
 
 Affected SDKs: All SDKs.

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -302,10 +302,6 @@ export function eventFromUnknownInput(
       event = eventFromString(stackParser, message, syntheticException, attachStacktrace);
       addExceptionTypeValue(event, message);
     }
-    if ('code' in domException) {
-      // eslint-disable-next-line typescript/no-deprecated
-      event.tags = { ...event.tags, 'DOMException.code': `${domException.code}` };
-    }
 
     return event;
   }

--- a/packages/browser/test/eventbuilder.test.ts
+++ b/packages/browser/test/eventbuilder.test.ts
@@ -294,6 +294,15 @@ describe('eventFromUnknownInput', () => {
       }),
     );
   });
+
+  it('does not set the deprecated DOMException.code as an event tag', () => {
+    const exception = new DOMException('Permission denied', 'NotAllowedError');
+
+    const event = eventFromUnknownInput(defaultStackParser, exception);
+
+    expect(event.exception?.values?.[0]?.type).toBe('NotAllowedError');
+    expect(event.tags).toBeUndefined();
+  });
 });
 
 describe('extractMessage', () => {


### PR DESCRIPTION
## Summary
- Stop setting the deprecated `DOMException.code` as an event tag
- `DOMException.name` remains available via `error.type` on the exception payload

Fixes #10501

## Test plan
- [x] Added regression test in `packages/browser/test/eventbuilder.test.ts`
- [ ] CI