### PR TITLE
feat(solid-start): Add `code.function.name` attribute to solid-start `function` spans

### DIFF
--- a/dev-packages/e2e-tests/test-applications/solidstart-2/tests/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-2/tests/performance.server.test.ts
@@ -20,6 +20,7 @@ test('sends a server action span on pageload', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });
 
@@ -42,5 +43,6 @@ test('sends a server action span on client navigation', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });

--- a/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/tests/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-dynamic-import/tests/performance.server.test.ts
@@ -20,6 +20,7 @@ test('sends a server action span on pageload', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });
 
@@ -42,5 +43,6 @@ test('sends a server action span on client navigation', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });

--- a/dev-packages/e2e-tests/test-applications/solidstart-spa/tests/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-spa/tests/performance.server.test.ts
@@ -18,6 +18,7 @@ test('sends a server action span on pageload', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });
 
@@ -40,5 +41,6 @@ test('sends a server action span on client navigation', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });

--- a/dev-packages/e2e-tests/test-applications/solidstart-static/tests/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-static/tests/performance.server.test.ts
@@ -18,6 +18,7 @@ test('sends a server action transaction on pageload', async ({ page }) => {
         data: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.solidstart',
+          'code.function.name': 'getPrefecture',
         },
       }),
     ]),
@@ -42,6 +43,7 @@ test('sends a server action transaction on client navigation', async ({ page }) 
         data: {
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.solidstart',
+          'code.function.name': 'getPrefecture',
         },
       }),
     ]),

--- a/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/tests/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart-top-level-import/tests/performance.server.test.ts
@@ -20,6 +20,7 @@ test('sends a server action span on pageload', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });
 
@@ -42,5 +43,6 @@ test('sends a server action span on client navigation', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });

--- a/dev-packages/e2e-tests/test-applications/solidstart/tests/performance.server.test.ts
+++ b/dev-packages/e2e-tests/test-applications/solidstart/tests/performance.server.test.ts
@@ -20,6 +20,7 @@ test('sends a server action span on pageload', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });
 
@@ -42,5 +43,6 @@ test('sends a server action span on client navigation', async ({ page }) => {
   expect(functionSpan?.attributes).toMatchObject({
     'sentry.op': { value: 'function', type: 'string' },
     'sentry.origin': { value: 'auto.function.solidstart', type: 'string' },
+    'code.function.name': { value: 'getPrefecture', type: 'string' },
   });
 });

--- a/packages/solidstart/src/server/withServerActionInstrumentation.ts
+++ b/packages/solidstart/src/server/withServerActionInstrumentation.ts
@@ -4,6 +4,7 @@ import { captureException, getActiveSpan, spanToJSON, startSpan } from '@sentry/
 import { isRedirect } from './utils';
 import {
   SENTRY_SEGMENT_NAME_SOURCE,
+  CODE_FUNCTION_NAME,
   HTTP_ROUTE,
   HTTP_TARGET,
   SENTRY_OP,
@@ -46,6 +47,7 @@ export async function withServerActionInstrumentation<A extends (...args: unknow
         name: serverActionName,
         attributes: {
           [SENTRY_OP]: FUNCTION,
+          [CODE_FUNCTION_NAME]: serverActionName,
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.solidstart',
           [SENTRY_SEGMENT_NAME_SOURCE]: 'component',
         },

--- a/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
+++ b/packages/solidstart/test/server/withServerActionInstrumentation.test.ts
@@ -1,4 +1,4 @@
-import { SENTRY_SEGMENT_NAME_SOURCE } from '@sentry/conventions/attributes';
+import { SENTRY_SEGMENT_NAME_SOURCE, CODE_FUNCTION_NAME } from '@sentry/conventions/attributes';
 import * as SentryCore from '@sentry/core';
 import * as SentryCoreServer from '@sentry/core/server';
 import * as SentryNode from '@sentry/node';
@@ -102,6 +102,7 @@ describe('withServerActionInstrumentation', () => {
         name: 'getPrefecture',
         attributes: expect.objectContaining({
           [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'function',
+          [CODE_FUNCTION_NAME]: 'getPrefecture',
           [SENTRY_SEGMENT_NAME_SOURCE]: 'component',
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.function.solidstart',
         }),


### PR DESCRIPTION
Similarly to #24305, this PR adds the `code.function.name` attribute to `function` spans from the solidStart SDK. Span names are already low card. and function names, so nothing to do other than ensuring that span description inference works via the new attribute.