### PR TITLE
test(node): Assert absence of PII attributes in OpenAI integration tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/openai/test.ts
@@ -322,6 +322,16 @@ describe('OpenAI integration', () => {
               type: 'string',
               value: 'auto.ai.openai',
             });
+
+            // PII attributes must never be recorded when `sendDefaultPii` is disabled.
+            // Asserting over every span in the envelope catches attributes leaking onto
+            // spans which are not individually inspected above.
+            for (const span of container.items) {
+              expect(span.attributes[GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+              expect(span.attributes[GEN_AI_SYSTEM_INSTRUCTIONS]).toBeUndefined();
+              expect(span.attributes[GEN_AI_RESPONSE_TEXT]).toBeUndefined();
+              expect(span.attributes[GEN_AI_EMBEDDINGS_INPUT]).toBeUndefined();
+            }
           },
         })
         .start()
@@ -845,6 +855,16 @@ describe('OpenAI integration', () => {
               type: 'integer',
               value: 10,
             });
+
+            // PII attributes must never be recorded when `sendDefaultPii` is disabled.
+            // Asserting over every span in the envelope catches attributes leaking onto
+            // spans which are not individually inspected above.
+            for (const span of container.items) {
+              expect(span.attributes[GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+              expect(span.attributes[GEN_AI_SYSTEM_INSTRUCTIONS]).toBeUndefined();
+              expect(span.attributes[GEN_AI_RESPONSE_TEXT]).toBeUndefined();
+              expect(span.attributes[GEN_AI_EMBEDDINGS_INPUT]).toBeUndefined();
+            }
           },
         })
         .start()


### PR DESCRIPTION
The OpenAI integration tests assert which attributes are **present** when GenAI recording is disabled, but never assert that the gated attributes are **absent**. As #19801 notes, a regression that leaked prompt or response content onto spans would pass the existing suite.

#19801 was filed against `sendDefaultPii`, which was removed in v11. The gap still exists under its replacement: the disabled scenarios now opt out with `dataCollection: { genAI: { inputs: false, outputs: false } }`, which `resolveAIRecordingOptions` turns into `recordInputs` / `recordOutputs`. Since v11 defaults to collecting GenAI inputs and outputs, the explicit opt-out is the path that most needs a guard.

This adds an explicit absence check to both `instrument.mjs` (recording disabled) scenarios — chat and embeddings — covering the four content-bearing attributes that the paired `instrument-with-pii.mjs` tests assert are present:

- `gen_ai.input.messages` (gated by `inputs`)
- `gen_ai.system_instructions` (gated by `inputs`)
- `gen_ai.embeddings.input` (gated by `inputs`)
- `gen_ai.response.text` (gated by `outputs`)

The check iterates every span in the envelope rather than only the spans asserted individually above, so content leaking onto an uninspected span is also caught. `for (const span of container.items)` already appears 4 times in this file, so the shape matches the surrounding style.

## Scope

Only the `openai` suite here, to keep the diff reviewable. The same gap exists in `anthropic`, `langchain` and `google-genai` — happy to follow up in a separate PR if you'd like the same treatment there.

I did not use the `flare-redact` approach suggested in the issue comments, since `AGENTS.md` says not to add dependencies unless explicitly asked. These assertions use vitest built-ins only.

## Testing note

I was unable to run `yarn install`, `yarn lint`, `yarn test` or `yarn format` locally — my environment enforces an npm registry publish-date cutoff that blocks resolving this repo's dependency tree. The change is additive test assertions with no production code touched, and I verified the constants used are still imported by this file on `develop`, but **CI is the first real execution of these assertions**. Please flag anything it turns up and I'll fix promptly.

Closes #19801
