### PR TITLE
fix(nextjs): Print unsupported Turbopack warning once

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig/getFinalConfigObjectBundlerUtils.ts
+++ b/packages/nextjs/src/config/withSentryConfig/getFinalConfigObjectBundlerUtils.ts
@@ -13,6 +13,8 @@ import { constructWebpackConfigFunction } from '../webpack';
 import { DEFAULT_SERVER_EXTERNAL_PACKAGES } from './constants';
 import type { VercelCronsConfigResult } from './getFinalConfigObjectUtils';
 
+const UNSUPPORTED_TURBOPACK_WARNING_SHOWN = '__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__';
+
 /**
  * Information about the active bundler and feature support based on Next.js version.
  */
@@ -43,7 +45,14 @@ export function maybeWarnAboutUnsupportedTurbopack(
   silent?: boolean,
 ): void {
   // Warn if using turbopack with an unsupported Next.js version
-  if (!bundlerInfo.isTurbopackSupported && bundlerInfo.isTurbopack) {
+  if (
+    !bundlerInfo.isTurbopackSupported &&
+    bundlerInfo.isTurbopack &&
+    !silent &&
+    process.env[UNSUPPORTED_TURBOPACK_WARNING_SHOWN] !== '1'
+  ) {
+    // Next.js may evaluate its config in child processes, which inherit this state from their parent.
+    process.env[UNSUPPORTED_TURBOPACK_WARNING_SHOWN] = '1';
     getBuildLogger(silent).warn(
       `[@sentry/nextjs] WARNING: You are using the Sentry SDK with Turbopack. The Sentry SDK is compatible with Turbopack on Next.js version 15.4.1 or later. You are currently on ${nextJsVersion}. Please upgrade to a newer Next.js version to use the Sentry SDK with Turbopack.`,
     );

--- a/packages/nextjs/test/config/silent.test.ts
+++ b/packages/nextjs/test/config/silent.test.ts
@@ -21,6 +21,14 @@ const WEBPACK: BundlerInfo = { isTurbopack: false, isWebpack: true, isTurbopackS
 // variants need distinct paths to both actually scan. Neither is a directory, which is what makes it log.
 const NOT_A_DIRECTORY = { silent: __filename, notSilent: path.join(__dirname, 'testUtils.ts') };
 
+beforeEach(() => {
+  delete process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
+});
+
+afterEach(() => {
+  delete process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
+});
+
 describe('getBuildLogger', () => {
   it('forwards to the console when not silent', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/nextjs/test/config/withSentryConfig.test.ts
+++ b/packages/nextjs/test/config/withSentryConfig.test.ts
@@ -17,8 +17,17 @@ const EXPECTED_DEFAULT_EXTERNALS = [
   ...filterInstrumentedExternals(DEFAULT_SERVER_EXTERNAL_PACKAGES, BUNDLE_SAFE_INSTRUMENTED_PACKAGES),
   ...ORCHESTRION_RUNTIME_EXTERNAL_PACKAGES,
 ];
+const originalTurbopackWarningShown = process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
 
 describe('withSentryConfig', () => {
+  afterEach(() => {
+    if (originalTurbopackWarningShown === undefined) {
+      delete process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
+    } else {
+      process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__ = originalTurbopackWarningShown;
+    }
+  });
+
   // `next.config.js` / `next.config.mjs` get no type checking, so this warning is the only signal
   // those users receive that the option is gone.
   describe('removed `unstable_sentryWebpackPluginOptions`', () => {
@@ -1276,6 +1285,21 @@ describe('withSentryConfig', () => {
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         '[@sentry/nextjs] WARNING: You are using the Sentry SDK with Turbopack. The Sentry SDK is compatible with Turbopack on Next.js version 15.4.1 or later. You are currently on 15.3.9. Please upgrade to a newer Next.js version to use the Sentry SDK with Turbopack.',
       );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('warns only once when the config is materialized repeatedly', () => {
+      process.env.TURBOPACK = '1';
+      vi.spyOn(util, 'getNextjsVersion').mockReturnValue('15.4.0');
+      vi.spyOn(util, 'supportsProductionCompileHook').mockReturnValue(false);
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      materializeFinalNextConfig(exportedNextConfig);
+      materializeFinalNextConfig(exportedNextConfig);
+      materializeFinalNextConfig(exportedNextConfig);
+
+      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
 
       consoleWarnSpy.mockRestore();
     });

--- a/packages/nextjs/test/config/withSentryConfig.test.ts
+++ b/packages/nextjs/test/config/withSentryConfig.test.ts
@@ -1298,7 +1298,10 @@ describe('withSentryConfig', () => {
       materializeFinalNextConfig(exportedNextConfig);
       materializeFinalNextConfig(exportedNextConfig);
 
-      expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+      const turbopackWarnings = consoleWarnSpy.mock.calls.filter(([message]) =>
+        String(message).includes('WARNING: You are using the Sentry SDK with Turbopack'),
+      );
+      expect(turbopackWarnings).toHaveLength(1);
 
       consoleWarnSpy.mockRestore();
     });

--- a/packages/nextjs/test/config/withSentryConfig.test.ts
+++ b/packages/nextjs/test/config/withSentryConfig.test.ts
@@ -17,15 +17,14 @@ const EXPECTED_DEFAULT_EXTERNALS = [
   ...filterInstrumentedExternals(DEFAULT_SERVER_EXTERNAL_PACKAGES, BUNDLE_SAFE_INSTRUMENTED_PACKAGES),
   ...ORCHESTRION_RUNTIME_EXTERNAL_PACKAGES,
 ];
-const originalTurbopackWarningShown = process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
 
 describe('withSentryConfig', () => {
+  beforeEach(() => {
+    delete process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
+  });
+
   afterEach(() => {
-    if (originalTurbopackWarningShown === undefined) {
-      delete process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
-    } else {
-      process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__ = originalTurbopackWarningShown;
-    }
+    delete process.env.__SENTRY_UNSUPPORTED_TURBOPACK_WARNING_SHOWN__;
   });
 
   // `next.config.js` / `next.config.mjs` get no type checking, so this warning is the only signal


### PR DESCRIPTION
The unsupported-Turbopack compatibility warning now appears once per Next.js command instead of once per config evaluation. This keeps the warning useful without repeating it as Next.js evaluates configuration in workers.

## Root cause

Each config evaluation logged the warning independently. A process-scoped environment marker was chosen so child processes inherit the emitted state, while a new command starts cleanly without stale temporary files. Silent evaluations do not consume the warning, so a later non-silent evaluation can still surface it.

Fixes #15069