### PR TITLE
ref(core)!:  Make `attributes` in sampling context required

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -2133,6 +2133,7 @@ The main entry re-exported the build plugin statically, which pulled the whole b
   `any`.
 - Attribute typing and serialization were unified across the SDK.
 - The `attributes` field on the `ScopeData` type is now required. `Scope.getScopeData()` always returned it, so this only affects code that constructs `ScopeData` objects manually — add `attributes: {}` there.
+- The `attributes` field on the `SamplingContext` passed to `tracesSampler` is now required (previously optional); it is always provided by the SDK, so this only affects code that narrows or constructs `SamplingContext` objects by hand.
 - The `endTimestamp` property was removed from the `SentrySpanArguments` interface. It was never part of
   `StartSpanOptions`, so it could only be passed by ignoring TypeScript, in which case the span ended itself
   during construction. Call `span.end(timestamp)` instead.

--- a/packages/core/src/types/samplingcontext.ts
+++ b/packages/core/src/types/samplingcontext.ts
@@ -38,7 +38,7 @@ export interface SamplingContext extends CustomSamplingContext {
   name: string;
 
   /** Initial attributes that have been passed to the span being sampled. */
-  attributes?: RawAttributes<Record<string, unknown>>;
+  attributes: RawAttributes<Record<string, unknown>>;
 }
 
 /**


### PR DESCRIPTION
This is technically breaking, I think, but I'm not even sure 🤔 any code that used to work before this should still work I believe. I guess it is only breaking if you add a handler manually that is typed in a way that `attributes` are optional, but now they aren't. It is already today always present, so really just a type change to ensure you don't need to guard this all the time in the handler.