### PR TITLE
fix(ember): Guard `routerService.recognize()` against unrecognizable URLs

### DIFF
--- a/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
+++ b/packages/ember/src/utils/instrumentEmberAppInstanceForPerformance.ts
@@ -63,7 +63,7 @@ export function instrumentEmberAppInstanceForPerformance(
     // Somehow the router service etc. may not be fully ready/initialized yet at this point
     // Probably because we are running this before the Ember setup is necessarily completed
     // So in order to accomodate this, we fall back to starting the pageload span with the current URL and update it later
-    const routeInfo = url ? routerService.recognize(url) : undefined;
+    const routeInfo = url ? _recognizeURL(routerService, url) : undefined;
 
     activeRootSpan = startBrowserTracingPageLoadSpan(client, {
       // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
@@ -129,7 +129,7 @@ export function instrumentEmberAppInstanceForPerformance(
       const location = getRouterMain(appInstance).location;
       const url = _getLocationURL(location);
       if (url) {
-        const routeInfo = routerService.recognize(url);
+        const routeInfo = _recognizeURL(routerService, url);
         activeRootSpan.updateName(`route:${toRoute}`);
         activeRootSpan.setAttributes({
           [SENTRY_SEGMENT_NAME_SOURCE]: 'route',
@@ -164,7 +164,7 @@ export function instrumentEmberAppInstanceForPerformance(
 
     const url = routerService.currentURL ?? _getLocationURL(location);
     if (url) {
-      const routeInfo = routerService.recognize(url);
+      const routeInfo = _recognizeURL(routerService, url);
       // `currentURL` is the normalized route path and never includes the hash fragment, so we source
       // `url.full` from the location URL (which preserves `#/...` for hash-location apps) when available.
       const fullUrl = _getLocationURL(location) || url;
@@ -256,6 +256,23 @@ function _getRouteUrlAttributes(
     [URL_FULL]: filterCollectedUrl(getAbsoluteUrl(fullUrl), client),
     [URL_TEMPLATE]: buildUrlTemplate(path, params),
   };
+}
+
+// Only exported for testing
+export function _recognizeURL(
+  routerService: RouterService,
+  url: string,
+): ReturnType<RouterService['recognize']> | undefined {
+  // `recognize()` throws for URLs the router cannot resolve. Most notably it asserts
+  // "You must pass a url that begins with the application's rootURL" whenever the URL is not
+  // prefixed with the app's `rootURL`, which is the case under Ember's `none` location (used by
+  // `@ember/test-helpers`). Every call site already treats a missing `routeInfo` as "fall back
+  // to the URL", so degrade to that instead of throwing out of the integration's setup.
+  try {
+    return routerService.recognize(url);
+  } catch {
+    return undefined;
+  }
 }
 
 // Only exported for testing

--- a/packages/ember/tests/instrument-router-location.test.ts
+++ b/packages/ember/tests/instrument-router-location.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { _getLocationURL } from '../src/utils/instrumentEmberAppInstanceForPerformance.ts';
+import { _getLocationURL, _recognizeURL } from '../src/utils/instrumentEmberAppInstanceForPerformance.ts';
 
 interface Location {
   formatURL?: (url: string) => string;
@@ -78,5 +78,38 @@ describe('_getLocationURL', () => {
     };
 
     expect(_getLocationURL(mockLocation)).toBe('');
+  });
+});
+
+type RouterServiceArg = Parameters<typeof _recognizeURL>[0];
+
+function mockRouterService(recognize: (url: string) => unknown): RouterServiceArg {
+  return { recognize } as unknown as RouterServiceArg;
+}
+
+describe('_recognizeURL', () => {
+  it('returns the route info when the router recognizes the URL', () => {
+    const routeInfo = { name: 'my.route', params: { id: '1' } };
+    const routerService = mockRouterService(() => routeInfo);
+
+    expect(_recognizeURL(routerService, '/my/route/1')).toBe(routeInfo);
+  });
+
+  it('returns undefined when the URL is not prefixed with the rootURL', () => {
+    // Ember's `none` location (used by `@ember/test-helpers`) yields URLs that `recognize()`
+    // rejects with this assertion, which previously threw out of the integration's setup.
+    const routerService = mockRouterService(() => {
+      throw new Error('Assertion Failed: You must pass a url that begins with the application\'s rootURL "/"');
+    });
+
+    expect(_recognizeURL(routerService, 'not-root-url-prefixed')).toBeUndefined();
+  });
+
+  it('returns undefined for any other recognize() failure', () => {
+    const routerService = mockRouterService(() => {
+      throw new Error('nope');
+    });
+
+    expect(_recognizeURL(routerService, '/unknown')).toBeUndefined();
   });
 });


### PR DESCRIPTION
- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
- [ ] Link an issue if there is one related to your pull request. If no issue is linked, one will be auto-generated and linked.

---

`instrumentEmberAppInstanceForPerformance` calls `routerService.recognize(url)` at three sites without guarding it.

`recognize()` throws for URLs the router cannot resolve. Most notably it asserts:

```
Assertion Failed: You must pass a url that begins with the application's rootURL "/"
```

whenever the URL is not prefixed with the app's `rootURL` — which is the case under Ember's `none` location, the one `@ember/test-helpers` installs. Since the first call happens inside `browserTracingIntegration`'s `afterAllSetup`, the assertion propagates out of integration setup and takes down every acceptance test that boots the app.

Reproducing it needs nothing exotic — an app that calls `instrumentAppInstancePerformance(appInstance)` and has any acceptance test using `visit()` will hit it. Host apps currently have to work around it by skipping instrumentation under test entirely, which also costs them tracing coverage in tests.

### The fix

All three call sites are *already written* for a missing `routeInfo`:

```ts
name: routeInfo ? `route:${routeInfo.name}` : /* …URL fallback… */   // pageload span
_getRouteUrlAttributes(client, url, routeInfo?.params)               // routeWillChange
routeInfo?.params ?? transition.to?.params                           // routeDidChange
```

The only thing missing is that `recognize()` *throws* instead of returning `undefined`. This routes the three sites through a small `_recognizeURL()` helper that catches and degrades to `undefined`, matching the intent the surrounding code already expresses. No intended behavior changes — a URL the router can resolve behaves exactly as before.

### Notes

- Follows the existing `_getLocationURL` convention in this module (`// Only exported for testing`).
- Return type is derived as `ReturnType<RouterService['recognize']> | undefined`, so no new imports.
- Tests are appended to `tests/instrument-router-location.test.ts`, which already covers this module: recognized URL passes through, the `rootURL` assertion yields `undefined`, and any other throw yields `undefined`.
- Happy to add a `DEBUG_BUILD`-gated debug log in the `catch` if you'd prefer the failure be visible rather than silent — left it out to keep the change minimal.

Affects the v2 addon introduced in #23252; still present on `develop` and in `11.0.0-beta.1`.
