### PR TITLE
fix(astro): Fall back to `dataCollection.userInfo` for `trackClientIp`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -244,6 +244,12 @@ User IP address inference, which was previously gated on `sendDefaultPii`, is no
 `dataCollection.userInfo`. An explicit `requestDataIntegration({ include: { ip: true } })` overrides
 `dataCollection.userInfo: false` for data collected by that integration.
 
+#### Astro client IP
+
+`trackClientIp` no longer defaults to `false`. When you leave it unset, `handleRequest` now follows
+`dataCollection.userInfo`, which defaults to `true`, so Astro apps that set neither option start
+reporting `user.ip_address`. Pass `trackClientIp: false` to keep the v10 behaviour.
+
 #### Remix action form data
 
 `captureActionFormDataKeys` is an integration-level override, so it no longer requires

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -53,7 +53,7 @@ type MiddlewareOptions = {
    *
    * Only set this to `true` if you're fine with collecting potentially personally identifiable information (PII).
    *
-   * @default false (recommended)
+   * @default `dataCollection.userInfo` (`true` unless disabled)
    */
   trackClientIp?: boolean;
 };
@@ -78,10 +78,7 @@ type AstroLocalsWithSentry = Record<string, unknown> & {
 };
 
 export const handleRequest: (options?: MiddlewareOptions) => MiddlewareHandler = options => {
-  const handlerOptions = {
-    trackClientIp: false,
-    ...options,
-  };
+  const handlerOptions = { ...options };
 
   return async (ctx, next) => {
     // If no Sentry client exists, just bail
@@ -209,7 +206,8 @@ async function instrumentRequestStartHttpServerSpan(
           normalizedRequest: winterCGRequestToRequestData(request),
         });
 
-        if (options.trackClientIp) {
+        // The integration option wins when set; otherwise `dataCollection.userInfo` decides.
+        if (options.trackClientIp ?? client.getDataCollectionOptions().userInfo) {
           isolationScope.setUser({ ip_address: ctx.clientAddress });
         }
 

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -308,6 +308,33 @@ describe('sentryMiddleware', () => {
       });
     });
 
+    it('follows `dataCollection.userInfo` when `trackClientIp` is not set', async () => {
+      // The shared client mock resolves `userInfo` to `false`.
+      const middleware = handleRequest();
+      const ctx = {
+        ...DYNAMIC_REQUEST_CONTEXT,
+      };
+
+      // @ts-expect-error, a partial ctx object is fine here
+      await middleware(ctx, async () => {
+        expect(SentryCore.getIsolationScope().getScopeData().user?.ip_address).toBeUndefined();
+        return nextResult;
+      });
+    });
+
+    it('does not attach a client IP if `trackClientIp=false`', async () => {
+      const middleware = handleRequest({ trackClientIp: false });
+      const ctx = {
+        ...DYNAMIC_REQUEST_CONTEXT,
+      };
+
+      // @ts-expect-error, a partial ctx object is fine here
+      await middleware(ctx, async () => {
+        expect(SentryCore.getIsolationScope().getScopeData().user?.ip_address).toBeUndefined();
+        return nextResult;
+      });
+    });
+
     it("doesn't attach a client IP if `trackClientIp=true` when handling static page requests", async () => {
       const middleware = handleRequest({ trackClientIp: true });
 

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -46,6 +46,29 @@ describe('sentryMiddleware', () => {
   });
   const setSDKProcessingMetadataMock = vi.fn();
 
+  const DATA_COLLECTION_DEFAULTS = {
+    userInfo: false,
+    cookies: true,
+    httpHeaders: { request: true, response: true },
+    httpBodies: [],
+    urlQueryParams: true,
+    graphQL: { document: true, variables: true },
+    genAI: { inputs: true, outputs: true },
+    databaseQueryData: true,
+    stackFrameVariables: true,
+    frameContextLines: 5,
+  };
+
+  function mockClientWith(dataCollection: Partial<typeof DATA_COLLECTION_DEFAULTS>): void {
+    vi.spyOn(SentryNode, 'getClient').mockImplementation(
+      () =>
+        ({
+          getOptions: () => ({}),
+          getDataCollectionOptions: () => ({ ...DATA_COLLECTION_DEFAULTS, ...dataCollection }),
+        }) as unknown as Client,
+    );
+  }
+
   beforeEach(() => {
     vi.spyOn(SentryNode, 'getCurrentScope').mockImplementation(() => {
       return {
@@ -56,24 +79,7 @@ describe('sentryMiddleware', () => {
       } as any;
     });
     vi.spyOn(SentryNode, 'getActiveSpan').mockImplementation(getSpanMock);
-    vi.spyOn(SentryNode, 'getClient').mockImplementation(
-      () =>
-        ({
-          getOptions: () => ({}),
-          getDataCollectionOptions: () => ({
-            userInfo: false,
-            cookies: true,
-            httpHeaders: { request: true, response: true },
-            httpBodies: [],
-            urlQueryParams: true,
-            graphQL: { document: true, variables: true },
-            genAI: { inputs: true, outputs: true },
-            databaseQueryData: true,
-            stackFrameVariables: true,
-            frameContextLines: 5,
-          }),
-        }) as unknown as Client,
-    );
+    mockClientWith({ userInfo: false });
     vi.spyOn(SentryNode, 'getTraceMetaTags').mockImplementation(
       () => `
     <meta name="sentry-trace" content="123">
@@ -308,8 +314,22 @@ describe('sentryMiddleware', () => {
       });
     });
 
-    it('follows `dataCollection.userInfo` when `trackClientIp` is not set', async () => {
-      // The shared client mock resolves `userInfo` to `false`.
+    it('attaches the client IP when `trackClientIp` is unset and `dataCollection.userInfo` is on', async () => {
+      mockClientWith({ userInfo: true });
+      const middleware = handleRequest();
+      const ctx = {
+        ...DYNAMIC_REQUEST_CONTEXT,
+      };
+
+      // @ts-expect-error, a partial ctx object is fine here
+      await middleware(ctx, async () => {
+        expect(SentryCore.getIsolationScope().getScopeData().user?.ip_address).toBe('192.168.0.1');
+        return nextResult;
+      });
+    });
+
+    it('does not attach a client IP when `trackClientIp` is unset and `dataCollection.userInfo` is off', async () => {
+      mockClientWith({ userInfo: false });
       const middleware = handleRequest();
       const ctx = {
         ...DYNAMIC_REQUEST_CONTEXT,
@@ -322,7 +342,8 @@ describe('sentryMiddleware', () => {
       });
     });
 
-    it('does not attach a client IP if `trackClientIp=false`', async () => {
+    it('lets `trackClientIp=false` win over `dataCollection.userInfo`', async () => {
+      mockClientWith({ userInfo: true });
       const middleware = handleRequest({ trackClientIp: false });
       const ctx = {
         ...DYNAMIC_REQUEST_CONTEXT,


### PR DESCRIPTION
`handleRequest` hard-defaulted `trackClientIp` to `false`, so the global `dataCollection.userInfo` could never switch client IP collection on. An integration option is only meant to win when the user actually sets it.

It is now `options.trackClientIp ?? dataCollection.userInfo`. Heads up, this changes the default. Astro apps that leave both alone start reporting `user.ip_address`, matching `userInfo`'s documented default of `true` and what the other server SDKs do.

Fixes #24086