### PR TITLE
test: Upgrade Playwright to 1.63 and fix the Chromium 153 fallout

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@babel/core": "^7.29.6",
     "@babel/preset-typescript": "^7.16.7",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry/rrweb": "2.43.2",
     "@sentry/browser": "10.67.0",
     "@sentry/replay": "10.67.0",

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
@@ -102,10 +102,12 @@ sentryTest('adds resource spans to pageload transaction', async ({ getLocalTestU
       'http.request.same_origin': false,
       'url.scheme': 'https',
       'url.full': 'https://sentry-test-site.example/path/to/image.svg',
+      // WebKit reports `deliveryType` as of Playwright 1.63's build, but still no response status
+      // or render blocking status.
+      'http.response_delivery_type': '',
       ...(!isWebkitRun && {
         'http.response.status_code': expect.any(Number),
         'resource.render_blocking_status': 'non-blocking',
-        'http.response_delivery_type': '',
       }),
     },
     description: 'https://sentry-test-site.example/path/to/image.svg',
@@ -119,10 +121,11 @@ sentryTest('adds resource spans to pageload transaction', async ({ getLocalTestU
     trace_id: traceId,
   });
 
-  // range check: TTFB must be >0 (at least in this case) and it's reasonable to
-  // assume <10 seconds. This also tests that we're reporting TTFB in seconds.
+  // range check: TTFB is reasonably <10 seconds, which is really a check that we report it in
+  // seconds rather than milliseconds. WebKit resolves these intercepted routes without measurable
+  // delay, so only the other engines are held to a non-zero value.
   const imgSpanTtfb = imgSpan?.data['http.request.time_to_first_byte'];
-  expect(imgSpanTtfb).toBeGreaterThan(0);
+  expect(imgSpanTtfb).toBeGreaterThan(isWebkitRun ? -1 : 0);
   expect(imgSpanTtfb).toBeLessThan(10);
 
   expect(linkSpan).toEqual({
@@ -152,10 +155,12 @@ sentryTest('adds resource spans to pageload transaction', async ({ getLocalTestU
       'http.request.same_origin': false,
       'url.scheme': 'https',
       'url.full': 'https://sentry-test-site.example/path/to/style.css',
+      // WebKit reports `deliveryType` as of Playwright 1.63's build, but still no response status
+      // or render blocking status.
+      'http.response_delivery_type': '',
       ...(!isWebkitRun && {
         'http.response.status_code': expect.any(Number),
         'resource.render_blocking_status': 'non-blocking',
-        'http.response_delivery_type': '',
       }),
     },
     description: 'https://sentry-test-site.example/path/to/style.css',
@@ -196,10 +201,12 @@ sentryTest('adds resource spans to pageload transaction', async ({ getLocalTestU
       'http.request.same_origin': false,
       'url.scheme': 'https',
       'url.full': 'https://sentry-test-site.example/path/to/script.js',
+      // WebKit reports `deliveryType` as of Playwright 1.63's build, but still no response status
+      // or render blocking status.
+      'http.response_delivery_type': '',
       ...(!isWebkitRun && {
         'http.response.status_code': expect.any(Number),
         'resource.render_blocking_status': 'non-blocking',
-        'http.response_delivery_type': '',
       }),
     },
     description: 'https://sentry-test-site.example/path/to/script.js',

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-cls/subject.js
@@ -3,7 +3,7 @@ import { simulateCLS } from '../../../../utils/web-vitals/cls.ts';
 // Getting expected CLS parameter from URL hash
 const expectedCLS = Number(location.hash.slice(1));
 
-simulateCLS(expectedCLS).then(
-  // Triggering reload to make sure getCLS has its closure before we send the transaction
-  () => location.reload(),
-);
+// CLS lands on the pageload span when it ends on the idle timeout, so nothing has to force the
+// page away to finalize it. Reloading here used to do that, but it raced the envelope: on a fast
+// browser the reload cancelled the in-flight send before it left the page.
+simulateCLS(expectedCLS);

--- a/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/metrics/web-vitals-lcp-streamed-spans/test.ts
@@ -1,7 +1,7 @@
 import type { Route } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
-import { hidePage, shouldSkipTracingTest } from '../../../../utils/helpers';
+import { shouldSkipTracingTest } from '../../../../utils/helpers';
 import { getSpanOp, waitForStreamedSpan } from '../../../../utils/spanUtils';
 
 sentryTest.beforeEach(async ({ browserName, page }) => {
@@ -30,7 +30,10 @@ sentryTest('captures LCP as a streamed span with element attributes', async ({ g
   // Wait for LCP to be captured
   await page.waitForTimeout(1000);
 
-  await hidePage(page);
+  // LCP finalizes on the first trusted input or visibility change, and web-vitals checks
+  // `isTrusted`, so a synthetically dispatched `visibilitychange` does not finalize it. Click to
+  // finalize the way a real user would.
+  await page.click('body');
 
   const lcpSpan = await lcpSpanPromise;
   const pageloadSpan = await pageloadSpanPromise;

--- a/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/wasm/instantiateBufferRegistration/test.ts
@@ -5,8 +5,9 @@ import path from 'path';
 import { sentryTest } from '../../../utils/fixtures';
 import { shouldSkipWASMTests } from '../../../utils/wasmHelpers';
 
-function serveWasmFixture(page: Page): Promise<void> {
-  return page.route('**/simple.wasm', (route: Route) => {
+async function serveWasmFixture(page: Page): Promise<void> {
+  // `page.route` resolves with a `Disposable` as of Playwright 1.63, so it can't be returned directly.
+  await page.route('**/simple.wasm', (route: Route) => {
     const wasmModule = fs.readFileSync(path.resolve(__dirname, '..', 'simple.wasm'));
 
     return route.fulfill({

--- a/dev-packages/browser-integration-tests/utils/helpers.ts
+++ b/dev-packages/browser-integration-tests/utils/helpers.ts
@@ -549,6 +549,21 @@ export async function getFirstSentryEnvelopeRequest<T>(
 }
 
 export async function hidePage(page: Page): Promise<void> {
+  // web-vitals defers processing an interaction's event entries into
+  // `requestIdleCallback(..., { timeout: 1000 })`, and Chromium only reaches idle here once that
+  // timeout elapses. Hiding the page first forces a report while the metric is still unset, so no
+  // vital is emitted at all. Idle callbacks run in scheduling order, so waiting for one queued now
+  // means web-vitals' earlier callback has already run.
+  await page.evaluate(() => {
+    return new Promise<void>(resolve => {
+      if (typeof requestIdleCallback !== 'function') {
+        resolve();
+        return;
+      }
+      requestIdleCallback(() => resolve(), { timeout: 1000 });
+    });
+  });
+
   await page.evaluate(() => {
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,

--- a/dev-packages/e2e-tests/test-applications/angular-17/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-17/package.json
@@ -29,7 +29,7 @@
     "zone.js": "~0.14.3"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@angular-devkit/build-angular": "^17.1.1",

--- a/dev-packages/e2e-tests/test-applications/angular-18/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-18/package.json
@@ -29,7 +29,7 @@
     "zone.js": "~0.14.3"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@angular-devkit/build-angular": "^18.0.0",

--- a/dev-packages/e2e-tests/test-applications/angular-19/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-19/package.json
@@ -35,7 +35,7 @@
     "@angular-devkit/build-angular": "^19.0.0",
     "@angular/cli": "^19.0.0",
     "@angular/compiler-cli": "^19.0.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@types/jasmine": "~5.1.0",

--- a/dev-packages/e2e-tests/test-applications/angular-20/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-20/package.json
@@ -32,7 +32,7 @@
     "@angular-devkit/build-angular": "^20.0.0",
     "@angular/cli": "^20.0.0",
     "@angular/compiler-cli": "^20.0.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@types/jasmine": "~5.1.0",

--- a/dev-packages/e2e-tests/test-applications/angular-21/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-21/package.json
@@ -33,7 +33,7 @@
     "@angular-devkit/build-angular": "^21.0.0",
     "@angular/cli": "^21.0.0",
     "@angular/compiler-cli": "^21.0.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@types/jasmine": "~5.1.0",

--- a/dev-packages/e2e-tests/test-applications/angular-22/package.json
+++ b/dev-packages/e2e-tests/test-applications/angular-22/package.json
@@ -33,7 +33,7 @@
     "@angular/build": "^22.0.0",
     "@angular/cli": "^22.0.0",
     "@angular/compiler-cli": "^22.0.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@types/jasmine": "~5.1.0",

--- a/dev-packages/e2e-tests/test-applications/astro-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-4/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@astrojs/check": "0.9.2",
     "@astrojs/node": "8.3.4",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@spotlightjs/astro": "2.1.6",

--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^12.6.12",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/astro-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-5/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@astrojs/internal-helpers": "^0.4.2",
     "@astrojs/node": "^9.0.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "astro": "^5.0.3"

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@astrojs/cloudflare": "^13.0.2",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/astro-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@astrojs/node": "^10.0.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "astro": "^6.2.0"

--- a/dev-packages/e2e-tests/test-applications/astro-7-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-7-static/package.json
@@ -16,7 +16,7 @@
   "//": "Need to use ioredis 5.10.1 because that's the last version before they support tracing channels",
   "dependencies": {
     "@astrojs/node": "^11.1.4",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "astro": "^7.2.4",

--- a/dev-packages/e2e-tests/test-applications/astro-7/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-7/package.json
@@ -16,7 +16,7 @@
   "//": "Need to use ioredis 5.10.1 because that's the last version before they support tracing channels",
   "dependencies": {
     "@astrojs/node": "^11.1.4",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/astro": "file:../../packed/sentry-astro-packed.tgz",
     "astro": "^7.2.4",

--- a/dev-packages/e2e-tests/test-applications/aws-serverless-layer/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless-layer/package.json
@@ -13,7 +13,7 @@
   "//": "We just need the @sentry/aws-serverless layer zip file, not the NPM package",
   "devDependencies": {
     "@aws-sdk/client-lambda": "^3.863.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/aws-serverless": "link:../../../../packages/aws-serverless/build/aws/dist-serverless/",
     "aws-cdk-lib": "^2.210.0",

--- a/dev-packages/e2e-tests/test-applications/aws-serverless/package.json
+++ b/dev-packages/e2e-tests/test-applications/aws-serverless/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-lambda": "^3.863.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/aws-serverless": "file:../../packed/sentry-aws-serverless-packed.tgz",
     "aws-cdk-lib": "^2.210.0",

--- a/dev-packages/e2e-tests/test-applications/browser-bfcache/iframe.html
+++ b/dev-packages/e2e-tests/test-applications/browser-bfcache/iframe.html
@@ -4,11 +4,23 @@
     <meta charset="UTF-8" />
     <title>BFCache E2E - iframe</title>
     <script>
-      // A same-origin child frame. With ?blocker=unload it registers an unload listener, which makes
-      // the *whole* embedding page bfcache-ineligible - the not-restored reason then comes from this
-      // child frame (frame: 'child').
-      if (new URLSearchParams(window.location.search).get('blocker') === 'unload') {
-        window.addEventListener('unload', () => {});
+      // A same-origin child frame. With ?blocker=indexeddb it holds up an IndexedDB version upgrade,
+      // which makes the *whole* embedding page bfcache-ineligible - the not-restored reason then
+      // comes from this child frame (frame: 'child'). Mirrors the top-level `indexeddb` botcher.
+      if (new URLSearchParams(window.location.search).get('blocker') === 'indexeddb') {
+        var dbName = 'bf_child_' + Math.random().toString(36).slice(2);
+        window.__idbBlocked = false;
+        var open1 = indexedDB.open(dbName, 1);
+        open1.addEventListener('upgradeneeded', function (event) {
+          event.target.result.createObjectStore('s');
+        });
+        open1.addEventListener('success', function (event) {
+          window.__db = event.target.result; // intentionally no `versionchange` handler
+          var open2 = indexedDB.open(dbName, 2);
+          open2.addEventListener('blocked', function () {
+            window.__idbBlocked = true;
+          });
+        });
       }
     </script>
   </head>

--- a/dev-packages/e2e-tests/test-applications/browser-bfcache/package.json
+++ b/dev-packages/e2e-tests/test-applications/browser-bfcache/package.json
@@ -16,7 +16,7 @@
     "@sentry/browser": "file:../../packed/sentry-browser-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "~5.8.3",
     "vite": "^7.3.2"

--- a/dev-packages/e2e-tests/test-applications/browser-bfcache/src/main.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-bfcache/src/main.ts
@@ -35,7 +35,8 @@ window.addEventListener(
 const botch = new URLSearchParams(window.location.search).get('botch');
 
 if (botch === 'unload') {
-  // An `unload` listener is the canonical, version-stable bfcache blocker.
+  // An `unload` listener still makes the page ineligible, though the reason Chrome reports for it
+  // has changed across versions.
   window.addEventListener('unload', () => {});
 }
 
@@ -79,11 +80,11 @@ if (botch === 'indexeddb') {
   });
 }
 
-if (botch === 'iframe-clean' || botch === 'iframe-unload') {
-  // Embed a same-origin child frame. A clean child keeps the top page eligible (hit); a child with an
-  // unload listener makes the whole top page ineligible, and the reason comes from the child frame.
+if (botch === 'iframe-clean' || botch === 'iframe-blocked') {
+  // Embed a same-origin child frame. A clean child keeps the top page eligible (hit); a child that
+  // blocks makes the whole top page ineligible, and the reason comes from the child frame.
   const iframe = document.createElement('iframe');
-  iframe.src = botch === 'iframe-unload' ? '/iframe.html?blocker=unload' : '/iframe.html';
+  iframe.src = botch === 'iframe-blocked' ? '/iframe.html?blocker=indexeddb' : '/iframe.html';
   const w = window as unknown as { __iframeLoaded?: boolean };
   w.__iframeLoaded = false;
   iframe.addEventListener('load', () => {

--- a/dev-packages/e2e-tests/test-applications/browser-bfcache/tests/bfcache.test.ts
+++ b/dev-packages/e2e-tests/test-applications/browser-bfcache/tests/bfcache.test.ts
@@ -45,13 +45,9 @@ test('reports a hit on a genuine back/forward-cache restore', async ({ page }) =
 
 test('reports a miss with notRestoredReasons when an unload listener blocks bfcache', async ({ page }) => {
   const missPromise = waitForMetric(PROXY_SERVER_NAME, metric => isNavigation(metric, 'miss'));
-  const unloadReasonPromise = waitForMetric(
-    PROXY_SERVER_NAME,
-    metric =>
-      metric.name === 'browser.bfcache.not_restored' && attr(metric, 'browser.bfcache.reason') === 'unload-listener',
-  );
-  // Chrome reports a privacy-masked reason alongside the real one. It's a top-frame reason here, so
-  // the integration must frame it positionally (`top`) and pass the value through untouched.
+  // An unload listener still makes the page ineligible, but from Chromium 151 on the only reason
+  // Chrome hands out for it is the privacy-masked one. It's a top-frame reason, so the integration
+  // must frame it positionally (`top`) and pass the value through untouched.
   const maskedReasonPromise = waitForMetric(
     PROXY_SERVER_NAME,
     metric => metric.name === 'browser.bfcache.not_restored' && attr(metric, 'browser.bfcache.reason') === 'masked',
@@ -82,12 +78,9 @@ test('reports a miss with notRestoredReasons when an unload listener blocks bfca
   expect(attr(miss, 'browser.bfcache.not_restored_reason_count')).toBeGreaterThanOrEqual(1);
   expect(attr(miss, 'sentry.origin')).toBe(BFCACHE_ORIGIN);
 
-  const unloadReason = await unloadReasonPromise;
-  expect(attr(unloadReason, 'browser.bfcache.frame')).toBe('top');
-  expect(attr(unloadReason, 'sentry.origin')).toBe(BFCACHE_ORIGIN);
-
   const maskedReason = await maskedReasonPromise;
   expect(attr(maskedReason, 'browser.bfcache.frame')).toBe('top');
+  expect(attr(maskedReason, 'sentry.origin')).toBe(BFCACHE_ORIGIN);
 
   const reloadDuration = await reloadDurationPromise;
   expect(reloadDuration.type).toBe('distribution');
@@ -218,15 +211,23 @@ test('reports a child-frame reason when an ineligible iframe blocks the top page
     PROXY_SERVER_NAME,
     metric =>
       metric.name === 'browser.bfcache.not_restored' &&
-      attr(metric, 'browser.bfcache.reason') === 'unload-listener' &&
+      attr(metric, 'browser.bfcache.reason') === 'idbversionchangeevent' &&
       attr(metric, 'browser.bfcache.frame') === 'child',
   );
 
-  await page.goto('/?botch=iframe-unload');
+  await page.goto('/?botch=iframe-blocked');
   await page.waitForFunction(() => document.title === 'BFCache E2E - Page 1');
   await page.waitForFunction(() => (window as unknown as { __iframeLoaded?: boolean }).__iframeLoaded === true, {
     timeout: 5000,
   });
+  // Only proceed once the child frame's version upgrade is actually blocked.
+  await page.waitForFunction(
+    () => {
+      const frame = document.querySelector('iframe') as HTMLIFrameElement | null;
+      return (frame?.contentWindow as unknown as { __idbBlocked?: boolean } | undefined)?.__idbBlocked === true;
+    },
+    { timeout: 5000 },
+  );
 
   await page.click('#to-page-2');
   await page.waitForFunction(() => document.title === 'BFCache E2E - Page 2');

--- a/dev-packages/e2e-tests/test-applications/browser-mfe-vite/package.json
+++ b/dev-packages/e2e-tests/test-applications/browser-mfe-vite/package.json
@@ -13,7 +13,7 @@
     "test:assert": "pnpm test"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "concurrently": "^8.2.2"
   },

--- a/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
+++ b/dev-packages/e2e-tests/test-applications/browser-webworker-vite/package.json
@@ -12,7 +12,7 @@
     "test:assert": "pnpm test"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "~5.8.3",
     "vite": "^7.3.2"

--- a/dev-packages/e2e-tests/test-applications/bun-mysql/package.json
+++ b/dev-packages/e2e-tests/test-applications/bun-mysql/package.json
@@ -15,7 +15,7 @@
     "mysql": "2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "bun-types": "^1.2.9"
   },

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
@@ -24,7 +24,7 @@
     "workers-ai-provider": "^3.3.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/vite-plugin": "^1.47.0",
     "@cloudflare/workers-types": "^5.20260727.1",
     "@sentry-internal/test-utils": "link:../../../test-utils",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/package.json
@@ -22,7 +22,7 @@
     "@babel/plugin-proposal-decorators": "^8.0.2",
     "@cloudflare/vite-plugin": "^1.47.0",
     "@cloudflare/workers-types": "^5.20260727.1",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^26.1.2",
     "@types/ws": "^8.18.1",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
@@ -17,7 +17,7 @@
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20240725.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260426.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^6.0.3",
     "wrangler": "^4.86.0"

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240725.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",
     "wrangler": "^4.61.0",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-orchestrion-mysql/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-orchestrion-mysql/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.35.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20260629.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^24.12.4",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.52.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20260426.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-static/package.json
@@ -17,7 +17,7 @@
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20240725.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/package.json
@@ -14,7 +14,7 @@
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20260303.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
@@ -17,7 +17,7 @@
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20240725.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
@@ -17,7 +17,7 @@
     "@sentry/cloudflare": "file:../../packed/sentry-cloudflare-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20240725.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.5.2",

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express-vite-dev/package.json
@@ -25,7 +25,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@remix-run/dev": "^2.17.4",
     "@types/compression": "^1.7.5",

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-express/package.json
@@ -28,7 +28,7 @@
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@remix-run/dev": "^2.17.4",
     "@types/compression": "^1.7.2",

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-non-vite/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@remix-run/dev": "2.17.4",
     "@remix-run/eslint-config": "2.17.4",

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2-static/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@remix-run/dev": "2.17.4",
     "@remix-run/eslint-config": "2.17.4",

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/package.json
@@ -24,7 +24,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@remix-run/dev": "2.17.4",
     "@remix-run/eslint-config": "2.17.4",

--- a/dev-packages/e2e-tests/test-applications/default-browser-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/default-browser-static/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "webpack": "^5.91.0",
     "serve": "14.0.1",

--- a/dev-packages/e2e-tests/test-applications/default-browser/package.json
+++ b/dev-packages/e2e-tests/test-applications/default-browser/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "webpack": "^5.91.0",
     "serve": "14.0.1",

--- a/dev-packages/e2e-tests/test-applications/deno-mysql/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno-mysql/package.json
@@ -14,7 +14,7 @@
     "mysql": "2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/deno-pg/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno-pg/package.json
@@ -14,7 +14,7 @@
     "pg": "8.16.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/deno-redis/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno-redis/package.json
@@ -15,7 +15,7 @@
     "redis": "^5.12.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/deno-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno-static/package.json
@@ -16,7 +16,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/deno/package.json
+++ b/dev-packages/e2e-tests/test-applications/deno/package.json
@@ -16,7 +16,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/effect-3-browser/package.json
+++ b/dev-packages/e2e-tests/test-applications/effect-3-browser/package.json
@@ -17,7 +17,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "webpack": "^5.91.0",
     "serve": "14.0.1",

--- a/dev-packages/e2e-tests/test-applications/effect-3-node/package.json
+++ b/dev-packages/e2e-tests/test-applications/effect-3-node/package.json
@@ -20,7 +20,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/package.json
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/package.json
@@ -17,7 +17,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "webpack": "^5.91.0",
     "serve": "14.0.1",

--- a/dev-packages/e2e-tests/test-applications/effect-4-node/package.json
+++ b/dev-packages/e2e-tests/test-applications/effect-4-node/package.json
@@ -19,7 +19,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/elysia-bun-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/elysia-bun-static/package.json
@@ -15,7 +15,7 @@
     "elysia": "^1.4.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "bun-types": "^1.2.9"
   },

--- a/dev-packages/e2e-tests/test-applications/elysia-bun/package.json
+++ b/dev-packages/e2e-tests/test-applications/elysia-bun/package.json
@@ -15,7 +15,7 @@
     "elysia": "^1.4.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "bun-types": "^1.2.9"
   },

--- a/dev-packages/e2e-tests/test-applications/elysia-node/package.json
+++ b/dev-packages/e2e-tests/test-applications/elysia-node/package.json
@@ -16,7 +16,7 @@
     "@elysiajs/node": "^1.4.5"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/ember-classic/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-classic/package.json
@@ -24,7 +24,7 @@
     "@ember/optional-features": "~2.0.0",
     "@glimmer/component": "~1.1.2",
     "@glimmer/tracking": "~1.1.2",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@ember/string": "~3.1.1",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/ember": "file:../../packed/sentry-ember-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-embroider/package.json
@@ -50,7 +50,7 @@
     "loader.js": "^4.7.0",
     "tracked-built-ins": "^3.3.0",
     "webpack": "~5.107.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry/ember": "file:../../packed/sentry-ember-packed.tgz",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@tsconfig/ember": "^3.0.6",

--- a/dev-packages/e2e-tests/test-applications/ember-strict-resolver/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-strict-resolver/package.json
@@ -14,7 +14,7 @@
     "test:assert:streamed": "E2E_TEST_TRACE_LIFECYCLE=stream pnpm run test"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@babel/core": "^7.29.0",
     "@babel/plugin-transform-typescript": "^7.28.6",
     "@babel/runtime": "^7.29.2",

--- a/dev-packages/e2e-tests/test-applications/ember-vite/package.json
+++ b/dev-packages/e2e-tests/test-applications/ember-vite/package.json
@@ -43,7 +43,7 @@
     "@glint/ember-tsc": "^1.5.0",
     "@glint/template": "^1.7.7",
     "@glint/tsserver-plugin": "^2.4.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@rollup/plugin-babel": "^7.0.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/ember": "file:../../packed/sentry-ember-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/hono-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/hono-4/package.json
@@ -22,7 +22,7 @@
     "hono": "^4.13.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@cloudflare/workers-types": "^4.20240725.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "tsx": "4.21.0",

--- a/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/package.json
+++ b/dev-packages/e2e-tests/test-applications/hydrogen-react-router-7/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.2",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@react-router/dev": "7.13.0",
     "@react-router/fs-routes": "7.13.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",

--- a/dev-packages/e2e-tests/test-applications/nestjs-11-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-11-static/package.json
@@ -24,7 +24,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-11/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-11/package.json
@@ -24,7 +24,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-12/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-12/package.json
@@ -26,7 +26,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^12.0.0",
     "@nestjs/schematics": "^12.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-8/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-8/package.json
@@ -24,7 +24,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic-with-graphql/package.json
@@ -26,7 +26,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-basic/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-basic/package.json
@@ -25,7 +25,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-bullmq/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-bullmq/package.json
@@ -23,7 +23,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-distributed-tracing/package.json
@@ -23,7 +23,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-fastify/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-fastify/package.json
@@ -25,7 +25,7 @@
     "fastify": "^4.28.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-graphql/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-graphql/package.json
@@ -26,7 +26,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-microservices/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-microservices/package.json
@@ -20,7 +20,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-websockets/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-websockets/package.json
@@ -20,7 +20,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^11.0.0",
     "@types/node": "^18.19.1",

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules-decorator/package.json
@@ -22,7 +22,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/package.json
+++ b/dev-packages/e2e-tests/test-applications/nestjs-with-submodules/package.json
@@ -22,7 +22,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/package.json
@@ -23,7 +23,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz"
   },

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-basepath/package.json
@@ -21,7 +21,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-intl/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-intl/package.json
@@ -22,7 +22,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nextjs-15-t3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15-t3/package.json
@@ -28,7 +28,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^22.15.21",
     "@types/react": "^19.1.0",

--- a/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-15/package.json
@@ -27,7 +27,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-bun/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-bun/package.json
@@ -22,7 +22,7 @@
     "require-in-the-middle": "^8"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cacheComponents/package.json
@@ -33,7 +33,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-cf-workers/package.json
@@ -25,7 +25,7 @@
     "react-dom": "19.1.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-standalone/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-standalone/package.json
@@ -27,7 +27,7 @@
     "require-in-the-middle": "^8"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-static/package.json
@@ -30,7 +30,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/pg": "^8.11.10",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming-cacheComponents/package.json
@@ -33,7 +33,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-streaming/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash-static/package.json
@@ -21,7 +21,7 @@
     "require-in-the-middle": "^8"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-trailing-slash/package.json
@@ -22,7 +22,7 @@
     "require-in-the-middle": "^8"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-tunnel/package.json
@@ -34,7 +34,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16-userfeedback/package.json
@@ -22,7 +22,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@tailwindcss/postcss": "^4",
     "tailwindcss": "^4"

--- a/dev-packages/e2e-tests/test-applications/nextjs-16/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-16/package.json
@@ -39,7 +39,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/pg": "^8.11.10",

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/package.json
@@ -24,7 +24,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "ts-node": "10.9.1"
   },

--- a/dev-packages/e2e-tests/test-applications/nextjs-orpc/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-orpc/package.json
@@ -25,7 +25,7 @@
     "server-only": "^0.0.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/eslint": "^8.56.10",
     "@types/node": "^18.19.1",

--- a/dev-packages/e2e-tests/test-applications/nextjs-otlp/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-otlp/package.json
@@ -33,7 +33,7 @@
     "require-in-the-middle": "^8"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-pages-dir/package.json
@@ -25,7 +25,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "ts-node": "10.9.1"
   },

--- a/dev-packages/e2e-tests/test-applications/nextjs-sourcemaps/package.json
+++ b/dev-packages/e2e-tests/test-applications/nextjs-sourcemaps/package.json
@@ -16,7 +16,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^18.19.1",
     "@types/react": "^19",

--- a/dev-packages/e2e-tests/test-applications/nitro-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nitro-3/package.json
@@ -16,7 +16,7 @@
     "@sentry/nitro": "latest || *"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "latest || *",
     "nitro": "^3.0.260522-beta",

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-loader/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-loader/package.json
@@ -15,7 +15,7 @@
     "mysql": "^2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-esm-without-loader/package.json
@@ -14,7 +14,7 @@
     "express": "^4.21.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-mcp-v2/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@modelcontextprotocol/client": "^2.0.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz"
   },

--- a/dev-packages/e2e-tests/test-applications/node-express-otlp/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-otlp/package.json
@@ -22,7 +22,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry-static/package.json
@@ -18,7 +18,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0"
+    "@playwright/test": "~1.63.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-send-to-sentry/package.json
@@ -18,7 +18,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0"
+    "@playwright/test": "~1.63.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/dev-packages/e2e-tests/test-applications/node-express-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-static/package.json
@@ -22,7 +22,7 @@
     "zod": "~3.25.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz"
   },

--- a/dev-packages/e2e-tests/test-applications/node-express-streaming/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-streaming/package.json
@@ -22,7 +22,7 @@
     "zod": "~3.25.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz"
   },

--- a/dev-packages/e2e-tests/test-applications/node-express-v5/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express-v5/package.json
@@ -23,7 +23,7 @@
     "zod": "~3.25.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz"
   },

--- a/dev-packages/e2e-tests/test-applications/node-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-express/package.json
@@ -22,7 +22,7 @@
     "zod": "~3.25.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz"
   },

--- a/dev-packages/e2e-tests/test-applications/node-fastify-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-3/package.json
@@ -18,7 +18,7 @@
     "ts-node": "10.9.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-fastify-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-4/package.json
@@ -18,7 +18,7 @@
     "ts-node": "10.9.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-fastify-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-fastify-5/package.json
@@ -18,7 +18,7 @@
     "ts-node": "10.9.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-firebase/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-firebase/package.json
@@ -20,7 +20,7 @@
     "typescript": "5.9.3"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "firebase-tools": "^14.20.0"
   },

--- a/dev-packages/e2e-tests/test-applications/node-hapi/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-hapi/package.json
@@ -16,7 +16,7 @@
     "@sentry/node": "file:../../packed/sentry-node-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-koa/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-koa/package.json
@@ -18,7 +18,7 @@
     "typescript": "~5.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-otel-sdk-node/package.json
@@ -19,7 +19,7 @@
     "express": "^4.21.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/node-profiling-cjs/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-cjs/package.json
@@ -10,7 +10,7 @@
     "test:assert": "pnpm run typecheck && pnpm run test"
   },
   "dependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@sentry/node": "file:../../packed/sentry-node-packed.tgz",
     "@sentry/profiling-node": "file:../../packed/sentry-profiling-node-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/node-profiling-electron/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-electron/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@electron/rebuild": "^3.7.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry/electron": "latest || *",
     "@sentry/node": "file:../../packed/sentry-node-packed.tgz",
     "@sentry/profiling-node": "file:../../packed/sentry-profiling-node-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/node-profiling-esm/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-profiling-esm/package.json
@@ -10,7 +10,7 @@
     "test:assert": "pnpm run typecheck && pnpm run test"
   },
   "dependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry/core": "file:../../packed/sentry-core-packed.tgz",
     "@sentry/node": "file:../../packed/sentry-node-packed.tgz",
     "@sentry/profiling-node": "file:../../packed/sentry-profiling-node-packed.tgz",

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-dynamic-import/package.json
@@ -18,7 +18,7 @@
     "nuxt": "^3.14.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-min/package.json
@@ -22,7 +22,7 @@
     "vue-router": "4.2.4"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3-top-level-import/package.json
@@ -19,7 +19,7 @@
     "nuxt": "^3.14.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-3/package.json
@@ -21,7 +21,7 @@
     "nuxt": "^3.14.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "sentryTest": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-4-cloudflare/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4-cloudflare/package.json
@@ -17,7 +17,7 @@
     "nuxt": "^4.1.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "wrangler": "^4.72.0"
   },

--- a/dev-packages/e2e-tests/test-applications/nuxt-4-sourcemaps/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4-sourcemaps/package.json
@@ -18,7 +18,7 @@
     "nuxt": "^4.1.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/node": "^22.20.0",
     "ts-node": "10.9.1",

--- a/dev-packages/e2e-tests/test-applications/nuxt-4-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4-static/package.json
@@ -25,7 +25,7 @@
     "nuxt": "^4.1.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-4/package.json
@@ -27,7 +27,7 @@
     "nuxt": "^4.1.2"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/nuxt-5/package.json
@@ -33,7 +33,7 @@
     "vue": "^3.5.41"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "sentryTest": {

--- a/dev-packages/e2e-tests/test-applications/react-17-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-17-static/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-17-static/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-17-static/tests/transactions.test.ts
@@ -76,7 +76,11 @@ test('sends an INP span', async ({ page }) => {
 
   await page.click('#exception-button');
 
-  await page.waitForTimeout(500);
+  // web-vitals defers processing the interaction's event entries to a
+  // `requestIdleCallback(..., { timeout: 1000 })`. Chromium only runs that on the timeout here, so
+  // hiding the page any earlier forces a report before the interaction has been processed and no
+  // INP is emitted at all.
+  await page.waitForTimeout(1500);
 
   // Page hide to trigger INP
   await page.evaluate(() => {

--- a/dev-packages/e2e-tests/test-applications/react-17/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-17/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-17/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-17/tests/spans.test.ts
@@ -58,7 +58,11 @@ test('sends an INP span', async ({ page }) => {
 
   await page.click('#exception-button');
 
-  await page.waitForTimeout(500);
+  // web-vitals defers processing the interaction's event entries to a
+  // `requestIdleCallback(..., { timeout: 1000 })`. Chromium only runs that on the timeout here, so
+  // hiding the page any earlier forces a report before the interaction has been processed and no
+  // INP is emitted at all.
+  await page.waitForTimeout(1500);
 
   // Page hide to trigger INP
   await page.evaluate(() => {

--- a/dev-packages/e2e-tests/test-applications/react-19/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-19/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-create-browser-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-browser-router/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-create-memory-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-create-memory-router/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-router-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-5/package.json
@@ -44,7 +44,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-descendant-routes/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1",
     "npm-run-all2": "^6.2.0"

--- a/dev-packages/e2e-tests/test-applications/react-router-6-router-entry/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-router-entry/package.json
@@ -11,7 +11,7 @@
     "react-router-dom": "^6.30.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "vite": "^6.4.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1"
   },

--- a/dev-packages/e2e-tests/test-applications/react-router-6/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1",
     "npm-run-all2": "^6.2.0"

--- a/dev-packages/e2e-tests/test-applications/react-router-6/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6/tests/spans.test.ts
@@ -58,7 +58,11 @@ test('sends an INP span', async ({ page }) => {
 
   await page.click('#exception-button');
 
-  await page.waitForTimeout(500);
+  // web-vitals defers processing the interaction's event entries to a
+  // `requestIdleCallback(..., { timeout: 1000 })`. Chromium only runs that on the timeout here, so
+  // hiding the page any earlier forces a report before the interaction has been processed and no
+  // INP is emitted at all.
+  await page.waitForTimeout(1500);
 
   // Page hide to trigger INP
   await page.evaluate(() => {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-cross-usage/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1",
     "npm-run-all2": "^6.2.0"

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-instrumentation/package.json
@@ -16,7 +16,7 @@
     "react-router": "^7"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@react-router/dev": "^7",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/mysql": "^2.15.26",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-spa/package.json
@@ -26,7 +26,7 @@
     "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@react-router/dev": "^7.13.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@tailwindcss/vite": "^4.1.4",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework-static/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "18.3.1",
     "@types/node": "^20",
     "@react-router/dev": "^7.13.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.6.3",
     "vite": "^5.4.11"

--- a/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-framework/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "18.3.1",
     "@types/node": "^20",
     "@react-router/dev": "^7.13.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.6.3",
     "vite": "^5.4.11"

--- a/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-lazy-routes/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1",
     "npm-run-all2": "^6.2.0"

--- a/dev-packages/e2e-tests/test-applications/react-router-7-router-entry/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-router-entry/package.json
@@ -11,7 +11,7 @@
     "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "vite": "^6.4.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa-streaming/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa-streaming/package.json
@@ -11,7 +11,7 @@
     "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "vite": "^6.4.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa-streaming/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa-streaming/tests/spans.test.ts
@@ -56,7 +56,11 @@ test('sends an INP span', async ({ page }) => {
 
   await page.click('#exception-button');
 
-  await page.waitForTimeout(500);
+  // web-vitals defers processing the interaction's event entries to a
+  // `requestIdleCallback(..., { timeout: 1000 })`. Chromium only runs that on the timeout here, so
+  // hiding the page any earlier forces a report before the interaction has been processed and no
+  // INP is emitted at all.
+  await page.waitForTimeout(1500);
 
   // Page hide to trigger INP
   await page.evaluate(() => {

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/package.json
@@ -11,7 +11,7 @@
     "react-router": "^7.13.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "vite": "^6.4.2",
     "@vitejs/plugin-react": "^4.3.4",

--- a/dev-packages/e2e-tests/test-applications/react-router-7-spa/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-7-spa/tests/spans.test.ts
@@ -58,7 +58,11 @@ test('sends an INP span', async ({ page }) => {
 
   await page.click('#exception-button');
 
-  await page.waitForTimeout(500);
+  // web-vitals defers processing the interaction's event entries to a
+  // `requestIdleCallback(..., { timeout: 1000 })`. Chromium only runs that on the timeout here, so
+  // hiding the page any earlier forces a report before the interaction has been processed and no
+  // INP is emitted at all.
+  await page.waitForTimeout(1500);
 
   // Page hide to trigger INP
   await page.evaluate(() => {

--- a/dev-packages/e2e-tests/test-applications/react-router-8-cloudflare/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-cloudflare/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.35.0",
     "@cloudflare/workers-types": "^4.20260504.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@react-router/dev": "^8",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/mysql": "^2.15.26",

--- a/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-cross-usage/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "serve": "14.0.1",
     "npm-run-all2": "^6.2.0"

--- a/dev-packages/e2e-tests/test-applications/react-router-8-framework/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-framework/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "19.2.3",
     "@types/node": "^22",
     "@react-router/dev": "^8.0.0",
-    "@playwright/test": "~1.58.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.6.3",
     "vite": "^7.3.2"

--- a/dev-packages/e2e-tests/test-applications/react-router-8-router-entry/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-router-entry/package.json
@@ -11,7 +11,7 @@
     "react-router": "^8.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "vite": "^7.3.2",
     "@vitejs/plugin-react": "^5.2.0",

--- a/dev-packages/e2e-tests/test-applications/react-router-8-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-spa/package.json
@@ -11,7 +11,7 @@
     "react-router": "^8.0.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "vite": "^7.3.2",
     "@vitejs/plugin-react": "^5.2.0",

--- a/dev-packages/e2e-tests/test-applications/react-router-8-spa/tests/spans.test.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-8-spa/tests/spans.test.ts
@@ -58,7 +58,11 @@ test('sends an INP span', async ({ page }) => {
 
   await page.click('#exception-button');
 
-  await page.waitForTimeout(500);
+  // web-vitals defers processing the interaction's event entries to a
+  // `requestIdleCallback(..., { timeout: 1000 })`. Chromium only runs that on the timeout here, so
+  // hiding the page any earlier forces a report before the interaction has been processed and no
+  // INP is emitted at all.
+  await page.waitForTimeout(1500);
 
   // Page hide to trigger INP
   await page.evaluate(() => {

--- a/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-router-sourcemaps/package.json
@@ -17,7 +17,7 @@
     "@types/react-dom": "19.2.3",
     "@types/node": "^20",
     "@react-router/dev": "^8.3.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "tsx": "^4.23.0",
     "typescript": "^5.6.3",

--- a/dev-packages/e2e-tests/test-applications/react-send-to-sentry/package.json
+++ b/dev-packages/e2e-tests/test-applications/react-send-to-sentry/package.json
@@ -41,7 +41,7 @@
     ]
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "serve": "14.0.1"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
+++ b/dev-packages/e2e-tests/test-applications/remix-hydrogen/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/cli": "5.0.2",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@remix-run/dev": "^2.17.4",
     "@remix-run/eslint-config": "^2.17.4",
     "@sentry-internal/test-utils": "link:../../../test-utils",

--- a/dev-packages/e2e-tests/test-applications/remix-server-timing/package.json
+++ b/dev-packages/e2e-tests/test-applications/remix-server-timing/package.json
@@ -21,7 +21,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@remix-run/dev": "2.17.4",
     "@remix-run/eslint-config": "2.17.4",

--- a/dev-packages/e2e-tests/test-applications/solid-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/solid-static/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.33",

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/package.json
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.0.6"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "typescript": "^5.7.2",
     "vite": "^7.3.2",

--- a/dev-packages/e2e-tests/test-applications/solid-tanstack-router/tests/routing-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solid-tanstack-router/tests/routing-instrumentation.test.ts
@@ -151,11 +151,10 @@ test('sends a pageload span with web vital attributes and a standalone LCP span'
 
   const pageloadSpan = await pageloadSpanPromise;
 
-  // LCP is only reported once the page is hidden or a navigation happens
-  await page.evaluate(() => {
-    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
-    document.dispatchEvent(new Event('visibilitychange'));
-  });
+  // LCP finalizes on the first trusted input or visibility change, and web-vitals checks
+  // `isTrusted`, so a synthetically dispatched `visibilitychange` does not finalize it. Click to
+  // finalize the way a real user would.
+  await page.click('body');
 
   const lcpSpan = await lcpSpanPromise;
 

--- a/dev-packages/e2e-tests/test-applications/solid/package.json
+++ b/dev-packages/e2e-tests/test-applications/solid/package.json
@@ -14,7 +14,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "autoprefixer": "^10.4.17",
     "postcss": "^8.4.33",

--- a/dev-packages/e2e-tests/test-applications/solidstart-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-2/package.json
@@ -17,7 +17,7 @@
     "nitro": "3.0.260610-beta"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^1.0.0",

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/package.json
@@ -15,7 +15,7 @@
     "@sentry/solidstart": "file:../../packed/sentry-solidstart-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^1.0.0",

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/package.json
@@ -15,7 +15,7 @@
     "@sentry/solidstart": "file:../../packed/sentry-solidstart-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^1.0.0",

--- a/dev-packages/e2e-tests/test-applications/solidstart-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-static/package.json
@@ -17,7 +17,7 @@
     "mysql": "^2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^1.0.0",

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/package.json
@@ -15,7 +15,7 @@
     "@sentry/solidstart": "file:../../packed/sentry-solidstart-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^1.0.0",

--- a/dev-packages/e2e-tests/test-applications/solidstart/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart/package.json
@@ -19,7 +19,7 @@
     "mysql": "^2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^1.0.0",

--- a/dev-packages/e2e-tests/test-applications/supabase-nextjs/package.json
+++ b/dev-packages/e2e-tests/test-applications/supabase-nextjs/package.json
@@ -29,7 +29,7 @@
     "typescript": "4.9.5"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "eslint": "8.34.0",
     "eslint-config-next": "14.2.25"

--- a/dev-packages/e2e-tests/test-applications/svelte-5-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/svelte-5-static/package.json
@@ -13,7 +13,7 @@
     "test:assert": "pnpm test:prod"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@tsconfig/svelte": "^5.0.2",

--- a/dev-packages/e2e-tests/test-applications/svelte-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/svelte-5/package.json
@@ -13,7 +13,7 @@
     "test:assert": "pnpm test:prod"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "@tsconfig/svelte": "^5.0.2",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-kit-tracing/package.json
@@ -19,7 +19,7 @@
     "@spotlightjs/spotlight": "2.0.0-alpha.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-node": "5.5.1",
     "@sveltejs/kit": "2.52.2",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-otlp/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-otlp/package.json
@@ -24,7 +24,7 @@
     "@sentry/sveltekit": "file:../../packed/sentry-sveltekit-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-node": "5.5.1",
     "@sveltejs/kit": "2.70.2",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-static/package.json
@@ -22,7 +22,7 @@
     "mysql": "^2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/adapter-node": "^2.0.0",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2-svelte-5/package.json
@@ -19,7 +19,7 @@
     "@spotlightjs/spotlight": "2.0.0-alpha.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/kit": "2.69.1",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2.5.0-twp/package.json
@@ -18,7 +18,7 @@
     "@sentry/sveltekit": "file:../../packed/sentry-sveltekit-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/kit": "2.8.3",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/package.json
@@ -22,7 +22,7 @@
     "mysql": "^2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "^3.0.0",
     "@sveltejs/adapter-node": "^2.0.0",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3-cloudflare-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3-cloudflare-workers/package.json
@@ -17,7 +17,7 @@
     "@sentry/sveltekit": "file:../../packed/sentry-sveltekit-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-cloudflare": "next",
     "@sveltejs/kit": "next",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-3/package.json
@@ -18,7 +18,7 @@
     "@sentry/sveltekit": "file:../../packed/sentry-sveltekit-packed.tgz"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-auto": "next",
     "@sveltejs/adapter-node": "next",

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
@@ -19,7 +19,7 @@
     "mysql": "2.18.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sveltejs/adapter-cloudflare": "^5.0.3",
     "@sveltejs/kit": "2.69.1",

--- a/dev-packages/e2e-tests/test-applications/tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstack-router/package.json
@@ -27,7 +27,7 @@
     "@vitejs/plugin-react-swc": "^3.5.0",
     "typescript": "^5.2.2",
     "vite": "^5.4.11",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.35.0",
     "@cloudflare/workers-types": "^4.20260504.0",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react/package.json
@@ -43,7 +43,7 @@
     "typescript": "^5.9.0",
     "vite": "7.3.2",
     "vite-tsconfig-paths": "^5.1.4",
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {

--- a/dev-packages/e2e-tests/test-applications/tsx-express/package.json
+++ b/dev-packages/e2e-tests/test-applications/tsx-express/package.json
@@ -22,7 +22,7 @@
     "zod": "~3.25.0"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "tsx": "^4.20.3"
   },

--- a/dev-packages/e2e-tests/test-applications/vue-3/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-3/package.json
@@ -27,7 +27,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@tsconfig/node20": "^20.1.2",
     "@types/node": "^18.19.1",

--- a/dev-packages/e2e-tests/test-applications/vue-tanstack-router/package.json
+++ b/dev-packages/e2e-tests/test-applications/vue-tanstack-router/package.json
@@ -18,7 +18,7 @@
     "vue": "^3.4.15"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@tsconfig/node20": "^20.1.2",
     "@types/node": "^18.19.1",

--- a/dev-packages/e2e-tests/test-applications/vue-tanstack-router/tests/routing-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-tanstack-router/tests/routing-instrumentation.test.ts
@@ -40,11 +40,10 @@ test('sends a pageload span for the root route with web vital attributes and a s
 
   const pageloadSpan = await pageloadSpanPromise;
 
-  // LCP is only reported once the page is hidden or a navigation happens
-  await page.evaluate(() => {
-    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
-    document.dispatchEvent(new Event('visibilitychange'));
-  });
+  // LCP finalizes on the first trusted input or visibility change, and web-vitals checks
+  // `isTrusted`, so a synthetically dispatched `visibilitychange` does not finalize it. Click to
+  // finalize the way a real user would.
+  await page.click('body');
 
   const lcpSpan = await lcpSpanPromise;
 

--- a/dev-packages/e2e-tests/test-applications/webpack-4/package.json
+++ b/dev-packages/e2e-tests/test-applications/webpack-4/package.json
@@ -8,7 +8,7 @@
     "test:assert": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/browser": "file:../../packed/sentry-browser-packed.tgz",
     "babel-loader": "^8.0.0",

--- a/dev-packages/e2e-tests/test-applications/webpack-5/package.json
+++ b/dev-packages/e2e-tests/test-applications/webpack-5/package.json
@@ -8,7 +8,7 @@
     "test:assert": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry-internal/test-utils": "link:../../../test-utils",
     "@sentry/browser": "file:../../packed/sentry-browser-packed.tgz",
     "webpack": "^5.91.0",

--- a/dev-packages/test-utils/package.json
+++ b/dev-packages/test-utils/package.json
@@ -40,14 +40,14 @@
     "clean": "rimraf -g ./node_modules ./build"
   },
   "peerDependencies": {
-    "@playwright/test": "~1.56.0"
+    "@playwright/test": "~1.63.0"
   },
   "dependencies": {
     "express": "^4.21.2",
     "ws": "^8.20.1"
   },
   "devDependencies": {
-    "@playwright/test": "~1.56.0",
+    "@playwright/test": "~1.63.0",
     "@sentry/core": "10.67.0",
     "@types/ws": "^8.18.1",
     "eslint-plugin-regexp": "^3.1.0"

--- a/dev-packages/test-utils/src/playwright-config.ts
+++ b/dev-packages/test-utils/src/playwright-config.ts
@@ -54,11 +54,11 @@ export function getPlaywrightConfig(
       {
         name: 'chromium',
         use: {
-          // This comes from `devices["Desktop Chrome"]` in Playwright 1.56.0
+          // This comes from `devices["Desktop Chrome"]` in Playwright 1.63.0
           // We inline this instead of importing this,
           // because playwright otherwise complains that it was imported twice :(
           userAgent:
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.7390.37 Safari/537.36',
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/153.0.8010.12 Safari/537.36',
           viewport: { width: 1280, height: 720 },
           deviceScaleFactor: 1,
           isMobile: false,

--- a/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
+++ b/packages/react/src/reactrouter-compat-utils/instrumentation.tsx
@@ -374,6 +374,20 @@ export function updateNavigationSpan(
 ): void {
   const { name: currentName, end_timestamp, attributes } = spanToJSON(activeRootSpan);
 
+  // React Router can start resolving the routes for the next location before the SDK has started
+  // that navigation's span, so the span captured for the resolution is still the previous
+  // navigation's. Renaming it would ship it under a route the user never visited on it, so a span
+  // the SDK is still tracking for a different location is left alone.
+  const client = getClient();
+  const trackedNav = client ? activeNavigationSpans.get(client) : undefined;
+  if (trackedNav?.span === activeRootSpan && trackedNav?.pathname !== location.pathname) {
+    DEBUG_BUILD &&
+      debug.log(
+        `[React Router] Not renaming the navigation span for "${trackedNav.pathname}" with the route of "${location.pathname}"`,
+      );
+    return;
+  }
+
   const hasBeenNamed = (activeRootSpan as { __sentry_navigation_name_set__?: boolean })?.__sentry_navigation_name_set__;
   const currentNameHasWildcard = currentName && transactionNameHasWildcard(currentName);
   const shouldUpdate = !hasBeenNamed || forceUpdate || currentNameHasWildcard;
@@ -397,7 +411,6 @@ export function updateNavigationSpan(
         (currentSource === 'route' && source === 'route' && currentNameHasWildcard)); // Route → better route (only if current has wildcard)
     if (isImprovement) {
       // With span streaming, span names have to be low cardinality, so we can't fall back to the URL.
-      const client = getClient();
       const isUnparameterizedStreamedNavigation = source !== 'route' && !!client && hasSpanStreamingEnabled(client);
       activeRootSpan.updateName(isUnparameterizedStreamedNavigation ? NAVIGATION_SPAN_NAME_FALLBACK : name);
       activeRootSpan.setAttribute(SENTRY_SEGMENT_NAME_SOURCE, source);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7228,12 +7228,12 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@playwright/test@~1.56.0":
-  version "1.56.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.56.1.tgz#6e3bf3d0c90c5cf94bf64bdb56fd15a805c8bd3f"
-  integrity sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==
+"@playwright/test@~1.63.0":
+  version "1.63.0"
+  resolved "https://sfw.security.sentry.io/npm/@playwright/test/-/test-1.63.0.tgz#808020c46e8b6b91f9d628cd0ebcbb32bdfd8b6c"
+  integrity sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==
   dependencies:
-    playwright "1.56.1"
+    playwright "1.63.0"
 
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.28"
@@ -16372,11 +16372,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -22478,19 +22473,17 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
-playwright-core@1.56.1:
-  version "1.56.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.56.1.tgz#24a66481e5cd33a045632230aa2c4f0cb6b1db3d"
-  integrity sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==
+playwright-core@1.63.0:
+  version "1.63.0"
+  resolved "https://sfw.security.sentry.io/npm/playwright-core/-/playwright-core-1.63.0.tgz#e57665bc32846c213ac39a1e4d5bc6228e76b376"
+  integrity sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==
 
-playwright@1.56.1:
-  version "1.56.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.56.1.tgz#62e3b99ddebed0d475e5936a152c88e68be55fbf"
-  integrity sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==
+playwright@1.63.0:
+  version "1.63.0"
+  resolved "https://sfw.security.sentry.io/npm/playwright/-/playwright-1.63.0.tgz#99b56f9f69b1b70c44f00bf84b2fe52348ae2511"
+  integrity sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==
   dependencies:
-    playwright-core "1.56.1"
-  optionalDependencies:
-    fsevents "2.3.2"
+    playwright-core "1.63.0"
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
Upgrades Playwright to 1.63 and fixes the existing tests that the newer browser broke. This unblocks being able to test soft navigation web vitals.

Some assertions needed updates due to browser behavior changes that wasn't accounted for:

- Timing changes for INP that surfaced a mismatch that we fix downstack, also timed out some tests.
- bfcache reason reporting, `unload` listener now has a `masked` reason instead which is surprising.