### PR TITLE
chore: Set `attribution.sessionUrl` to false for claude code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "attribution": {
+    "sessionUrl": false
+  },
   "env": { "ENABLE_LSP_TOOL": "1" },
   "hooks": {
     "SessionStart": [


### PR DESCRIPTION
avoids claude adding a link to the claude code sessions in PR descriptions
