### PR TITLE
test(e2e): Unroll the two-query loop in the create-remix-app-v2 db spec

### DIFF
--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/db.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/db.test.ts
@@ -53,22 +53,22 @@ test.describe('orchestrion DB instrumentation', () => {
 
     // With span streaming the span name is the low-cardinality query summary; the statement
     // stays in `db.query.text`.
-    for (const query of ['SELECT 1 + 1 AS solution', 'SELECT NOW()']) {
-      expect(mysqlSpans).toContainEqual(
-        expect.objectContaining({
-          name: 'SELECT',
-          status: 'ok',
-          attributes: expect.objectContaining({
-            'sentry.origin': { value: 'auto.db.mysql', type: 'string' },
-            'db.system.name': { value: 'mysql', type: 'string' },
-            'db.query.text': { value: query, type: 'string' },
-            'db.user': { value: 'root', type: 'string' },
-            'db.connection_string': { value: expect.any(String), type: 'string' },
-            'server.address': { value: expect.any(String), type: 'string' },
-            'server.port': { value: 3306, type: 'integer' },
-          }),
+    const expectedQuerySpan = (query: string) =>
+      expect.objectContaining({
+        name: 'SELECT',
+        status: 'ok',
+        attributes: expect.objectContaining({
+          'sentry.origin': { value: 'auto.db.mysql', type: 'string' },
+          'db.system.name': { value: 'mysql', type: 'string' },
+          'db.query.text': { value: query, type: 'string' },
+          'db.user': { value: 'root', type: 'string' },
+          'db.connection_string': { value: expect.any(String), type: 'string' },
+          'server.address': { value: expect.any(String), type: 'string' },
+          'server.port': { value: 3306, type: 'integer' },
         }),
-      );
-    }
+      });
+
+    expect(mysqlSpans).toContainEqual(expectedQuerySpan('SELECT 1 + 1 AS solution'));
+    expect(mysqlSpans).toContainEqual(expectedQuerySpan('SELECT NOW()'));
   });
 });


### PR DESCRIPTION
## What

Replaces the `for (const query of ['SELECT 1 + 1 AS solution', 'SELECT NOW()'])` loop with two `toContainEqual` assertions sharing a small matcher factory.

## Why

A loop over two literals is harder to read than the two assertions it stands for, and a failure now names the query it was looking for.

Ref: #23807