### PR TITLE
test(e2e): Add `create-remix-app-v2-static` E2E app

### DIFF
--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+
+/.cache
+/build
+/public/build
+.env

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/README.md
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/README.md
@@ -1,0 +1,61 @@
+# Welcome to Remix!
+
+- [Remix Docs](https://remix.run/docs)
+
+## Development
+
+From your terminal:
+
+```sh
+npm run dev
+```
+
+This starts your app in development mode, rebuilding assets on file changes.
+
+## Deployment
+
+First, build your app for production:
+
+```sh
+npm run build
+```
+
+Then run the app in production mode:
+
+```sh
+npm start
+```
+
+Now you'll need to pick a host to deploy it to.
+
+### DIY
+
+If you're familiar with deploying node applications, the built-in Remix app server is production-ready.
+
+Make sure to deploy the output of `remix build`
+
+- `build/`
+- `public/build/`
+
+### Using a Template
+
+When you ran `npx create-remix@latest` there were a few choices for hosting. You can run that again to create a new
+project, then copy over relevant code/assets from your current app to the new project that's pre-configured for your
+target server.
+
+Most importantly, this means everything in the `app/` directory, but if you've further customized your current
+application outside of there it may also include:
+
+- Any assets you've added/updated in `public/`
+- Any updated versions of root files such as `.eslintrc.js`, etc.
+
+```sh
+cd ..
+# create a new project, and pick a pre-configured host
+npx create-remix@latest
+cd my-new-remix-app
+# remove the new project's app (not the old one!)
+rm -rf app
+# copy your app over
+cp -R ../my-old-remix-app/app app
+```

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/entry.client.tsx
@@ -1,0 +1,49 @@
+/**
+ * By default, Remix will handle hydrating your app on the client for you.
+ * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
+ * For more information, see https://remix.run/file-conventions/entry.client
+ */
+
+// Extend the Window interface to include ENV
+declare global {
+  interface Window {
+    ENV: {
+      SENTRY_DSN: string;
+      [key: string]: unknown;
+    };
+  }
+}
+
+import { RemixBrowser, useLocation, useMatches } from '@remix-run/react';
+import * as Sentry from '@sentry/remix';
+import { StrictMode, startTransition, useEffect } from 'react';
+import { hydrateRoot } from 'react-dom/client';
+
+Sentry.init({
+  traceLifecycle: 'static',
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  dsn: window.ENV.SENTRY_DSN,
+  integrations: [
+    Sentry.browserTracingIntegration({
+      useEffect,
+      useLocation,
+      useMatches,
+    }),
+    Sentry.replayIntegration(),
+  ],
+  // Performance Monitoring
+  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+  // Session Replay
+  replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+  replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+  tunnel: 'http://localhost:3031/', // proxy server
+});
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <RemixBrowser />
+    </StrictMode>,
+  );
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/entry.server.tsx
@@ -1,0 +1,130 @@
+import * as Sentry from '@sentry/remix';
+
+/**
+ * By default, Remix will handle generating the HTTP Response for you.
+ * You are free to delete this file if you'd like to, but if you ever want it revealed again, you can run `npx remix reveal` ✨
+ * For more information, see https://remix.run/file-conventions/entry.server
+ */
+
+import { PassThrough } from 'node:stream';
+
+import type { AppLoadContext, EntryContext } from '@remix-run/node';
+import { createReadableStreamFromReadable } from '@remix-run/node';
+import { installGlobals } from '@remix-run/node';
+import { RemixServer } from '@remix-run/react';
+import isbot from 'isbot';
+import { renderToPipeableStream } from 'react-dom/server';
+
+installGlobals();
+
+const ABORT_DELAY = 5_000;
+
+const handleErrorImpl = () => {
+  Sentry.setTag('remix-test-tag', 'remix-test-value');
+};
+
+export const handleError = Sentry.wrapHandleErrorWithSentry(handleErrorImpl);
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext,
+  loadContext: AppLoadContext,
+) {
+  return isbot(request.headers.get('user-agent'))
+    ? handleBotRequest(request, responseStatusCode, responseHeaders, remixContext)
+    : handleBrowserRequest(request, responseStatusCode, responseHeaders, remixContext);
+}
+
+function handleBotRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext,
+) {
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer context={remixContext} url={request.url} abortDelay={ABORT_DELAY} />,
+      {
+        onAllReady() {
+          shellRendered = true;
+          const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set('Content-Type', 'text/html');
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            }),
+          );
+
+          pipe(body);
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      },
+    );
+
+    setTimeout(abort, ABORT_DELAY);
+  });
+}
+
+function handleBrowserRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext,
+) {
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer context={remixContext} url={request.url} abortDelay={ABORT_DELAY} />,
+      {
+        onShellReady() {
+          shellRendered = true;
+          const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set('Content-Type', 'text/html');
+
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            }),
+          );
+
+          pipe(body);
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      },
+    );
+
+    setTimeout(abort, ABORT_DELAY);
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/root.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/root.tsx
@@ -1,0 +1,80 @@
+import { cssBundleHref } from '@remix-run/css-bundle';
+import { LinksFunction, MetaFunction, json } from '@remix-run/node';
+import {
+  Links,
+  LiveReload,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+  useLoaderData,
+  useRouteError,
+} from '@remix-run/react';
+import { captureRemixErrorBoundaryError, withSentry } from '@sentry/remix';
+import type { SentryMetaArgs } from '@sentry/remix';
+
+export const links: LinksFunction = () => [...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : [])];
+
+export const loader = () => {
+  return json({
+    ENV: {
+      SENTRY_DSN: process.env.E2E_TEST_DSN,
+    },
+  });
+};
+
+export const meta = ({ data }: SentryMetaArgs<MetaFunction<typeof loader>>) => {
+  return [
+    {
+      env: data.ENV,
+    },
+    {
+      name: 'sentry-trace',
+      content: data.sentryTrace,
+    },
+    {
+      name: 'baggage',
+      content: data.sentryBaggage,
+    },
+  ];
+};
+
+export function ErrorBoundary() {
+  const error = useRouteError();
+  const eventId = captureRemixErrorBoundaryError(error);
+
+  return (
+    <div>
+      <span>ErrorBoundary Error</span>
+      <span id="event-id">{eventId}</span>
+    </div>
+  );
+}
+
+function App() {
+  const { ENV } = useLoaderData() as { ENV: { SENTRY_DSN: string } };
+
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `window.ENV = ${JSON.stringify(ENV)}`,
+          }}
+        />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
+  );
+}
+
+export default withSentry(App);

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/_index.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/_index.tsx
@@ -1,0 +1,26 @@
+import { Link, useSearchParams } from '@remix-run/react';
+import * as Sentry from '@sentry/remix';
+
+export default function Index() {
+  const [searchParams] = useSearchParams();
+
+  if (searchParams.get('tag')) {
+    Sentry.setTag('sentry_test', searchParams.get('tag'));
+  }
+
+  return (
+    <div>
+      <input
+        type="button"
+        value="Capture Exception"
+        id="exception-button"
+        onClick={() => {
+          throw new Error('I am an error!');
+        }}
+      />
+      <Link to="/user/5" id="navigation">
+        navigate
+      </Link>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/client-error.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/client-error.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react';
+
+export default function ErrorBoundaryCapture() {
+  const [count, setCount] = useState(0);
+
+  if (count > 0) {
+    throw new Error('Sentry React Component Error');
+  } else {
+    setTimeout(() => setCount(count + 1), 0);
+  }
+
+  return <div>{count}</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/db-ioredis.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/db-ioredis.tsx
@@ -1,0 +1,24 @@
+import Redis from 'ioredis';
+
+// Page route (not a loader-only resource route): so the http.server
+// transaction is renamed to the matched route (`GET db-ioredis`) and the
+// orchestrion-injected ioredis spans land on a per-route transaction.
+export async function loader() {
+  const redis = new Redis({
+    // Don't keep retrying forever if Redis goes away (e.g. on test teardown)
+    maxRetriesPerRequest: 1,
+    retryStrategy: () => null,
+  });
+
+  try {
+    await redis.set('test-key', 'test-value');
+    const value = await redis.get('test-key');
+    return { value };
+  } finally {
+    redis.disconnect();
+  }
+}
+
+export default function DbIoredis() {
+  return <div>db-ioredis</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/db-mysql.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/db-mysql.tsx
@@ -1,0 +1,24 @@
+import mysql from 'mysql';
+
+export async function loader() {
+  const connection = mysql.createConnection({
+    user: 'root',
+    password: 'docker',
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      connection.query('SELECT 1 + 1 AS solution', err => (err ? reject(err) : resolve()));
+    });
+    await new Promise<void>((resolve, reject) => {
+      connection.query('SELECT NOW()', ['1', '2'], err => (err ? reject(err) : resolve()));
+    });
+    return { status: 'ok' };
+  } finally {
+    connection.end();
+  }
+}
+
+export default function DbMysql() {
+  return <div>db-mysql</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/navigate.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/navigate.tsx
@@ -1,0 +1,20 @@
+import { LoaderFunction } from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+
+export const loader: LoaderFunction = async ({ params: { id } }) => {
+  if (id === '-1') {
+    throw new Error('Unexpected Server Error');
+  }
+
+  return null;
+};
+
+export default function LoaderError() {
+  const data = useLoaderData() as { test?: string };
+
+  return (
+    <div>
+      <h1>{data?.test ? data.test : 'Not Found'}</h1>
+    </div>
+  );
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/user.$id.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/app/routes/user.$id.tsx
@@ -1,0 +1,3 @@
+export default function User() {
+  return <div>I am a blank page</div>;
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/docker-compose.yml
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  db:
+    image: mysql:8.0
+    restart: always
+    container_name: e2e-tests-create-remix-app-v2-static-mysql
+    # The `mysql` 2.x driver doesn't speak MySQL 8's default
+    # `caching_sha2_password` auth, so force the legacy plugin.
+    command: ['--default-authentication-plugin=mysql_native_password']
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: docker
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 -uroot -pdocker']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  redis:
+    image: redis:7
+    restart: always
+    container_name: e2e-tests-create-remix-app-v2-static-redis
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/global-setup.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/global-setup.mjs
@@ -1,0 +1,27 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Boot MySQL and Redis here (rather than in the `start` script) so the cold
+// image pulls happen outside Playwright's webServer startup-timeout window.
+// `--wait` blocks until the healthchecks in docker-compose.yml pass, so the app
+// can connect immediately.
+export default async function globalSetup() {
+  // Each run copies this app to a fresh temp dir, so `docker compose` doesn't
+  // recognize a leftover container from a previous (e.g. interrupted) run as
+  // part of the same project - but the container names are fixed, so the daemon
+  // still refuses to create new ones. Force-remove any stale leftovers first.
+  for (const container of [
+    'e2e-tests-create-remix-app-v2-static-mysql',
+    'e2e-tests-create-remix-app-v2-static-redis',
+  ]) {
+    try {
+      execSync(`docker rm -f ${container}`, { stdio: 'ignore' });
+    } catch {
+      // no stale container to remove
+    }
+  }
+  execSync('docker compose up -d --wait', { cwd: __dirname, stdio: 'inherit' });
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/global-teardown.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/global-teardown.mjs
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function globalTeardown() {
+  execSync('docker compose down --volumes', {
+    cwd: __dirname,
+    stdio: 'inherit',
+  });
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/globals.d.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/globals.d.ts
@@ -1,0 +1,7 @@
+interface Window {
+  recordedTransactions?: string[];
+  capturedExceptionId?: string;
+  ENV: {
+    SENTRY_DSN: string;
+  };
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/instrument.server.cjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/instrument.server.cjs
@@ -1,0 +1,9 @@
+const Sentry = require('@sentry/remix');
+
+Sentry.init({
+  traceLifecycle: 'static',
+  tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+  environment: 'qa', // dynamic sampling bias to keep transactions
+  dsn: process.env.E2E_TEST_DSN,
+  tunnel: 'http://localhost:3031/', // proxy server
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/package.json
@@ -1,0 +1,46 @@
+{
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "scripts": {
+    "build": "remix vite:build && pnpm typecheck",
+    "dev": "remix vite:dev",
+    "start": "NODE_OPTIONS='--import=./instrument.server.cjs' remix-serve build/server/index.js",
+    "typecheck": "tsc",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm playwright test && TEST_ENV=development pnpm playwright test db"
+  },
+  "dependencies": {
+    "@sentry/remix": "file:../../packed/sentry-remix-packed.tgz",
+    "@remix-run/css-bundle": "2.17.4",
+    "@remix-run/node": "2.17.4",
+    "@remix-run/react": "2.17.4",
+    "@remix-run/serve": "2.17.4",
+    "isbot": "^3.6.8",
+    "ioredis": "5.10.1",
+    "mysql": "^2.18.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.56.0",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "@remix-run/dev": "2.17.4",
+    "@remix-run/eslint-config": "2.17.4",
+    "@types/mysql": "^2.15.26",
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.34",
+    "@types/prop-types": "15.7.7",
+    "eslint": "^8.38.0",
+    "typescript": "^5.1.6",
+    "vite": "^5.4.11",
+    "vite-tsconfig-paths": "^4.2.1"
+  },
+  "resolutions": {
+    "@types/react": "18.2.22"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/playwright.config.mjs
@@ -1,0 +1,23 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+import { fileURLToPath } from 'url';
+
+// `remix vite:dev` ignores PORT, so the port goes on the command. The dev server has no
+// bundle, so the SDK is loaded through `--import` the way `pnpm start` does it.
+const startCommand =
+  process.env.TEST_ENV === 'development'
+    ? `NODE_OPTIONS='--import=./instrument.server.cjs' pnpm dev --port 3030`
+    : `pnpm start`;
+
+const config = getPlaywrightConfig(
+  {
+    startCommand,
+  },
+  // The DB tests exercise real MySQL/Redis. Boot them before the tests run, outside the
+  // webServer startup-timeout window.
+  {
+    globalSetup: fileURLToPath(new URL('./global-setup.mjs', import.meta.url)),
+    globalTeardown: fileURLToPath(new URL('./global-teardown.mjs', import.meta.url)),
+  },
+);
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/remix.env.d.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/remix.env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="@remix-run/dev" />
+/// <reference types="@remix-run/node" />

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'create-remix-app-v2-static',
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/build-injection.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/build-injection.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+
+// The `db.test.ts` runtime assertions prove orchestrion spans appear, but spans alone
+// don't prove they came from the BUILD-time transform: if the Vite plugin silently
+// failed to load, the deps would stay external and the runtime `--import` hook would
+// inject the channels at runtime instead - the span tests would still pass. These
+// assertions inspect the built server bundle directly so a broken plugin can't hide
+// behind that runtime fallback.
+test.describe('orchestrion build-time injection', () => {
+  const serverBundle = readFileSync(path.join(process.cwd(), 'build/server/index.js'), 'utf8');
+
+  test('force-bundles the instrumented deps instead of externalizing them', () => {
+    // The plugin adds mysql/ioredis to `ssr.noExternal` so the transform sees their
+    // source. Without it they'd be left as bare imports or `require(...)` calls resolved
+    // from node_modules at runtime - untouched, with no channels injected.
+    expect(serverBundle).not.toMatch(/(from\s*["']mysql["']|require\(["']mysql["']\))/);
+    expect(serverBundle).not.toMatch(/(from\s*["']ioredis["']|require\(["']ioredis["']\))/);
+  });
+
+  test('injects the diagnostics-channel publishers into the bundled deps', () => {
+    // The transform wraps each instrumented function with a `tracingChannel("<name>")`
+    // publisher whose channel name is a string literal. The subscriber side passes the
+    // channel name as a variable, so a literal-arg match is unique to the injected
+    // publisher and proves the build-time transform ran.
+    expect(serverBundle).toMatch(/tracingChannel(\$?\d)?\(["']orchestrion:mysql:query["']\)/);
+    expect(serverBundle).toMatch(/tracingChannel(\$?\d)?\(["']orchestrion:ioredis:command["']\)/);
+    expect(serverBundle).toMatch(/tracingChannel(\$?\d)?\(["']orchestrion:ioredis:connect["']\)/);
+  });
+
+  test('injects the diagnostics-channel publishers into @remix-run/server-runtime', () => {
+    // Remix's own instrumentation is orchestrion-based too: the transform force-bundles
+    // and injects channels into `@remix-run/server-runtime`
+    expect(serverBundle).toMatch(
+      /tracingChannel(\$?\d)?\(["']orchestrion:@remix-run\/server-runtime:requestHandler["']\)/,
+    );
+    expect(serverBundle).toMatch(
+      /tracingChannel(\$?\d)?\(["']orchestrion:@remix-run\/server-runtime:matchServerRoutes["']\)/,
+    );
+    expect(serverBundle).toMatch(
+      /tracingChannel(\$?\d)?\(["']orchestrion:@remix-run\/server-runtime:callRouteLoader["']\)/,
+    );
+    expect(serverBundle).toMatch(
+      /tracingChannel(\$?\d)?\(["']orchestrion:@remix-run\/server-runtime:callRouteAction["']\)/,
+    );
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/client-errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/client-errors.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+import { waitForError } from '@sentry-internal/test-utils';
+
+test('Sends a client-side exception to Sentry', async ({ page }) => {
+  const errorPromise = waitForError('create-remix-app-v2-static', errorEvent => {
+    return errorEvent.exception?.values?.[0].value === 'I am an error!';
+  });
+
+  await page.goto('/');
+
+  const exceptionButton = page.locator('id=exception-button');
+  await exceptionButton.click();
+
+  const errorEvent = await errorPromise;
+
+  expect(errorEvent).toBeDefined();
+});
+
+test('Sends a client-side ErrorBoundary exception to Sentry', async ({ page }) => {
+  const errorPromise = waitForError('create-remix-app-v2-static', errorEvent => {
+    return errorEvent.exception?.values?.[0].value === 'Sentry React Component Error';
+  });
+
+  await page.goto('/client-error');
+
+  const errorEvent = await errorPromise;
+
+  expect(errorEvent).toBeDefined();
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/client-transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/client-transactions.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('Sends a pageload transaction to Sentry', async ({ page }) => {
+  const transactionPromise = waitForTransaction('create-remix-app-v2-static', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.transaction === '/';
+  });
+
+  await page.goto('/');
+
+  const transactionEvent = await transactionPromise;
+
+  expect(transactionEvent).toBeDefined();
+  expect(transactionEvent.contexts?.trace?.data).toEqual(
+    expect.objectContaining({
+      'sentry.segment.name.source': 'route',
+      'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/$/),
+      'url.path': '/',
+      'url.template': '/',
+    }),
+  );
+});
+
+test('Sends a navigation transaction to Sentry', async ({ page }) => {
+  const transactionPromise = waitForTransaction('create-remix-app-v2-static', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'navigation' && transactionEvent.transaction === '/user/:id';
+  });
+
+  await page.goto('/');
+
+  const linkElement = page.locator('id=navigation');
+  await linkElement.click();
+
+  const transactionEvent = await transactionPromise;
+
+  expect(transactionEvent).toBeDefined();
+  expect(transactionEvent.contexts?.trace?.data).toEqual(
+    expect.objectContaining({
+      'sentry.segment.name.source': 'route',
+      'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/user\/5$/),
+      'url.path': '/user/5',
+      'url.template': '/user/:id',
+    }),
+  );
+});
+
+test('Renders `sentry-trace` and `baggage` meta tags for the root route', async ({ page }) => {
+  await page.goto('/');
+
+  const sentryTraceMetaTag = await page.waitForSelector('meta[name="sentry-trace"]', {
+    state: 'attached',
+  });
+  const baggageMetaTag = await page.waitForSelector('meta[name="baggage"]', {
+    state: 'attached',
+  });
+
+  expect(sentryTraceMetaTag).toBeTruthy();
+  expect(baggageMetaTag).toBeTruthy();
+});
+
+test('Renders `sentry-trace` and `baggage` meta tags for a sub-route', async ({ page }) => {
+  await page.goto('/user/123');
+
+  const sentryTraceMetaTag = await page.waitForSelector('meta[name="sentry-trace"]', {
+    state: 'attached',
+  });
+  const baggageMetaTag = await page.waitForSelector('meta[name="baggage"]', {
+    state: 'attached',
+  });
+
+  expect(sentryTraceMetaTag).toBeTruthy();
+  expect(baggageMetaTag).toBeTruthy();
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/db.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/db.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+// Orchestrion force-bundles + transforms mysql/ioredis at build time, and the databases
+// are booted via docker-compose in the Playwright global setup.
+test.describe('orchestrion DB instrumentation', () => {
+  test('Instruments ioredis automatically via orchestrion', async ({ baseURL }) => {
+    const transactionEventPromise = waitForTransaction('create-remix-app-v2-static', transactionEvent => {
+      return (
+        transactionEvent.contexts?.trace?.op === 'http.server' && !!transactionEvent.transaction?.includes('db-ioredis')
+      );
+    });
+
+    await fetch(`${baseURL}/db-ioredis`);
+
+    const transactionEvent = await transactionEventPromise;
+
+    const spans = transactionEvent.spans || [];
+
+    expect(spans).toContainEqual(
+      expect.objectContaining({
+        op: 'db.query',
+        origin: 'auto.db.redis',
+        description: 'set test-key [1 other arguments]',
+        status: 'ok',
+        data: expect.objectContaining({
+          'db.system.name': 'redis',
+          'db.operation.name': 'set',
+          'db.query.text': 'set test-key [1 other arguments]',
+        }),
+      }),
+    );
+    expect(spans).toContainEqual(
+      expect.objectContaining({
+        op: 'db.query',
+        origin: 'auto.db.redis',
+        description: 'get test-key',
+        status: 'ok',
+        data: expect.objectContaining({
+          'db.system.name': 'redis',
+          'db.operation.name': 'get',
+          'db.query.text': 'get test-key',
+        }),
+      }),
+    );
+  });
+
+  test('Instruments mysql automatically via orchestrion', async ({ baseURL }) => {
+    const transactionEventPromise = waitForTransaction('create-remix-app-v2-static', transactionEvent => {
+      return (
+        transactionEvent.contexts?.trace?.op === 'http.server' && !!transactionEvent.transaction?.includes('db-mysql')
+      );
+    });
+
+    await fetch(`${baseURL}/db-mysql`);
+
+    const transactionEvent = await transactionEventPromise;
+
+    const spans = transactionEvent.spans || [];
+
+    expect(spans).toContainEqual(
+      expect.objectContaining({
+        op: 'db',
+        origin: 'auto.db.mysql',
+        description: 'SELECT 1 + 1 AS solution',
+        status: 'ok',
+        data: expect.objectContaining({
+          'db.system.name': 'mysql',
+          'db.query.text': 'SELECT 1 + 1 AS solution',
+          'db.user': 'root',
+          'db.connection_string': expect.any(String),
+          'server.address': expect.any(String),
+          'server.port': 3306,
+        }),
+      }),
+    );
+    expect(spans).toContainEqual(
+      expect.objectContaining({
+        op: 'db',
+        origin: 'auto.db.mysql',
+        description: 'SELECT NOW()',
+        status: 'ok',
+        data: expect.objectContaining({
+          'db.system.name': 'mysql',
+          'db.query.text': 'SELECT NOW()',
+          'db.user': 'root',
+          'db.connection_string': expect.any(String),
+          'server.address': expect.any(String),
+          'server.port': 3306,
+        }),
+      }),
+    );
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/server-transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tests/server-transactions.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test.describe.configure({ mode: 'serial' });
+
+test('Sends parameterized transaction name to Sentry', async ({ page }) => {
+  const transactionPromise = waitForTransaction('create-remix-app-v2-static', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'http.server';
+  });
+
+  await page.goto('/user/123');
+
+  const transaction = await transactionPromise;
+
+  expect(transaction).toBeDefined();
+  expect(transaction.transaction).toBe('GET user/:id');
+});
+
+test('Sends two linked transactions (server & client) to Sentry', async ({ page }) => {
+  // We use this to identify the transactions
+  const testTag = crypto.randomUUID();
+
+  const httpServerTransactionPromise = waitForTransaction('create-remix-app-v2-static', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'http.server' && transactionEvent.tags?.['sentry_test'] === testTag;
+  });
+
+  const pageLoadTransactionPromise = waitForTransaction('create-remix-app-v2-static', transactionEvent => {
+    return transactionEvent.contexts?.trace?.op === 'pageload' && transactionEvent.tags?.['sentry_test'] === testTag;
+  });
+
+  page.goto(`/?tag=${testTag}`);
+
+  const pageloadTransaction = await pageLoadTransactionPromise;
+  const httpServerTransaction = await httpServerTransactionPromise;
+
+  expect(pageloadTransaction).toBeDefined();
+  expect(httpServerTransaction).toBeDefined();
+
+  const httpServerTraceId = httpServerTransaction.contexts?.trace?.trace_id;
+  const httpServerSpanId = httpServerTransaction.contexts?.trace?.span_id;
+  const loaderSpanId = httpServerTransaction?.spans?.find(
+    span => span.data && span.data['code.function.name'] === 'loader',
+  )?.span_id;
+
+  const pageLoadTraceId = pageloadTransaction.contexts?.trace?.trace_id;
+  const pageLoadSpanId = pageloadTransaction.contexts?.trace?.span_id;
+  const pageLoadParentSpanId = pageloadTransaction.contexts?.trace?.parent_span_id;
+
+  expect(httpServerTransaction.transaction).toBe('GET /');
+  expect(pageloadTransaction.transaction).toBe('/');
+
+  expect(httpServerTraceId).toBeDefined();
+  expect(httpServerSpanId).toBeDefined();
+
+  expect(pageLoadTraceId).toEqual(httpServerTraceId);
+  expect(pageLoadParentSpanId).toEqual(loaderSpanId);
+  expect(pageLoadSpanId).not.toEqual(httpServerSpanId);
+});

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "include": ["remix.env.d.ts", "./app/**/*.ts", "./app/**/*.tsx"],
+  "exclude": ["node_modules", "build"],
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2019"],
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "target": "ES2019",
+    "strict": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./app/*"]
+    },
+
+    // Remix takes care of building everything in `remix build`.
+    "noEmit": true
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/vite.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/vite.config.ts
@@ -1,0 +1,14 @@
+import { vitePlugin as remix } from '@remix-run/dev';
+import { sentryRemixVitePlugin } from '@sentry/remix/vite';
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [
+    remix({
+      ignoredRouteFiles: ['**/.*'],
+    }),
+    sentryRemixVitePlugin(),
+    tsconfigPaths(),
+  ],
+});


### PR DESCRIPTION
## What

Copies `create-remix-app-v2` to a new `create-remix-app-v2-static` E2E app that stays on `traceLifecycle: 'static'` and on the transaction-based specs. Only the app name changes (proxy server name, test app name, docker container names).

## Why

The Remix and Hydrogen apps move to span streaming in #23807. This copy keeps the static trace lifecycle covered after that move.

Ref: #23807