### PR TITLE
test(e2e): Port the nestjs-websockets E2E app to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/instrument.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/src/instrument.ts
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/nestjs';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa',
   dsn: process.env.E2E_TEST_DSN,
   tunnel: `http://localhost:3031/`,

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/tests/transactions.test.ts
@@ -1,18 +1,15 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('Sends an HTTP transaction', async ({ baseURL }) => {
-  const txPromise = waitForTransaction('nestjs-websockets', tx => {
-    return tx?.contexts?.trace?.op === 'http.server' && tx?.transaction === 'GET /test-transaction';
+test('Sends an HTTP segment span', async ({ baseURL }) => {
+  const spanPromise = waitForStreamedSpan('nestjs-websockets', span => {
+    return span.is_segment && span.name === 'GET /test-transaction';
   });
 
   await fetch(`${baseURL}/test-transaction`);
 
-  const tx = await txPromise;
+  const span = await spanPromise;
 
-  expect(tx.contexts?.trace).toEqual(
-    expect.objectContaining({
-      op: 'http.server',
-    }),
-  );
+  expect(getSpanOp(span)).toBe('http.server');
+  expect(span.status).toBe('ok');
 });


### PR DESCRIPTION
Removes the `traceLifecycle: 'static'` pin and rewrites the specs against streamed spans.

Ref: #23801

🤖 Generated with [Claude Code](https://claude.com/claude-code)
