### PR TITLE
test(node): Port express maxIncomingRequestBodySize suite to span streaming

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-always.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-always.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-default.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-default.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-medium.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-medium.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-none.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-none.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-small.mjs
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/instrument-small.mjs
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/node';
 import { loggingTransport } from '@sentry-internal/node-integration-tests';
 
 Sentry.init({
-  traceLifecycle: 'static',
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,

--- a/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/with-http/maxIncomingRequestBodySize/test.ts
@@ -21,11 +21,13 @@ describe('express with httpIntegration and not defined maxRequestBodySize', () =
     test('captures medium request bodies with default setting (medium)', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: JSON.stringify(generatePayload(MAX_MEDIUM)),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: JSON.stringify(generatePayload(MAX_MEDIUM)) },
+              }),
+            });
           },
         })
         .start();
@@ -41,11 +43,13 @@ describe('express with httpIntegration and not defined maxRequestBodySize', () =
     test('truncates large request bodies with default setting (medium)', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: generatePayloadString(MAX_MEDIUM, true),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: generatePayloadString(MAX_MEDIUM, true) },
+              }),
+            });
           },
         })
         .start();
@@ -69,11 +73,13 @@ describe('express with httpIntegration, disabled httpBodies, and explicit maxReq
     test('captures request bodies because the explicit size overrides dataCollection.httpBodies', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: JSON.stringify(generatePayload(MAX_SMALL)),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: JSON.stringify(generatePayload(MAX_SMALL)) },
+              }),
+            });
           },
         })
         .start();
@@ -97,11 +103,10 @@ describe('express with httpIntegration and maxRequestBodySize: "none"', () => {
     test('does not capture any request bodies with "none" setting', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: expect.not.objectContaining({
-              data: expect.any(String),
-            }),
+          span: container => {
+            const serverSpan = container.items.find(item => item.is_segment);
+            expect(serverSpan?.name).toBe('POST /test-body-size');
+            expect(serverSpan?.attributes['http.request.body.data']).toBeUndefined();
           },
         })
         .start();
@@ -117,19 +122,17 @@ describe('express with httpIntegration and maxRequestBodySize: "none"', () => {
     test('does not capture any request bodies with "none" setting and "ignoreRequestBody"', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: expect.not.objectContaining({
-              data: expect.any(String),
-            }),
+          span: container => {
+            const serverSpan = container.items.find(item => item.is_segment);
+            expect(serverSpan?.name).toBe('POST /test-body-size');
+            expect(serverSpan?.attributes['http.request.body.data']).toBeUndefined();
           },
         })
         .expect({
-          transaction: {
-            transaction: 'POST /ignore-request-body',
-            request: expect.not.objectContaining({
-              data: expect.any(String),
-            }),
+          span: container => {
+            const serverSpan = container.items.find(item => item.is_segment);
+            expect(serverSpan?.name).toBe('POST /ignore-request-body');
+            expect(serverSpan?.attributes['http.request.body.data']).toBeUndefined();
           },
         })
         .start();
@@ -158,11 +161,13 @@ describe('express with httpIntegration and maxRequestBodySize: "always"', () => 
     test('captures maximum allowed request body length with "always" setting', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: JSON.stringify(generatePayload(MAX_GENERAL)),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: JSON.stringify(generatePayload(MAX_GENERAL)) },
+              }),
+            });
           },
         })
         .start();
@@ -178,11 +183,13 @@ describe('express with httpIntegration and maxRequestBodySize: "always"', () => 
     test('captures large request bodies with "always" setting but respects maximum size limit', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: generatePayloadString(MAX_GENERAL, true),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: generatePayloadString(MAX_GENERAL, true) },
+              }),
+            });
           },
         })
         .start();
@@ -206,11 +213,13 @@ describe('express with httpIntegration and maxRequestBodySize: "small"', () => {
     test('keeps small request bodies with "small" setting', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: JSON.stringify(generatePayload(MAX_SMALL)),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: JSON.stringify(generatePayload(MAX_SMALL)) },
+              }),
+            });
           },
         })
         .start();
@@ -226,11 +235,13 @@ describe('express with httpIntegration and maxRequestBodySize: "small"', () => {
     test('truncates too large request bodies with "small" setting', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: generatePayloadString(MAX_SMALL, true),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: generatePayloadString(MAX_SMALL, true) },
+              }),
+            });
           },
         })
         .start();
@@ -246,12 +257,14 @@ describe('express with httpIntegration and maxRequestBodySize: "small"', () => {
     test('truncates too large non-ASCII request bodies with "small" setting', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              // 250 emojis, each 4 bytes in UTF-8 (resulting in 1000 bytes --> MAX_SMALL)
-              data: generateEmojiPayloadString(250, true),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                // 250 emojis, each 4 bytes in UTF-8 (resulting in 1000 bytes --> MAX_SMALL)
+                'http.request.body.data': { type: 'string', value: generateEmojiPayloadString(250, true) },
+              }),
+            });
           },
         })
         .start();
@@ -275,11 +288,13 @@ describe('express with httpIntegration and maxRequestBodySize: "medium"', () => 
     test('keeps medium request bodies with "medium" setting', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: JSON.stringify(generatePayload(MAX_MEDIUM)),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: JSON.stringify(generatePayload(MAX_MEDIUM)) },
+              }),
+            });
           },
         })
         .start();
@@ -295,11 +310,13 @@ describe('express with httpIntegration and maxRequestBodySize: "medium"', () => 
     test('truncates large request bodies with "medium" setting', async () => {
       const runner = createRunner()
         .expect({
-          transaction: {
-            transaction: 'POST /test-body-size',
-            request: {
-              data: generatePayloadString(MAX_MEDIUM, true),
-            },
+          span: container => {
+            expect(container.items.find(item => item.is_segment)).toMatchObject({
+              name: 'POST /test-body-size',
+              attributes: expect.objectContaining({
+                'http.request.body.data': { type: 'string', value: generatePayloadString(MAX_MEDIUM, true) },
+              }),
+            });
           },
         })
         .start();


### PR DESCRIPTION
Asserts the captured request body on the segment span's `http.request.body.data` attribute instead of the transaction's `request.data`. Refs #24136