### PR TITLE
test(node): Port express error-handling suites to span streaming

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-no-tracing.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-no-tracing.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-sample-rate-0.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-sample-rate-0.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-setup-error-handler.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-setup-error-handler.mjs
@@ -5,7 +5,6 @@ import { loggingTransport } from '@sentry-internal/node-integration-tests';
 // middleware is the sole error capturer (mechanism `auto.middleware.express`) — the fallback for
 // setups where the channel-based auto capture is unavailable.
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument-should-handle-error.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument-should-handle-error.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/instrument.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/express/handle-error/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/test.ts
@@ -12,17 +12,16 @@ describe('express error handling', () => {
         const runner = createRunner()
           .unordered()
           .expect({
-            transaction: {
-              transaction: 'GET /test/express/:id',
-              contexts: {
-                trace: {
-                  op: 'http.server',
-                  status: 'internal_error',
-                  data: expect.objectContaining({
-                    'http.response.status_code': 500,
-                  }),
-                },
-              },
+            span: container => {
+              expect(container.items.find(item => item.is_segment)).toMatchObject({
+                name: 'GET /test/express/:id',
+                status: 'error',
+                attributes: expect.objectContaining({
+                  'sentry.op': { type: 'string', value: 'http.server' },
+                  'sentry.status.message': { type: 'string', value: 'internal_error' },
+                  'http.response.status_code': { type: 'integer', value: 500 },
+                }),
+              });
             },
           })
           .expect({
@@ -99,7 +98,7 @@ describe('express error handling', () => {
     createCjsTests(__dirname, 'scenario.mjs', 'instrument-no-tracing.mjs', (createRunner, test) => {
       test('should capture and send Express controller error if tracesSampleRate is not set.', async () => {
         const runner = createRunner()
-          .ignore('transaction')
+          .ignore('span')
           .expect({
             event: {
               exception: {

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/instrument.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   // No dsn, means  client is disabled
   // dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',

--- a/dev-packages/node-integration-tests/suites/express/multiple-init/scenario.mjs
+++ b/dev-packages/node-integration-tests/suites/express/multiple-init/scenario.mjs
@@ -19,7 +19,6 @@ app.get('/test/no-init', (_req, res) => {
 app.get('/test/init', (_req, res) => {
   // Call init again, but with DSN
   Sentry.init({
-    traceLifecycle: 'static',
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     release: '1.0',
     transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/requestUser/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/requestUser/instrument.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/instrument.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',

--- a/dev-packages/node-integration-tests/suites/express/tracing/withError/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/tracing/withError/instrument.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // disable attaching headers to /test/* endpoints

--- a/dev-packages/node-integration-tests/suites/express/tracing/withError/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/withError/test.ts
@@ -9,7 +9,7 @@ describe('express tracing with error', () => {
   createCjsTests(__dirname, 'scenario.mjs', 'instrument.mjs', (createRunner, test) => {
     test('should apply the scope transactionName to error events', async () => {
       const runner = createRunner()
-        .ignore('transaction')
+        .ignore('span')
         .expect({
           event: {
             exception: {
@@ -29,7 +29,7 @@ describe('express tracing with error', () => {
 
     test('preserves encoded query parameters while filtering sensitive values on events', async () => {
       const runner = createRunner()
-        .ignore('transaction')
+        .ignore('span')
         .expect({
           event: {
             request: {

--- a/dev-packages/node-integration-tests/suites/express/without-tracing/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/express/without-tracing/instrument.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   transport: loggingTransport,


### PR DESCRIPTION
Drops the static trace lifecycle pins from the express suites that only capture error events (handle-error, multiple-init, requestUser, sentry-trace, without-tracing, withError). Refs #24136