### PR TITLE
feat(deps): Bump `@sentry/conventions` to 0.23.0

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -845,6 +845,7 @@ Attribute availability remains runtime-dependent. For example, browser and Worke
 - The `fs_error` span attribute on `file` spans was replaced by `error.type`. The value changed from the full error message to just the syscall's error code instead (`ENOENT`).
 - The Cloudflare-specific `sentry.cloudflare_tracer` span attribute is no longer set. `@sentry/cloudflare` now creates spans through the shared `SentryTracerProvider`, so spans emitted via `@opentelemetry/api` no longer carry a marker distinguishing them from other Sentry spans.
 - The `url.path.params.<key>` attribute was removed from the TanStack Router (library) integration. The replacement is `url.path.parameter.<key>` and holds the same values.
+- The `navigation.route.id` attribute set by the Vue Router instrumentation was renamed to `router.navigation.route.id`. It holds the same value (the matched route's name). The attribute moved to the `router.*` namespace to separate client-side router navigations from browser navigations.
 
 #### Attribute constants
 

--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -63,7 +63,7 @@
     "@sentry/browser": "10.67.0",
     "@sentry/replay": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",
-    "@sentry/conventions": "0.20.0",
+    "@sentry/conventions": "0.23.0",
     "@supabase/supabase-js": "2.109.0",
     "axios": "1.18.0",
     "babel-loader": "^10.1.1",

--- a/dev-packages/cloudflare-integration-tests/package.json
+++ b/dev-packages/cloudflare-integration-tests/package.json
@@ -33,7 +33,7 @@
     "@cloudflare/workers-types": "^4.20260426.0",
     "@cloudflare/workers-types-v5": "npm:@cloudflare/workers-types@5.20260710.1",
     "@sentry-internal/test-utils": "10.67.0",
-    "@sentry/conventions": "0.20.0",
+    "@sentry/conventions": "0.23.0",
     "eslint-plugin-regexp": "^3.1.0",
     "prisma": "6.15.0",
     "vite": "7.3.5",

--- a/dev-packages/e2e-tests/test-applications/vue-3-static/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3-static/tests/performance.test.ts
@@ -123,7 +123,7 @@ test('sends a pageload transaction with a route name as transaction name if avai
           'sentry.segment.name.source': 'custom',
           'sentry.origin': 'auto.pageload.vue',
           'sentry.op': 'pageload',
-          'navigation.route.id': 'AboutView',
+          'router.navigation.route.id': 'AboutView',
           'url.path': '/about',
           'url.full': expect.stringMatching(/^https?:\/\/localhost:\d+\/about$/),
         },

--- a/dev-packages/e2e-tests/test-applications/vue-3/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/tests/performance.test.ts
@@ -99,7 +99,7 @@ test('sends a pageload span with a route name as span name if available', async 
       'sentry.segment.name.source': { type: 'string', value: 'custom' },
       'sentry.origin': { type: 'string', value: 'auto.pageload.vue' },
       'sentry.op': { type: 'string', value: 'pageload' },
-      'navigation.route.id': { type: 'string', value: 'AboutView' },
+      'router.navigation.route.id': { type: 'string', value: 'AboutView' },
       'url.path': { type: 'string', value: '/about' },
       'url.full': { type: 'string', value: expect.stringMatching(/^https?:\/\/localhost:\d+\/about$/) },
     },

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -105,7 +105,7 @@
   },
   "devDependencies": {
     "@opentelemetry/instrumentation-http": "0.220.0",
-    "@sentry/conventions": "0.20.0",
+    "@sentry/conventions": "0.23.0",
     "@sentry-internal/test-utils": "10.67.0",
     "@types/amqplib": "^0.10.5",
     "@types/node-cron": "^3.0.11",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "tslib": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-runtime-injection": "10.67.0",
     "@sentry/server-utils": "10.67.0",

--- a/packages/aws-serverless/package.json
+++ b/packages/aws-serverless/package.json
@@ -56,7 +56,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-runtime-injection": "10.67.0",

--- a/packages/browser-utils/package.json
+++ b/packages/browser-utils/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "web-vitals": "^6.1.1"
   },
   "scripts": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@sentry/browser-utils": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/feedback": "10.67.0",
     "@sentry/replay": "10.67.0",
     "@sentry/replay-canvas": "10.67.0",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"
   },

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",
     "@sentry/server-utils": "10.67.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,6 +94,6 @@
     "zod": "^3.24.1"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.20.0"
+    "@sentry/conventions": "^0.23.0"
   }
 }

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/server-runtime-injection": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0"
   },

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@sentry/bun": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0"
+    "@sentry/conventions": "^0.23.0"
   },
   "peerDependencies": {
     "elysia": "^1.4.0"

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -45,7 +45,7 @@
     "@embroider/addon-shim": "^1.10.2",
     "@embroider/macros": "^1.20.2",
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "decorator-transforms": "^2.3.2"
   },

