### PR TITLE
ref(bundler-plugins): Replace `find-up` with a local package.json lookup

### DIFF
--- a/packages/bundler-plugins/package.json
+++ b/packages/bundler-plugins/package.json
@@ -113,7 +113,6 @@
     "@babel/core": "^7.18.5",
     "@sentry/core": "10.67.0",
     "dotenv": "^17.4.2",
-    "find-up": "^5.0.0",
     "glob": "^13.0.6",
     "magic-string": "~0.30.8",
     "sentry": "^0.44.0",

--- a/packages/bundler-plugins/src/core/utils.ts
+++ b/packages/bundler-plugins/src/core/utils.ts
@@ -1,5 +1,4 @@
 /* oxlint-disable max-lines */
-import findUp from 'find-up';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -138,18 +137,32 @@ export function getDependencies(packageJson: PackageJson): {
   return { deps, depsVersions };
 }
 
-function lookupPackageJson(cwd: string, stopAt: string): PackageJson | undefined {
-  const jsonPath = findUp.sync(
-    dirName => {
-      // Stop if we reach this dir
-      if (path.normalize(dirName) === stopAt) {
-        return findUp.stop;
-      }
+function findPackageJson(cwd: string, stopAt: string): string | undefined {
+  let dirName = path.resolve(cwd);
 
-      return findUp.sync.exists(`${dirName}/package.json`) ? 'package.json' : undefined;
-    },
-    { cwd },
-  );
+  for (;;) {
+    // Stop if we reach this dir
+    if (path.normalize(dirName) === stopAt) {
+      return undefined;
+    }
+
+    const jsonPath = path.join(dirName, 'package.json');
+    if (fs.existsSync(jsonPath)) {
+      return jsonPath;
+    }
+
+    const parentDirName = path.dirname(dirName);
+    // We reached the file system root
+    if (parentDirName === dirName) {
+      return undefined;
+    }
+
+    dirName = parentDirName;
+  }
+}
+
+function lookupPackageJson(cwd: string, stopAt: string): PackageJson | undefined {
+  const jsonPath = findPackageJson(cwd, stopAt);
 
   if (!jsonPath) {
     return undefined;

--- a/packages/bundler-plugins/test/core/utils.test.ts
+++ b/packages/bundler-plugins/test/core/utils.test.ts
@@ -61,6 +61,21 @@ describe('getPackageJson', () => {
 
     expect(packageJson).toBeUndefined();
   });
+
+  test('it stops at the file system root when `stopAt` is never reached', () => {
+    const existsSyncSpy = vi.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    try {
+      const packageJson = getPackageJson({
+        cwd: getCwdFor('/fixtures/no-valid-package/deeply/nested'),
+        stopAt: getCwdFor('/fixtures/this-directory-is-not-an-ancestor'),
+      });
+
+      expect(packageJson).toBeUndefined();
+    } finally {
+      existsSyncSpy.mockRestore();
+    }
+  });
 });
 
 describe('parseMajorVersion', () => {


### PR DESCRIPTION
## What

Drops the `find-up` dependency from `@sentry/bundler-plugins` and walks the directory tree directly in `lookupPackageJson`. Behavior is unchanged.

## Why

`find-up` is pure ESM from v6 on, so dependabot's bump to v8 (#23703) breaks the CJS build of a package we publish. The plugin only used `find-up` to test whether a `package.json` exists and then walked the tree itself anyway, so a local loop removes the dependency and the interop risk at the same time. Supersedes #23703.