### PR TITLE
ref(cloudflare): Add whitespace in warning

### DIFF
--- a/packages/cloudflare/src/vite/autoInstrument.ts
+++ b/packages/cloudflare/src/vite/autoInstrument.ts
@@ -137,7 +137,7 @@ export function sentryCloudflareAutoInstrumentPlugin(options: { wranglerConfigPa
         this.warn?.(
           `[sentry] Could not auto-instrument ${missing.join(', ')}.` +
             'The worker entry has no export matching them. ' +
-            'Star re-exports (`export * from "./do"`) are not matched.' +
+            'Star re-exports (`export * from "./do"`) are not matched. ' +
             'Export them by name or wrap them manually with corresponding `instrument*WithSentry` helpers.',
         );
       }


### PR DESCRIPTION
It seems in #23282 we missed an whitespace based on https://github.com/getsentry/sentry-javascript/pull/24181#discussion_r3956490351 (came up on a backport)