### PR TITLE
feat(node): Add `getInstrumentedModuleNames()`

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-eve/agent/agent.ts
+++ b/dev-packages/e2e-tests/test-applications/node-eve/agent/agent.ts
@@ -1,4 +1,5 @@
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+import { getInstrumentedModuleNames } from '@sentry/node';
 import { defineAgent } from 'eve';
 
 const apiKey = process.env.E2E_OPENROUTER_API_KEY;
@@ -24,17 +25,18 @@ export default defineAgent({
     // Only configure externals for orchestrion mode, to ensure everything else works without it
     ...(useOrchestrion
       ? {
-          // `dataloader` is instrumented by Sentry via orchestrion (a module
-          // transform). Keep it external so it stays a real module the transform can
-          // hook; if eve inlined it into the server bundle it could never be
-          // instrumented. (The Vercel AI SDK needs none of this — it uses a native
-          // diagnostics channel.)
+          // Keep every package Sentry instruments via orchestrion (a module transform) external, so
+          // it stays a real module the transform can hook rather than being inlined into eve's server
+          // bundle (an inlined module never reaches the transform's `onLoad`). Rather than hardcode
+          // the set, ask the SDK for it — this app exercises `dataloader`, and the rest are no-ops
+          // when the app doesn't use them. (The Vercel AI SDK needs none of this; it uses a native
+          // diagnostics channel and `ai` v7 is registration-only under the transform.)
           //
           // Do NOT add `@sentry/server-runtime-injection` here: the `--import`
           // loader instruments regardless (so the "bundled ... uninstrumented"
           // warning is a false positive), and externalizing it makes eve's dev
           // host fail to resolve its `/register` subpath (`eve dev` only).
-          externalDependencies: ['dataloader'],
+          externalDependencies: getInstrumentedModuleNames(),
         }
       : {}),
   },

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -185,6 +185,7 @@ export {
   withStreamedSpan,
   metrics,
   eveConversationHook,
+  getInstrumentedModuleNames,
 } from '@sentry/node';
 
 export { init } from './server/sdk';

--- a/packages/aws-serverless/src/index.ts
+++ b/packages/aws-serverless/src/index.ts
@@ -171,6 +171,7 @@ export {
   // oxlint-disable-next-line typescript/no-deprecated
   withStreamedSpan,
   eveConversationHook,
+  getInstrumentedModuleNames,
 } from '@sentry/node';
 
 export {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -188,6 +188,7 @@ export {
   // oxlint-disable-next-line typescript/no-deprecated
   withStreamedSpan,
   eveConversationHook,
+  getInstrumentedModuleNames,
 } from '@sentry/node';
 
 export {

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -135,6 +135,7 @@ export {
   instrumentCreateReactAgent,
   vercelAIIntegration,
   eveConversationHook,
+  getInstrumentedModuleNames,
 } from '@sentry/server-utils';
 
 export { instrumentWorkflowWithSentry } from './workflows';

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -145,6 +145,7 @@ export {
   postgresJsIntegration,
   tediousIntegration,
   eveConversationHook,
+  getInstrumentedModuleNames,
 } from '@sentry/server-utils';
 export { openTelemetryIntegration, getOtlpTracesEndpoint } from '@sentry/server-utils/no-diagnostic-channels';
 // Deprecated aliases kept for back-compat. Each forwards to the shared

--- a/packages/google-cloud-serverless/src/index.ts
+++ b/packages/google-cloud-serverless/src/index.ts
@@ -171,6 +171,7 @@ export {
   // oxlint-disable-next-line typescript/no-deprecated
   withStreamedSpan,
   eveConversationHook,
+  getInstrumentedModuleNames,
 } from '@sentry/node';
 
 export {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -216,7 +216,7 @@ export { makeNodeTransport } from './transports';
 export { createGetModuleFromFilename } from './utils/module';
 
 export { SENTRY_SEGMENT_NAME_SOURCE } from '@sentry/conventions/attributes';
-export { eveConversationHook } from '@sentry/server-utils';
+export { eveConversationHook, getInstrumentedModuleNames } from '@sentry/server-utils';
 export { httpServerIntegration } from './integrations/http/httpServerIntegration';
 export { httpServerSpansIntegration } from './integrations/http/httpServerSpansIntegration';
 export { processSessionIntegration } from './integrations/processSession';

--- a/packages/server-utils/src/index.ts
+++ b/packages/server-utils/src/index.ts
@@ -14,6 +14,7 @@ export type { InstrumentationConfig } from './orchestrion/apmTypes';
 // helper with no orchestrion build-time dependency.
 export { orchestrionModuleInjected } from './utils/moduleInjected';
 export { eveConversationHook } from './eve';
+export { getInstrumentedModuleNames } from './orchestrion/config';
 export {
   fastifyIntegration,
   // oxlint-disable-next-line typescript/no-deprecated

--- a/packages/server-utils/src/orchestrion/config/index.ts
+++ b/packages/server-utils/src/orchestrion/config/index.ts
@@ -137,6 +137,21 @@ export function instrumentedModuleNames(instrumentations: InstrumentationConfig[
 export const INSTRUMENTED_MODULE_NAMES: string[] = instrumentedModuleNames();
 
 /**
+ * The package names the SDK instruments through the orchestrion module transform (its
+ * diagnostics-channel injection). Pass these to a server bundler's "keep external" option so the
+ * packages load through Node's module loader — the only path the transform can hook — instead of
+ * being inlined into the server bundle. A framework that has no Sentry bundler plugin (e.g. eve, via
+ * `build.externalDependencies`) is the main caller; a listed package the app doesn't use is simply
+ * ignored by the bundler.
+ *
+ * Unlike {@link INSTRUMENTED_MODULE_NAMES}, this is the plain instrumented set with no bundler-only
+ * additions — those force a helper package to be *bundled*, the opposite of keeping it external.
+ */
+export function getInstrumentedModuleNames(): string[] {
+  return uniq(SENTRY_INSTRUMENTATIONS.map(instrumentation => instrumentation.module.name));
+}
+
+/**
  * Returns `external` with any instrumented packages removed, so a bundler that
  * uses an "external" denylist (esbuild, Bun, Rollup) still bundles — and thus
  * transforms — them. Matches an exact package name (`'mysql'`) or a subpath

--- a/packages/server-utils/test/orchestrion/config.test.ts
+++ b/packages/server-utils/test/orchestrion/config.test.ts
@@ -1,6 +1,7 @@
 import type { InstrumentationConfig } from '@apm-js-collab/code-transformer-bundler-plugins/core';
 import { describe, expect, it } from 'vitest';
 import {
+  getInstrumentedModuleNames,
   INSTRUMENTED_MODULE_NAMES,
   instrumentedModuleNames,
   SENTRY_INSTRUMENTATIONS,
@@ -20,6 +21,32 @@ describe('orchestrion config — scoped @hapi/hapi module', () => {
     // exercises `withoutInstrumentedExternals` against a name containing a `/`.
     const external = ['react', '@hapi/hapi', '@hapi/hapi/lib/server.js'];
     expect(withoutInstrumentedExternals(external)).toEqual(['react']);
+  });
+});
+
+describe('getInstrumentedModuleNames', () => {
+  it('returns the instrumented package names', () => {
+    const names = getInstrumentedModuleNames();
+
+    for (const name of ['dataloader', 'ai', 'express', 'pg', 'redis']) {
+      expect(names).toContain(name);
+    }
+  });
+
+  it('has no duplicates', () => {
+    const names = getInstrumentedModuleNames();
+
+    expect(names.length).toBe(new Set(names).size);
+  });
+
+  it('is the plain instrumented set, without the bundler-only additions in INSTRUMENTED_MODULE_NAMES', () => {
+    // `INSTRUMENTED_MODULE_NAMES` adds packages that must be force-bundled (e.g. `@remix-run/node`),
+    // which is the opposite of what a "keep external" caller wants.
+    expect(getInstrumentedModuleNames()).not.toContain('@remix-run/node');
+    expect(INSTRUMENTED_MODULE_NAMES).toContain('@remix-run/node');
+    expect(new Set(getInstrumentedModuleNames())).toEqual(
+      new Set(SENTRY_INSTRUMENTATIONS.map(instrumentation => instrumentation.module.name)),
+    );
   });
 });
 


### PR DESCRIPTION
Stacked on #24247 (base branch `feat/eve-conversation-hook`).

Exposes `getInstrumentedModuleNames()` — the package names Sentry instruments through the orchestrion module transform (its diagnostics-channel injection).

```ts
import { getInstrumentedModuleNames } from '@sentry/node';

// eve agent.ts — keep every Sentry-instrumented package external so the
// transform can hook it, instead of hardcoding the list:
build: { externalDependencies: getInstrumentedModuleNames() }
```

_Why:_

- A framework with no Sentry bundler plugin (eve, via `build.externalDependencies`) otherwise has to hardcode which packages to keep external. An inlined dependency never reaches the transform's `onLoad`, so it's silently never instrumented — this hands the app the authoritative set.
- It returns the plain `module.name` set, deliberately **without** the bundler-only additions in the internal `INSTRUMENTED_MODULE_NAMES` (e.g. `@remix-run/node`), which exist to force a helper package to be *bundled* — the opposite of keeping it external.

_Export surface:_ lives in `@sentry/server-utils` (home of the orchestrion config). Re-exported from `@sentry/node`, so `export *` consumers — **nitro** (eve's base), astro, nestjs, hono, effect — surface it automatically; and added explicitly to `@sentry/bun`, `@sentry/aws-serverless`, `@sentry/google-cloud-serverless` (from node) and `@sentry/deno`, `@sentry/cloudflare` (from server-utils), i.e. everywhere a server bundle is configured — the same footprint as `eveConversationHook`.

_node-eve e2e:_ the orchestrion variant's `build.externalDependencies` now uses `getInstrumentedModuleNames()` instead of a hardcoded `['dataloader']`. The app only uses `dataloader` of that set, so the others are no-ops; `ai` v7 stays correct when externalized (native `ai:telemetry` channel, and registration-only under the transform, so no double instrumentation). The existing `dataloader` assertion continues to prove the transform still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)