### PR TITLE
fix(remix): Strip trailing underscore from route segments

### DIFF
--- a/packages/remix/src/config/createRemixRouteManifest.ts
+++ b/packages/remix/src/config/createRemixRouteManifest.ts
@@ -36,6 +36,7 @@ function isRouteFile(filename: string): boolean {
  *   - users/$id.tsx (nested folder) -> /users/:id
  *   - users/$id/posts.tsx (nested folder) -> /users/:id/posts
  *   - users/_index.tsx (nested folder) -> /users
+ *   - concerts_.mine.tsx -> /concerts/mine (trailing underscore opts out of layout nesting only)
  *   - _layout.tsx -> null (pathless layout route, not URL-addressable)
  *   - _auth.tsx -> null (pathless layout route, not URL-addressable)
  *
@@ -75,18 +76,22 @@ export function convertRemixRouteToPath(filename: string): { path: string; isDyn
       continue;
     }
 
-    if (segment === '$') {
+    // A trailing underscore opts a segment out of layout nesting without appearing in the URL,
+    // so it has to be dropped before the segment is turned into a path segment.
+    const pathSegment = segment.endsWith('_') ? segment.slice(0, -1) : segment;
+
+    if (pathSegment === '$') {
       pathSegments.push(':*');
       isDynamic = true;
       continue;
     }
 
-    if (segment.startsWith('$')) {
-      const paramName = segment.substring(1);
+    if (pathSegment.startsWith('$')) {
+      const paramName = pathSegment.substring(1);
       pathSegments.push(`:${paramName}`);
       isDynamic = true;
     } else {
-      pathSegments.push(segment);
+      pathSegments.push(pathSegment);
     }
   }
 

--- a/packages/remix/src/utils/utils.ts
+++ b/packages/remix/src/utils/utils.ts
@@ -70,19 +70,23 @@ export function convertRemixRouteIdToPath(routeId: string): string {
       continue;
     }
 
+    // A trailing underscore opts a segment out of layout nesting without appearing in the URL,
+    // so it has to be dropped before the segment is turned into a path segment.
+    const pathSegment = segment.endsWith('_') ? segment.slice(0, -1) : segment;
+
     // Handle splat routes (catch-all)
     // Remix accesses splat params via params["*"] at runtime
-    if (segment === '$') {
+    if (pathSegment === '$') {
       pathSegments.push(':*');
       continue;
     }
 
     // Handle dynamic segments (prefixed with $)
-    if (segment.startsWith('$')) {
-      const paramName = segment.substring(1);
+    if (pathSegment.startsWith('$')) {
+      const paramName = pathSegment.substring(1);
       pathSegments.push(`:${paramName}`);
     } else {
-      pathSegments.push(segment);
+      pathSegments.push(pathSegment);
     }
   }
 

--- a/packages/remix/test/config/routeConversion.test.ts
+++ b/packages/remix/test/config/routeConversion.test.ts
@@ -146,6 +146,25 @@ describe('Route Conversion Consistency', () => {
     });
   });
 
+  describe('Trailing underscore routes', () => {
+    it('should strip a trailing underscore at build time and at runtime', () => {
+      const buildTime = convertRemixRouteToPath('concerts_.mine.tsx');
+      const runtime = convertRemixRouteIdToPath('routes/concerts_.mine');
+
+      expect(buildTime?.path).toBe('/concerts/mine');
+      expect(runtime).toBe('/concerts/mine');
+    });
+
+    it('should strip a trailing underscore from dynamic segments', () => {
+      const buildTime = convertRemixRouteToPath('app.projects.$id_.roadmap.tsx');
+      const runtime = convertRemixRouteIdToPath('routes/app.projects.$id_.roadmap');
+
+      expect(buildTime?.path).toBe('/app/projects/:id/roadmap');
+      expect(buildTime?.isDynamic).toBe(true);
+      expect(runtime).toBe('/app/projects/:id/roadmap');
+    });
+  });
+
   describe('Pathless layout routes', () => {
     it('should return null for standalone pathless layout routes', () => {
       // These are layout routes that don't contribute to the URL path

--- a/packages/remix/test/utils/utils.test.ts
+++ b/packages/remix/test/utils/utils.test.ts
@@ -16,9 +16,21 @@ describe('getTransactionName', () => {
       id: 'routes/blog.$slug',
       path: '/blog/:slug',
     },
+    {
+      id: 'routes/concerts_.mine',
+      path: '/concerts/mine',
+    },
   ];
 
   describe('route parameterization', () => {
+    it('should not leak a trailing underscore into the transaction name', () => {
+      const url = new URL('http://localhost/concerts/mine');
+      const [name, source] = getTransactionName(mockRoutes, url);
+
+      expect(name).toBe('/concerts/mine');
+      expect(source).toBe('route');
+    });
+
     it('should return parameterized path for matched dynamic routes', () => {
       const url = new URL('http://localhost/user/123');
       const [name, source] = getTransactionName(mockRoutes, url);
@@ -147,6 +159,21 @@ describe('convertRemixRouteIdToPath', () => {
 
     it('should handle multiple pathless layouts', () => {
       expect(convertRemixRouteIdToPath('routes/_auth._layout.login')).toBe('/login');
+    });
+  });
+
+  describe('trailing underscore routes', () => {
+    it('should strip a trailing underscore from static segments', () => {
+      expect(convertRemixRouteIdToPath('routes/concerts_.mine')).toBe('/concerts/mine');
+      expect(convertRemixRouteIdToPath('routes/app_.projects.$id.roadmap')).toBe('/app/projects/:id/roadmap');
+    });
+
+    it('should strip a trailing underscore from dynamic segments', () => {
+      expect(convertRemixRouteIdToPath('routes/app.projects.$id_.roadmap')).toBe('/app/projects/:id/roadmap');
+    });
+
+    it('should still skip segments that also start with an underscore', () => {
+      expect(convertRemixRouteIdToPath('routes/_auth_.login')).toBe('/login');
     });
   });
 


### PR DESCRIPTION
A trailing underscore opts a Remix v2 route segment out of layout nesting without appearing in the URL, so `routes/concerts_.mine` was named `/concerts_/mine` — with source `route`, matching no real URL.

Fixed in both converters (runtime naming and the build-time manifest). The strip runs after the pathless-layout check and before the dynamic-segment handling, mirroring Remix's `createRoutePath`: `_auth_.login` stays a skipped layout, and `$id_` resolves to `:id`.

Fixes #24119