### PR TITLE
fix(node): Bootstrap Mastra observability under ESM

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -44,8 +44,6 @@
     "@langchain/core": "^0.3.80",
     "@langchain/langgraph": "^0.2.32",
     "@langchain/openai": "^0.5.0",
-    "@mastra/core": "1.63.2",
-    "@mastra/observability": "1.17.4",
     "@modelcontextprotocol/client": "^2.0.0",
     "@modelcontextprotocol/server": "^2.0.0",
     "@nestjs/common": "^11",

--- a/dev-packages/node-integration-tests/suites/tracing/mastra/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/mastra/test.ts
@@ -20,191 +20,242 @@ import { afterAll, expect } from 'vitest';
 import { conditionalTest } from '../../../utils';
 import { cleanupChildProcesses, createEsmAndCjsTests } from '../../../utils/runner';
 
-// `@mastra/core` declares `engines.node >= 22.13`, and the CI matrix still includes 20.19.
+// `@mastra/core` declares `engines.node >= 22.13`, so it can't live in the package's root
+// `devDependencies` (that would break `yarn install` on the 20.19 CI matrix). Install it per-suite
+// instead, guarded by the `min: 22` skip below.
+const MASTRA_DEPENDENCIES = {
+  additionalDependencies: {
+    '@mastra/core': '1.63.2',
+    '@mastra/observability': '1.17.4',
+  },
+};
+
 conditionalTest({ min: 22 })('Mastra integration', () => {
   afterAll(() => {
     cleanupChildProcesses();
   });
 
-  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
-    test('creates invoke_agent and chat spans following the gen_ai conventions', async () => {
-      await createRunner()
-        .expect({ transaction: { transaction: 'mastra-test' } })
-        .expect({
-          span: container => {
-            expect(container.items.map(span => span.name).sort()).toEqual([
-              'chat gpt-4o-mini',
-              'invoke_agent weather_agent',
-            ]);
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario.mjs',
+    'instrument.mjs',
+    (createRunner, test) => {
+      test('creates invoke_agent and chat spans following the gen_ai conventions', async () => {
+        await createRunner()
+          .expect({ transaction: { transaction: 'mastra-test' } })
+          .expect({
+            span: container => {
+              expect(container.items.map(span => span.name).sort()).toEqual([
+                'chat gpt-4o-mini',
+                'invoke_agent weather_agent',
+              ]);
 
-            const agentSpan = container.items.find(span => span.name === 'invoke_agent weather_agent')!;
-            expect(agentSpan.status).toBe('ok');
-            expect(agentSpan.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(agentSpan.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
-            expect(agentSpan.attributes[GEN_AI_OPERATION_NAME].value).toBe('invoke_agent');
-            expect(agentSpan.attributes[GEN_AI_AGENT_NAME].value).toBe('weather_agent');
-            expect(agentSpan.attributes[GEN_AI_PIPELINE_NAME].value).toBe('weather_agent');
-            expect(agentSpan.attributes[GEN_AI_USAGE_INPUT_TOKENS].value).toBe(12);
-            expect(agentSpan.attributes[GEN_AI_USAGE_OUTPUT_TOKENS].value).toBe(7);
-            expect(agentSpan.attributes[GEN_AI_USAGE_TOTAL_TOKENS].value).toBe(19);
-            expect(agentSpan.attributes[GEN_AI_RESPONSE_MODEL].value).toBe('gpt-4o-mini');
+              const agentSpan = container.items.find(span => span.name === 'invoke_agent weather_agent')!;
+              expect(agentSpan.status).toBe('ok');
+              expect(agentSpan.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(agentSpan.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
+              expect(agentSpan.attributes[GEN_AI_OPERATION_NAME].value).toBe('invoke_agent');
+              expect(agentSpan.attributes[GEN_AI_AGENT_NAME].value).toBe('weather_agent');
+              expect(agentSpan.attributes[GEN_AI_PIPELINE_NAME].value).toBe('weather_agent');
+              expect(agentSpan.attributes[GEN_AI_USAGE_INPUT_TOKENS].value).toBe(12);
+              expect(agentSpan.attributes[GEN_AI_USAGE_OUTPUT_TOKENS].value).toBe(7);
+              expect(agentSpan.attributes[GEN_AI_USAGE_TOTAL_TOKENS].value).toBe(19);
+              expect(agentSpan.attributes[GEN_AI_RESPONSE_MODEL].value).toBe('gpt-4o-mini');
 
-            const chatSpan = container.items.find(span => span.name === 'chat gpt-4o-mini')!;
-            expect(chatSpan.status).toBe('ok');
-            expect(chatSpan.attributes['sentry.op'].value).toBe('gen_ai.chat');
-            expect(chatSpan.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
-            expect(chatSpan.attributes[GEN_AI_OPERATION_NAME].value).toBe('chat');
-            expect(chatSpan.attributes[GEN_AI_REQUEST_MODEL].value).toBe('gpt-4o-mini');
-            expect(chatSpan.attributes[GEN_AI_PROVIDER_NAME].value).toBe('openai');
-            expect(chatSpan.attributes[GEN_AI_USAGE_TOTAL_TOKENS].value).toBe(19);
+              const chatSpan = container.items.find(span => span.name === 'chat gpt-4o-mini')!;
+              expect(chatSpan.status).toBe('ok');
+              expect(chatSpan.attributes['sentry.op'].value).toBe('gen_ai.chat');
+              expect(chatSpan.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
+              expect(chatSpan.attributes[GEN_AI_OPERATION_NAME].value).toBe('chat');
+              expect(chatSpan.attributes[GEN_AI_REQUEST_MODEL].value).toBe('gpt-4o-mini');
+              expect(chatSpan.attributes[GEN_AI_PROVIDER_NAME].value).toBe('openai');
+              expect(chatSpan.attributes[GEN_AI_USAGE_TOTAL_TOKENS].value).toBe(19);
 
-            expect(chatSpan.parent_span_id).toBe(agentSpan.span_id);
-          },
-        })
-        .start()
-        .completed();
-    });
+              expect(chatSpan.parent_span_id).toBe(agentSpan.span_id);
+            },
+          })
+          .start()
+          .completed();
+      });
 
-    test('omits prompts and responses when genAI recording is off', async () => {
-      await createRunner()
-        .expect({ transaction: { transaction: 'mastra-test' } })
-        .expect({
-          span: container => {
-            for (const span of container.items) {
-              expect(span.attributes[GEN_AI_INPUT_MESSAGES]).toBeUndefined();
-              expect(span.attributes[GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
-              expect(span.attributes[GEN_AI_SYSTEM_INSTRUCTIONS]).toBeUndefined();
-            }
-          },
-        })
-        .start()
-        .completed();
-    });
-  });
+      test('omits prompts and responses when genAI recording is off', async () => {
+        await createRunner()
+          .expect({ transaction: { transaction: 'mastra-test' } })
+          .expect({
+            span: container => {
+              for (const span of container.items) {
+                expect(span.attributes[GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+                expect(span.attributes[GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
+                expect(span.attributes[GEN_AI_SYSTEM_INSTRUCTIONS]).toBeUndefined();
+              }
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    MASTRA_DEPENDENCIES,
+  );
 
-  createEsmAndCjsTests(__dirname, 'scenario.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
-    test('records prompts and responses when genAI recording is on', async () => {
-      await createRunner()
-        .expect({ transaction: { transaction: 'mastra-test' } })
-        .expect({
-          span: container => {
-            const agentSpan = container.items.find(span => span.name === 'invoke_agent weather_agent')!;
-            expect(agentSpan.attributes[GEN_AI_SYSTEM_INSTRUCTIONS].value).toBe('You report the weather.');
-            expect(agentSpan.attributes[GEN_AI_INPUT_MESSAGES].value).toContain('What is the weather in Berlin?');
-            expect(agentSpan.attributes[GEN_AI_OUTPUT_MESSAGES].value).toContain('It is 22C in Berlin.');
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario.mjs',
+    'instrument-with-pii.mjs',
+    (createRunner, test) => {
+      test('records prompts and responses when genAI recording is on', async () => {
+        await createRunner()
+          .expect({ transaction: { transaction: 'mastra-test' } })
+          .expect({
+            span: container => {
+              const agentSpan = container.items.find(span => span.name === 'invoke_agent weather_agent')!;
+              expect(agentSpan.attributes[GEN_AI_SYSTEM_INSTRUCTIONS].value).toBe('You report the weather.');
+              expect(agentSpan.attributes[GEN_AI_INPUT_MESSAGES].value).toContain('What is the weather in Berlin?');
+              expect(agentSpan.attributes[GEN_AI_OUTPUT_MESSAGES].value).toContain('It is 22C in Berlin.');
 
-            const chatSpan = container.items.find(span => span.name === 'chat gpt-4o-mini')!;
-            expect(chatSpan.attributes[GEN_AI_INPUT_MESSAGES].value).toContain('What is the weather in Berlin?');
-            expect(chatSpan.attributes[GEN_AI_OUTPUT_MESSAGES].value).toContain('It is 22C in Berlin.');
-          },
-        })
-        .start()
-        .completed();
-    });
-  });
+              const chatSpan = container.items.find(span => span.name === 'chat gpt-4o-mini')!;
+              expect(chatSpan.attributes[GEN_AI_INPUT_MESSAGES].value).toContain('What is the weather in Berlin?');
+              expect(chatSpan.attributes[GEN_AI_OUTPUT_MESSAGES].value).toContain('It is 22C in Berlin.');
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    MASTRA_DEPENDENCIES,
+  );
 
-  createEsmAndCjsTests(__dirname, 'scenario-tools.mjs', 'instrument-with-pii.mjs', (createRunner, test) => {
-    test('creates an execute_tool span parented onto the generation', async () => {
-      await createRunner()
-        .expect({ transaction: { transaction: 'mastra-test' } })
-        .expect({
-          span: container => {
-            expect(container.items.map(span => span.name).sort()).toEqual([
-              'chat gpt-4o-mini',
-              'execute_tool get_weather',
-              'invoke_agent weather_agent',
-            ]);
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-tools.mjs',
+    'instrument-with-pii.mjs',
+    (createRunner, test) => {
+      test('creates an execute_tool span parented onto the generation', async () => {
+        await createRunner()
+          .expect({ transaction: { transaction: 'mastra-test' } })
+          .expect({
+            span: container => {
+              expect(container.items.map(span => span.name).sort()).toEqual([
+                'chat gpt-4o-mini',
+                'execute_tool get_weather',
+                'invoke_agent weather_agent',
+              ]);
 
-            const toolSpan = container.items.find(span => span.name === 'execute_tool get_weather')!;
-            expect(toolSpan.status).toBe('ok');
-            expect(toolSpan.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
-            expect(toolSpan.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
-            expect(toolSpan.attributes[GEN_AI_OPERATION_NAME].value).toBe('execute_tool');
-            expect(toolSpan.attributes[GEN_AI_TOOL_NAME].value).toBe('get_weather');
-            expect(toolSpan.attributes[GEN_AI_TOOL_CALL_ARGUMENTS].value).toContain('Berlin');
-            expect(toolSpan.attributes[GEN_AI_TOOL_CALL_RESULT].value).toContain('22');
+              const toolSpan = container.items.find(span => span.name === 'execute_tool get_weather')!;
+              expect(toolSpan.status).toBe('ok');
+              expect(toolSpan.attributes['sentry.op'].value).toBe('gen_ai.execute_tool');
+              expect(toolSpan.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
+              expect(toolSpan.attributes[GEN_AI_OPERATION_NAME].value).toBe('execute_tool');
+              expect(toolSpan.attributes[GEN_AI_TOOL_NAME].value).toBe('get_weather');
+              expect(toolSpan.attributes[GEN_AI_TOOL_CALL_ARGUMENTS].value).toContain('Berlin');
+              expect(toolSpan.attributes[GEN_AI_TOOL_CALL_RESULT].value).toContain('22');
 
-            const chatSpan = container.items.find(span => span.name === 'chat gpt-4o-mini')!;
-            expect(toolSpan.parent_span_id).toBe(chatSpan.span_id);
+              const chatSpan = container.items.find(span => span.name === 'chat gpt-4o-mini')!;
+              expect(toolSpan.parent_span_id).toBe(chatSpan.span_id);
 
-            const agentSpan = container.items.find(span => span.name === 'invoke_agent weather_agent')!;
-            expect(agentSpan.attributes[GEN_AI_TOOL_DEFINITIONS].value).toContain('get_weather');
-            expect(agentSpan.attributes[GEN_AI_USAGE_INPUT_TOKENS].value).toBe(50);
-            expect(agentSpan.attributes[GEN_AI_USAGE_OUTPUT_TOKENS].value).toBe(13);
-            expect(agentSpan.attributes[GEN_AI_USAGE_TOTAL_TOKENS].value).toBe(63);
-          },
-        })
-        .start()
-        .completed();
-    });
-  });
+              const agentSpan = container.items.find(span => span.name === 'invoke_agent weather_agent')!;
+              expect(agentSpan.attributes[GEN_AI_TOOL_DEFINITIONS].value).toContain('get_weather');
+              expect(agentSpan.attributes[GEN_AI_USAGE_INPUT_TOKENS].value).toBe(50);
+              expect(agentSpan.attributes[GEN_AI_USAGE_OUTPUT_TOKENS].value).toBe(13);
+              expect(agentSpan.attributes[GEN_AI_USAGE_TOTAL_TOKENS].value).toBe(63);
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    MASTRA_DEPENDENCIES,
+  );
 
-  createEsmAndCjsTests(__dirname, 'scenario-workflow.mjs', 'instrument.mjs', (createRunner, test) => {
-    test('exports the workflow run but drops workflow steps, which have no conventional op', async () => {
-      await createRunner()
-        .expect({ transaction: { transaction: 'mastra-test' } })
-        .expect({
-          span: container => {
-            expect(container.items.map(span => span.name)).toEqual(['invoke_agent math_workflow']);
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-workflow.mjs',
+    'instrument.mjs',
+    (createRunner, test) => {
+      test('exports the workflow run but drops workflow steps, which have no conventional op', async () => {
+        await createRunner()
+          .expect({ transaction: { transaction: 'mastra-test' } })
+          .expect({
+            span: container => {
+              expect(container.items.map(span => span.name)).toEqual(['invoke_agent math_workflow']);
 
-            const workflowSpan = container.items[0]!;
-            expect(workflowSpan.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
-            expect(workflowSpan.attributes[GEN_AI_PIPELINE_NAME].value).toBe('math_workflow');
-          },
-        })
-        .start()
-        .completed();
-    });
-  });
+              const workflowSpan = container.items[0]!;
+              expect(workflowSpan.attributes['sentry.op'].value).toBe('gen_ai.invoke_agent');
+              expect(workflowSpan.attributes[GEN_AI_PIPELINE_NAME].value).toBe('math_workflow');
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    MASTRA_DEPENDENCIES,
+  );
 
-  createEsmAndCjsTests(__dirname, 'scenario-auto.mjs', 'instrument.mjs', (createRunner, test) => {
-    test('auto-instruments a Mastra app that configured no observability at all', async () => {
-      await createRunner()
-        .expect({ transaction: { transaction: 'mastra-test' } })
-        .expect({
-          span: container => {
-            expect(container.items.map(span => span.name).sort()).toEqual([
-              'chat gpt-4o-mini',
-              'invoke_agent weather_agent',
-            ]);
-            for (const span of container.items) {
-              expect(span.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
-            }
-          },
-        })
-        .start()
-        .completed();
-    });
-  });
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-auto.mjs',
+    'instrument.mjs',
+    (createRunner, test) => {
+      test('auto-instruments a Mastra app that configured no observability at all', async () => {
+        await createRunner()
+          .expect({ transaction: { transaction: 'mastra-test' } })
+          .expect({
+            span: container => {
+              expect(container.items.map(span => span.name).sort()).toEqual([
+                'chat gpt-4o-mini',
+                'invoke_agent weather_agent',
+              ]);
+              for (const span of container.items) {
+                expect(span.attributes['sentry.origin'].value).toBe('auto.ai.mastra');
+              }
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    MASTRA_DEPENDENCIES,
+  );
 
-  createEsmAndCjsTests(__dirname, 'scenario-community-exporter.mjs', 'instrument.mjs', (createRunner, test) => {
-    test('still exports its own spans when the community @mastra/sentry exporter is present', async () => {
-      await createRunner()
-        .expect({ transaction: { transaction: 'mastra-test' } })
-        .expect({
-          span: container => {
-            expect(container.items.map(span => span.name).sort()).toEqual([
-              'chat gpt-4o-mini',
-              'invoke_agent weather_agent',
-            ]);
-          },
-        })
-        .start()
-        .completed();
-    });
-  });
-  createEsmAndCjsTests(__dirname, 'scenario-auto.mjs', 'instrument-no-bootstrap.mjs', (createRunner, test) => {
-    test('leaves an unconfigured app alone when bootstrapObservability is false', async () => {
-      await createRunner()
-        .expect({
-          transaction: event => {
-            expect(event.transaction).toBe('mastra-test');
-            const genAiSpans = (event.spans ?? []).filter(span => span.op?.startsWith('gen_ai.'));
-            expect(genAiSpans).toEqual([]);
-          },
-        })
-        .start()
-        .completed();
-    });
-  });
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-community-exporter.mjs',
+    'instrument.mjs',
+    (createRunner, test) => {
+      test('still exports its own spans when the community @mastra/sentry exporter is present', async () => {
+        await createRunner()
+          .expect({ transaction: { transaction: 'mastra-test' } })
+          .expect({
+            span: container => {
+              expect(container.items.map(span => span.name).sort()).toEqual([
+                'chat gpt-4o-mini',
+                'invoke_agent weather_agent',
+              ]);
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    MASTRA_DEPENDENCIES,
+  );
+  createEsmAndCjsTests(
+    __dirname,
+    'scenario-auto.mjs',
+    'instrument-no-bootstrap.mjs',
+    (createRunner, test) => {
+      test('leaves an unconfigured app alone when bootstrapObservability is false', async () => {
+        await createRunner()
+          .expect({
+            transaction: event => {
+              expect(event.transaction).toBe('mastra-test');
+              const genAiSpans = (event.spans ?? []).filter(span => span.op?.startsWith('gen_ai.'));
+              expect(genAiSpans).toEqual([]);
+            },
+          })
+          .start()
+          .completed();
+      });
+    },
+    MASTRA_DEPENDENCIES,
+  );
 });

--- a/packages/core/src/utils/worldwide.ts
+++ b/packages/core/src/utils/worldwide.ts
@@ -62,6 +62,15 @@ export type InternalGlobal = {
     /** Empty array signifies runtime hooked */
     runtime?: string[];
     /**
+     * The resolved `file:` URL of a transformed file for each runtime-injected
+     * module, keyed by module name (e.g. `@mastra/core`). Lets an integration
+     * anchor `createRequire` on the app's actual copy of a dependency without
+     * relying on `process.cwd()` or the CJS `require.cache` — the latter is
+     * always empty for ESM-loaded modules. Only the runtime `--import`/hook path
+     * populates this; the bundler path inlines modules and records none.
+     */
+    runtimeFiles?: Record<string, string>;
+    /**
      * Module names recorded as each bundler-transformed module loads (the
      * injected snippet calls `orchestrionModuleInjected`). The bundler plugin's
      * entry banner ensures an empty `Set` at boot, so a defined set — even

--- a/packages/server-runtime-injection/src/register.ts
+++ b/packages/server-runtime-injection/src/register.ts
@@ -97,7 +97,7 @@ export function registerDiagnosticsChannelInjection(): void {
   // we build against, hence the cast.
   const mod = Module as NodeModule;
 
-  setDiagnosticsHook(({ moduleName, error }): void => {
+  setDiagnosticsHook(({ url, moduleName, error }): void => {
     if (error) {
       // A stripped transformer surfaces as a `TypeError` (`parse`/`generate` are `undefined`) and
       // costs the user this module's instrumentation, so it is worth an always-on warning. Every
@@ -110,6 +110,9 @@ export function registerDiagnosticsChannelInjection(): void {
       GLOBAL_OBJ.__SENTRY_ORCHESTRION__ = GLOBAL_OBJ.__SENTRY_ORCHESTRION__ || {};
       GLOBAL_OBJ.__SENTRY_ORCHESTRION__.runtime = GLOBAL_OBJ.__SENTRY_ORCHESTRION__.runtime || [];
       GLOBAL_OBJ.__SENTRY_ORCHESTRION__.runtime.push(moduleName);
+      // Record the module's resolved file so integrations can anchor dependency resolution on the
+      // app's actual copy, even under ESM (where the CJS `require.cache` never sees the module).
+      (GLOBAL_OBJ.__SENTRY_ORCHESTRION__.runtimeFiles ??= {})[moduleName] = url;
       // Tell channel integrations their module just loaded, so they subscribe
       // now. They hold off at `init()` to avoid claiming channel slots for
       // modules that never load, because Node caps channels in use at 1024.

--- a/packages/server-utils/src/integrations/mastra.ts
+++ b/packages/server-utils/src/integrations/mastra.ts
@@ -1,8 +1,9 @@
 import * as diagnosticsChannel from 'node:diagnostics_channel';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { IntegrationFn } from '@sentry/core';
-import { consoleSandbox, debug, defineIntegration } from '@sentry/core';
+import { consoleSandbox, debug, defineIntegration, GLOBAL_OBJ } from '@sentry/core';
 import {
   COMMUNITY_MASTRA_SENTRY_EXPORTER_NAME,
   MASTRA_EXPORTER_BRAND,
@@ -170,8 +171,27 @@ function appRequire(): ReturnType<typeof createRequire> {
 }
 
 /**
+ * The runtime injection hook records the resolved file of each instrumented module as it loads.
+ * Unlike the CJS `require.cache`, this is populated for ESM-loaded modules too, so it is the
+ * reliable anchor for finding the app's `@mastra/observability` next to its `@mastra/core`.
+ */
+function findInjectedMastraCoreFilename(): string | undefined {
+  const url = GLOBAL_OBJ.__SENTRY_ORCHESTRION__?.runtimeFiles?.['@mastra/core'];
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    return url.startsWith('file:') ? fileURLToPath(url) : url;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * `@mastra/core` is already evaluated (we are in its constructor). Prefer that file so a
  * serverless/test cwd that is not the app still finds the app's `@mastra/observability`.
+ * Only sees CJS-loaded modules; ESM apps rely on {@link findInjectedMastraCoreFilename}.
  */
 function findLoadedMastraCoreFilename(): string | undefined {
   const cache = appRequire().cache;
@@ -197,11 +217,16 @@ function tryRequireObservability(parent: string): Record<string, unknown> | unde
 }
 
 /**
- * Prefer the already-loaded `@mastra/core` file, then cwd-resolved core, then cwd itself.
- * A cache hit can still fail under pnpm if that copy cannot see `@mastra/observability`.
+ * Prefer the runtime-injected `@mastra/core` file (works under ESM and CJS), then the CJS-cached
+ * copy, then cwd-resolved core, then cwd itself. A hit can still fail under pnpm if that copy
+ * cannot see `@mastra/observability`, hence the fallbacks.
  */
 function loadMastraObservability(): Record<string, unknown> {
   const parents = new Set<string>();
+  const injectedCore = findInjectedMastraCoreFilename();
+  if (injectedCore) {
+    parents.add(injectedCore);
+  }
   const loadedCore = findLoadedMastraCoreFilename();
   if (loadedCore) {
     parents.add(loadedCore);

--- a/packages/server-utils/test/integrations/mastra/bootstrap-resolve.test.ts
+++ b/packages/server-utils/test/integrations/mastra/bootstrap-resolve.test.ts
@@ -8,6 +8,8 @@ import { CHANNELS } from '../../../src/orchestrion/channels';
 const observabilityFrom = vi.hoisted(() => ({
   parent: undefined as string | undefined,
   cache: {} as NodeJS.Dict<NodeModule>,
+  injectedCoreUrl: 'file:///app/node_modules/@mastra/core/dist/mastra-abc123.js',
+  injectedCore: '/app/node_modules/@mastra/core/dist/mastra-abc123.js',
   loadedCore: '/app/node_modules/@mastra/core/dist/index.js',
   cwdCore: '/cwd/node_modules/@mastra/core/index.js',
   cwd: `${process.cwd()}/noop.js`,
@@ -57,6 +59,39 @@ describe('mastraIntegration observability resolve', () => {
 
   afterEach(() => {
     delete GLOBAL_OBJ.__SENTRY_ORCHESTRION__;
+  });
+
+  it('loads @mastra/observability from the runtime-injected @mastra/core file (ESM path)', () => {
+    // No CJS cache entry — mirrors an ESM app, where the loaded module never reaches `require.cache`.
+    GLOBAL_OBJ.__SENTRY_ORCHESTRION__ = {
+      runtime: ['@mastra/core'],
+      runtimeFiles: { '@mastra/core': observabilityFrom.injectedCoreUrl },
+    };
+    const registerExporter = vi.fn();
+
+    tracingChannel(CHANNELS.MASTRA_CONSTRUCTOR).end.publish({
+      self: { registerExporter },
+      arguments: [],
+    });
+
+    expect(observabilityFrom.parent).toBe(observabilityFrom.injectedCore);
+    expect(registerExporter).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything());
+  });
+
+  it('prefers the runtime-injected file over the CJS-cached copy', () => {
+    observabilityFrom.cache[observabilityFrom.loadedCore] = {} as NodeModule;
+    GLOBAL_OBJ.__SENTRY_ORCHESTRION__ = {
+      runtime: ['@mastra/core'],
+      runtimeFiles: { '@mastra/core': observabilityFrom.injectedCoreUrl },
+    };
+    const registerExporter = vi.fn();
+
+    tracingChannel(CHANNELS.MASTRA_CONSTRUCTOR).end.publish({
+      self: { registerExporter },
+      arguments: [],
+    });
+
+    expect(observabilityFrom.parent).toBe(observabilityFrom.injectedCore);
   });
 
   it('loads @mastra/observability from a loaded @mastra/core file, not cwd', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,6 @@
 # yarn lockfile v1
 
 
-"@a2a-js/sdk-v0_3@npm:@a2a-js/sdk@~0.3.14":
-  version "0.3.14"
-  resolved "https://sfw.security.sentry.io/npm/@a2a-js/sdk/-/sdk-0.3.14.tgz#e807b4e6516ea8c4af621ad9789d8dad6173058d"
-  integrity sha512-F6Ew1AtPzCLhTn8h9yiqTe7DiDf6XVrSnq9V1YqSl9eWqPm6anMveTiKdCSb/76cW0YiJc24rNaUrVezFFHbqQ==
-  dependencies:
-    uuid "^11.1.0"
-
-"@a2a-js/sdk-v1@npm:@a2a-js/sdk@~1.0.1":
-  version "1.0.1"
-  resolved "https://sfw.security.sentry.io/npm/@a2a-js/sdk/-/sdk-1.0.1.tgz#4a66be6a8cacc3276d6b71db9bf88ce6733f53f6"
-  integrity sha512-CJQdh3Wzwo8qIx5UUkSJ7+7BEI16PB+MXMHHNSmx8JQsQed2HlQgvx1ENOiKUfYA3PlcEvxIwv14dBblhDuPmw==
-  dependencies:
-    jose "^6.2.3"
-    uuid "^11.1.0"
-
 "@actions/artifact@^6.2.1":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@actions/artifact/-/artifact-6.2.1.tgz#3f813d42d08d8d105fa46010f6ce2bb35e292b66"
@@ -146,34 +131,6 @@
     "@ai-sdk/provider-utils" "4.0.35"
     "@vercel/oidc" "3.2.0"
 
-"@ai-sdk/provider-utils-v5@npm:@ai-sdk/provider-utils@3.0.30":
-  version "3.0.30"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider-utils/-/provider-utils-3.0.30.tgz#c9e611246706c8f5b617ad8c75eefb16479f47e9"
-  integrity sha512-NCJ9JKow5ENAgEZxzvEvF20thwDiH+hutvzmrUDbloRX0azpJHNst8+7pZIVryYhLM9wgpT5/ShTSjPTFhkxEQ==
-  dependencies:
-    "@ai-sdk/provider" "2.0.3"
-    "@standard-schema/spec" "^1.0.0"
-    eventsource-parser "^3.0.6"
-
-"@ai-sdk/provider-utils-v6@npm:@ai-sdk/provider-utils@4.0.40":
-  version "4.0.40"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz#5daa46e0cc8d876887994e335fca7f14eca53fd3"
-  integrity sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==
-  dependencies:
-    "@ai-sdk/provider" "3.0.14"
-    "@standard-schema/spec" "^1.1.0"
-    eventsource-parser "^3.0.8"
-
-"@ai-sdk/provider-utils-v7@npm:@ai-sdk/provider-utils@5.0.13":
-  version "5.0.13"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider-utils/-/provider-utils-5.0.13.tgz#0baab013772b1611a0c743b951ddf4c67cc1cd5c"
-  integrity sha512-fScDJMDnTbx32kLDQqp0MvPjvwkgiwvlBxlmIg7XW5PbS91LG6JjH3PQG+34oMFglqfpQA355e24OdGj5PPoDw==
-  dependencies:
-    "@ai-sdk/provider" "4.0.4"
-    "@standard-schema/spec" "^1.1.0"
-    "@workflow/serde" "4.1.0"
-    eventsource-parser "^3.0.8"
-
 "@ai-sdk/provider-utils@2.2.8":
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz#ad11b92d5a1763ab34ba7b5fc42494bfe08b76d1"
@@ -192,27 +149,6 @@
     "@standard-schema/spec" "^1.1.0"
     eventsource-parser "^3.0.8"
 
-"@ai-sdk/provider-v5@npm:@ai-sdk/provider@2.0.3":
-  version "2.0.3"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider/-/provider-2.0.3.tgz#8a3727d31947c6238e59dcbb72b7e1a871fd570c"
-  integrity sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==
-  dependencies:
-    json-schema "^0.4.0"
-
-"@ai-sdk/provider-v6@npm:@ai-sdk/provider@3.0.14":
-  version "3.0.14"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider/-/provider-3.0.14.tgz#5893a90e0b5355ec6a5c148f06bd7f08355c1a6f"
-  integrity sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==
-  dependencies:
-    json-schema "^0.4.0"
-
-"@ai-sdk/provider-v7@npm:@ai-sdk/provider@4.0.4":
-  version "4.0.4"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider/-/provider-4.0.4.tgz#7b1a3616d3e1c731a06a90f0a0e26e4d767a5b25"
-  integrity sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==
-  dependencies:
-    json-schema "^0.4.0"
-
 "@ai-sdk/provider@1.1.3":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-1.1.3.tgz#ebdda8077b8d2b3f290dcba32c45ad19b2704681"
@@ -220,31 +156,10 @@
   dependencies:
     json-schema "^0.4.0"
 
-"@ai-sdk/provider@2.0.3":
-  version "2.0.3"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider/-/provider-2.0.3.tgz#8a3727d31947c6238e59dcbb72b7e1a871fd570c"
-  integrity sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==
-  dependencies:
-    json-schema "^0.4.0"
-
 "@ai-sdk/provider@3.0.13":
   version "3.0.13"
   resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-3.0.13.tgz#8d2d64bcf5bd077133c82cc1eeefad3bee0b192d"
   integrity sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==
-  dependencies:
-    json-schema "^0.4.0"
-
-"@ai-sdk/provider@3.0.14":
-  version "3.0.14"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider/-/provider-3.0.14.tgz#5893a90e0b5355ec6a5c148f06bd7f08355c1a6f"
-  integrity sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==
-  dependencies:
-    json-schema "^0.4.0"
-
-"@ai-sdk/provider@4.0.4":
-  version "4.0.4"
-  resolved "https://sfw.security.sentry.io/npm/@ai-sdk/provider/-/provider-4.0.4.tgz#7b1a3616d3e1c731a06a90f0a0e26e4d767a5b25"
-  integrity sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==
   dependencies:
     json-schema "^0.4.0"
 
@@ -5419,11 +5334,6 @@
   dependencies:
     minipass "^7.0.4"
 
-"@isaacs/ttlcache@^2.1.5":
-  version "2.1.5"
-  resolved "https://sfw.security.sentry.io/npm/@isaacs/ttlcache/-/ttlcache-2.1.5.tgz#9972fc5e801698907feb0b112ea19d8ff7d7689d"
-  integrity sha512-VwGZqqjAWPICTmxUZnbpEfO60LhPWzquik+bmyXGY7pYRn6diEvCI5i6Ca+J6o2y4vS73HrpuMTo2dOvUevH8w==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"
@@ -5646,17 +5556,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@lukeed/csprng@^1.0.0", "@lukeed/csprng@^1.1.0":
+"@lukeed/csprng@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
   integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
-
-"@lukeed/uuid@^2.0.1":
-  version "2.0.1"
-  resolved "https://sfw.security.sentry.io/npm/@lukeed/uuid/-/uuid-2.0.1.tgz#4f6c34259ee0982a455e1797d56ac27bb040fd74"
-  integrity sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==
-  dependencies:
-    "@lukeed/csprng" "^1.1.0"
 
 "@mapbox/node-pre-gyp@^2.0.0":
   version "2.0.3"
@@ -5670,57 +5573,6 @@
     nopt "^8.0.0"
     semver "^7.5.3"
     tar "^7.4.0"
-
-"@mastra/core@1.63.2":
-  version "1.63.2"
-  resolved "https://sfw.security.sentry.io/npm/@mastra/core/-/core-1.63.2.tgz#3a04cc5397cec6edd77cf7570395d2f6aec514f9"
-  integrity sha512-BHVDF4GtQnIqRND/lPVVoTnmoNzZ7+voz+EpI4YSY0W7In6c/EOrmMnshuNQSDJ9NpxQNrwip0WGYpRYwzFirQ==
-  dependencies:
-    "@a2a-js/sdk-v0_3" "npm:@a2a-js/sdk@~0.3.14"
-    "@a2a-js/sdk-v1" "npm:@a2a-js/sdk@~1.0.1"
-    "@ai-sdk/provider-utils-v5" "npm:@ai-sdk/provider-utils@3.0.30"
-    "@ai-sdk/provider-utils-v6" "npm:@ai-sdk/provider-utils@4.0.40"
-    "@ai-sdk/provider-utils-v7" "npm:@ai-sdk/provider-utils@5.0.13"
-    "@ai-sdk/provider-v5" "npm:@ai-sdk/provider@2.0.3"
-    "@ai-sdk/provider-v6" "npm:@ai-sdk/provider@3.0.14"
-    "@ai-sdk/provider-v7" "npm:@ai-sdk/provider@4.0.4"
-    "@isaacs/ttlcache" "^2.1.5"
-    "@lukeed/uuid" "^2.0.1"
-    "@mastra/schema-compat" "1.3.7"
-    "@modelcontextprotocol/server" "2.0.0"
-    "@sindresorhus/slugify" "^2.2.1"
-    "@standard-schema/spec" "^1.1.0"
-    ajv "^8.20.0"
-    chat "^4.34.0"
-    croner "^10.0.1"
-    dotenv "^17.3.1"
-    execa "^9.6.1"
-    fastq "^1.20.1"
-    gray-matter "^4.0.3"
-    ignore "^7.0.5"
-    jpeg-js "^0.4.4"
-    json-schema "^0.4.0"
-    lru-cache "^11.2.7"
-    p-map "^7.0.4"
-    p-retry "^7.1.1"
-    picomatch "^4.0.3"
-    posthog-node "^5.46.1"
-    tokenx "^1.3.0"
-    ws "^8.21.0"
-    xxhash-wasm "^1.1.0"
-
-"@mastra/observability@1.17.4":
-  version "1.17.4"
-  resolved "https://sfw.security.sentry.io/npm/@mastra/observability/-/observability-1.17.4.tgz#dc49c11c0640b5d2f0fcd1af03c9f1d2c71ccfec"
-  integrity sha512-7TzbNNPR6h1LPUPW+kPkqqBKyubF9fZapGWJF4Y2f5JAhGva8Qj/NX0hbDgx54hqtvkTNh56+flAerwuNf1mMw==
-
-"@mastra/schema-compat@1.3.7":
-  version "1.3.7"
-  resolved "https://sfw.security.sentry.io/npm/@mastra/schema-compat/-/schema-compat-1.3.7.tgz#f5e5cc8769e7c113c0ec1a8e18ab95c828870457"
-  integrity sha512-06WfY+j9rulYnDp8CM7pL7JIyrntkMolqmyyb1VJNEzlYTQCIcJcY0SwQiubZv2tztmoYGikszDiRVyXp0E9gA==
-  dependencies:
-    json-schema-to-zod "^2.7.0"
-    zod-from-json-schema "^0.5.2"
 
 "@mjackson/node-fetch-server@^0.2.0":
   version "0.2.0"
@@ -5747,7 +5599,7 @@
   dependencies:
     zod "^4.2.0"
 
-"@modelcontextprotocol/server@2.0.0", "@modelcontextprotocol/server@^2.0.0":
+"@modelcontextprotocol/server@^2.0.0":
   version "2.0.0"
   resolved "https://sfw.security.sentry.io/npm/@modelcontextprotocol/server/-/server-2.0.0.tgz#4fae5ccb8f7925ed9a6bf6595bb3b58617063ffd"
   integrity sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==
@@ -7262,18 +7114,6 @@
   resolved "https://registry.yarnpkg.com/@poppinss/exception/-/exception-1.2.2.tgz#8d30d42e126c54fe84e997433e4dcac610090743"
   integrity sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==
 
-"@posthog/core@^1.49.1":
-  version "1.49.2"
-  resolved "https://sfw.security.sentry.io/npm/@posthog/core/-/core-1.49.2.tgz#9b2772038c8f390e2fe7e1681539d8f8c5d12401"
-  integrity sha512-AXHDo/4nisUg7OPG1TQNgREK7n+chBQXLQyttp7bDTDsDg2k9lV06TmnpvuNbwJs53q9mP9hjezKEZu4fYadfg==
-  dependencies:
-    "@posthog/types" "^1.407.1"
-
-"@posthog/types@^1.407.1":
-  version "1.407.1"
-  resolved "https://sfw.security.sentry.io/npm/@posthog/types/-/types-1.407.1.tgz#aca89563a8b6799751b20ef9678641c13ba9441b"
-  integrity sha512-WhbkXPC2rgylXqmxHqv70ffI3k+KxyR6s7DBIfr5NvIqHkxp6v0pk31D/jbz0DNVbzwkLjyll2pxr4FNbJiYzg==
-
 "@prisma/adapter-d1@6.15.0":
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/@prisma/adapter-d1/-/adapter-d1-6.15.0.tgz#a3fd43a1b966d0012f1461ea278732b7464fb371"
@@ -8055,11 +7895,6 @@
     "@angular-devkit/schematics" "14.2.13"
     jsonc-parser "3.1.0"
 
-"@sec-ant/readable-stream@^0.4.1":
-  version "0.4.1"
-  resolved "https://sfw.security.sentry.io/npm/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz#60de891bb126abfdc5410fdc6166aca065f10a0c"
-  integrity sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==
-
 "@sentry/conventions@0.20.0", "@sentry/conventions@^0.20.0":
   version "0.20.0"
   resolved "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.20.0.tgz#f73f6f46934d754dacef447755b5adf1bf7f3245"
@@ -8202,21 +8037,6 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz#abb11d99aeb6d27f1b563c38147a72d50058e339"
   integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
-
-"@sindresorhus/slugify@^2.2.1":
-  version "2.2.1"
-  resolved "https://sfw.security.sentry.io/npm/@sindresorhus/slugify/-/slugify-2.2.1.tgz#fa2e2e25d6e1e74a2eeb5e2c37f5ccc516ed2c4b"
-  integrity sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==
-  dependencies:
-    "@sindresorhus/transliterate" "^1.0.0"
-    escape-string-regexp "^5.0.0"
-
-"@sindresorhus/transliterate@^1.0.0":
-  version "1.6.0"
-  resolved "https://sfw.security.sentry.io/npm/@sindresorhus/transliterate/-/transliterate-1.6.0.tgz#2309fff65a868047e6d2dd70dec747c5b36a8327"
-  integrity sha512-doH1gimEu3A46VX6aVxpHTeHrytJAG6HgdxntYnCFiIFHEM/ZGpG8KiZGBChchjQmG0XFIBL552kBTjVcMZXwQ==
-  dependencies:
-    escape-string-regexp "^5.0.0"
 
 "@size-limit/esbuild@~12.1.0":
   version "12.1.0"
@@ -10863,16 +10683,6 @@
   dependencies:
     tslib "^2.6.3"
 
-"@workflow/serde@4.1.0":
-  version "4.1.0"
-  resolved "https://sfw.security.sentry.io/npm/@workflow/serde/-/serde-4.1.0.tgz#82dbbaf2370f7b8ae46d9a9a4ab0917258f8db62"
-  integrity sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==
-
-"@workflow/serde@4.1.0-beta.2":
-  version "4.1.0-beta.2"
-  resolved "https://sfw.security.sentry.io/npm/@workflow/serde/-/serde-4.1.0-beta.2.tgz#ac10377f50e9f83dbf4994edd4fe9c940bcef6a9"
-  integrity sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==
-
 "@xstate/fsm@^1.4.0":
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/@xstate/fsm/-/fsm-1.6.5.tgz#f599e301997ad7e3c572a0b1ff0696898081bea5"
@@ -11110,7 +10920,7 @@ ajv@^6.11.0, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.0, ajv@^8.10.0, ajv@^8.12.0, ajv@^8.20.0, ajv@^8.9.0:
+ajv@^8.0.0, ajv@^8.10.0, ajv@^8.12.0, ajv@^8.9.0:
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.20.0.tgz#304b3636add88ba7d936760dd50ece006dea95f9"
   integrity sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==
@@ -12746,19 +12556,6 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
-
-chat@^4.34.0:
-  version "4.39.0"
-  resolved "https://sfw.security.sentry.io/npm/chat/-/chat-4.39.0.tgz#dce04af60c2b5c1c0c75ab3528f7f7ca9fffc07f"
-  integrity sha512-o7D+oAbQAYFVoc9+OH8wya11609ybRThNTF3s/5C1LAABGGi6IrxoQQEN/aIe+4h5pmKYzUjXeqTcuOZcpIAZA==
-  dependencies:
-    "@workflow/serde" "4.1.0-beta.2"
-    mdast-util-to-string "^4.0.0"
-    remark-gfm "^4.0.0"
-    remark-parse "^11.0.0"
-    remark-stringify "^11.0.0"
-    remend "^1.2.1"
-    unified "^11.0.5"
 
 check-error@^2.1.1:
   version "2.1.1"
@@ -15594,7 +15391,7 @@ events@^3.0.0, events@^3.2.0, events@^3.3.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
-eventsource-parser@^3.0.0, eventsource-parser@^3.0.1, eventsource-parser@^3.0.6, eventsource-parser@^3.0.8:
+eventsource-parser@^3.0.0, eventsource-parser@^3.0.1, eventsource-parser@^3.0.8:
   version "3.1.1"
   resolved "https://sfw.security.sentry.io/npm/eventsource-parser/-/eventsource-parser-3.1.1.tgz#b96cbb7dace4f3774f58a9e3b1ae9a4a524872e2"
   integrity sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==
@@ -15660,24 +15457,6 @@ execa@^8.0.1:
     onetime "^6.0.0"
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
-
-execa@^9.6.1:
-  version "9.6.1"
-  resolved "https://sfw.security.sentry.io/npm/execa/-/execa-9.6.1.tgz#5b90acedc6bdc0fa9b9a6ddf8f9cbb0c75a7c471"
-  integrity sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==
-  dependencies:
-    "@sindresorhus/merge-streams" "^4.0.0"
-    cross-spawn "^7.0.6"
-    figures "^6.1.0"
-    get-stream "^9.0.0"
-    human-signals "^8.0.1"
-    is-plain-obj "^4.1.0"
-    is-stream "^4.0.1"
-    npm-run-path "^6.0.0"
-    pretty-ms "^9.2.0"
-    signal-exit "^4.1.0"
-    strip-final-newline "^4.0.0"
-    yoctocolors "^2.1.1"
 
 exit-hook@2.2.1:
   version "2.2.1"
@@ -16021,7 +15800,7 @@ fastify@^5.12.1:
     semver "^7.6.0"
     toad-cache "^3.7.0"
 
-fastq@^1.17.1, fastq@^1.20.1, fastq@^1.6.0:
+fastq@^1.17.1, fastq@^1.6.0:
   version "1.20.3"
   resolved "https://sfw.security.sentry.io/npm/fastq/-/fastq-1.20.3.tgz#7ab8731e647b56abcfeee997dae333ca3ee1d04d"
   integrity sha512-XKv5nnLs6nLF71NgiKJLIZFLkPyIEuOselLG7ujZnGrRfQK8HpvY+WqKhAJUAdLomwVHErVS4LfxFlPq0/FTAw==
@@ -16075,13 +15854,6 @@ figures@^2.0.0:
   integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
   dependencies:
     escape-string-regexp "^1.0.5"
-
-figures@^6.1.0:
-  version "6.1.0"
-  resolved "https://sfw.security.sentry.io/npm/figures/-/figures-6.1.0.tgz#935479f51865fa7479f6fa94fc6fc7ac14e62c4a"
-  integrity sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==
-  dependencies:
-    is-unicode-supported "^2.0.0"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -16641,14 +16413,6 @@ get-stream@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
   integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
-
-get-stream@^9.0.0:
-  version "9.0.1"
-  resolved "https://sfw.security.sentry.io/npm/get-stream/-/get-stream-9.0.1.tgz#95157d21df8eb90d1647102b63039b1df60ebd27"
-  integrity sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==
-  dependencies:
-    "@sec-ant/readable-stream" "^0.4.1"
-    is-stream "^4.0.1"
 
 get-symbol-description@^1.1.0:
   version "1.1.0"
@@ -17579,11 +17343,6 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
-human-signals@^8.0.1:
-  version "8.0.1"
-  resolved "https://sfw.security.sentry.io/npm/human-signals/-/human-signals-8.0.1.tgz#f08bb593b6d1db353933d06156cedec90abe51fb"
-  integrity sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==
-
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
@@ -18090,11 +17849,6 @@ is-negative-zero@^2.0.3:
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.3.tgz#ced903a027aca6381b777a5743069d7376a49747"
   integrity sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==
 
-is-network-error@^1.1.0:
-  version "1.3.2"
-  resolved "https://sfw.security.sentry.io/npm/is-network-error/-/is-network-error-1.3.2.tgz#9460bc30f8419a4bca77114f4de88a3ee5e0c519"
-  integrity sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==
-
 is-node-process@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-node-process/-/is-node-process-1.2.0.tgz#ea02a1b90ddb3934a19aea414e88edef7e11d134"
@@ -18133,7 +17887,7 @@ is-plain-obj@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
-is-plain-obj@^4.0.0, is-plain-obj@^4.1.0:
+is-plain-obj@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
@@ -18215,11 +17969,6 @@ is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
   integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
-
-is-stream@^4.0.1:
-  version "4.0.1"
-  resolved "https://sfw.security.sentry.io/npm/is-stream/-/is-stream-4.0.1.tgz#375cf891e16d2e4baec250b85926cffc14720d9b"
-  integrity sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==
 
 is-string@^1.0.7, is-string@^1.1.1:
   version "1.1.1"
@@ -18487,15 +18236,10 @@ jiti@^2.4.2, jiti@^2.6.1, jiti@^2.7.0:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.7.0.tgz#974228f2f4ca2bc21885a1797b45fea68e950c64"
   integrity sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==
 
-jose@^6.1.3, jose@^6.2.3:
+jose@^6.1.3:
   version "6.2.10"
   resolved "https://sfw.security.sentry.io/npm/jose/-/jose-6.2.10.tgz#b70436c920c4b3f97314c28a8b8612c15b1d9e7f"
   integrity sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==
-
-jpeg-js@^0.4.4:
-  version "0.4.4"
-  resolved "https://sfw.security.sentry.io/npm/jpeg-js/-/jpeg-js-0.4.4.tgz#a9f1c6f1f9f0fa80cdb3484ed9635054d28936aa"
-  integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
 
 js-md4@^0.3.2:
   version "0.3.2"
@@ -18693,11 +18437,6 @@ json-schema-to-ts@^3.1.1:
   dependencies:
     "@babel/runtime" "^7.18.3"
     ts-algebra "^2.0.0"
-
-json-schema-to-zod@^2.7.0:
-  version "2.8.1"
-  resolved "https://sfw.security.sentry.io/npm/json-schema-to-zod/-/json-schema-to-zod-2.8.1.tgz#684fcbe64cb178c1008c498209fff0890c9de725"
-  integrity sha512-fRr1mHgZ7hboLKBUdR428gd9dIHUFGivUqOeiDcSmyXkNZCtB1uGaZLvsjZ4GaN5pwBIs+TGIOf6s+Rp5/R/zA==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -21986,7 +21725,7 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
-p-map@^7.0.3, p-map@^7.0.4:
+p-map@^7.0.3:
   version "7.0.7"
   resolved "https://sfw.security.sentry.io/npm/p-map/-/p-map-7.0.7.tgz#a82175dd690468a930b9ae45c2b9829c5bf60fa3"
   integrity sha512-VaWRu2i4FJNRtiRWCuuQRgfQ1B7a6+gMSrO+3j0EQi/k0ULfS9kosRxGoiqwzIjZTDI02tGfk5mXXltLg6QtfQ==
@@ -22014,13 +21753,6 @@ p-retry@4, p-retry@^4.5.0:
   dependencies:
     "@types/retry" "0.12.0"
     retry "^0.13.1"
-
-p-retry@^7.1.1:
-  version "7.1.1"
-  resolved "https://sfw.security.sentry.io/npm/p-retry/-/p-retry-7.1.1.tgz#7470fdecb1152ba50f1334e48378c9e401330e24"
-  integrity sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==
-  dependencies:
-    is-network-error "^1.1.0"
 
 p-timeout@^3.0.0, p-timeout@^3.1.0, p-timeout@^3.2.0:
   version "3.2.0"
@@ -22143,11 +21875,6 @@ parse-ms@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
   integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
-
-parse-ms@^4.0.0:
-  version "4.0.0"
-  resolved "https://sfw.security.sentry.io/npm/parse-ms/-/parse-ms-4.0.0.tgz#c0c058edd47c2a590151a718990533fd62803df4"
-  integrity sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==
 
 parse-node-version@^1.0.1:
   version "1.0.1"
@@ -23249,13 +22976,6 @@ postgres@^3.4.7:
   resolved "https://registry.yarnpkg.com/postgres/-/postgres-3.4.7.tgz#122f460a808fe300cae53f592108b9906e625345"
   integrity sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==
 
-posthog-node@^5.46.1:
-  version "5.51.4"
-  resolved "https://sfw.security.sentry.io/npm/posthog-node/-/posthog-node-5.51.4.tgz#0a6e86f772e26399b62ee515ba7f3a9be93b36f7"
-  integrity sha512-gI6JMBnU3vjDNclUBWonw3y7k8Y0UPIAVO4AQ2zu9eyW+7sY8UQRofx4JIA7IGYLMEbs4gykfogOmXp16+oUdg==
-  dependencies:
-    "@posthog/core" "^1.49.1"
-
 powershell-utils@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/powershell-utils/-/powershell-utils-0.1.0.tgz#5a42c9a824fb4f2f251ccb41aaae73314f5d6ac2"
@@ -23368,13 +23088,6 @@ pretty-ms@^7.0.1:
   integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
   dependencies:
     parse-ms "^2.1.0"
-
-pretty-ms@^9.2.0:
-  version "9.3.1"
-  resolved "https://sfw.security.sentry.io/npm/pretty-ms/-/pretty-ms-9.3.1.tgz#7b58d8fbf376f01602ff05230358e8fa5e0f072b"
-  integrity sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==
-  dependencies:
-    parse-ms "^4.0.0"
 
 prisma@6.15.0:
   version "6.15.0"
@@ -24216,11 +23929,6 @@ remark-stringify@^11.0.0:
     "@types/mdast" "^4.0.0"
     mdast-util-to-markdown "^2.0.0"
     unified "^11.0.0"
-
-remend@^1.2.1:
-  version "1.3.1"
-  resolved "https://sfw.security.sentry.io/npm/remend/-/remend-1.3.1.tgz#474575f709d39d01f5d3b04333d4fa40d4491133"
-  integrity sha512-N3DiY5qbRPoa5vkxn1oDLMyXOVTeo6Hp+XOj6SIqJAYUgLS0Q587gILPMom/qm86AQ/ZrcOdwEIzCz8V3J0nxQ==
 
 remove-types@^1.0.0:
   version "1.0.0"
@@ -25985,11 +25693,6 @@ strip-final-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
-strip-final-newline@^4.0.0:
-  version "4.0.0"
-  resolved "https://sfw.security.sentry.io/npm/strip-final-newline/-/strip-final-newline-4.0.0.tgz#35a369ec2ac43df356e3edd5dcebb6429aa1fa5c"
-  integrity sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==
-
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -26559,11 +26262,6 @@ token-types@^6.1.1:
     "@borewit/text-codec" "^0.2.1"
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
-
-tokenx@^1.3.0:
-  version "1.6.0"
-  resolved "https://sfw.security.sentry.io/npm/tokenx/-/tokenx-1.6.0.tgz#8a5fde974ebd559d43081f143c7d70750b6dbea1"
-  integrity sha512-CKTjk345ajvBAUp5xUI9a5KKN0zU0lBueVHQbCskH1Hp6WkUKsPW2qGCYNs0pxNyfzxfo+IIjdt2W4sMbw/qBw==
 
 toml@^4.1.1:
   version "4.3.0"
@@ -28593,7 +28291,7 @@ ws@8.18.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
-ws@^8.13.0, ws@^8.18.0, ws@^8.20.1, ws@^8.21.0, ws@^8.21.1, ws@^8.4.2:
+ws@^8.13.0, ws@^8.18.0, ws@^8.20.1, ws@^8.21.1, ws@^8.4.2:
   version "8.21.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
   integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
@@ -28782,11 +28480,6 @@ yocto-queue@^1.1.1:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
   integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==
 
-yoctocolors@^2.1.1:
-  version "2.2.0"
-  resolved "https://sfw.security.sentry.io/npm/yoctocolors/-/yoctocolors-2.2.0.tgz#c4b68ee477f3982c33e4de24a5aa4a354be506d3"
-  integrity sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==
-
 youch-core@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/youch-core/-/youch-core-0.3.3.tgz#c5d3d85aeea0d8bc7b36e9764ed3f14b7ceddc7d"
@@ -28826,13 +28519,6 @@ zip-stream@^6.0.1:
     compress-commons "^6.0.2"
     readable-stream "^4.0.0"
 
-zod-from-json-schema@^0.5.2:
-  version "0.5.6"
-  resolved "https://sfw.security.sentry.io/npm/zod-from-json-schema/-/zod-from-json-schema-0.5.6.tgz#a8c7a188a795715d6fff15604101a37dd455d4b1"
-  integrity sha512-U33AJ7ZWS6y9XNSzMWcdy8hRAvZmWhTtpYJu0SXPT5AArbc9nq2ur7Magzmn5RF9KBV4b3FP0nCpmqqlfXlR9w==
-  dependencies:
-    zod "^4.0.17"
-
 zod-to-json-schema@^3.22.3, zod-to-json-schema@^3.23.5, zod-to-json-schema@^3.24.1:
   version "3.25.2"
   resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz#3fa799a7badd554541472fb65843fdc460b2e5aa"
@@ -28848,7 +28534,7 @@ zod@^3.23.8, zod@^3.24.1, zod@^3.25.32:
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
 
-zod@^4.0.0, zod@^4.0.17, zod@^4.2.0:
+zod@^4.0.0, zod@^4.2.0:
   version "4.5.4"
   resolved "https://sfw.security.sentry.io/npm/zod/-/zod-4.5.4.tgz#e215c62420c528dd7951e31fb52c5438f1fd184a"
   integrity sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==


### PR DESCRIPTION
The Mastra integration failed to auto-bootstrap `@mastra/observability` under ESM when the app configured no observability of its own. `loadMastraObservability()` anchored module resolution on `process.cwd()` and the CJS `require.cache`, but an ESM-loaded `@mastra/core` never lands in that cache, leaving cwd as the only anchor. When the app's dependencies don't live under cwd — a serverless/monorepo layout, or concretely the per-suite temp install the integration tests use — resolution failed silently: no exporter was attached and no `gen_ai` spans were produced, so the ESM `scenario-auto` test timed out.

The runtime injection hook already receives the resolved `file:` URL of every module it instruments and was throwing it away. We now record it on `__SENTRY_ORCHESTRION__.runtimeFiles` and let the Mastra integration anchor `@mastra/observability` resolution on the app's actual `@mastra/core` file. This works under both ESM and CJS and no longer depends on cwd; the CJS-cache and cwd lookups remain as fallbacks.

Decisions:

- Anchor on `@mastra/core`, not `@mastra/observability`. The latter is never loaded in the failing case — that is precisely why the SDK has to bootstrap it — so there is nothing to hook there. `@mastra/core` is always loaded when the integration runs.
- Fix it in SDK code rather than by changing the scenario child's cwd in the test runner. The cwd approach would have papered over a real production gap (ESM apps whose cwd is not the app directory, e.g. serverless) that the code's own comments already acknowledged.

This also moves `@mastra/core` and `@mastra/observability` out of the `node-integration-tests` workspace `devDependencies` into the runner's per-suite `additionalDependencies`. `@mastra/core` declares `engines.node >= 22.13`, so a workspace `devDependency` broke `yarn install` on the Node 20.19 CI matrix even though the suite is gated behind `conditionalTest({ min: 22 })`. Installing them into the test's temp dir at run time means Node 20 never resolves them, while Node 22+ runs get them exactly as before.

_Root cause_: cwd/`require.cache`-based resolution has no valid anchor for an optional peer dependency of an ESM-loaded module when the app's `node_modules` is not under `process.cwd()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
