### PR TITLE
ci(size-limit): Run size-limit action on node24

### DIFF
--- a/dev-packages/size-limit-gh-action/action.yml
+++ b/dev-packages/size-limit-gh-action/action.yml
@@ -13,5 +13,5 @@ inputs:
     default: '0.0125'
     description: 'The percentage threshold for size changes before posting a comment'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.mjs'


### PR DESCRIPTION
Bumps the `size-limit-gh-action` JS action runtime from `node20` to `node24`.

The `node20` action runtime is deprecated on GitHub Actions runners, so the action now executes `index.mjs` under Node 24, which current runners support natively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)