### PR TITLE
chore: Update base node version to 24.21.0

### DIFF
--- a/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-5-cf-workers/package.json
@@ -21,7 +21,6 @@
     "wrangler": "^4.63.0"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/astro-6-cf-workers/package.json
@@ -23,7 +23,6 @@
     "wrangler": "^4.72.0"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
@@ -45,7 +45,6 @@
     "optional": true
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-autoinstrument/package.json
@@ -32,7 +32,6 @@
     "ws": "^8.21.1"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-local-workers/package.json
@@ -25,7 +25,6 @@
     "ws": "^8.18.3"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp-agent/package.json
@@ -27,7 +27,6 @@
     "wrangler": "^4.86.0"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-mcp/package.json
@@ -28,7 +28,6 @@
     "ws": "^8.18.3"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-orchestrion-mysql/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-orchestrion-mysql/package.json
@@ -28,7 +28,6 @@
     "ws": "^8.18.3"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-vercelai-v7/package.json
@@ -27,7 +27,6 @@
     "ws": "^8.18.3"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-static/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-static/package.json
@@ -25,7 +25,6 @@
     "ws": "^8.18.3"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers-workflow-legacy/package.json
@@ -21,7 +21,6 @@
     "wrangler": "4.70.0"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workers/package.json
@@ -25,7 +25,6 @@
     "ws": "^8.18.3"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-workersentrypoint/package.json
@@ -25,7 +25,6 @@
     "ws": "^8.18.3"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "pnpm": {

--- a/dev-packages/e2e-tests/test-applications/effect-4-browser/package.json
+++ b/dev-packages/e2e-tests/test-applications/effect-4-browser/package.json
@@ -37,7 +37,6 @@
     ]
   },
   "volta": {
-    "node": "22.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/effect-4-node/package.json
+++ b/dev-packages/e2e-tests/test-applications/effect-4-node/package.json
@@ -23,7 +23,6 @@
     "@sentry-internal/test-utils": "link:../../../test-utils"
   },
   "volta": {
-    "node": "22.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/solidstart-2/package.json
+++ b/dev-packages/e2e-tests/test-applications/solidstart-2/package.json
@@ -34,8 +34,7 @@
     "vitest": "^1.5.0"
   },
   "volta": {
-    "extends": "../../package.json",
-    "node": "24.15.0"
+    "extends": "../../package.json"
   },
   "engines": {
     "node": ">=24"

--- a/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-cloudflare-pages/package.json
@@ -31,7 +31,6 @@
     "wrangler": "^4.61.0"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   }
 }

--- a/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
+++ b/dev-packages/e2e-tests/test-applications/tanstackstart-react-cloudflare/package.json
@@ -35,7 +35,6 @@
     "wrangler": "^4.68.1"
   },
   "volta": {
-    "node": "24.15.0",
     "extends": "../../package.json"
   },
   "sentryTest": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "yalc:publish": "nx run-many -t yalc:publish"
   },
   "volta": {
-    "node": "20.19.5",
+    "node": "24.21.0",
     "yarn": "1.22.22",
     "pnpm": "9.15.9"
   },

--- a/packages/browser/test/integrations/httpcontext.test.ts
+++ b/packages/browser/test/integrations/httpcontext.test.ts
@@ -8,20 +8,20 @@ const USER_AGENT =
   'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36';
 
 describe('httpContextIntegration', () => {
-  globalThis.navigator = {
+  vi.stubGlobal('navigator', {
     userAgent:
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-  } as unknown as Navigator;
-  globalThis.location = {
+  } as unknown as Navigator);
+  vi.stubGlobal('location', {
     href: 'https://example.com',
-  } as unknown as Location;
-  globalThis.document = {
+  } as unknown as Location);
+  vi.stubGlobal('document', {
     referrer: 'https://example.com',
     addEventListener: vi.fn(),
     location: {
       href: 'https://example.com',
     },
-  } as unknown as Document;
+  } as unknown as Document);
 
   it("doesn't attach url.full to http.client segment spans", () => {
     const integration = httpContextIntegration();

--- a/packages/react/test/reactrouter-cross-usage.test.tsx
+++ b/packages/react/test/reactrouter-cross-usage.test.tsx
@@ -35,6 +35,23 @@ import {
   wrapUseRoutesV6,
 } from '../src/reactrouterv6';
 
+// jsdom provides its own AbortSignal, which the undici `Request` of Node >= 24 rejects
+// in `RequestInit`. React Router only reads the signal back off the request, so keep it
+// as an own property instead of handing it to undici.
+const NativeRequest = globalThis.Request;
+vi.stubGlobal(
+  'Request',
+  class extends NativeRequest {
+    public constructor(input: RequestInfo | URL, init: RequestInit = {}) {
+      const { signal, ...rest } = init;
+      super(input, rest);
+      if (signal) {
+        Object.defineProperty(this, 'signal', { value: signal, configurable: true });
+      }
+    }
+  },
+);
+
 const mockStartBrowserTracingPageLoadSpan = vi.fn();
 const mockStartBrowserTracingNavigationSpan = vi.fn();
 


### PR DESCRIPTION
This updates our base local node version to 24.21.0. 

There is only 1 benefit for Cloudflare. We can update `wrangler` (see: https://github.com/getsentry/sentry-javascript/pull/24314)

Kept tests were it was explicitly set to v22. v24 pins were removed