### PR TITLE
docs(react-router): Remove beta label from README

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1710,6 +1710,9 @@ Note that `ignoreStatusCodes` is itself [deprecated](#ignorestatuscodes-is-depre
 
 ### `@sentry/react-router`
 
+`@sentry/react-router` is now out of beta. With this, the SDK fully relies on React Router's instrumentation API for
+tracing loaders and actions.
+
 - The deprecated server wrappers `wrapServerLoader` and `wrapServerAction` were removed. Loaders and
   actions are instrumented automatically via the instrumentation API - export
   `instrumentations = [Sentry.createSentryServerInstrumentation()]` from your `entry.server.tsx`

--- a/packages/react-router/README.md
+++ b/packages/react-router/README.md
@@ -4,13 +4,12 @@
   </a>
 </p>
 
-# Official Sentry SDK for React Router Framework (BETA)
+# Official Sentry SDK for React Router Framework
 
 [![npm version](https://img.shields.io/npm/v/@sentry/react-router.svg)](https://www.npmjs.com/package/@sentry/react-router)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/react-router.svg)](https://www.npmjs.com/package/@sentry/react-router)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/react-router.svg)](https://www.npmjs.com/package/@sentry/react-router)
 
-> This SDK is currently in beta. Beta features are still in progress and may have bugs. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/) if you have any feedback or concerns.
 > This SDK is for [React Router (framework)](https://reactrouter.com/start/framework/installation). If you're using [React Router (library)](https://reactrouter.com/start/library/installation) see our
 > [React SDK here](https://docs.sentry.io/platforms/javascript/guides/react/features/react-router/v7/).
 


### PR DESCRIPTION
Marks the React Router SDK as stable.