### PR TITLE
test(e2e): Port the nestjs-graphql E2E app to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-graphql/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-graphql/src/instrument.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`, // proxy server


### PR DESCRIPTION
Removes the `traceLifecycle: 'static'` pin. The specs assert on error events only, so they needed no rewrite.

Ref: #23801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
