### PR TITLE
fix(nextjs): Only include emitted chunk directories in Turbopack sourcemap upload

### DIFF
--- a/packages/nextjs/src/config/getBuildPluginOptions.ts
+++ b/packages/nextjs/src/config/getBuildPluginOptions.ts
@@ -98,15 +98,16 @@ function createSourcemapUploadAssetPatterns(
     assets.push(path.posix.join(normalizedDistPath, getServerPattern({ useDirectoryPath: true })));
 
     if (buildTool === 'after-production-compile-turbopack') {
-      // In turbopack we always want to upload the full static chunks directory
-      // as the build output is not split into pages|app chunks
-      assets.push(path.posix.join(normalizedDistPath, getStaticChunksPattern({ useDirectoryPath: true })));
-
-      // With `experimental.supportsImmutableAssets` (auto-enabled on Vercel preview), Turbopack emits
-      // client chunks to `static/immutable/chunks` instead of `static/chunks`
+      // Turbopack output is not split into pages|app chunks, so the whole chunks directory is uploaded.
+      // With `experimental.supportsImmutableAssets` (e.g. on Vercel), Turbopack emits client chunks to
+      // `static/immutable/chunks` instead of `static/chunks`. The upload errors on asset directories that
+      // don't exist, so each directory is only included when Turbopack actually emitted it.
+      const staticChunksPath = path.posix.join(normalizedDistPath, getStaticChunksPattern({ useDirectoryPath: true }));
       const immutableChunksPath = path.posix.join(normalizedDistPath, FILE_PATTERNS.STATIC_IMMUTABLE_CHUNKS.PATH);
-      if (fs.existsSync(immutableChunksPath)) {
-        assets.push(immutableChunksPath);
+      for (const chunksPath of [staticChunksPath, immutableChunksPath]) {
+        if (fs.existsSync(chunksPath)) {
+          assets.push(chunksPath);
+        }
       }
     } else {
       // Webpack client builds in after-production-compile mode

--- a/packages/nextjs/test/config/getBuildPluginOptions.test.ts
+++ b/packages/nextjs/test/config/getBuildPluginOptions.test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getBuildPluginOptions } from '../../src/config/getBuildPluginOptions';
 import type { SentryBuildOptions } from '../../src/config/types';
 
@@ -11,6 +11,14 @@ vi.mock('fs', async importOriginal => {
 describe('getBuildPluginOptions', () => {
   const mockReleaseName = 'test-release-1.0.0';
   const mockDistDirAbsPath = '/path/to/.next';
+
+  function mockExistingDirectories(existingDirectories: string[]): void {
+    vi.mocked(fs.existsSync).mockImplementation(p => existingDirectories.includes(String(p)));
+  }
+
+  afterEach(() => {
+    vi.mocked(fs.existsSync).mockReset();
+  });
 
   describe('basic functionality', () => {
     it('returns correct build plugin options with minimal configuration for after-production-compile-webpack', () => {
@@ -273,6 +281,8 @@ describe('getBuildPluginOptions', () => {
     });
 
     it('configures after-production-compile-turbopack build correctly', () => {
+      mockExistingDirectories(['/path/to/.next/static/chunks']);
+
       const result = getBuildPluginOptions({
         sentryBuildOptions: baseSentryOptions,
         releaseName: mockReleaseName,
@@ -302,8 +312,8 @@ describe('getBuildPluginOptions', () => {
       expect(result.reactComponentAnnotation).toBeUndefined();
     });
 
-    it('includes the immutable chunks directory in after-production-compile-turbopack assets when it exists', () => {
-      vi.mocked(fs.existsSync).mockImplementationOnce(p => p === '/path/to/.next/static/immutable/chunks');
+    it('includes both chunk directories in after-production-compile-turbopack assets when both exist', () => {
+      mockExistingDirectories(['/path/to/.next/static/chunks', '/path/to/.next/static/immutable/chunks']);
 
       const result = getBuildPluginOptions({
         sentryBuildOptions: baseSentryOptions,
@@ -320,7 +330,7 @@ describe('getBuildPluginOptions', () => {
     });
 
     it('does not include the immutable chunks directory in after-production-compile-turbopack assets when it does not exist', () => {
-      vi.mocked(fs.existsSync).mockReturnValueOnce(false);
+      mockExistingDirectories(['/path/to/.next/static/chunks']);
 
       const result = getBuildPluginOptions({
         sentryBuildOptions: baseSentryOptions,
@@ -330,6 +340,32 @@ describe('getBuildPluginOptions', () => {
       });
 
       expect(result.sourcemaps?.assets).toEqual(['/path/to/.next/server', '/path/to/.next/static/chunks']);
+    });
+
+    it('does not include the static chunks directory in after-production-compile-turbopack assets when only the immutable chunks directory exists', () => {
+      mockExistingDirectories(['/path/to/.next/static/immutable/chunks']);
+
+      const result = getBuildPluginOptions({
+        sentryBuildOptions: baseSentryOptions,
+        releaseName: mockReleaseName,
+        distDirAbsPath: mockDistDirAbsPath,
+        buildTool: 'after-production-compile-turbopack',
+      });
+
+      expect(result.sourcemaps?.assets).toEqual(['/path/to/.next/server', '/path/to/.next/static/immutable/chunks']);
+    });
+
+    it('only includes the server directory in after-production-compile-turbopack assets when no chunk directory exists', () => {
+      mockExistingDirectories([]);
+
+      const result = getBuildPluginOptions({
+        sentryBuildOptions: baseSentryOptions,
+        releaseName: mockReleaseName,
+        distDirAbsPath: mockDistDirAbsPath,
+        buildTool: 'after-production-compile-turbopack',
+      });
+
+      expect(result.sourcemaps?.assets).toEqual(['/path/to/.next/server']);
     });
   });
 
@@ -1077,6 +1113,7 @@ describe('getBuildPluginOptions', () => {
 
     it('handles complex nested path structures', () => {
       const complexPath = '/very/deep/nested/path/with/multiple/segments/.next';
+      mockExistingDirectories([`${complexPath}/static/chunks`]);
       const sentryBuildOptions: SentryBuildOptions = {
         org: 'test-org',
         project: 'test-project',


### PR DESCRIPTION
Turbopack builds with `supportsImmutableAssets` only emit `static/immutable/chunks`, but the `after-production-compile-turbopack` asset list still added `static/chunks` unconditionally, so the sourcemap upload logged `Directory '.next/static/chunks' does not exist` on Vercel.

This guards `static/chunks` with the same `existsSync` check that #21978 added for the immutable path, so only directories Turbopack actually emitted are uploaded.

closes https://linear.app/getsentry/issue/JS-3641