### PR TITLE
ref(browser)!: Remove the deprecated `enableInp` option

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1472,6 +1472,20 @@ Sentry.init({
 - The experimental `_experiments.enableStandaloneClsSpans` and `_experiments.enableStandaloneLcpSpans` options were removed from both `browserTracingIntegration` and `webVitalsIntegration`. CLS and LCP are no longer configurable: they are recorded as measurements on the pageload span, unless span streaming is enabled (`traceLifecycle: 'stream'`), in which case they are sent as dedicated spans.
 - INP is now always sent as a web vital span (streamed when span streaming is enabled, standalone otherwise) that carries its value as a `browser.web_vital.inp.value` attribute. Previously, with span streaming disabled, INP was sent as a standalone span that carried its value as a span measurement.
 
+- The deprecated `enableInp` option of `browserTracingIntegration` was removed. INP is captured by default; to opt out, ignore it via the `webVitals` option.
+
+```js
+// before
+Sentry.init({
+  integrations: [Sentry.browserTracingIntegration({ enableInp: false })],
+});
+
+// after
+Sentry.init({
+  integrations: [Sentry.browserTracingIntegration({ webVitals: { ignore: ['inp'] } })],
+});
+```
+
 - `browserTracingIntegration` no longer captures spans created by `performance.mark()` and `performance.measure()` by default. Add `userTimingIntegration()` to continue capturing them. The `ignorePerformanceApiSpans` option moved to the new integration as `ignore`.
 
 ```js

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/tracesSampler-precedence/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces-streamed/consistent-sampling/tracesSampler-precedence/init.js
@@ -8,7 +8,7 @@ Sentry.init({
     Sentry.browserTracingIntegration({
       linkPreviousTrace: 'in-memory',
       consistentTraceSampling: true,
-      enableInp: false,
+      webVitals: { ignore: ['inp'] },
     }),
     Sentry.spanStreamingIntegration(),
   ],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/tracesSampler-precedence/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/linked-traces/consistent-sampling/tracesSampler-precedence/init.js
@@ -9,7 +9,7 @@ Sentry.init({
     Sentry.browserTracingIntegration({
       linkPreviousTrace: 'in-memory',
       consistentTraceSampling: true,
-      enableInp: false,
+      webVitals: { ignore: ['inp'] },
     }),
   ],
   tracePropagationTargets: ['sentry-test-external.io'],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation-streamed/init.js
@@ -9,7 +9,7 @@ Sentry.init({
       enableLongTask: false,
       enableLongAnimationFrame: true,
       instrumentPageLoad: false,
-      enableInp: false,
+      webVitals: { ignore: ['inp'] },
     }),
     Sentry.spanStreamingIntegration(),
   ],

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-animation-frame-before-navigation/init.js
@@ -10,7 +10,7 @@ Sentry.init({
       enableLongTask: false,
       enableLongAnimationFrame: true,
       instrumentPageLoad: false,
-      enableInp: false,
+      webVitals: { ignore: ['inp'] },
     }),
   ],
   tracesSampleRate: 1,

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation-streamed/init.js
@@ -9,7 +9,7 @@ Sentry.init({
       enableLongAnimationFrame: false,
       instrumentPageLoad: false,
       instrumentNavigation: true,
-      enableInp: false,
+      webVitals: { ignore: ['inp'] },
       enableLongTask: true,
     }),
     Sentry.spanStreamingIntegration(),

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegration/long-tasks-before-navigation/init.js
@@ -10,7 +10,7 @@ Sentry.init({
       enableLongAnimationFrame: false,
       instrumentPageLoad: false,
       instrumentNavigation: true,
-      enableInp: false,
+      webVitals: { ignore: ['inp'] },
       enableLongTask: true,
     }),
   ],

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-before-send-span/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-before-send-span/init.js
@@ -9,7 +9,6 @@ Sentry.init({
     Sentry.browserTracingIntegration({
       idleTimeout: 4000,
       enableLongTask: false,
-      enableInp: true,
       instrumentPageLoad: false,
       instrumentNavigation: false,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-late/init.js
@@ -8,7 +8,6 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
       enableLongTask: false,
-      enableInp: true,
       instrumentPageLoad: false,
       instrumentNavigation: false,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-navigate/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-navigate/init.js
@@ -9,7 +9,6 @@ Sentry.init({
     Sentry.browserTracingIntegration({
       idleTimeout: 1000,
       enableLongTask: false,
-      enableInp: true,
       instrumentPageLoad: false,
       instrumentNavigation: false,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized-late/init.js
@@ -8,7 +8,6 @@ Sentry.init({
   integrations: [
     Sentry.browserTracingIntegration({
       enableLongTask: false,
-      enableInp: true,
       instrumentPageLoad: false,
       instrumentNavigation: false,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp-parametrized/init.js
@@ -9,7 +9,6 @@ Sentry.init({
     Sentry.browserTracingIntegration({
       idleTimeout: 4000,
       enableLongTask: false,
-      enableInp: true,
       instrumentPageLoad: false,
       instrumentNavigation: false,
     }),

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-inp/init.js
@@ -9,7 +9,6 @@ Sentry.init({
     Sentry.browserTracingIntegration({
       idleTimeout: 4000,
       enableLongTask: false,
-      enableInp: true,
       instrumentPageLoad: false,
       instrumentNavigation: false,
     }),

--- a/packages/browser/src/tracing/browserTracingIntegration.ts
+++ b/packages/browser/src/tracing/browserTracingIntegration.ts
@@ -119,15 +119,6 @@ export interface BrowserTracingOptions {
   enableLongAnimationFrame: boolean;
 
   /**
-   * If true, Sentry will capture first input delay and add it to the corresponding transaction.
-   *
-   * Default: true
-   *
-   * @deprecated Use {@link BrowserTracingOptions.webVitals} instead: `webVitals: { ignore: ['inp'] }`.
-   */
-  enableInp: boolean;
-
-  /**
    * Options for the `webVitalsIntegration` that is auto-registered when none is present.
    * Ignored if you register `webVitalsIntegration` yourself.
    */
@@ -268,8 +259,6 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   markBackgroundSpan: true,
   enableLongTask: true,
   enableLongAnimationFrame: true,
-  // oxlint-disable-next-line typescript/no-deprecated -- still honoured until it is removed
-  enableInp: true,
   ignoreResourceSpans: [],
   detectRedirects: true,
   linkPreviousTrace: 'in-memory',
@@ -304,8 +293,6 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
   const optionalWindowDocument = WINDOW.document as (typeof WINDOW)['document'] | undefined;
 
   const {
-    // oxlint-disable-next-line typescript/no-deprecated -- still honoured until it is removed
-    enableInp,
     enableLongTask,
     enableLongAnimationFrame,
     webVitals,
@@ -607,13 +594,7 @@ export const browserTracingIntegration = ((options: Partial<BrowserTracingOption
       // afterAllSetup so that a user-provided webVitalsIntegration - which may be ordered after
       // browserTracingIntegration in the integrations array - has already been installed.
       if (client.addIntegration && !client.getIntegrationByName?.(WEB_VITALS_INTEGRATION_NAME)) {
-        const ignore = webVitals?.ignore ?? [];
-        client.addIntegration(
-          webVitalsIntegration({
-            ...webVitals,
-            ignore: enableInp || ignore.includes('inp') ? ignore : [...ignore, 'inp'],
-          }),
-        );
+        client.addIntegration(webVitalsIntegration(webVitals));
       }
 
       let startingUrl: string | undefined = getLocationHref();

--- a/packages/browser/test/tracing/browserTracingIntegration.test.ts
+++ b/packages/browser/test/tracing/browserTracingIntegration.test.ts
@@ -211,37 +211,27 @@ describe('browserTracingIntegration', () => {
     const client = new BrowserClient(
       getDefaultBrowserClientOptions({
         tracesSampleRate: 1,
-        integrations: [browserTracingIntegration({ webVitals: { softNavigations: false } })],
+        integrations: [browserTracingIntegration({ webVitals: { softNavigations: false, ignore: ['inp'] } })],
       }),
     );
     setCurrentClient(client);
     client.init();
 
-    expect(webVitalsSpy).toHaveBeenCalledWith(expect.objectContaining({ softNavigations: false }));
+    expect(webVitalsSpy).toHaveBeenCalledWith(expect.objectContaining({ softNavigations: false, ignore: ['inp'] }));
   });
 
-  it.each([
-    ['leaves the ignore list alone when INP is enabled', {}, []],
-    // oxlint-disable-next-line typescript/no-deprecated
-    ['appends inp to the ignore list when disabled', { enableInp: false }, ['inp']],
-    [
-      'keeps user-provided entries when appending inp',
-      // oxlint-disable-next-line typescript/no-deprecated
-      { enableInp: false, webVitals: { ignore: ['cls' as const] } },
-      ['cls', 'inp'],
-    ],
-  ])('enableInp %s', (_name, options, expected) => {
+  it('does not ignore any web vital by default', () => {
     const webVitalsSpy = vi.spyOn(webVitalsModule, 'webVitalsIntegration');
     const client = new BrowserClient(
       getDefaultBrowserClientOptions({
         tracesSampleRate: 1,
-        integrations: [browserTracingIntegration(options)],
+        integrations: [browserTracingIntegration()],
       }),
     );
     setCurrentClient(client);
     client.init();
 
-    expect(webVitalsSpy).toHaveBeenCalledWith(expect.objectContaining({ ignore: expected }));
+    expect(webVitalsSpy).toHaveBeenCalledWith(undefined);
   });
 
   it('works with tracing disabled', () => {


### PR DESCRIPTION
Removes the deprecated `enableInp` option from `browserTracingIntegration`. It was already deprecated in favor of `webVitals: { ignore: ['inp'] }`, and since this stack lands in v11 it seemed like the right moment to drop it rather than carry a second way of configuring the same thing.

With it gone, `browserTracingIntegration` just forwards `webVitals` to the auto-registered `webVitalsIntegration` instead of splicing `'inp'` into the ignore list itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
