### PR TITLE
test(e2e): Port plain browser and bundler E2E apps to span streaming

### DIFF
--- a/dev-packages/e2e-tests/test-applications/browser-mfe-vite/apps/shell/src/main.tsx
+++ b/dev-packages/e2e-tests/test-applications/browser-mfe-vite/apps/shell/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom/client';
 import * as Sentry from '@sentry/react';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: import.meta.env.MODE || 'development',
   integrations: [Sentry.browserTracingIntegration()],

--- a/dev-packages/e2e-tests/test-applications/browser-mfe-vite/tests/mfe-span-attribution.test.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-mfe-vite/tests/mfe-span-attribution.test.ts
@@ -1,28 +1,36 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp } from '@sentry-internal/test-utils';
+
+function hasUrlPath(span: { attributes: Record<string, { value: unknown }> }, path: string): boolean {
+  return `${span.attributes['url.full']?.value}`.includes(path);
+}
 
 test('attributes fetch spans to their originating microfrontend', async ({ page }) => {
-  const transactionPromise = waitForTransaction('browser-mfe-vite', transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  const spansPromise = collectStreamedSpans('browser-mfe-vite', spans => {
+    const httpSpans = spans.filter(span => getSpanOp(span) === 'http.client');
+
+    return ['/api/header-data', '/api/mfe-one-data', '/api/shell-config'].every(path =>
+      httpSpans.some(span => hasUrlPath(span, path)),
+    );
   });
 
   await page.goto('/');
 
-  const transactionEvent = await transactionPromise;
-  const httpSpans = transactionEvent.spans?.filter(span => span.op === 'http.client') || [];
+  const spans = await spansPromise;
+  const httpSpans = spans.filter(span => getSpanOp(span) === 'http.client');
 
   // MFE spans carry the mfe.name attribute set via withScope + spanStart hook
-  const headerSpan = httpSpans.find(s => s.description?.includes('/api/header-data'));
-  const mfeOneSpan = httpSpans.find(s => s.description?.includes('/api/mfe-one-data'));
-  const shellSpan = httpSpans.find(s => s.description?.includes('/api/shell-config'));
+  const headerSpan = httpSpans.find(span => hasUrlPath(span, '/api/header-data'));
+  const mfeOneSpan = httpSpans.find(span => hasUrlPath(span, '/api/mfe-one-data'));
+  const shellSpan = httpSpans.find(span => hasUrlPath(span, '/api/shell-config'));
 
   expect(headerSpan).toBeDefined();
   expect(mfeOneSpan).toBeDefined();
   expect(shellSpan).toBeDefined();
 
-  expect(headerSpan?.data?.['mfe.name']).toBe('mfe-header');
-  expect(mfeOneSpan?.data?.['mfe.name']).toBe('mfe-one');
+  expect(headerSpan?.attributes['mfe.name']).toEqual({ value: 'mfe-header', type: 'string' });
+  expect(mfeOneSpan?.attributes['mfe.name']).toEqual({ value: 'mfe-one', type: 'string' });
 
   // Shell span has no MFE tag
-  expect(shellSpan?.data?.['mfe.name']).toBeUndefined();
+  expect(shellSpan?.attributes['mfe.name']).toBeUndefined();
 });

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/src/main.ts
@@ -3,7 +3,6 @@ import MyWorker2 from './worker2.ts?worker';
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: import.meta.env.PUBLIC_E2E_TEST_DSN,
   environment: import.meta.env.MODE || 'development',
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/tests/errors.test.ts
@@ -1,14 +1,18 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForError, waitForStreamedSpan } from '@sentry-internal/test-utils';
+
+function waitForPageloadSpan() {
+  return waitForStreamedSpan('browser-webworker-vite', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
+  });
+}
 
 test('captures an error with debug ids and pageload trace context', async ({ page }) => {
   const errorEventPromise = waitForError('browser-webworker-vite', async event => {
     return !event.type && !!event.exception?.values?.[0];
   });
 
-  const transactionPromise = waitForTransaction('browser-webworker-vite', transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
-  });
+  const pageloadSpanPromise = waitForPageloadSpan();
 
   await page.goto('/');
 
@@ -17,10 +21,7 @@ test('captures an error with debug ids and pageload trace context', async ({ pag
   await page.waitForTimeout(1000);
 
   const errorEvent = await errorEventPromise;
-  const transactionEvent = await transactionPromise;
-
-  const pageloadTraceId = transactionEvent.contexts?.trace?.trace_id;
-  const pageloadSpanId = transactionEvent.contexts?.trace?.span_id;
+  const pageloadSpan = await pageloadSpanPromise;
 
   expect(errorEvent.exception?.values).toHaveLength(1);
   expect(errorEvent.exception?.values?.[0]?.value).toBe('Uncaught Error: Uncaught error in worker');
@@ -28,7 +29,7 @@ test('captures an error with debug ids and pageload trace context', async ({ pag
   expect(errorEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toMatch(/worker-.+\.js$/);
 
   expect(errorEvent.transaction).toBe('/');
-  expect(transactionEvent.transaction).toBe('/');
+  expect(pageloadSpan.name).toBe('Pageload');
 
   expect(errorEvent.request).toEqual({
     url: 'http://localhost:3030/',
@@ -36,8 +37,8 @@ test('captures an error with debug ids and pageload trace context', async ({ pag
   });
 
   expect(errorEvent.contexts?.trace).toEqual({
-    trace_id: pageloadTraceId,
-    span_id: pageloadSpanId,
+    trace_id: pageloadSpan.trace_id,
+    span_id: pageloadSpan.span_id,
   });
 
   expect(errorEvent.debug_meta).toEqual({
@@ -77,9 +78,7 @@ test('captures an error from the second eagerly added worker', async ({ page }) 
     return !event.type && !!event.exception?.values?.[0];
   });
 
-  const transactionPromise = waitForTransaction('browser-webworker-vite', transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
-  });
+  const pageloadSpanPromise = waitForPageloadSpan();
 
   await page.goto('/');
 
@@ -88,10 +87,7 @@ test('captures an error from the second eagerly added worker', async ({ page }) 
   await page.waitForTimeout(1000);
 
   const errorEvent = await errorEventPromise;
-  const transactionEvent = await transactionPromise;
-
-  const pageloadTraceId = transactionEvent.contexts?.trace?.trace_id;
-  const pageloadSpanId = transactionEvent.contexts?.trace?.span_id;
+  const pageloadSpan = await pageloadSpanPromise;
 
   expect(errorEvent.exception?.values).toHaveLength(1);
   expect(errorEvent.exception?.values?.[0]?.value).toBe('Uncaught Error: Uncaught error in worker 2');
@@ -99,7 +95,7 @@ test('captures an error from the second eagerly added worker', async ({ page }) 
   expect(errorEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toMatch(/worker2-.+\.js$/);
 
   expect(errorEvent.transaction).toBe('/');
-  expect(transactionEvent.transaction).toBe('/');
+  expect(pageloadSpan.name).toBe('Pageload');
 
   expect(errorEvent.request).toEqual({
     url: 'http://localhost:3030/',
@@ -107,8 +103,8 @@ test('captures an error from the second eagerly added worker', async ({ page }) 
   });
 
   expect(errorEvent.contexts?.trace).toEqual({
-    trace_id: pageloadTraceId,
-    span_id: pageloadSpanId,
+    trace_id: pageloadSpan.trace_id,
+    span_id: pageloadSpan.span_id,
   });
 
   expect(errorEvent.debug_meta).toEqual({
@@ -127,9 +123,7 @@ test('captures an error from the third lazily added worker', async ({ page }) =>
     return !event.type && !!event.exception?.values?.[0];
   });
 
-  const transactionPromise = waitForTransaction('browser-webworker-vite', transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
-  });
+  const pageloadSpanPromise = waitForPageloadSpan();
 
   await page.goto('/');
 
@@ -138,10 +132,7 @@ test('captures an error from the third lazily added worker', async ({ page }) =>
   await page.waitForTimeout(1000);
 
   const errorEvent = await errorEventPromise;
-  const transactionEvent = await transactionPromise;
-
-  const pageloadTraceId = transactionEvent.contexts?.trace?.trace_id;
-  const pageloadSpanId = transactionEvent.contexts?.trace?.span_id;
+  const pageloadSpan = await pageloadSpanPromise;
 
   expect(errorEvent.exception?.values).toHaveLength(1);
   expect(errorEvent.exception?.values?.[0]?.value).toBe('Uncaught Error: Uncaught error in worker 3');
@@ -149,7 +140,7 @@ test('captures an error from the third lazily added worker', async ({ page }) =>
   expect(errorEvent.exception?.values?.[0]?.stacktrace?.frames?.[0]?.filename).toMatch(/worker3-.+\.js$/);
 
   expect(errorEvent.transaction).toBe('/');
-  expect(transactionEvent.transaction).toBe('/');
+  expect(pageloadSpan.name).toBe('Pageload');
 
   expect(errorEvent.request).toEqual({
     url: 'http://localhost:3030/',
@@ -157,8 +148,8 @@ test('captures an error from the third lazily added worker', async ({ page }) =>
   });
 
   expect(errorEvent.contexts?.trace).toEqual({
-    trace_id: pageloadTraceId,
-    span_id: pageloadSpanId,
+    trace_id: pageloadSpan.trace_id,
+    span_id: pageloadSpan.span_id,
   });
 
   expect(errorEvent.debug_meta).toEqual({

--- a/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/src/app.js
@@ -1,7 +1,6 @@
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
-  traceLifecycle: 'static',
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
 });

--- a/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/__snapshots__/server.test.ts.snap
+++ b/dev-packages/e2e-tests/test-applications/debug-id-sourcemaps/tests/__snapshots__/server.test.ts.snap
@@ -4,13 +4,13 @@ exports[`Find symbolicated event on sentry 1`] = `
 {
   "colno": 41,
   "contextLine": "const eventId = Sentry.captureException(new Error('Sentry Debug ID E2E Test Error'));",
-  "lineno": 9,
+  "lineno": 8,
   "postContext": [
     "",
     "process.stdout.write(eventId);",
   ],
   "preContext": [
-    "  traceLifecycle: 'static',",
+    "Sentry.init({",
     "  environment: 'qa', // dynamic sampling bias to keep transactions",
     "  dsn: process.env.E2E_TEST_DSN,",
     "});",

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/.gitignore
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/.gitignore
@@ -1,0 +1,29 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
+!*.d.ts

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/build.mjs
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/build.mjs
@@ -1,0 +1,49 @@
+import * as path from 'path';
+import * as url from 'url';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import TerserPlugin from 'terser-webpack-plugin';
+import webpack from 'webpack';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+webpack(
+  {
+    entry: path.join(__dirname, 'src/index.js'),
+    output: {
+      path: path.join(__dirname, 'build'),
+      filename: 'app.js',
+    },
+    optimization: {
+      minimize: true,
+      minimizer: [new TerserPlugin()],
+    },
+    plugins: [
+      new webpack.EnvironmentPlugin(['E2E_TEST_DSN']),
+      new HtmlWebpackPlugin({
+        template: path.join(__dirname, 'public/index.html'),
+      }),
+    ],
+    mode: 'production',
+  },
+  (err, stats) => {
+    if (err) {
+      console.error(err.stack || err);
+      if (err.details) {
+        console.error(err.details);
+      }
+      return;
+    }
+
+    const info = stats.toJson();
+
+    if (stats.hasErrors()) {
+      console.error(info.errors);
+      process.exit(1);
+    }
+
+    if (stats.hasWarnings()) {
+      console.warn(info.warnings);
+      process.exit(1);
+    }
+  },
+);

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "default-browser-static-test-app",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@sentry/browser": "file:../../packed/sentry-browser-packed.tgz",
+    "@types/node": "^18.19.1",
+    "typescript": "~5.0.0"
+  },
+  "scripts": {
+    "start": "serve -s build",
+    "build": "node build.mjs",
+    "test": "playwright test",
+    "clean": "npx rimraf node_modules pnpm-lock.yaml",
+    "test:build": "pnpm install && pnpm build",
+    "test:assert": "pnpm test"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  },
+  "devDependencies": {
+    "@playwright/test": "~1.56.0",
+    "@sentry-internal/test-utils": "link:../../../test-utils",
+    "webpack": "^5.91.0",
+    "serve": "14.0.1",
+    "terser-webpack-plugin": "^5.3.10",
+    "html-webpack-plugin": "^5.6.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  }
+}

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/playwright.config.mjs
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/playwright.config.mjs
@@ -1,0 +1,7 @@
+import { getPlaywrightConfig } from '@sentry-internal/test-utils';
+
+const config = getPlaywrightConfig({
+  startCommand: `pnpm start`,
+});
+
+export default config;

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/public/index.html
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/public/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Default Browser App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <input type="button" value="Capture Exception" id="exception-button" />
+
+    <div id="navigation">
+      <a id="navigation-link" href="#navigation-target">Navigation Link</a>
+
+      <div id="navigation-target">Navigated Element</div>
+    </div>
+
+    <!-- The script tags for the bundled JavaScript files will be injected here by HtmlWebpackPlugin in build.mjs-->
+  </body>
+</html>

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/src/index.js
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
 Sentry.init({
+  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [Sentry.browserTracingIntegration()],
   tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/start-event-proxy.mjs
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/start-event-proxy.mjs
@@ -1,0 +1,6 @@
+import { startEventProxyServer } from '@sentry-internal/test-utils';
+
+startEventProxyServer({
+  port: 3031,
+  proxyServerName: 'default-browser-static',
+});

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/tests/errors.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { getSpanOp, waitForError, waitForStreamedSpan } from '@sentry-internal/test-utils';
+import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
 
 test('captures an error', async ({ page }) => {
-  const errorEventPromise = waitForError('default-browser', event => {
+  const errorEventPromise = waitForError('default-browser-static', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'I am an error!';
   });
 
@@ -30,16 +30,16 @@ test('captures an error', async ({ page }) => {
 });
 
 test('sets correct transactionName', async ({ page }) => {
-  const pageloadSpanPromise = waitForStreamedSpan('default-browser', span => {
-    return getSpanOp(span) === 'pageload' && span.is_segment;
+  const transactionPromise = waitForTransaction('default-browser-static', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
   });
 
-  const errorEventPromise = waitForError('default-browser', event => {
+  const errorEventPromise = waitForError('default-browser-static', event => {
     return !event.type && event.exception?.values?.[0]?.value === 'I am an error!';
   });
 
   await page.goto('/');
-  const pageloadSpan = await pageloadSpanPromise;
+  const transactionEvent = await transactionPromise;
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();
@@ -52,7 +52,7 @@ test('sets correct transactionName', async ({ page }) => {
   expect(errorEvent.transaction).toEqual('/');
 
   expect(errorEvent.contexts?.trace).toEqual({
-    trace_id: pageloadSpan.trace_id,
-    span_id: expect.not.stringContaining(pageloadSpan.span_id),
+    trace_id: transactionEvent.contexts?.trace?.trace_id,
+    span_id: expect.not.stringContaining(transactionEvent.contexts?.trace?.span_id || ''),
   });
 });

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/tests/performance.test.ts
@@ -1,0 +1,99 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '@sentry-internal/test-utils';
+
+test('captures a pageload transaction', async ({ page }) => {
+  const transactionPromise = waitForTransaction('default-browser-static', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  });
+
+  await page.goto(`/`);
+
+  const pageLoadTransaction = await transactionPromise;
+
+  expect(pageLoadTransaction).toMatchObject({
+    contexts: {
+      trace: {
+        data: expect.objectContaining({
+          'sentry.idle_span_finish_reason': 'idleTimeout',
+          'sentry.op': 'pageload',
+          'sentry.origin': 'auto.pageload.browser',
+          'sentry.sample_rate': 1,
+          'sentry.segment.name.source': 'url',
+          'url.full': 'http://localhost:3030/',
+          'url.path': '/',
+        }),
+        op: 'pageload',
+        origin: 'auto.pageload.browser',
+        span_id: expect.stringMatching(/[a-f0-9]{16}/),
+        trace_id: expect.stringMatching(/[a-f0-9]{32}/),
+      },
+    },
+    environment: 'qa',
+    event_id: expect.stringMatching(/[a-f0-9]{32}/),
+    measurements: expect.any(Object),
+    platform: 'javascript',
+    release: 'e2e-test',
+    request: {
+      headers: {
+        'User-Agent': expect.any(String),
+      },
+      url: 'http://localhost:3030/',
+    },
+    sdk: {
+      integrations: expect.any(Array),
+      name: 'sentry.javascript.browser',
+      packages: [
+        {
+          name: 'npm:@sentry/browser',
+          version: expect.any(String),
+        },
+      ],
+      version: expect.any(String),
+    },
+    spans: expect.any(Array),
+    start_timestamp: expect.any(Number),
+    timestamp: expect.any(Number),
+    transaction: '/',
+    transaction_info: {
+      source: 'url',
+    },
+    type: 'transaction',
+  });
+});
+
+test('captures a navigation transaction', async ({ page }) => {
+  page.on('console', msg => console.log(msg.text()));
+  const pageLoadTransactionPromise = waitForTransaction('default-browser-static', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  });
+
+  const navigationTransactionPromise = waitForTransaction('default-browser-static', async transactionEvent => {
+    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'navigation';
+  });
+
+  await page.goto(`/`);
+  await pageLoadTransactionPromise;
+
+  const linkElement = page.locator('id=navigation-link');
+
+  await linkElement.click();
+
+  const navigationTransaction = await navigationTransactionPromise;
+
+  expect(navigationTransaction).toMatchObject({
+    contexts: {
+      trace: {
+        op: 'navigation',
+        origin: 'auto.navigation.browser',
+        data: expect.objectContaining({
+          'url.full': 'http://localhost:3030/#navigation-target',
+          'url.path': '/',
+        }),
+      },
+    },
+    transaction: '/',
+    transaction_info: {
+      source: 'url',
+    },
+  });
+});

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/tsconfig.json
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": ["src", "tests"]
+}

--- a/dev-packages/e2e-tests/test-applications/default-browser/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/default-browser/tests/errors.test.ts
@@ -29,7 +29,7 @@ test('captures an error', async ({ page }) => {
   });
 });
 
-test('sets correct transactionName', async ({ page }) => {
+test('sets the pageload span name and error transaction name', async ({ page }) => {
   const pageloadSpanPromise = waitForStreamedSpan('default-browser', span => {
     return getSpanOp(span) === 'pageload' && span.is_segment;
   });
@@ -40,6 +40,7 @@ test('sets correct transactionName', async ({ page }) => {
 
   await page.goto('/');
   const pageloadSpan = await pageloadSpanPromise;
+  expect(pageloadSpan.name).toBe('Pageload');
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();

--- a/dev-packages/e2e-tests/test-applications/default-browser/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/default-browser/tests/performance.test.ts
@@ -1,99 +1,58 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('captures a pageload transaction', async ({ page }) => {
-  const transactionPromise = waitForTransaction('default-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('captures a pageload span', async ({ page }) => {
+  const spanPromise = waitForStreamedSpan('default-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto(`/`);
 
-  const pageLoadTransaction = await transactionPromise;
+  const span = await spanPromise;
 
-  expect(pageLoadTransaction).toMatchObject({
-    contexts: {
-      trace: {
-        data: expect.objectContaining({
-          'sentry.idle_span_finish_reason': 'idleTimeout',
-          'sentry.op': 'pageload',
-          'sentry.origin': 'auto.pageload.browser',
-          'sentry.sample_rate': 1,
-          'sentry.segment.name.source': 'url',
-          'url.full': 'http://localhost:3030/',
-          'url.path': '/',
-        }),
-        op: 'pageload',
-        origin: 'auto.pageload.browser',
-        span_id: expect.stringMatching(/[a-f0-9]{16}/),
-        trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-      },
-    },
-    environment: 'qa',
-    event_id: expect.stringMatching(/[a-f0-9]{32}/),
-    measurements: expect.any(Object),
-    platform: 'javascript',
-    release: 'e2e-test',
-    request: {
-      headers: {
-        'User-Agent': expect.any(String),
-      },
-      url: 'http://localhost:3030/',
-    },
-    sdk: {
-      integrations: expect.any(Array),
-      name: 'sentry.javascript.browser',
-      packages: [
-        {
-          name: 'npm:@sentry/browser',
-          version: expect.any(String),
-        },
-      ],
-      version: expect.any(String),
-    },
-    spans: expect.any(Array),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    transaction: '/',
-    transaction_info: {
-      source: 'url',
-    },
-    type: 'transaction',
+  expect(span.name).toBe('Pageload');
+  expect(span.status).toBe('ok');
+  expect(span.span_id).toMatch(/[a-f0-9]{16}/);
+  expect(span.trace_id).toMatch(/[a-f0-9]{32}/);
+  expect(span.attributes).toMatchObject({
+    'sentry.idle_span_finish_reason': { value: 'idleTimeout', type: 'string' },
+    'sentry.op': { value: 'pageload', type: 'string' },
+    'sentry.origin': { value: 'auto.pageload.browser', type: 'string' },
+    'sentry.sample_rate': { value: 1, type: 'integer' },
+    'sentry.segment.name.source': { value: 'url', type: 'string' },
+    'url.full': { value: 'http://localhost:3030/', type: 'string' },
+    'url.path': { value: '/', type: 'string' },
   });
 });
 
-test('captures a navigation transaction', async ({ page }) => {
+test('captures a navigation span', async ({ page }) => {
   page.on('console', msg => console.log(msg.text()));
-  const pageLoadTransactionPromise = waitForTransaction('default-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  const pageloadSpanPromise = waitForStreamedSpan('default-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const navigationTransactionPromise = waitForTransaction('default-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'navigation';
+  const navigationSpanPromise = waitForStreamedSpan('default-browser', span => {
+    return getSpanOp(span) === 'navigation' && span.is_segment;
   });
 
   await page.goto(`/`);
-  await pageLoadTransactionPromise;
+  await pageloadSpanPromise;
 
   const linkElement = page.locator('id=navigation-link');
 
   await linkElement.click();
 
-  const navigationTransaction = await navigationTransactionPromise;
+  const navigationSpan = await navigationSpanPromise;
 
-  expect(navigationTransaction).toMatchObject({
-    contexts: {
-      trace: {
-        op: 'navigation',
-        origin: 'auto.navigation.browser',
-        data: expect.objectContaining({
-          'url.full': 'http://localhost:3030/#navigation-target',
-          'url.path': '/',
-        }),
-      },
-    },
-    transaction: '/',
-    transaction_info: {
-      source: 'url',
-    },
+  expect(navigationSpan.name).toBe('Navigation');
+  expect(navigationSpan.status).toBe('ok');
+  expect(navigationSpan.span_id).toMatch(/[a-f0-9]{16}/);
+  expect(navigationSpan.trace_id).toMatch(/[a-f0-9]{32}/);
+  expect(navigationSpan.attributes).toMatchObject({
+    'sentry.op': { value: 'navigation', type: 'string' },
+    'sentry.origin': { value: 'auto.navigation.browser', type: 'string' },
+    'sentry.segment.name.source': { value: 'url', type: 'string' },
+    'url.full': { value: 'http://localhost:3030/#navigation-target', type: 'string' },
+    'url.path': { value: '/', type: 'string' },
   });
 });

--- a/dev-packages/e2e-tests/test-applications/effect-3-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/effect-3-browser/src/index.js
@@ -9,7 +9,6 @@ import * as Effect from 'effect/Effect';
 const LogLevelLive = Logger.minimumLogLevel(LogLevel.Debug);
 const AppLayer = Layer.mergeAll(
   Sentry.effectLayer({
-    traceLifecycle: 'static',
     dsn: process.env.E2E_TEST_DSN,
     integrations: [Sentry.browserTracingIntegration(), Sentry.interactionsIntegration()],
     tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/effect-3-browser/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-3-browser/tests/errors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForError, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
 test('captures an error', async ({ page }) => {
   const errorEventPromise = waitForError('effect-3-browser', event => {
@@ -29,8 +29,8 @@ test('captures an error', async ({ page }) => {
 });
 
 test('sets correct transactionName', async ({ page }) => {
-  const transactionPromise = waitForTransaction('effect-3-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  const pageloadSpanPromise = waitForStreamedSpan('effect-3-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   const errorEventPromise = waitForError('effect-3-browser', event => {
@@ -38,7 +38,7 @@ test('sets correct transactionName', async ({ page }) => {
   });
 
   await page.goto('/');
-  const transactionEvent = await transactionPromise;
+  const pageloadSpan = await pageloadSpanPromise;
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();
@@ -50,7 +50,7 @@ test('sets correct transactionName', async ({ page }) => {
   expect(errorEvent.transaction).toEqual('/');
 
   expect(errorEvent.contexts?.trace).toEqual({
-    trace_id: transactionEvent.contexts?.trace?.trace_id,
-    span_id: expect.not.stringContaining(transactionEvent.contexts?.trace?.span_id || ''),
+    trace_id: pageloadSpan.trace_id,
+    span_id: expect.not.stringContaining(pageloadSpan.span_id),
   });
 });

--- a/dev-packages/e2e-tests/test-applications/effect-3-browser/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-3-browser/tests/errors.test.ts
@@ -28,7 +28,7 @@ test('captures an error', async ({ page }) => {
   });
 });
 
-test('sets correct transactionName', async ({ page }) => {
+test('sets the pageload span name and error transaction name', async ({ page }) => {
   const pageloadSpanPromise = waitForStreamedSpan('effect-3-browser', span => {
     return getSpanOp(span) === 'pageload' && span.is_segment;
   });
@@ -39,6 +39,7 @@ test('sets correct transactionName', async ({ page }) => {
 
   await page.goto('/');
   const pageloadSpan = await pageloadSpanPromise;
+  expect(pageloadSpan.name).toBe('Pageload');
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();

--- a/dev-packages/e2e-tests/test-applications/effect-3-browser/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-3-browser/tests/transactions.test.ts
@@ -1,120 +1,78 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('captures a pageload transaction', async ({ page }) => {
-  const transactionPromise = waitForTransaction('effect-3-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('captures a pageload span', async ({ page }) => {
+  const spanPromise = waitForStreamedSpan('effect-3-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto('/');
 
-  const pageLoadTransaction = await transactionPromise;
+  const span = await spanPromise;
 
-  expect(pageLoadTransaction).toMatchObject({
-    contexts: {
-      trace: {
-        data: expect.objectContaining({
-          'sentry.idle_span_finish_reason': 'idleTimeout',
-          'sentry.op': 'pageload',
-          'sentry.origin': 'auto.pageload.browser',
-          'sentry.sample_rate': 1,
-          'sentry.segment.name.source': 'url',
-        }),
-        op: 'pageload',
-        origin: 'auto.pageload.browser',
-        span_id: expect.stringMatching(/[a-f0-9]{16}/),
-        trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-      },
-    },
-    environment: 'qa',
-    event_id: expect.stringMatching(/[a-f0-9]{32}/),
-    measurements: expect.any(Object),
-    platform: 'javascript',
-    release: 'e2e-test',
-    request: {
-      headers: {
-        'User-Agent': expect.any(String),
-      },
-      url: 'http://localhost:3030/',
-    },
-    spans: expect.any(Array),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    transaction: '/',
-    transaction_info: {
-      source: 'url',
-    },
-    type: 'transaction',
+  expect(span.name).toBe('Pageload');
+  expect(span.status).toBe('ok');
+  expect(span.span_id).toMatch(/[a-f0-9]{16}/);
+  expect(span.trace_id).toMatch(/[a-f0-9]{32}/);
+  expect(span.attributes).toMatchObject({
+    'sentry.idle_span_finish_reason': { value: 'idleTimeout', type: 'string' },
+    'sentry.op': { value: 'pageload', type: 'string' },
+    'sentry.origin': { value: 'auto.pageload.browser', type: 'string' },
+    'sentry.sample_rate': { value: 1, type: 'integer' },
+    'sentry.segment.name.source': { value: 'url', type: 'string' },
   });
 });
 
-test('captures a navigation transaction', async ({ page }) => {
-  const pageLoadTransactionPromise = waitForTransaction('effect-3-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('captures a navigation span', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('effect-3-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const navigationTransactionPromise = waitForTransaction('effect-3-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'navigation';
+  const navigationSpanPromise = waitForStreamedSpan('effect-3-browser', span => {
+    return getSpanOp(span) === 'navigation' && span.is_segment;
   });
 
   await page.goto('/');
-  await pageLoadTransactionPromise;
+  await pageloadSpanPromise;
 
   const linkElement = page.locator('id=navigation-link');
   await linkElement.click();
 
-  const navigationTransaction = await navigationTransactionPromise;
+  const navigationSpan = await navigationSpanPromise;
 
-  expect(navigationTransaction).toMatchObject({
-    contexts: {
-      trace: {
-        op: 'navigation',
-        origin: 'auto.navigation.browser',
-      },
-    },
-    transaction: '/',
-    transaction_info: {
-      source: 'url',
-    },
+  expect(navigationSpan.name).toBe('Navigation');
+  expect(navigationSpan.status).toBe('ok');
+  expect(navigationSpan.span_id).toMatch(/[a-f0-9]{16}/);
+  expect(navigationSpan.trace_id).toMatch(/[a-f0-9]{32}/);
+  expect(navigationSpan.attributes).toMatchObject({
+    'sentry.op': { value: 'navigation', type: 'string' },
+    'sentry.origin': { value: 'auto.navigation.browser', type: 'string' },
+    'sentry.segment.name.source': { value: 'url', type: 'string' },
   });
 });
 
 test('captures Effect spans with correct parent-child structure', async ({ page }) => {
-  const pageloadPromise = waitForTransaction('effect-3-browser', transactionEvent => {
-    return transactionEvent?.contexts?.trace?.op === 'pageload';
+  const pageloadSpanPromise = waitForStreamedSpan('effect-3-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const transactionPromise = waitForTransaction('effect-3-browser', transactionEvent => {
-    return (
-      transactionEvent?.contexts?.trace?.op === 'ui.action.click' &&
-      transactionEvent.spans?.some(span => span.description === 'custom-effect-span')
-    );
+  const spansPromise = collectStreamedSpans('effect-3-browser', spans => {
+    return spans.some(span => span.name === 'custom-effect-span') && spans.some(span => span.name === 'nested-span');
   });
 
   await page.goto('/');
-  await pageloadPromise;
+  await pageloadSpanPromise;
 
   const effectSpanButton = page.locator('id=effect-span-button');
   await effectSpanButton.click();
 
   await expect(page.locator('id=effect-span-result')).toHaveText('Span sent!');
 
-  const transactionEvent = await transactionPromise;
-  const spans = transactionEvent.spans || [];
+  const spans = await spansPromise;
 
-  expect(spans).toContainEqual(
-    expect.objectContaining({
-      description: 'custom-effect-span',
-    }),
-  );
-
-  expect(spans).toContainEqual(
-    expect.objectContaining({
-      description: 'nested-span',
-    }),
-  );
-
-  const parentSpan = spans.find(s => s.description === 'custom-effect-span');
-  const nestedSpan = spans.find(s => s.description === 'nested-span');
+  const parentSpan = spans.find(span => span.name === 'custom-effect-span');
+  const nestedSpan = spans.find(span => span.name === 'nested-span');
+  expect(parentSpan).toBeDefined();
+  expect(nestedSpan).toBeDefined();
   expect(nestedSpan?.parent_span_id).toBe(parentSpan?.span_id);
 });

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/src/index.js
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/src/index.js
@@ -9,7 +9,6 @@ import * as Effect from 'effect/Effect';
 
 const AppLayer = Layer.mergeAll(
   Sentry.effectLayer({
-    traceLifecycle: 'static',
     dsn: process.env.E2E_TEST_DSN,
     integrations: [Sentry.browserTracingIntegration(), Sentry.interactionsIntegration()],
     tracesSampleRate: 1.0,

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/tests/errors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { waitForError, waitForTransaction } from '@sentry-internal/test-utils';
+import { getSpanOp, waitForError, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
 test('captures an error', async ({ page }) => {
   const errorEventPromise = waitForError('effect-4-browser', event => {
@@ -29,8 +29,8 @@ test('captures an error', async ({ page }) => {
 });
 
 test('sets correct transactionName', async ({ page }) => {
-  const transactionPromise = waitForTransaction('effect-4-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+  const pageloadSpanPromise = waitForStreamedSpan('effect-4-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   const errorEventPromise = waitForError('effect-4-browser', event => {
@@ -38,7 +38,7 @@ test('sets correct transactionName', async ({ page }) => {
   });
 
   await page.goto('/');
-  const transactionEvent = await transactionPromise;
+  const pageloadSpan = await pageloadSpanPromise;
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();
@@ -50,7 +50,7 @@ test('sets correct transactionName', async ({ page }) => {
   expect(errorEvent.transaction).toEqual('/');
 
   expect(errorEvent.contexts?.trace).toEqual({
-    trace_id: transactionEvent.contexts?.trace?.trace_id,
-    span_id: expect.not.stringContaining(transactionEvent.contexts?.trace?.span_id || ''),
+    trace_id: pageloadSpan.trace_id,
+    span_id: expect.not.stringContaining(pageloadSpan.span_id),
   });
 });

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/tests/errors.test.ts
@@ -28,7 +28,7 @@ test('captures an error', async ({ page }) => {
   });
 });
 
-test('sets correct transactionName', async ({ page }) => {
+test('sets the pageload span name and error transaction name', async ({ page }) => {
   const pageloadSpanPromise = waitForStreamedSpan('effect-4-browser', span => {
     return getSpanOp(span) === 'pageload' && span.is_segment;
   });
@@ -39,6 +39,7 @@ test('sets correct transactionName', async ({ page }) => {
 
   await page.goto('/');
   const pageloadSpan = await pageloadSpanPromise;
+  expect(pageloadSpan.name).toBe('Pageload');
 
   const exceptionButton = page.locator('id=exception-button');
   await exceptionButton.click();

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/tests/transactions.test.ts
@@ -1,120 +1,78 @@
 import { expect, test } from '@playwright/test';
-import { waitForTransaction } from '@sentry-internal/test-utils';
+import { collectStreamedSpans, getSpanOp, waitForStreamedSpan } from '@sentry-internal/test-utils';
 
-test('captures a pageload transaction', async ({ page }) => {
-  const transactionPromise = waitForTransaction('effect-4-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('captures a pageload span', async ({ page }) => {
+  const spanPromise = waitForStreamedSpan('effect-4-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
   await page.goto('/');
 
-  const pageLoadTransaction = await transactionPromise;
+  const span = await spanPromise;
 
-  expect(pageLoadTransaction).toMatchObject({
-    contexts: {
-      trace: {
-        data: expect.objectContaining({
-          'sentry.idle_span_finish_reason': 'idleTimeout',
-          'sentry.op': 'pageload',
-          'sentry.origin': 'auto.pageload.browser',
-          'sentry.sample_rate': 1,
-          'sentry.segment.name.source': 'url',
-        }),
-        op: 'pageload',
-        origin: 'auto.pageload.browser',
-        span_id: expect.stringMatching(/[a-f0-9]{16}/),
-        trace_id: expect.stringMatching(/[a-f0-9]{32}/),
-      },
-    },
-    environment: 'qa',
-    event_id: expect.stringMatching(/[a-f0-9]{32}/),
-    measurements: expect.any(Object),
-    platform: 'javascript',
-    release: 'e2e-test',
-    request: {
-      headers: {
-        'User-Agent': expect.any(String),
-      },
-      url: 'http://localhost:3030/',
-    },
-    spans: expect.any(Array),
-    start_timestamp: expect.any(Number),
-    timestamp: expect.any(Number),
-    transaction: '/',
-    transaction_info: {
-      source: 'url',
-    },
-    type: 'transaction',
+  expect(span.name).toBe('Pageload');
+  expect(span.status).toBe('ok');
+  expect(span.span_id).toMatch(/[a-f0-9]{16}/);
+  expect(span.trace_id).toMatch(/[a-f0-9]{32}/);
+  expect(span.attributes).toMatchObject({
+    'sentry.idle_span_finish_reason': { value: 'idleTimeout', type: 'string' },
+    'sentry.op': { value: 'pageload', type: 'string' },
+    'sentry.origin': { value: 'auto.pageload.browser', type: 'string' },
+    'sentry.sample_rate': { value: 1, type: 'integer' },
+    'sentry.segment.name.source': { value: 'url', type: 'string' },
   });
 });
 
-test('captures a navigation transaction', async ({ page }) => {
-  const pageLoadTransactionPromise = waitForTransaction('effect-4-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'pageload';
+test('captures a navigation span', async ({ page }) => {
+  const pageloadSpanPromise = waitForStreamedSpan('effect-4-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const navigationTransactionPromise = waitForTransaction('effect-4-browser', async transactionEvent => {
-    return !!transactionEvent?.transaction && transactionEvent.contexts?.trace?.op === 'navigation';
+  const navigationSpanPromise = waitForStreamedSpan('effect-4-browser', span => {
+    return getSpanOp(span) === 'navigation' && span.is_segment;
   });
 
   await page.goto('/');
-  await pageLoadTransactionPromise;
+  await pageloadSpanPromise;
 
   const linkElement = page.locator('id=navigation-link');
   await linkElement.click();
 
-  const navigationTransaction = await navigationTransactionPromise;
+  const navigationSpan = await navigationSpanPromise;
 
-  expect(navigationTransaction).toMatchObject({
-    contexts: {
-      trace: {
-        op: 'navigation',
-        origin: 'auto.navigation.browser',
-      },
-    },
-    transaction: '/',
-    transaction_info: {
-      source: 'url',
-    },
+  expect(navigationSpan.name).toBe('Navigation');
+  expect(navigationSpan.status).toBe('ok');
+  expect(navigationSpan.span_id).toMatch(/[a-f0-9]{16}/);
+  expect(navigationSpan.trace_id).toMatch(/[a-f0-9]{32}/);
+  expect(navigationSpan.attributes).toMatchObject({
+    'sentry.op': { value: 'navigation', type: 'string' },
+    'sentry.origin': { value: 'auto.navigation.browser', type: 'string' },
+    'sentry.segment.name.source': { value: 'url', type: 'string' },
   });
 });
 
 test('captures Effect spans with correct parent-child structure', async ({ page }) => {
-  const pageloadPromise = waitForTransaction('effect-4-browser', transactionEvent => {
-    return transactionEvent?.contexts?.trace?.op === 'pageload';
+  const pageloadSpanPromise = waitForStreamedSpan('effect-4-browser', span => {
+    return getSpanOp(span) === 'pageload' && span.is_segment;
   });
 
-  const transactionPromise = waitForTransaction('effect-4-browser', transactionEvent => {
-    return (
-      transactionEvent?.contexts?.trace?.op === 'ui.action.click' &&
-      transactionEvent.spans?.some(span => span.description === 'custom-effect-span')
-    );
+  const spansPromise = collectStreamedSpans('effect-4-browser', spans => {
+    return spans.some(span => span.name === 'custom-effect-span') && spans.some(span => span.name === 'nested-span');
   });
 
   await page.goto('/');
-  await pageloadPromise;
+  await pageloadSpanPromise;
 
   const effectSpanButton = page.locator('id=effect-span-button');
   await effectSpanButton.click();
 
   await expect(page.locator('id=effect-span-result')).toHaveText('Span sent!');
 
-  const transactionEvent = await transactionPromise;
-  const spans = transactionEvent.spans || [];
+  const spans = await spansPromise;
 
-  expect(spans).toContainEqual(
-    expect.objectContaining({
-      description: 'custom-effect-span',
-    }),
-  );
-
-  expect(spans).toContainEqual(
-    expect.objectContaining({
-      description: 'nested-span',
-    }),
-  );
-
-  const parentSpan = spans.find(s => s.description === 'custom-effect-span');
-  const nestedSpan = spans.find(s => s.description === 'nested-span');
+  const parentSpan = spans.find(span => span.name === 'custom-effect-span');
+  const nestedSpan = spans.find(span => span.name === 'nested-span');
+  expect(parentSpan).toBeDefined();
+  expect(nestedSpan).toBeDefined();
   expect(nestedSpan?.parent_span_id).toBe(parentSpan?.span_id);
 });

--- a/dev-packages/e2e-tests/test-applications/webpack-4/entry.js
+++ b/dev-packages/e2e-tests/test-applications/webpack-4/entry.js
@@ -1,7 +1,6 @@
 import { browserTracingIntegration, init } from '@sentry/browser';
 
 init({
-  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [browserTracingIntegration()],
   tunnel: 'http://localhost:3031',

--- a/dev-packages/e2e-tests/test-applications/webpack-5/entry.js
+++ b/dev-packages/e2e-tests/test-applications/webpack-5/entry.js
@@ -1,7 +1,6 @@
 import { browserTracingIntegration, init } from '@sentry/browser';
 
 init({
-  traceLifecycle: 'static',
   dsn: process.env.E2E_TEST_DSN,
   integrations: [browserTracingIntegration()],
   tunnel: 'http://localhost:3031',


### PR DESCRIPTION
Ports the plain browser and bundler E2E apps to the default span-streaming lifecycle, while retaining `default-browser-static` as representative coverage for the legacy static lifecycle. Streamed trace assertions collect spans across envelopes where needed and check low-cardinality segment names.

Fixes #23806