### PR TITLE
test(e2e): Tell the two nestjs-basic interceptor specs traces apart

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/tests/spans.test.ts
@@ -105,6 +105,18 @@ test('Sends an app_creation span', async () => {
   });
 });
 
+/**
+ * Two specs hit each interceptor route, and `collectStreamedSpans` resolves with any trace that
+ * satisfies the predicate - including one left over from the spec before. Each request therefore
+ * carries a marker that tells its own trace apart. `url.query` keeps it out of the span name.
+ */
+function collectSpansOfRequest(segmentName: string, spec: string): Promise<SerializedStreamedSpan[]> {
+  return collectStreamedSpansUntilSegment(
+    APP_NAME,
+    span => span.name === segmentName && span.attributes['url.query']?.value === `spec=${spec}`,
+  );
+}
+
 test('Sends streamed spans for an API route', async ({ baseURL }) => {
   const spansPromise = collectStreamedSpansUntilSegment(APP_NAME, 'GET /test-transaction');
 
@@ -292,9 +304,9 @@ test('API route trace includes nest pipe span for invalid request', async ({ bas
 test('API route trace includes nest interceptor spans before route execution. Spans created in and after interceptor are nested correctly', async ({
   baseURL,
 }) => {
-  const spansPromise = collectStreamedSpansUntilSegment(APP_NAME, 'GET /test-interceptor-instrumentation');
+  const spansPromise = collectSpansOfRequest('GET /test-interceptor-instrumentation', 'interceptor-before-route');
 
-  const response = await fetch(`${baseURL}/test-interceptor-instrumentation`);
+  const response = await fetch(`${baseURL}/test-interceptor-instrumentation?spec=interceptor-before-route`);
   expect(response.status).toBe(200);
 
   const spans = await spansPromise;
@@ -328,9 +340,9 @@ test('API route trace includes nest interceptor spans before route execution. Sp
 test('API route trace includes exactly one nest interceptor span after route execution. Spans created in controller and in interceptor are nested correctly', async ({
   baseURL,
 }) => {
-  const spansPromise = collectStreamedSpansUntilSegment(APP_NAME, 'GET /test-interceptor-instrumentation');
+  const spansPromise = collectSpansOfRequest('GET /test-interceptor-instrumentation', 'interceptor-after-route');
 
-  const response = await fetch(`${baseURL}/test-interceptor-instrumentation`);
+  const response = await fetch(`${baseURL}/test-interceptor-instrumentation?spec=interceptor-after-route`);
   expect(response.status).toBe(200);
 
   const spans = await spansPromise;
@@ -356,9 +368,12 @@ test('API route trace includes exactly one nest interceptor span after route exe
 test('API route trace includes nest async interceptor spans before route execution. Spans created in and after async interceptor are nested correctly', async ({
   baseURL,
 }) => {
-  const spansPromise = collectStreamedSpansUntilSegment(APP_NAME, 'GET /test-async-interceptor-instrumentation');
+  const spansPromise = collectSpansOfRequest(
+    'GET /test-async-interceptor-instrumentation',
+    'async-interceptor-before-route',
+  );
 
-  const response = await fetch(`${baseURL}/test-async-interceptor-instrumentation`);
+  const response = await fetch(`${baseURL}/test-async-interceptor-instrumentation?spec=async-interceptor-before-route`);
   expect(response.status).toBe(200);
 
   const spans = await spansPromise;
@@ -384,9 +399,12 @@ test('API route trace includes nest async interceptor spans before route executi
 test('API route trace includes exactly one nest async interceptor span after route execution. Spans created in controller and in async interceptor are nested correctly', async ({
   baseURL,
 }) => {
-  const spansPromise = collectStreamedSpansUntilSegment(APP_NAME, 'GET /test-async-interceptor-instrumentation');
+  const spansPromise = collectSpansOfRequest(
+    'GET /test-async-interceptor-instrumentation',
+    'async-interceptor-after-route',
+  );
 
-  const response = await fetch(`${baseURL}/test-async-interceptor-instrumentation`);
+  const response = await fetch(`${baseURL}/test-async-interceptor-instrumentation?spec=async-interceptor-after-route`);
   expect(response.status).toBe(200);
 
   const spans = await spansPromise;


### PR DESCRIPTION
Both specs of each interceptor route produce a trace with the same segment name, and `collectStreamedSpans` resolves with any trace satisfying the predicate, so a leftover trace from the preceding spec could satisfy it instead. Each request now carries a `spec` query marker, which lands in `url.query` and not in the span name.

This was meant to ship with #24099 but landed on the branch after it merged.

Ref: #23801
