### PR TITLE
ref(node): Remove two Node <20 leftovers (hrtime.bigint, undici channel refs)

### DIFF
--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -286,16 +286,14 @@ if (options.captureStackTrace) {
 }
 
 function createHrTimer(): { getTimeMs: () => number; reset: VoidFunction } {
-  // TODO (v8): We can use process.hrtime.bigint() after we drop node v8
-  let lastPoll = process.hrtime();
+  let lastPoll = process.hrtime.bigint();
 
   return {
     getTimeMs: (): number => {
-      const [seconds, nanoSeconds] = process.hrtime(lastPoll);
-      return Math.floor(seconds * 1e3 + nanoSeconds / 1e6);
+      return Number((process.hrtime.bigint() - lastPoll) / 1_000_000n);
     },
     reset: (): void => {
-      lastPoll = process.hrtime();
+      lastPoll = process.hrtime.bigint();
     },
   };
 }

--- a/packages/node/src/integrations/node-fetch/undici-instrumentation.ts
+++ b/packages/node/src/integrations/node-fetch/undici-instrumentation.ts
@@ -74,9 +74,7 @@ import type {
 // `http.request.method_original` is not part of `@sentry/conventions`, so we keep it inline.
 const ATTR_HTTP_REQUEST_METHOD_ORIGINAL = 'http.request.method_original';
 
-// Keep ref to avoid https://github.com/nodejs/node/issues/42170 bug
-// We can replace this with _isInstrumented once we drop support for Node.js 18.18.0
-const _channelSubs: Array<unknown> = [];
+let _isInstrumented = false;
 const spanFromReq = new WeakMap<UndiciRequest, Span>();
 // Whether breadcrumbs (and span-less trace propagation) should be skipped for a given request.
 // We evaluate this at request-creation time because the active context is no longer correct by the
@@ -101,9 +99,10 @@ const propagationDecisionMap = new LRUMap<string, boolean>(100);
  */
 export function instrumentUndici(config: NodeFetchOptions = {}): void {
   // Avoid duplicate subscriptions
-  if (_channelSubs.length) {
+  if (_isInstrumented) {
     return;
   }
+  _isInstrumented = true;
 
   subscribeToChannel('undici:request:create', message => onRequestCreated(config, message as RequestMessage));
   subscribeToChannel('undici:client:sendHeaders', message =>
@@ -118,7 +117,7 @@ function subscribeToChannel(
   diagnosticChannel: string,
   onMessage: (message: unknown, name: string | symbol) => void,
 ): void {
-  _channelSubs.push(diagch.subscribe?.(diagnosticChannel, onMessage));
+  diagch.subscribe?.(diagnosticChannel, onMessage);
 }
 
 function parseRequestHeaders(request: UndiciRequest): Map<string, string | string[]> {


### PR DESCRIPTION
Both notes named the exact condition for their own removal, and both conditions passed when the engine floor moved to Node `>=20.19.0` in 4f0343802.

`createHrTimer()`'s TODO was conditioned on dropping Node 8; `process.hrtime.bigint()` has been available since Node 10.7. `getTimeMs()` still returns an integer `number` of milliseconds — BigInt division truncates toward zero and the elapsed delta is never negative, so it yields the same value the previous `Math.floor(seconds * 1e3 + nanoSeconds / 1e6)` did.

`_channelSubs` existed only to hold a reference around nodejs/node#42170, which mattered while Node 18.18.0 was supported. It is replaced by the `_isInstrumented` boolean its own comment proposed. Nothing else in the repo read the array — the only uses were the `.length` guard and the `.push()`. The flag is now set before subscribing rather than after, so a re-entrant call cannot double-subscribe; the old `.length` check only flipped after the first push, making this equal-or-stricter.

Fixes #24182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGK2ap3HHAy2WuDwoS8yTW
