### PR TITLE
test(e2e): Restore dropped url attribute assertions in the astro-4 and astro-5 specs

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-4/tests/tracing.static.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-4/tests/tracing.static.test.ts
@@ -33,6 +33,9 @@ test.describe('tracing in static/pre-rendered routes', () => {
       'sentry.op': { value: 'pageload', type: 'string' },
       'sentry.origin': { value: 'auto.pageload.astro', type: 'string' },
       'sentry.segment.name.source': { value: 'route', type: 'string' },
+      'url.template': { value: '/test-static', type: 'string' },
+      'url.path': { value: '/test-static', type: 'string' },
+      'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/test-static$/), type: 'string' },
     });
 
     await page.waitForTimeout(1000); // wait another sec to ensure no server span is sent

--- a/dev-packages/e2e-tests/test-applications/astro-5/tests/tracing.serverIslands.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-5/tests/tracing.serverIslands.test.ts
@@ -34,6 +34,9 @@ test.describe('tracing in static routes with server islands', () => {
       'sentry.op': { value: 'pageload', type: 'string' },
       'sentry.origin': { value: 'auto.pageload.astro', type: 'string' },
       'sentry.segment.name.source': { value: 'route', type: 'string' },
+      'url.template': { value: '/server-island', type: 'string' },
+      'url.path': { value: '/server-island', type: 'string' },
+      'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/server-island$/), type: 'string' },
     });
 
     // the pageload trace contains a resource link span for the preloaded server island request.

--- a/dev-packages/e2e-tests/test-applications/astro-5/tests/tracing.static.test.ts
+++ b/dev-packages/e2e-tests/test-applications/astro-5/tests/tracing.static.test.ts
@@ -33,6 +33,9 @@ test.describe('tracing in static/pre-rendered routes', () => {
       'sentry.op': { value: 'pageload', type: 'string' },
       'sentry.origin': { value: 'auto.pageload.astro', type: 'string' },
       'sentry.segment.name.source': { value: 'route', type: 'string' },
+      'url.template': { value: '/test-static', type: 'string' },
+      'url.path': { value: '/test-static', type: 'string' },
+      'url.full': { value: expect.stringMatching(/^https?:\/\/localhost:\d+\/test-static$/), type: 'string' },
     });
 
     await page.waitForTimeout(1000); // wait another sec to ensure no server span is sent


### PR DESCRIPTION
## What

Puts `url.template`, `url.path` and `url.full` back on the client pageload assertions in `astro-4/tests/tracing.static`, `astro-5/tests/tracing.static` and `astro-5/tests/tracing.serverIslands`, as streamed span attributes.

## Why

The span-streaming ports (#24079, #24078) dropped them by accident. Lukas spotted the same drop in astro-6 on #24077, where it is fixed in place; these two apps had already merged.

Ref: #23809