--- a/packages/google-cloud-serverless/package.json
+++ b/packages/google-cloud-serverless/package.json
@@ -36,7 +36,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-runtime-injection": "10.67.0",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0"
+    "@sentry/conventions": "^0.23.0"
   },
   "peerDependencies": {
     "@cloudflare/workers-types": "^4.x",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-utils": "10.67.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -76,7 +76,7 @@
     "@rollup/plugin-commonjs": "28.0.1",
     "@sentry/browser-utils": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",

--- a/packages/nitro/package.json
+++ b/packages/nitro/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@sentry/bundler-plugins": "^10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-runtime-injection": "10.67.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/opentelemetry": "10.67.0",
     "@sentry/server-runtime-injection": "10.67.0",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -56,7 +56,7 @@
     "@nuxt/kit": "^4.5.2",
     "@sentry/browser": "10.67.0",
     "@sentry/cloudflare": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0"
   },
   "peerDependencies": {

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0"
+    "@sentry/conventions": "^0.23.0"
   },
   "peerDependencies": {
     "react": "17.x || 18.x || 19.x",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@remix-run/router": "^1.23.4",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/server-utils/package.json
+++ b/packages/server-utils/package.json
@@ -89,7 +89,7 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0"
   },
   "devDependencies": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0"
+    "@sentry/conventions": "^0.23.0"
   },
   "peerDependencies": {
     "@solidjs/router": ">=0.13.4 <2.0.0-0",

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -87,7 +87,7 @@
     "@sentry/server-utils": "10.67.0",
     "@sentry/solid": "10.67.0",
     "@sentry/bundler-plugins": "10.67.0",
-    "@sentry/conventions": "0.20.0"
+    "@sentry/conventions": "0.23.0"
   },
   "devDependencies": {
     "@solidjs/router": "^1.0.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@sentry/browser": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "magic-string": "~0.30.0"
   },

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -67,7 +67,7 @@
   "dependencies": {
     "@sentry/cloudflare": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/node": "10.67.0",
     "@sentry/server-runtime-injection": "10.67.0",
     "@sentry/server-utils": "10.67.0",

--- a/packages/tanstackstart-react/package.json
+++ b/packages/tanstackstart-react/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
     "@sentry/browser-utils": "10.67.0",
-    "@sentry/conventions": "^0.20.0",
+    "@sentry/conventions": "^0.23.0",
     "@sentry/core": "10.67.0",
     "@sentry/node": "10.67.0",
     "@sentry/react": "10.67.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@sentry/browser": "10.67.0",
     "@sentry/core": "10.67.0",
-    "@sentry/conventions": "^0.20.0"
+    "@sentry/conventions": "^0.23.0"
   },
   "peerDependencies": {
     "@tanstack/vue-router": "^1.64.0",

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -1,7 +1,7 @@
 import { captureException, getAbsoluteUrl } from '@sentry/browser';
 import {
   SENTRY_SEGMENT_NAME_SOURCE,
-  NAVIGATION_ROUTE_ID,
+  ROUTER_NAVIGATION_ROUTE_ID,
   PARAMS_KEY_BASE,
   SENTRY_OP,
   URL_PATH_PARAMETER_KEY_BASE,
@@ -113,7 +113,7 @@ export function instrumentVueRouter(
     }
 
     if (to.name) {
-      attributes[NAVIGATION_ROUTE_ID] = to.name.toString();
+      attributes[ROUTER_NAVIGATION_ROUTE_ID] = to.name.toString();
     }
 
     getCurrentScope().setTransactionName(spanName);

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -2,7 +2,7 @@ import * as SentryBrowser from '@sentry/browser';
 import type { Span, SpanAttributes } from '@sentry/core';
 import * as SentryCore from '@sentry/core';
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN } from '@sentry/core';
-import { SENTRY_SEGMENT_NAME_SOURCE, NAVIGATION_ROUTE_ID, URL_TEMPLATE } from '@sentry/conventions/attributes';
+import { SENTRY_SEGMENT_NAME_SOURCE, ROUTER_NAVIGATION_ROUTE_ID, URL_TEMPLATE } from '@sentry/conventions/attributes';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Route } from '../src/router';
 import { instrumentVueRouter } from '../src/router';
@@ -523,7 +523,7 @@ function getAttributesForRoute(route: Route, urlTemplate?: string): SpanAttribut
   }
 
   if (route.name) {
-    attributes[NAVIGATION_ROUTE_ID] = route.name.toString();
+    attributes[ROUTER_NAVIGATION_ROUTE_ID] = route.name.toString();
   }
 
   return attributes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8051,10 +8051,10 @@
     "@angular-devkit/schematics" "14.2.13"
     jsonc-parser "3.1.0"
 
-"@sentry/conventions@0.20.0", "@sentry/conventions@^0.20.0":
-  version "0.20.0"
-  resolved "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.20.0.tgz#f73f6f46934d754dacef447755b5adf1bf7f3245"
-  integrity sha512-nAL3tL+xgom6Dbuxq0NCEZZfBNIrUspjDJRcMMRl3WLiBCSeZzNCa7an48IpnrZoVMpAi2NQ2v9rFU+EQziKuQ==
+"@sentry/conventions@0.23.0", "@sentry/conventions@^0.23.0":
+  version "0.23.0"
+  resolved "https://sfw.security.sentry.io/npm/@sentry/conventions/-/conventions-0.23.0.tgz#26ecad45f91bcf70940325ab9af2b9544fa18242"
+  integrity sha512-+Euyo7CNVecoOusgUnq27oV97oshifgceKfnGnuKfXrPUVWA/cisvii3E1rlvy2yBrKvl9K1gCEo1Jqog5zjEQ==
 
 "@sentry/node-cpu-profiler@^2.4.4":
   version "2.4.4"


### PR DESCRIPTION
Bumps the package after todays release. One change I figured I'd sneak in while  pre-v11: directly replace the deprecated `NAVIGATION_ROUTE_ID` with the replacing `ROUTER_NAVIGATION_ROUTE_ID` attribute. Should be fine since we only set this in one place prior to v11. Added a migration note.