### PR TITLE
test(e2e/node-eve): Assert a manual span nests under gen_ai.execute_tool

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-eve/agent/tools/get_weather.ts
+++ b/dev-packages/e2e-tests/test-applications/node-eve/agent/tools/get_weather.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { defineTool } from 'eve/tools';
 import { z } from 'zod';
 
@@ -5,6 +6,12 @@ export default defineTool({
   description: 'Get the current weather for a city.',
   inputSchema: z.object({ city: z.string().min(1) }),
   async execute({ city }) {
-    return { city, condition: 'Sunny', temperatureC: 22 };
+    // Manual instrumentation inside a tool call: eve runs `execute` while the
+    // SDK's `gen_ai.execute_tool` span is active, so this user span should nest
+    // under it. The e2e test asserts that parent/child link.
+    return Sentry.startSpan(
+      { name: 'resolve-weather', op: 'gen_ai.tool.manual', attributes: { 'weather.city': city } },
+      () => ({ city, condition: 'Sunny', temperatureC: 22 }),
+    );
   },
 });

--- a/dev-packages/e2e-tests/test-applications/node-eve/tests/eve.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-eve/tests/eve.test.ts
@@ -29,7 +29,7 @@ test('captures Vercel AI agent spans (invoke_agent, generate_content, execute_to
   const traceSpansPromise = collectStreamedSpans(
     APP,
     spansOfTrace =>
-      ['gen_ai.invoke_agent', 'gen_ai.generate_content', 'gen_ai.execute_tool'].every(op =>
+      ['gen_ai.invoke_agent', 'gen_ai.generate_content', 'gen_ai.execute_tool', 'gen_ai.tool.manual'].every(op =>
         spansOfTrace.some(span => getSpanOp(span) === op),
       ) && spansOfTrace.some(isAgentServerSpan),
   );
@@ -65,6 +65,16 @@ test('captures Vercel AI agent spans (invoke_agent, generate_content, execute_to
   expect(executeTool?.attributes?.['gen_ai.tool.call.arguments']?.value).toContain('Paris');
   // The tool returns `{ city, condition: 'Sunny', temperatureC: 22 }`.
   expect(executeTool?.attributes?.['gen_ai.tool.call.result']?.value).toContain('Sunny');
+
+  // `get_weather` wraps its work in a manual `Sentry.startSpan`. Because eve runs
+  // the tool while the SDK's `execute_tool` span is active, that user span nests
+  // directly under it — this is the manual-instrumentation-inside-a-tool case.
+  const manualSpan = traceSpans.find(span => getSpanOp(span) === 'gen_ai.tool.manual');
+  expect(manualSpan?.name).toBe('resolve-weather');
+  expect(manualSpan?.attributes?.['weather.city']?.value).toBe('Paris');
+  expect(manualSpan?.is_segment).toBe(false);
+  expect(manualSpan?.trace_id).toBe(executeTool?.trace_id);
+  expect(manualSpan?.parent_span_id).toBe(executeTool?.span_id);
 
   // `agent/hooks/sentry.ts` sets the eve session id as the conversation id via
   // `Sentry.eveConversationHook()`, so every gen_ai span in the turn is tagged with it — that is


### PR DESCRIPTION
Extends the `node-eve` e2e app so a tool call (`get_weather`) wraps its work in a manual `Sentry.startSpan`, then asserts the resulting user span lands as a direct child of the SDK's `gen_ai.execute_tool` span (same trace, `parent_span_id` = the tool span's `span_id`).

The point is to prove that manual instrumentation added inside a tool slots into the active gen_ai context rather than floating off as its own segment — i.e. eve runs `execute` while the tool span is active. We fold the check into the existing weather turn instead of adding a new agent turn to avoid a second LLM call.

Stacked on #24254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)