### PR TITLE
feat(v10): Streamline isolation scope handling & reset in isolation scopes

### DIFF
--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -19,7 +19,6 @@ import {
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromSpan,
-  getIsolationScope,
   getLocationHref,
   GLOBAL_OBJ,
   hasSpansEnabled,
@@ -585,12 +584,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
         lastInteractionTimestamp = undefined;
 
         maybeEndActiveSpan();
-
-        getIsolationScope().setPropagationContext({
-          traceId: generateTraceId(),
-          sampleRand: Math.random(),
-          propagationSpanId: hasSpansEnabled() ? undefined : generateSpanId(),
-        });
 
         const scope = getCurrentScope();
         scope.setPropagationContext({

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -928,12 +928,10 @@ describe('browserTracingIntegration', () => {
       setCurrentClient(client);
       client.init();
 
-      const oldIsolationScopePropCtx = getIsolationScope().getPropagationContext();
       const oldCurrentScopePropCtx = getCurrentScope().getPropagationContext();
 
       startBrowserTracingNavigationSpan(client, { name: 'test navigation span' });
 
-      const newIsolationScopePropCtx = getIsolationScope().getPropagationContext();
       const newCurrentScopePropCtx = getCurrentScope().getPropagationContext();
 
       expect(oldCurrentScopePropCtx).toEqual({
@@ -941,24 +939,13 @@ describe('browserTracingIntegration', () => {
         propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
-      expect(oldIsolationScopePropCtx).toEqual({
-        traceId: expect.stringMatching(/[a-f0-9]{32}/),
-        sampleRand: expect.any(Number),
-      });
+
       expect(newCurrentScopePropCtx).toEqual({
         traceId: expect.stringMatching(/[a-f0-9]{32}/),
         propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
         sampleRand: expect.any(Number),
       });
-      expect(newIsolationScopePropCtx).toEqual({
-        traceId: expect.stringMatching(/[a-f0-9]{32}/),
-        propagationSpanId: expect.stringMatching(/[a-f0-9]{16}/),
-        sampleRand: expect.any(Number),
-      });
-
-      expect(newIsolationScopePropCtx.traceId).not.toEqual(oldIsolationScopePropCtx.traceId);
       expect(newCurrentScopePropCtx.traceId).not.toEqual(oldCurrentScopePropCtx.traceId);
-      expect(newIsolationScopePropCtx.propagationSpanId).not.toEqual(oldIsolationScopePropCtx.propagationSpanId);
     });
 
     it("saves the span's positive sampling decision and its DSC on the propagationContext when the span finishes", () => {

--- a/packages/cloudflare/src/async.ts
+++ b/packages/cloudflare/src/async.ts
@@ -4,8 +4,11 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
 import {
   _INTERNAL_createTracingChannelBinding,
+  _INTERNAL_safeMathRandom,
+  generateTraceId,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
+  isContinuingTrace,
   setAsyncContextStrategy,
 } from '@sentry/core';
 
@@ -55,8 +58,25 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
   }
 
   function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T {
-    const scope = getScopes().scope;
+    // The current scope is forked alongside the isolation scope, matching the OpenTelemetry strategy
+    // (`buildContextWithSentryScopes` clones it on every fork). Sharing it by reference would let
+    // the propagation context reset below leak back out to the caller.
+    const scope = getScopes().scope.clone();
     const isolationScope = getScopes().isolationScope.clone();
+
+    // When forking an isolation scope, unless we are continuing an incoming
+    // trace, we give the freshly forked scope its own trace. This way, new
+    // root spans in an isolation scope will get separate traces. The previous
+    // trace's `sampled` and `propagationSpanId` are dropped on purpose.
+    // Carrying them over would apply the old trace's sampling decision to the
+    // new one and propagate a span id from a different trace.
+    if (!isContinuingTrace(scope.getPropagationContext())) {
+      scope.setPropagationContext({
+        traceId: generateTraceId(),
+        sampleRand: _INTERNAL_safeMathRandom(),
+      });
+    }
+
     return asyncStorage.run({ scope, isolationScope }, () => {
       return callback(isolationScope);
     });

--- a/packages/cloudflare/test/async.test.ts
+++ b/packages/cloudflare/test/async.test.ts
@@ -167,4 +167,92 @@ describe('withIsolationScope()', () => {
         done();
       });
     }));
+
+  it('forks the current scope as well, so mutations do not leak out', () =>
+    new Promise<void>(done => {
+      const initialScope = getCurrentScope();
+      initialScope.setTag('aa', 'aa');
+
+      withIsolationScope(() => {
+        const scope = getCurrentScope();
+        expect(scope).not.toBe(initialScope);
+        expect(scope.getScopeData().tags).toEqual({ aa: 'aa' });
+
+        scope.setTag('bb', 'bb');
+        done();
+      });
+
+      expect(initialScope.getScopeData().tags).toEqual({ aa: 'aa' });
+    }));
+
+  it('gives each forked isolation scope its own trace id when not continuing an incoming trace', () => {
+    const traceIds: string[] = [];
+
+    withIsolationScope(() => {
+      traceIds.push(getCurrentScope().getPropagationContext().traceId);
+    });
+    withIsolationScope(() => {
+      traceIds.push(getCurrentScope().getPropagationContext().traceId);
+    });
+
+    expect(traceIds[0]).toMatch(/^[a-f0-9]{32}$/);
+    expect(traceIds[1]).toMatch(/^[a-f0-9]{32}$/);
+    expect(traceIds[0]).not.toBe(traceIds[1]);
+  });
+
+  it('keeps the trace id when continuing an incoming trace (parentSpanId set)', () => {
+    const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+    getCurrentScope().setPropagationContext({
+      traceId: incomingTraceId,
+      parentSpanId: '1234567890abcdef',
+      sampleRand: 0.42,
+    });
+
+    withIsolationScope(() => {
+      expect(getCurrentScope().getPropagationContext().traceId).toBe(incomingTraceId);
+    });
+  });
+
+  // A trace-id-only `sentry-trace` header yields a propagation context with a `dsc` but no
+  // `parentSpanId`, because the span id is optional in the header. Such a trace is still being
+  // continued, so its trace id must survive the fork.
+  it('keeps the trace id when continuing an incoming trace without a span id (dsc set)', () => {
+    const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+    getCurrentScope().setPropagationContext({
+      traceId: incomingTraceId,
+      sampleRand: 0.42,
+      dsc: { trace_id: incomingTraceId, sample_rate: '1' },
+    });
+
+    withIsolationScope(() => {
+      const propagationContext = getCurrentScope().getPropagationContext();
+
+      expect(propagationContext.traceId).toBe(incomingTraceId);
+      expect(propagationContext.dsc).toEqual({ trace_id: incomingTraceId, sample_rate: '1' });
+    });
+  });
+
+  // A new trace must not inherit the previous trace's sampling decision or propagation span id.
+  // Keeping them would apply the old trace's sampling decision to the new one and propagate a
+  // span id belonging to a different trace.
+  it('drops the previous trace data when giving a forked isolation scope its own trace', () => {
+    const oldTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    getCurrentScope().setPropagationContext({
+      traceId: oldTraceId,
+      sampleRand: 0.1,
+      sampled: true,
+      propagationSpanId: 'bbbbbbbbbbbbbbbb',
+    });
+
+    withIsolationScope(() => {
+      const propagationContext = getCurrentScope().getPropagationContext();
+
+      expect(propagationContext.traceId).toMatch(/^[a-f0-9]{32}$/);
+      expect(propagationContext.traceId).not.toBe(oldTraceId);
+      expect(propagationContext.sampleRand).toEqual(expect.any(Number));
+      expect(propagationContext.sampled).toBeUndefined();
+      expect(propagationContext.propagationSpanId).toBeUndefined();
+      expect(propagationContext.dsc).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -1,10 +1,8 @@
 import type { AttributeObject, RawAttribute, RawAttributes } from './attributes';
-import { getClient, getCurrentScope, getIsolationScope, withIsolationScope } from './currentScopes';
+import { getClient, getCurrentScope, getIsolationScope } from './currentScopes';
 import { DEBUG_BUILD } from './debug-build';
 import type { CaptureContext } from './scope';
 import { closeSession, makeSession, updateSession } from './session';
-import { startNewTrace } from './tracing/trace';
-import type { CheckIn, FinishedCheckIn, MonitorConfig } from './types/checkin';
 import type { Event, EventHint } from './types/event';
 import type { EventProcessor } from './types/eventprocessor';
 import type { Extra, Extras } from './types/extra';
@@ -13,12 +11,9 @@ import type { Session, SessionContext } from './types/session';
 import type { SeverityLevel } from './types/severity';
 import type { User } from './types/user';
 import { debug } from './utils/debug-logger';
-import { isThenable } from './utils/is';
-import { uuid4 } from './utils/misc';
 import type { ExclusiveEventHintOrCaptureContext } from './utils/prepareEvent';
 import { parseEventHintOrCaptureContext } from './utils/prepareEvent';
 import { getCombinedScopeData } from './utils/scopeData';
-import { timestampInSeconds } from './utils/time';
 import { GLOBAL_OBJ } from './utils/worldwide';
 
 /**
@@ -180,76 +175,6 @@ export function setConversationId(conversationId: string | null | undefined): vo
  */
 export function lastEventId(): string | undefined {
   return getIsolationScope().lastEventId();
-}
-
-/**
- * Create a cron monitor check in and send it to Sentry.
- *
- * @param checkIn An object that describes a check in.
- * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
- * to create a monitor automatically when sending a check in.
- */
-export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorConfig): string {
-  const scope = getCurrentScope();
-  const client = getClient();
-  if (!client) {
-    DEBUG_BUILD && debug.warn('Cannot capture check-in. No client defined.');
-  } else if (!client.captureCheckIn) {
-    DEBUG_BUILD && debug.warn('Cannot capture check-in. Client does not support sending check-ins.');
-  } else {
-    return client.captureCheckIn(checkIn, upsertMonitorConfig, scope);
-  }
-
-  return uuid4();
-}
-
-/**
- * Wraps a callback with a cron monitor check in. The check in will be sent to Sentry when the callback finishes.
- *
- * @param monitorSlug The distinct slug of the monitor.
- * @param callback Callback to be monitored
- * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
- * to create a monitor automatically when sending a check in.
- */
-export function withMonitor<T>(
-  monitorSlug: CheckIn['monitorSlug'],
-  callback: () => T,
-  upsertMonitorConfig?: MonitorConfig,
-): T {
-  function runCallback(): T {
-    const checkInId = captureCheckIn({ monitorSlug, status: 'in_progress' }, upsertMonitorConfig);
-    const now = timestampInSeconds();
-
-    function finishCheckIn(status: FinishedCheckIn['status']): void {
-      captureCheckIn({ monitorSlug, status, checkInId, duration: timestampInSeconds() - now });
-    }
-    // Default behavior without isolateTrace
-    let maybePromiseResult: T;
-    try {
-      maybePromiseResult = callback();
-    } catch (e) {
-      finishCheckIn('error');
-      throw e;
-    }
-
-    if (isThenable(maybePromiseResult)) {
-      return maybePromiseResult.then(
-        r => {
-          finishCheckIn('ok');
-          return r;
-        },
-        e => {
-          finishCheckIn('error');
-          throw e;
-        },
-      ) as T;
-    }
-    finishCheckIn('ok');
-
-    return maybePromiseResult;
-  }
-
-  return withIsolationScope(() => (upsertMonitorConfig?.isolateTrace ? startNewTrace(runCallback) : runCallback()));
 }
 
 /**

--- a/packages/core/src/monitor.ts
+++ b/packages/core/src/monitor.ts
@@ -1,0 +1,98 @@
+import { getClient, getCurrentScope, withIsolationScope } from './currentScopes';
+import { DEBUG_BUILD } from './debug-build';
+import { startNewTrace } from './tracing/trace';
+import type { CheckIn, FinishedCheckIn, MonitorConfig } from './types/checkin';
+import { debug } from './utils/debug-logger';
+import { isThenable } from './utils/is';
+import { uuid4 } from './utils/misc';
+import { timestampInSeconds } from './utils/time';
+import { isContinuingTrace } from './utils/tracing';
+
+/**
+ * Wraps a callback with a cron monitor check in. The check in will be sent to Sentry when the callback finishes.
+ *
+ * @param monitorSlug The distinct slug of the monitor.
+ * @param callback Callback to be monitored
+ * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
+ * to create a monitor automatically when sending a check in.
+ */
+export function withMonitor<T>(
+  monitorSlug: CheckIn['monitorSlug'],
+  callback: () => T,
+  upsertMonitorConfig?: MonitorConfig,
+): T {
+  function runCallback(): T {
+    const checkInId = captureCheckIn({ monitorSlug, status: 'in_progress' }, upsertMonitorConfig);
+    const now = timestampInSeconds();
+
+    function finishCheckIn(status: FinishedCheckIn['status']): void {
+      captureCheckIn({ monitorSlug, status, checkInId, duration: timestampInSeconds() - now });
+    }
+    // Default behavior without isolateTrace
+    let maybePromiseResult: T;
+    try {
+      maybePromiseResult = callback();
+    } catch (e) {
+      finishCheckIn('error');
+      throw e;
+    }
+
+    if (isThenable(maybePromiseResult)) {
+      return maybePromiseResult.then(
+        r => {
+          finishCheckIn('ok');
+          return r;
+        },
+        e => {
+          finishCheckIn('error');
+          throw e;
+        },
+      ) as T;
+    }
+    finishCheckIn('ok');
+
+    return maybePromiseResult;
+  }
+
+  // `withIsolationScope` gives the fork its own trace, so unless `isolateTrace` is set we restore the
+  // parent's trace below. Copied rather than aliased: sharing the object with the parent scope would
+  // let in-place writes inside the callback (e.g. the HTTP server integration assigning
+  // `propagationSpanId`) rewrite the parent's trace.
+  const oldPropagationContext = { ...getCurrentScope().getPropagationContext() };
+
+  return withIsolationScope(() => {
+    if (upsertMonitorConfig?.isolateTrace) {
+      return startNewTrace(runCallback);
+    }
+
+    // Mirrors the reset condition in the async context strategies: only a fork that was given a fresh
+    // trace needs the parent's trace put back.
+    const scope = getCurrentScope();
+    if (!isContinuingTrace(scope.getPropagationContext())) {
+      scope.setPropagationContext(oldPropagationContext);
+    }
+
+    return runCallback();
+  });
+}
+
+/**
+ * Create a cron monitor check in and send it to Sentry.
+ *
+ * @param checkIn An object that describes a check in.
+ * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
+ * to create a monitor automatically when sending a check in.
+ */
+export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorConfig): string {
+  const scope = getCurrentScope();
+  const client = getClient();
+  if (!client) {
+    DEBUG_BUILD && debug.warn('Cannot capture check-in. No client defined.');
+  } else if (!client.captureCheckIn) {
+    DEBUG_BUILD && debug.warn('Cannot capture check-in. Client does not support sending check-ins.');
+  } else {
+    return client.captureCheckIn(checkIn, upsertMonitorConfig, scope);
+  }
+
+  return uuid4();
+}

--- a/packages/core/src/shared-exports.ts
+++ b/packages/core/src/shared-exports.ts
@@ -12,8 +12,6 @@ export * from './tracing';
 export * from './semanticAttributes';
 export { createEventEnvelope, createSessionEnvelope, createSpanEnvelope } from './envelope';
 export {
-  captureCheckIn,
-  withMonitor,
   captureException,
   captureEvent,
   captureMessage,
@@ -36,6 +34,7 @@ export {
   captureSession,
   addEventProcessor,
 } from './exports';
+export { withMonitor, captureCheckIn } from './monitor';
 export {
   getCurrentScope,
   getIsolationScope,
@@ -350,6 +349,7 @@ export {
   TRACEPARENT_REGEXP,
   extractTraceparentData,
   generateSentryTraceHeader,
+  isContinuingTrace,
   propagationContextFromHeaders,
   shouldContinueTrace,
   generateTraceparentHeader,

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -375,7 +375,7 @@ function createChildOrRootSpan({
   const isolationScope = getIsolationScope();
 
   if (!hasSpansEnabled()) {
-    const scopePropagationContext = { ...isolationScope.getPropagationContext(), ...scope.getPropagationContext() };
+    const scopePropagationContext = scope.getPropagationContext();
     const traceId = parentSpan ? parentSpan.spanContext().traceId : scopePropagationContext.traceId;
 
     // The placeholder is a thin marker; it carries no sampling decision or DSC. Both are read from
@@ -440,15 +440,7 @@ function createChildOrRootSpan({
 
     freezeDscOnSpan(span, dsc);
   } else {
-    const {
-      traceId,
-      dsc,
-      parentSpanId,
-      sampled: parentSampled,
-    } = {
-      ...isolationScope.getPropagationContext(),
-      ...scope.getPropagationContext(),
-    };
+    const { traceId, dsc, parentSpanId, sampled: parentSampled } = scope.getPropagationContext();
 
     span = _startRootSpan(
       {

--- a/packages/core/src/utils/tracing.ts
+++ b/packages/core/src/utils/tracing.ts
@@ -53,6 +53,17 @@ export function extractTraceparentData(traceparent?: string): TraceparentData | 
 }
 
 /**
+ * Whether a propagation context continues an incoming trace, rather than being the head of a new one.
+ *
+ * Both fields have to be checked. `parentSpanId` is unset when the incoming `sentry-trace` header
+ * carried no span id, which the header format allows. `dsc` is unset when a remote parent arrived
+ * without any incoming baggage. Either one on its own therefore misses a continued trace.
+ */
+export function isContinuingTrace(propagationContext: PropagationContext): boolean {
+  return !!propagationContext.parentSpanId || !!propagationContext.dsc;
+}
+
+/**
  * Create a propagation context from incoming headers or
  * creates a minimal new one if the headers are undefined.
  */

--- a/packages/core/test/lib/monitor.test.ts
+++ b/packages/core/test/lib/monitor.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getCurrentScope, getGlobalScope, getIsolationScope } from '../../src/currentScopes';
+import { withMonitor } from '../../src/monitor';
+import { setCurrentClient } from '../../src/sdk';
+import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
+
+describe('withMonitor', () => {
+  beforeEach(() => {
+    getCurrentScope().clear();
+    getIsolationScope().clear();
+    getGlobalScope().clear();
+
+    const client = new TestClient(getDefaultTestClientOptions({ dsn: 'https://username@domain/123' }));
+    setCurrentClient(client);
+    client.init();
+  });
+
+  it('keeps the parent trace when not isolating the trace', () => {
+    const parentTraceId = getCurrentScope().getPropagationContext().traceId;
+
+    withMonitor('cron-job', () => {
+      expect(getCurrentScope().getPropagationContext().traceId).toBe(parentTraceId);
+    });
+  });
+
+  it('starts a separate trace when isolateTrace is set', () => {
+    const parentTraceId = getCurrentScope().getPropagationContext().traceId;
+
+    withMonitor(
+      'cron-job',
+      () => {
+        expect(getCurrentScope().getPropagationContext().traceId).not.toBe(parentTraceId);
+      },
+      { schedule: { type: 'crontab', value: '* * * * *' }, isolateTrace: true },
+    );
+  });
+
+  // The parent's propagation context is restored onto the monitor scope, so it
+  // must be copied rather than aliased. Several call sites mutate the
+  // propagation context in place (e.g. the Node HTTP server integration
+  // assigns `propagationSpanId`), which would otherwise rewrite the parent's
+  // trace from inside the callback.
+  it('does not let the callback mutate the parent propagation context', () => {
+    const parentScope = getCurrentScope();
+    const parentPropagationContext = parentScope.getPropagationContext();
+
+    withMonitor('cron-job', () => {
+      const propagationContext = getCurrentScope().getPropagationContext();
+
+      expect(propagationContext).not.toBe(parentPropagationContext);
+      expect(propagationContext).toEqual(parentPropagationContext);
+
+      propagationContext.propagationSpanId = 'deadbeefdeadbeef';
+      propagationContext.traceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    });
+
+    expect(parentScope.getPropagationContext()).toEqual(parentPropagationContext);
+    expect(parentPropagationContext.propagationSpanId).toBeUndefined();
+  });
+});

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, type Mock, test, vi } from 'vitest';
 import type { Client } from '../../src/client';
 import { getCurrentScope } from '../../src/currentScopes';
-import { captureCheckIn } from '../../src/exports';
+import { captureCheckIn } from '../../src/monitor';
 import { installedIntegrations } from '../../src/integration';
 import { initAndBind, setCurrentClient } from '../../src/sdk';
 import type { Integration } from '../../src/types/integration';

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1502,6 +1502,30 @@ describe('startInactiveSpan', () => {
     expect(getActiveSpan()).toBeUndefined();
   });
 
+  // A root span reads its trace from the current scope only. The isolation
+  // scope's propagation context must not contribute: mixing the two yields
+  // a span whose `parent_span_id` and frozen DSC describe a different trace
+  // than its own `trace_id`.
+  it('ignores the propagation context on the isolation scope', () => {
+    const isolationTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    getIsolationScope().setPropagationContext({
+      traceId: isolationTraceId,
+      sampleRand: 0.1,
+      parentSpanId: 'bbbbbbbbbbbbbbbb',
+      sampled: true,
+      dsc: { trace_id: isolationTraceId, transaction: 'from-isolation-scope' },
+    });
+
+    const currentTraceId = getCurrentScope().getPropagationContext().traceId;
+    const span = startInactiveSpan({ name: 'GET users/[id]' });
+
+    expect(spanToJSON(span).trace_id).toBe(currentTraceId);
+    expect(spanToJSON(span).parent_span_id).toBeUndefined();
+    expect(getDynamicSamplingContextFromSpan(span)).toEqual(
+      expect.objectContaining({ trace_id: currentTraceId, transaction: 'GET users/[id]' }),
+    );
+  });
+
   it('allows to pass a scope', () => {
     const initialScope = getCurrentScope();
 

--- a/packages/deno/src/async.ts
+++ b/packages/deno/src/async.ts
@@ -3,8 +3,11 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
 import {
   _INTERNAL_createTracingChannelBinding,
+  _INTERNAL_safeMathRandom,
+  generateTraceId,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
+  isContinuingTrace,
   setAsyncContextStrategy,
 } from '@sentry/core';
 
@@ -63,8 +66,25 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
   }
 
   function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T {
-    const scope = getScopes().scope;
+    // The current scope is forked alongside the isolation scope, matching the OpenTelemetry strategy
+    // (`buildContextWithSentryScopes` clones it on every fork). Sharing it by reference would let
+    // the propagation context reset below leak back out to the caller.
+    const scope = getScopes().scope.clone();
     const isolationScope = getScopes().isolationScope.clone();
+
+    // When forking an isolation scope, unless we are continuing an incoming
+    // trace, we give the freshly forked scope its own trace. This way, new
+    // root spans in an isolation scope will get separate traces. The previous
+    // trace's `sampled` and `propagationSpanId` are dropped on purpose.
+    // Carrying them over would apply the old trace's sampling decision to the
+    // new one and propagate a span id from a different trace.
+    if (!isContinuingTrace(scope.getPropagationContext())) {
+      scope.setPropagationContext({
+        traceId: generateTraceId(),
+        sampleRand: _INTERNAL_safeMathRandom(),
+      });
+    }
+
     return asyncStorage.run({ scope, isolationScope }, () => {
       return callback(isolationScope);
     });

--- a/packages/node-core/src/light/asyncLocalStorageStrategy.ts
+++ b/packages/node-core/src/light/asyncLocalStorageStrategy.ts
@@ -2,8 +2,11 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Scope } from '@sentry/core';
 import {
   _INTERNAL_createTracingChannelBinding,
+  _INTERNAL_safeMathRandom,
+  generateTraceId,
   getDefaultCurrentScope,
   getDefaultIsolationScope,
+  isContinuingTrace,
   setAsyncContextStrategy,
   SUPPRESS_TRACING_KEY,
 } from '@sentry/core';
@@ -53,6 +56,20 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
   function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T {
     const scope = getScopes().scope.clone();
     const isolationScope = getScopes().isolationScope.clone();
+
+    // When forking an isolation scope, unless we are continuing an incoming
+    // trace, we give the freshly forked scope its own trace. This way, new
+    // root spans in an isolation scope will get separate traces. The previous
+    // trace's `sampled` and `propagationSpanId` are dropped on purpose.
+    // Carrying them over would apply the old trace's sampling decision to the
+    // new one and propagate a span id from a different trace.
+    if (!isContinuingTrace(scope.getPropagationContext())) {
+      scope.setPropagationContext({
+        traceId: generateTraceId(),
+        sampleRand: _INTERNAL_safeMathRandom(),
+      });
+    }
+
     return asyncStorage.run({ scope, isolationScope }, () => {
       return callback(isolationScope);
     });

--- a/packages/node-core/test/light/asyncLocalStorageStrategy.test.ts
+++ b/packages/node-core/test/light/asyncLocalStorageStrategy.test.ts
@@ -190,6 +190,87 @@ describe('Light Mode | AsyncLocalStorage Strategy', () => {
     });
   });
 
+  describe('withIsolationScope trace handling', () => {
+    it('gives each forked isolation scope its own trace id when not continuing an incoming trace', () => {
+      mockLightSdkInit();
+
+      const traceIds: string[] = [];
+
+      Sentry.withIsolationScope(() => {
+        traceIds.push(Sentry.getCurrentScope().getPropagationContext().traceId);
+      });
+      Sentry.withIsolationScope(() => {
+        traceIds.push(Sentry.getCurrentScope().getPropagationContext().traceId);
+      });
+
+      expect(traceIds[0]).toMatch(/^[a-f0-9]{32}$/);
+      expect(traceIds[1]).toMatch(/^[a-f0-9]{32}$/);
+      expect(traceIds[0]).not.toBe(traceIds[1]);
+    });
+
+    it('keeps the trace id when continuing an incoming trace (parentSpanId set)', () => {
+      mockLightSdkInit();
+
+      const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+      Sentry.getCurrentScope().setPropagationContext({
+        traceId: incomingTraceId,
+        parentSpanId: '1234567890abcdef',
+        sampleRand: 0.42,
+      });
+
+      Sentry.withIsolationScope(() => {
+        expect(Sentry.getCurrentScope().getPropagationContext().traceId).toBe(incomingTraceId);
+      });
+    });
+
+    // A trace-id-only `sentry-trace` header yields a propagation context with a `dsc` but no
+    // `parentSpanId`, because the span id is optional in the header. Such a trace is still being
+    // continued, so its trace id must survive the fork.
+    it('keeps the trace id when continuing an incoming trace without a span id (dsc set)', () => {
+      mockLightSdkInit();
+
+      const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+      Sentry.getCurrentScope().setPropagationContext({
+        traceId: incomingTraceId,
+        sampleRand: 0.42,
+        dsc: { trace_id: incomingTraceId, sample_rate: '1' },
+      });
+
+      Sentry.withIsolationScope(() => {
+        const propagationContext = Sentry.getCurrentScope().getPropagationContext();
+
+        expect(propagationContext.traceId).toBe(incomingTraceId);
+        expect(propagationContext.dsc).toEqual({ trace_id: incomingTraceId, sample_rate: '1' });
+      });
+    });
+
+    // A new trace must not inherit the previous trace's sampling decision or propagation span id.
+    // Keeping them would apply the old trace's sampling decision to the new one and propagate a
+    // span id belonging to a different trace.
+    it('drops the previous trace data when giving a forked isolation scope its own trace', () => {
+      mockLightSdkInit();
+
+      const oldTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      Sentry.getCurrentScope().setPropagationContext({
+        traceId: oldTraceId,
+        sampleRand: 0.1,
+        sampled: true,
+        propagationSpanId: 'bbbbbbbbbbbbbbbb',
+      });
+
+      Sentry.withIsolationScope(() => {
+        const propagationContext = Sentry.getCurrentScope().getPropagationContext();
+
+        expect(propagationContext.traceId).toMatch(/^[a-f0-9]{32}$/);
+        expect(propagationContext.traceId).not.toBe(oldTraceId);
+        expect(propagationContext.sampleRand).toEqual(expect.any(Number));
+        expect(propagationContext.sampled).toBeUndefined();
+        expect(propagationContext.propagationSpanId).toBeUndefined();
+        expect(propagationContext.dsc).toBeUndefined();
+      });
+    });
+  });
+
   describe('fallback behavior', () => {
     it('returns default scopes when AsyncLocalStorage store is empty', () => {
       resetGlobals();

--- a/packages/opentelemetry/src/asyncContextStrategy.ts
+++ b/packages/opentelemetry/src/asyncContextStrategy.ts
@@ -1,6 +1,13 @@
 import * as api from '@opentelemetry/api';
 import type { Scope, TracingChannelBinding, withActiveSpan as defaultWithActiveSpan } from '@sentry/core';
-import { getDefaultCurrentScope, getDefaultIsolationScope, setAsyncContextStrategy } from '@sentry/core';
+import {
+  _INTERNAL_safeMathRandom,
+  generateTraceId,
+  getDefaultCurrentScope,
+  getDefaultIsolationScope,
+  isContinuingTrace,
+  setAsyncContextStrategy,
+} from '@sentry/core';
 import {
   SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY,
   SENTRY_FORK_SET_ISOLATION_SCOPE_CONTEXT_KEY,
@@ -68,6 +75,19 @@ export function setOpenTelemetryContextAsyncContextStrategy(options?: {
     // the OTEL context manager, which uses the presence of this key to determine if it should
     // fork the isolation scope, or not
     return api.context.with(ctx.setValue(SENTRY_FORK_ISOLATION_SCOPE_CONTEXT_KEY, true), () => {
+      // When forking an isolation scope, unless we are continuing an incoming
+      // trace, we give the freshly forked scope its own trace. This way, new
+      // root spans in an isolation scope will get separate traces. The
+      // previous trace's `sampled` and `propagationSpanId` are dropped on
+      // purpose. Carrying them over would apply the old trace's sampling
+      // decision to the new one and propagate a span id from a different trace.
+      const scope = getCurrentScope();
+      if (!isContinuingTrace(scope.getPropagationContext())) {
+        scope.setPropagationContext({
+          traceId: generateTraceId(),
+          sampleRand: _INTERNAL_safeMathRandom(),
+        });
+      }
       return callback(getIsolationScope());
     });
   }

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -25,6 +25,15 @@ import { getDefaultTestClientOptions, TestClient } from './helpers/TestClient';
 describe('asyncContextStrategy', () => {
   let provider: BasicTracerProvider | undefined;
 
+  // `withIsolationScope` gives the forked current scope a fresh propagation context (unless it is
+  // continuing an incoming trace), so scope data is expected to match apart from that context.
+  function scopeDataWithoutPropagationContext(
+    scope: Scope,
+  ): Omit<ReturnType<Scope['getScopeData']>, 'propagationContext'> {
+    const { propagationContext: _propagationContext, ...rest } = scope.getScopeData();
+    return rest;
+  }
+
   beforeEach(() => {
     getCurrentScope().clear();
     getIsolationScope().clear();
@@ -58,7 +67,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b', 'b');
@@ -175,7 +185,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       await asyncSetExtra(scope1, 'b', 'b');
@@ -220,7 +231,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b', 'b');
@@ -257,7 +269,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b2', 'b');
@@ -307,7 +320,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       await asyncSetExtra(scope1, 'b', 'b');
@@ -344,7 +358,8 @@ describe('asyncContextStrategy', () => {
       expect(scope1).not.toBe(initialScope);
       expect(isolationScope1).not.toBe(initialIsolationScope);
 
-      expect(scope1.getScopeData()).toEqual(initialScope.getScopeData());
+      expect(scopeDataWithoutPropagationContext(scope1)).toEqual(scopeDataWithoutPropagationContext(initialScope));
+      expect(scope1.getPropagationContext().traceId).not.toBe(initialScope.getPropagationContext().traceId);
       expect(isolationScope1.getScopeData()).toEqual(initialIsolationScope.getScopeData());
 
       scope1.setExtra('b2', 'b');
@@ -513,5 +528,50 @@ describe('asyncContextStrategy', () => {
           done();
         });
       }));
+
+    // A trace-id-only `sentry-trace` header yields a propagation context with
+    // a `dsc` but no `parentSpanId`, because the span id is optional in the
+    // header. Such a trace is still being continued, so its trace id must
+    // survive the fork.
+    it('keeps the trace id when continuing an incoming trace without a span id (dsc set)', () => {
+      const incomingTraceId = 'cafecafecafecafecafecafecafecafe';
+      getCurrentScope().setPropagationContext({
+        traceId: incomingTraceId,
+        sampleRand: 0.42,
+        dsc: { trace_id: incomingTraceId, sample_rate: '1' },
+      });
+
+      withIsolationScope(() => {
+        const propagationContext = getCurrentScope().getPropagationContext();
+
+        expect(propagationContext.traceId).toBe(incomingTraceId);
+        expect(propagationContext.dsc).toEqual({ trace_id: incomingTraceId, sample_rate: '1' });
+      });
+    });
+
+    // A new trace must not inherit the previous trace's sampling decision or
+    // propagation span id. Keeping them would apply the old trace's sampling
+    // decision to the new one and propagate a span id belonging to a
+    // different trace.
+    it('drops the previous trace data when giving a forked isolation scope its own trace', () => {
+      const oldTraceId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      getCurrentScope().setPropagationContext({
+        traceId: oldTraceId,
+        sampleRand: 0.1,
+        sampled: true,
+        propagationSpanId: 'bbbbbbbbbbbbbbbb',
+      });
+
+      withIsolationScope(() => {
+        const propagationContext = getCurrentScope().getPropagationContext();
+
+        expect(propagationContext.traceId).toMatch(/^[a-f0-9]{32}$/);
+        expect(propagationContext.traceId).not.toBe(oldTraceId);
+        expect(propagationContext.sampleRand).toEqual(expect.any(Number));
+        expect(propagationContext.sampled).toBeUndefined();
+        expect(propagationContext.propagationSpanId).toBeUndefined();
+        expect(propagationContext.dsc).toBeUndefined();
+      });
+    });
   });
 });

--- a/packages/profiling-node/src/integration.ts
+++ b/packages/profiling-node/src/integration.ts
@@ -547,8 +547,7 @@ class ContinuousProfiler {
       return;
     }
 
-    const traceId =
-      getCurrentScope().getPropagationContext().traceId || getIsolationScope().getPropagationContext().traceId;
+    const traceId = getCurrentScope().getPropagationContext().traceId;
     const chunk = this._initializeChunk(traceId);
 
     CpuProfilerBindings.startProfiling(chunk.id);


### PR DESCRIPTION
Backport of: #22890

## Differences to the original PR

- `packages/server-utils/` does not exist on v10. The AsyncLocalStorage async context strategy lives in three copies there: `packages/node-core/src/light/asyncLocalStorageStrategy.ts`, `packages/cloudflare/src/async.ts` and `packages/deno/src/async.ts`. The propagation context reset in `withIsolationScope` is applied to all three.
- The cloudflare and deno copies share the current scope by reference in `withIsolationScope` on v10 (develop forks it since #22889, which is not on v10). The backport forks the current scope in those two `withIsolationScope` implementations, otherwise the reset would overwrite the caller's propagation context. `withSetIsolationScope` and `withSetScope` are left as they are on v10.
- The `packages/server-utils/test/async-context.test.ts` cases are added to `packages/cloudflare/test/async.test.ts` (plus one case for the current-scope fork above) and to `packages/node-core/test/light/asyncLocalStorageStrategy.test.ts`. There is no vitest suite for the deno strategy, so that copy is not covered by a unit test.
- Dropped the `packages/vercel-edge/test/middlewareTraceIsolation.test.ts` hunk; that file does not exist on v10.


Fixes #24118

Before: https://sentry-sdks.sentry.io/explore/traces/trace/aeac0f0087dc4636af1c1ea2080dc8be/
After: https://sentry-sdks.sentry.io/explore/traces/trace/94a5f3cc2384449ab8fe0891c69cfc75/
