### PR TITLE
test(e2e): Fix stale mysql query-text assertion in tanstackstart-react-static

### DIFF
--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-static/tests/db-drivers.test.ts
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-static/tests/db-drivers.test.ts
@@ -67,11 +67,11 @@ test('Instruments mysql automatically', async ({ baseURL }) => {
     expect.objectContaining({
       op: 'db',
       origin: 'auto.db.mysql',
-      description: 'SELECT 1 + 1 AS solution',
+      description: 'SELECT ? + ? AS solution',
       status: 'ok',
       data: expect.objectContaining({
         'db.system.name': 'mysql',
-        'db.query.text': 'SELECT 1 + 1 AS solution',
+        'db.query.text': 'SELECT ? + ? AS solution',
         'db.user': 'root',
         'db.connection_string': expect.any(String),
         'server.address': expect.any(String),


### PR DESCRIPTION
The `tanstackstart-react-static` E2E app's `Instruments mysql automatically` test asserts the raw mysql query text `SELECT 1 + 1 AS solution`, but the SDK now always sanitizes inline literals and emits `SELECT ? + ? AS solution`. This updates the two stale assertions (the span `description` and `db.query.text`) to the sanitized form, matching the non-static `tanstackstart-react` test and the current sanitizer.

### Root cause

- #24089 changed the mysql instrumentation to always sanitize inline literals out of `db.query.text`, and updated the original `tanstackstart-react` db-drivers test to expect `SELECT ? + ? AS solution`.
- #24167 added `tanstackstart-react-static` as a new-file copy of the app and its tests, but the copied `db-drivers.test.ts` still carried the pre-#24089 raw expectation. Because it is a new file path, #24089's test update never applied to it and no merge conflict surfaced.
- The static app bundles the freshly packed local SDK, so it runs the post-#24089 sanitizer. `sanitizeSqlQuery('SELECT 1 + 1 AS solution', 'mysql')` is deterministic and always returns `SELECT ? + ? AS solution`, so the span is present but its text never matches the stale assertion.
- Only the first query appeared to "flake": `SELECT NOW()` has no numeric literals, so its raw and sanitized forms are identical and its assertion still passed.

Fixes #24288
