### PR TITLE
fix(v10/browser): Set `user_agent.original` on all spans for consistent filtering

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/httpContext-streamed/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpContext-streamed/subject.js
@@ -1,0 +1,5 @@
+Sentry.startSpan({ name: 'parent-span', op: 'test' }, () => {
+  Sentry.startSpan({ name: 'child-span', op: 'test-child' }, () => {
+    // noop
+  });
+});

--- a/dev-packages/browser-integration-tests/suites/integrations/httpContext-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpContext-streamed/test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../utils/helpers';
+import { URL_FULL, USER_AGENT_ORIGINAL } from '@sentry/conventions/attributes';
 import { getSpanOp, waitForStreamedSpans } from '../../../utils/spanUtils';
 
 sentryTest('httpContextIntegration captures url, user-agent, and referer', async ({ getLocalTestUrl, page }) => {
@@ -15,8 +16,8 @@ sentryTest('httpContextIntegration captures url, user-agent, and referer', async
 
   const pageloadSpan = spans.find(s => getSpanOp(s) === 'pageload');
 
-  expect(pageloadSpan!.attributes['url.full']).toEqual({ type: 'string', value: expect.any(String) });
-  expect(pageloadSpan!.attributes['http.request.header.user_agent']).toEqual({
+  expect(pageloadSpan!.attributes[URL_FULL]).toEqual({ type: 'string', value: expect.any(String) });
+  expect(pageloadSpan!.attributes[USER_AGENT_ORIGINAL]).toEqual({
     type: 'string',
     value: expect.any(String),
   });
@@ -25,3 +26,25 @@ sentryTest('httpContextIntegration captures url, user-agent, and referer', async
     value: 'https://sentry.io/',
   });
 });
+
+sentryTest(
+  'httpContextIntegration only attaches the user agent to non-segment spans',
+  async ({ getLocalTestUrl, page }) => {
+    sentryTest.skip(shouldSkipTracingTest());
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    const spansPromise = waitForStreamedSpans(page, spans => spans.some(s => s.name === 'child-span'));
+
+    await page.goto(url, { referer: 'https://sentry.io/' });
+
+    const spans = await spansPromise;
+
+    const childSpan = spans.find(s => s.name === 'child-span');
+
+    expect(childSpan!.is_segment).toBe(false);
+    expect(childSpan!.attributes[USER_AGENT_ORIGINAL]).toEqual({ type: 'string', value: expect.any(String) });
+    // The document URL and referer only belong on the segment span.
+    expect(childSpan!.attributes[URL_FULL]).toBeUndefined();
+    expect(childSpan!.attributes['http.request.header.referer']).toBeUndefined();
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/streamed/test.ts
@@ -18,6 +18,7 @@ import {
   SENTRY_SDK_NAME,
   SENTRY_SDK_VERSION,
   SENTRY_TRACE_LIFECYCLE,
+  USER_AGENT_ORIGINAL,
 } from '@sentry/conventions/attributes';
 
 sentryTest(
@@ -107,6 +108,10 @@ sentryTest(
             type: 'string',
             value: 'stream',
           },
+          [USER_AGENT_ORIGINAL]: {
+            type: 'string',
+            value: expect.any(String),
+          },
         },
         end_timestamp: expect.any(Number),
         is_segment: false,
@@ -146,6 +151,10 @@ sentryTest(
           [SENTRY_TRACE_LIFECYCLE]: {
             type: 'string',
             value: 'stream',
+          },
+          [USER_AGENT_ORIGINAL]: {
+            type: 'string',
+            value: expect.any(String),
           },
         },
         end_timestamp: expect.any(Number),
@@ -191,6 +200,10 @@ sentryTest(
             type: 'string',
             value: 'stream',
           },
+          [USER_AGENT_ORIGINAL]: {
+            type: 'string',
+            value: expect.any(String),
+          },
         },
         end_timestamp: expect.any(Number),
         is_segment: false,
@@ -215,7 +228,7 @@ sentryTest(
             type: 'string',
             value: expect.any(String),
           },
-          'http.request.header.user_agent': {
+          [USER_AGENT_ORIGINAL]: {
             type: 'string',
             value: expect.any(String),
           },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/interactions-streamed/test.ts
@@ -14,6 +14,7 @@ import {
   SENTRY_SDK_NAME,
   SENTRY_SDK_VERSION,
   SENTRY_TRACE_LIFECYCLE,
+  USER_AGENT_ORIGINAL,
 } from '@sentry/conventions/attributes';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
@@ -61,7 +62,7 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
         type: 'string',
         value: expect.any(String),
       },
-      'http.request.header.user_agent': {
+      [USER_AGENT_ORIGINAL]: {
         type: 'string',
         value: expect.any(String),
       },
@@ -136,6 +137,10 @@ sentryTest('captures streamed interaction span tree. @firefox', async ({ browser
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: {
         type: 'string',
         value: 'ui.interaction.click',
+      },
+      [USER_AGENT_ORIGINAL]: {
+        type: 'string',
+        value: expect.any(String),
       },
       [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: {
         type: 'string',

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/navigation-streamed/test.ts
@@ -8,7 +8,7 @@ import {
   SEMANTIC_ATTRIBUTE_SENTRY_SDK_INTEGRATIONS,
   SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
 } from '@sentry/core';
-import { SENTRY_TRACE_LIFECYCLE, URL_FULL, URL_PATH } from '@sentry/conventions/attributes';
+import { SENTRY_TRACE_LIFECYCLE, URL_FULL, URL_PATH, USER_AGENT_ORIGINAL } from '@sentry/conventions/attributes';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import {
@@ -88,7 +88,7 @@ sentryTest('starts a streamed navigation span on page navigation', async ({ brow
         type: 'string',
         value: expect.any(String),
       },
-      'http.request.header.user_agent': {
+      [USER_AGENT_ORIGINAL]: {
         type: 'string',
         value: expect.any(String),
       },

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/pageload-streamed/test.ts
@@ -16,6 +16,7 @@ import {
   SENTRY_TRACE_LIFECYCLE,
   URL_FULL,
   URL_PATH,
+  USER_AGENT_ORIGINAL,
 } from '@sentry/conventions/attributes';
 import { sentryTest } from '../../../../utils/fixtures';
 import { shouldSkipTracingTest } from '../../../../utils/helpers';
@@ -81,7 +82,7 @@ sentryTest(
           type: 'string',
           value: expect.any(String),
         },
-        'http.request.header.user_agent': {
+        [USER_AGENT_ORIGINAL]: {
           type: 'string',
           value: expect.any(String),
         },

--- a/dev-packages/e2e-tests/test-applications/nitro-3/tests/errors.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/tests/errors.test.ts
@@ -2,8 +2,16 @@ import { expect, test } from '@playwright/test';
 import { waitForError } from '@sentry-internal/test-utils';
 
 test('Sends an error event to Sentry', async ({ request }) => {
+  // The thrown error is reported twice: once via the h3 tracing channel and once via Nitro's `error`
+  // hook (which sees it wrapped in an `HTTPError`). Match on the mechanism so we deterministically
+  // await the event under test instead of whichever arrives first.
   const errorEventPromise = waitForError('nitro-3', event => {
-    return !event.type && !!event.exception?.values?.some(v => v.value === 'This is a test error');
+    return (
+      !event.type &&
+      !!event.exception?.values?.some(
+        v => v.value === 'This is a test error' && v.mechanism?.type === 'auto.http.nitro.onTraceError',
+      )
+    );
   });
 
   await request.get('/api/test-error').catch(() => {

--- a/packages/browser/src/integrations/httpcontext.ts
+++ b/packages/browser/src/integrations/httpcontext.ts
@@ -1,6 +1,6 @@
-import { defineIntegration, safeSetSpanJSONAttributes, SEMANTIC_ATTRIBUTE_SENTRY_OP } from '@sentry/core/browser';
+import { defineIntegration, safeSetSpanJSONAttributes } from '@sentry/core/browser';
 import { getHttpRequestData, WINDOW } from '../helpers';
-import { URL_FULL } from '@sentry/conventions/attributes';
+import { HTTP_REQUEST_HEADER_KEY_BASE, SENTRY_OP, URL_FULL, USER_AGENT_ORIGINAL } from '@sentry/conventions/attributes';
 
 /**
  * Collects information about HTTP request headers and
@@ -27,9 +27,8 @@ export const httpContextIntegration = defineIntegration(() => {
         headers,
       };
     },
-    processSegmentSpan(span) {
-      const spanOp = span.attributes?.[SEMANTIC_ATTRIBUTE_SENTRY_OP];
 
+    processSpan(span) {
       // if none of the information we want exists, don't bother
       if (!WINDOW.navigator && !WINDOW.location && !WINDOW.document) {
         return;
@@ -38,11 +37,17 @@ export const httpContextIntegration = defineIntegration(() => {
       const reqData = getHttpRequestData();
 
       safeSetSpanJSONAttributes(span, {
-        // Coerce empty string to undefined so the helper's nullish check drops it,
-        // rather than writing an empty `url.full` attribute onto the span.
-        [URL_FULL]: spanOp !== 'http.client' ? reqData.url : undefined,
-        'http.request.header.user_agent': reqData.headers['User-Agent'],
-        'http.request.header.referer': reqData.headers['Referer'],
+        // This attribute is used by the "Filter out events from legacy browsers and crawlers" features on the Sentry backend.
+        // Therefore, it's set on every span.
+        [USER_AGENT_ORIGINAL]: reqData.headers['User-Agent'],
+
+        // These attributes, we only need on the segment span (analogous to the `request` context for events)
+        ...(span.is_segment && {
+          // Coerce empty string to undefined so the helper's nullish check drops it,
+          // rather than writing an empty `url.full` attribute onto the span.
+          [URL_FULL]: span.attributes?.[SENTRY_OP] !== 'http.client' ? reqData.url : undefined,
+          [`${HTTP_REQUEST_HEADER_KEY_BASE}.referer`]: reqData.headers['Referer'],
+        }),
       });
     },
   };

--- a/packages/browser/test/integrations/httpcontext.test.ts
+++ b/packages/browser/test/integrations/httpcontext.test.ts
@@ -4,6 +4,9 @@ import type { StreamedSpanJSON } from '@sentry/core';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
 import { BrowserClient } from '../../src/client';
 
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
+
 describe('httpContextIntegration', () => {
   globalThis.navigator = {
     userAgent:
@@ -24,6 +27,7 @@ describe('httpContextIntegration', () => {
     const integration = httpContextIntegration();
 
     const span: Partial<StreamedSpanJSON> = {
+      is_segment: true,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client',
       },
@@ -31,14 +35,13 @@ describe('httpContextIntegration', () => {
 
     const browserClient = new BrowserClient(getDefaultBrowserClientOptions());
 
-    integration.processSegmentSpan!(span as StreamedSpanJSON, browserClient);
+    integration.processSpan!(span as StreamedSpanJSON, browserClient);
 
     expect(span.attributes).not.toHaveProperty('url.full');
     expect(span.attributes).toEqual({
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'http.client',
       'http.request.header.referer': 'https://example.com',
-      'http.request.header.user_agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+      'user_agent.original': USER_AGENT,
     });
   });
 
@@ -46,6 +49,7 @@ describe('httpContextIntegration', () => {
     const integration = httpContextIntegration();
 
     const span: Partial<StreamedSpanJSON> = {
+      is_segment: true,
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
       },
@@ -53,14 +57,30 @@ describe('httpContextIntegration', () => {
 
     const browserClient = new BrowserClient(getDefaultBrowserClientOptions());
 
-    integration.processSegmentSpan!(span as StreamedSpanJSON, browserClient);
+    integration.processSpan!(span as StreamedSpanJSON, browserClient);
 
     expect(span.attributes).toEqual({
       [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
       'http.request.header.referer': 'https://example.com',
-      'http.request.header.user_agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+      'user_agent.original': USER_AGENT,
       'url.full': 'https://example.com',
+    });
+  });
+
+  it('only attaches the user agent to non-segment spans', () => {
+    const integration = httpContextIntegration();
+
+    const span: Partial<StreamedSpanJSON> = {
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.click',
+      },
+    };
+
+    integration.processSpan!(span as StreamedSpanJSON, new BrowserClient(getDefaultBrowserClientOptions()));
+
+    expect(span.attributes).toEqual({
+      [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'ui.click',
+      'user_agent.original': USER_AGENT,
     });
   });
 });


### PR DESCRIPTION
Backport of: #24216

Technically, this removes an attribute and sets another. However, this only affects span streaming, which is opt-in and not 100% stable on v10, so I think it's fine. 

## Differences to the original PR

- `packages/browser/src/integrations/httpcontext.ts`: kept v10's `@sentry/core/browser` import path and its unfiltered `reqData.headers` / `reqData.url`. v10 has no `dataCollection` header filtering (`_INTERNAL_filterKeyValueData`, `filterCollectedUrl`), so `processSpan` takes no `client` argument here.
- `packages/browser/test/integrations/httpcontext.test.ts`: dropped the `dataCollection` suite updates (that suite doesn't exist on v10) and added the `USER_AGENT` const the ported assertions reference.
- Skipped `nextjs-app-dir` / `nextjs-pages-dir` `transactions.test.ts`: on v10 these still assert on transaction-event `contexts.trace.data`, which carries no user-agent attribute, so there is nothing to rename.
- The interaction test lives at `browserTracingIntegration/interactions-streamed/` on v10 rather than `tracing/interactions/spans/`; same content, different path.

The behavioral fix itself is ported in full.
