### PR TITLE
fix(server-utils): Forward `resolveId` options in the orchestrion Rollup plugin

### DIFF
--- a/packages/server-utils/src/orchestrion/bundler/rollup.ts
+++ b/packages/server-utils/src/orchestrion/bundler/rollup.ts
@@ -1,5 +1,12 @@
 import codeTransformer from '@apm-js-collab/code-transformer-bundler-plugins/rollup';
-import type { ExternalOption, InputOptions, NormalizedInputOptions, Plugin, PluginContext } from 'rollup';
+import type {
+  ExternalOption,
+  InputOptions,
+  NormalizedInputOptions,
+  Plugin,
+  PluginContext,
+  ResolveIdHook,
+} from 'rollup';
 
 export type { Plugin as RollupPlugin } from 'rollup';
 import { instrumentedModuleNames } from '../config';
@@ -60,11 +67,20 @@ export function sentryOrchestrionPlugin(options: PluginOptions = {}): Plugin {
     // specifier doesn't resolve from an instrumented package's location, so when
     // normal resolution fails, fall back to this package's own resolution so it
     // gets bundled from its real on-disk path.
-    async resolveId(this: PluginContext, source: string, importer: string | undefined) {
+    //
+    // Forward `options` unchanged: it carries the `custom` metadata `@rollup/plugin-commonjs`
+    // uses to recognize a `require()` it is already resolving. Drop it and that plugin warns
+    // (THIS_RESOLVE_WITHOUT_OPTIONS), then abandons the resolution.
+    async resolveId(
+      this: PluginContext,
+      source: string,
+      importer: string | undefined,
+      options: Parameters<ResolveIdHook>[2],
+    ) {
       if (source !== SNIPPET_IMPORT_SPECIFIER) {
         return null;
       }
-      const resolved = await this.resolve(source, importer, { skipSelf: true });
+      const resolved = await this.resolve(source, importer, { ...options, skipSelf: true });
       if (resolved) {
         return resolved;
       }

--- a/packages/server-utils/test/orchestrion/bundler.test.ts
+++ b/packages/server-utils/test/orchestrion/bundler.test.ts
@@ -68,6 +68,46 @@ describe('sentryOrchestrionPlugin (rollup)', () => {
     // skips the warning when external is not a normalized predicate
     expect(warn).not.toHaveBeenCalled();
   });
+
+  it('forwards the resolveId options to this.resolve and falls back to self-resolution', async () => {
+    const plugin = rollupPlugin();
+    const resolveId = plugin.resolveId as (
+      this: unknown,
+      source: string,
+      importer: string | undefined,
+      opts: unknown,
+    ) => Promise<unknown>;
+
+    const resolve = vi.fn().mockResolvedValue(null);
+    // `custom` is what `@rollup/plugin-commonjs` uses to recognise its own `require()` resolution;
+    // dropping it makes the plugin warn (THIS_RESOLVE_WITHOUT_OPTIONS) and abandon the resolution.
+    const options = { attributes: {}, custom: { 'node-resolve': { isRequire: true } }, isEntry: false };
+
+    resolve.mockResolvedValueOnce({ id: '/resolved.js' });
+    await expect(resolveId.call({ resolve }, '@sentry/server-utils', '/x.js', options)).resolves.toEqual({
+      id: '/resolved.js',
+    });
+    expect(resolve).toHaveBeenCalledWith('@sentry/server-utils', '/x.js', { ...options, skipSelf: true });
+
+    // When it fails (pnpm isolation), fall back to this package's own resolution.
+    const fallback = await resolveId.call({ resolve }, '@sentry/server-utils', '/x.js', options);
+    expect(typeof fallback).toBe('string');
+    expect(fallback).toContain('server-utils');
+  });
+
+  it('ignores specifiers other than the injected snippet import', async () => {
+    const plugin = rollupPlugin();
+    const resolveId = plugin.resolveId as (
+      this: unknown,
+      source: string,
+      importer: string | undefined,
+      opts: unknown,
+    ) => Promise<unknown>;
+
+    const resolve = vi.fn();
+    await expect(resolveId.call({ resolve }, 'mysql', '/x.js', { attributes: {}, isEntry: false })).resolves.toBeNull();
+    expect(resolve).not.toHaveBeenCalled();
+  });
 });
 
 describe('sentryOrchestrionPlugin (esbuild)', () => {


### PR DESCRIPTION


Building a Nitro app printed `THIS_RESOLVE_WITHOUT_OPTIONS` once per instrumented module (see log below).

Our `resolveId` never forwarded its third `options` argument. `@rollup/plugin-commonjs` needs the `custom` field in there to spot a `require()` it's already resolving; without it the plugin assumes dropped options, warns, and gives up on the resolution.

The Vite variant already forwards it:

https://github.com/getsentry/sentry-javascript/blob/a4762fe1116ba3213a808cbc8a5f53b7eb0d7dd6/packages/server-utils/src/orchestrion/bundler/vite.ts#L70-L79


Behavior change: downstream resolvers now receive `custom`, so a `require('@sentry/server-utils')` from a CJS file can resolve to a different id. Before, it could fall through to the ES path.

Shapes match on both Rollup 4 and Rolldown, and Rolldown gets `kind` back too. `skipSelf` already defaults to `true`, so it stays only for readability.

## Logs (before)
```
[plugin commonjs--resolver] It appears a plugin has implemented a "resolveId" hook that uses "this.resolve" without forwarding the third "options" parameter of "resolveId". This is problematic as it can lead to wrong module resolutions especially for the node-resolve plugin and in certain cases cause early exit errors for the commonjs plugin.

In rare cases, this warning can appear if the same file is both imported and required from the same mixed ES/CommonJS module, in which case it can be ignored.
```