### PR TITLE
fix(server-utils): Repoint SQL util imports after move out of core

### DIFF
--- a/packages/nuxt/src/runtime/utils/instrumentDatabase.ts
+++ b/packages/nuxt/src/runtime/utils/instrumentDatabase.ts
@@ -13,7 +13,8 @@ import {
   startSpan,
   type StartSpanOptions,
 } from '@sentry/core';
-import { _INTERNAL_getSqlQuerySummary, _INTERNAL_sanitizeSqlQuery, flushIfServerless } from '@sentry/core/server';
+import { flushIfServerless } from '@sentry/core/server';
+import { getSqlQuerySummary, sanitizeSqlQuery } from '@sentry/server-utils';
 import type { Database, PreparedStatement } from 'db0';
 import { type DatabaseConnectionConfig, type DatabaseSpanData, getDatabaseSpanData } from './database-span-data';
 import { DB_NAMESPACE, DB_QUERY_SUMMARY, DB_QUERY_TEXT, DB_SYSTEM_NAME } from '@sentry/conventions/attributes';
@@ -249,7 +250,7 @@ function createBreadcrumb(query: string): void {
  * Creates a start span options object.
  */
 function createStartSpanOptions(query: string, data: DatabaseSpanData): StartSpanOptions {
-  const querySummary = query ? _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(query)) : undefined;
+  const querySummary = query ? getSqlQuerySummary(sanitizeSqlQuery(query)) : undefined;
 
   const client = getClient();
   const name =

--- a/packages/server-utils/src/integrations/knex.ts
+++ b/packages/server-utils/src/integrations/knex.ts
@@ -33,7 +33,7 @@ import { DB } from '@sentry/conventions/op';
 import { DEBUG_BUILD } from '../debug-build';
 import { CHANNELS } from '../orchestrion/channels';
 import { bindTracingChannelToSpan } from '../tracing-channel';
-import { _INTERNAL_getSqlQuerySummary, _INTERNAL_sanitizeSqlQuery } from '@sentry/core/server';
+import { getSqlQuerySummary, sanitizeSqlQuery } from '../utils/sql';
 
 // NOTE: this uses the same name as the OTel integration by design. `@sentry/node`'s `knexIntegration`
 // picks this subscriber over the vendored OTel path when orchestrion injection is active.
@@ -176,9 +176,7 @@ function subscribeQuery(): void {
 
       const dbStatement = query?.sql != null ? truncate(query.sql, MAX_QUERY_LENGTH) : undefined;
       const dialect = client?.driverName === 'mysql' || client?.driverName === 'mysql2' ? 'mysql' : undefined;
-      const querySummary = dbStatement
-        ? _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(dbStatement, dialect))
-        : undefined;
+      const querySummary = dbStatement ? getSqlQuerySummary(sanitizeSqlQuery(dbStatement, dialect)) : undefined;
       const attributes: SpanAttributes = {
         [SENTRY_OP]: DB,
         [SENTRY_KIND]: 'client',

--- a/packages/server-utils/src/integrations/prisma/tracing-helper.ts
+++ b/packages/server-utils/src/integrations/prisma/tracing-helper.ts
@@ -35,7 +35,7 @@ import {
   SENTRY_KIND,
   SENTRY_OP,
 } from '@sentry/conventions/attributes';
-import { _INTERNAL_getSqlQuerySummary, _INTERNAL_sanitizeSqlQuery } from '@sentry/core/server';
+import { getSqlQuerySummary, sanitizeSqlQuery } from '../../utils/sql';
 
 // Reading `process.env` can throw in runtimes that gate env access (e.g. Deno without `--allow-env`)
 // and `process` may be absent altogether (edge runtimes), so this degrades to `false` in those cases.
@@ -117,7 +117,7 @@ function buildSpanAttributes(name: string, attributes: Record<string, unknown> |
   if (statement) {
     // Sanitized before summarizing, so that a string literal containing `from`/`join` can't leak a
     // value into the summary.
-    merged[DB_QUERY_SUMMARY] = _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(statement));
+    merged[DB_QUERY_SUMMARY] = getSqlQuerySummary(sanitizeSqlQuery(statement));
   }
 
   return merged;

--- a/packages/server-utils/src/integrations/tedious.ts
+++ b/packages/server-utils/src/integrations/tedious.ts
@@ -28,7 +28,7 @@ import { DB } from '@sentry/conventions/op';
 import { CHANNELS } from '../orchestrion/channels';
 import { tediousModuleNames } from '../orchestrion/config/tedious';
 import { invokeOrchestrionInstrumentation } from '../orchestrion/instrumentation';
-import { _INTERNAL_getSqlQuerySummary, _INTERNAL_sanitizeSqlQuery } from '@sentry/core/server';
+import { getSqlQuerySummary, sanitizeSqlQuery } from '../utils/sql';
 
 // NOTE: this uses the same name as the OTel integration by design. When orchestrion injection is active,
 // `_init` swaps the OTel `Tedious` integration out of the defaults and appends this one (matched by name).
@@ -132,8 +132,7 @@ function subscribeQuery(channelName: string, operation: string): void {
 
     const databaseName = connection[currentDatabaseSymbol];
     const sql = extractSql(request);
-    const querySummary =
-      sql && operation !== 'callProcedure' ? _INTERNAL_getSqlQuerySummary(_INTERNAL_sanitizeSqlQuery(sql)) : undefined;
+    const querySummary = sql && operation !== 'callProcedure' ? getSqlQuerySummary(sanitizeSqlQuery(sql)) : undefined;
 
     const attributes: SpanAttributes = {
       [SENTRY_OP]: DB,


### PR DESCRIPTION
#23828 moved the SQL utils out of `@sentry/core/server`, but four call sites kept importing the old `_INTERNAL_`-prefixed names from core, breaking the build on `develop`.