### PR TITLE
feat(node): Enable dataloader and knex integrations by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Work in this release was contributed by @psh4607, @thijsw, @trinitiwowka, @nehap
   - `DenoMysql` => `Mysql`
   - `DenoPostgres` => `Postgres`
 - feat(node): Add first-party Mastra integration ([#23823](https://github.com/getsentry/sentry-javascript/pull/23823)). Enabled by default; disable with `defaultIntegrations: integrations => integrations.filter(i => i.name !== 'Mastra')`.
+- feat(node): Enable the `dataloader` and `knex` integrations by default. Both were previously opt-in — `dataloader` was removed from the defaults in v8 due to an upstream OpenTelemetry bug that has since been fixed, and `knex` was never enabled by default. You no longer need to add `dataloaderIntegration()` or `knexIntegration()` manually. Disable either with `defaultIntegrations: integrations => integrations.filter(i => i.name !== 'Dataloader' /* or 'Knex' */)`.
 - **feat(browser): Add `bfcacheMetricsIntegration` to track back/forward cache health**
 
   The new opt-in `bfcacheMetricsIntegration` emits metrics about browser back/forward cache (bfcache) navigations, so you can

--- a/dev-packages/node-integration-tests/suites/tracing/dataloader/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/dataloader/instrument.mjs
@@ -7,5 +7,4 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.dataloaderIntegration()],
 });

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument-span-streaming.mjs
@@ -6,6 +6,5 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.knexIntegration()],
   traceLifecycle: 'stream',
 });

--- a/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/mysql2/instrument.mjs
@@ -7,5 +7,4 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.knexIntegration()],
 });

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument-span-streaming.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument-span-streaming.mjs
@@ -6,6 +6,5 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.knexIntegration()],
   traceLifecycle: 'stream',
 });

--- a/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument.mjs
+++ b/dev-packages/node-integration-tests/suites/tracing/knex/pg/instrument.mjs
@@ -7,5 +7,4 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   transport: loggingTransport,
-  integrations: [Sentry.knexIntegration()],
 });

--- a/packages/server-utils/src/integrations/index.ts
+++ b/packages/server-utils/src/integrations/index.ts
@@ -1,4 +1,6 @@
 import { amqplibIntegration } from './amqplib';
+import { dataloaderIntegration } from './dataloader';
+import { knexIntegration } from './knex';
 import { mongoIntegration } from './mongodb';
 import { graphqlIntegration } from './graphql';
 import { redisIntegration } from './redis';
@@ -39,10 +41,12 @@ export function getTracingIntegrations(): Integration[] {
     postgresIntegration(),
     prismaIntegration(),
     tediousIntegration(),
+    knexIntegration(),
     genericPoolIntegration(),
     kafkaIntegration(),
     amqplibIntegration(),
     lruMemoizerIntegration(),
+    dataloaderIntegration(),
     awsIntegration(),
     // AI providers
     // LangChain must come first to disable AI provider integrations before they instrument


### PR DESCRIPTION
Adds `dataloaderIntegration` and `knexIntegration` to `getTracingIntegrations()`, so both ship as default tracing integrations like every other channel-based integration, rather than requiring users to register them manually.

Both were the only two orchestrion-instrumented integrations that are publicly exported and have channel definitions but were absent from the default set. Investigating why surfaced that neither omission is still justified:

- **`dataloader`** was originally a default (added in #13664) but was removed in #13873 because of an upstream OpenTelemetry bug (#13869) where instrumenting DataLoader broke custom subclass methods (`context.dataloaders.x.loadByInternalId is not a function`). That issue was fixed upstream ([open-telemetry/opentelemetry-js-contrib#2498](https://github.com/open-telemetry/opentelemetry-js-contrib/pull/2498)) and closed on 2025-08-11, confirmed resolved on v10. On top of that, since #22754 the integration is channel-only: it instruments via `diagnostics_channel` and no longer wraps/replaces the `DataLoader` class, so the mechanism that caused the original breakage no longer exists. There is no remaining reason to keep it opt-in.
- **`knex`** was never enabled by default — it was introduced (#13526) purely as an opt-in integration with no accompanying default-list change. There's no documented reason for it to stay opt-in, and it uses the same channel mechanism as the other DB integrations that are on by default.

Users can still disable either via `defaultIntegrations`.

The now-redundant explicit `dataloaderIntegration()` / `knexIntegration()` registrations are dropped from the node integration-test instrument files so those suites now exercise the default-registration path. The dataloader suite passes with no explicit registration, confirming the default wiring works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)