### PR TITLE
test(cloudflare): Pin ai-chat on cloudflare-agent tests

### DIFF
--- a/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
+++ b/dev-packages/e2e-tests/test-applications/cloudflare-agent/package.json
@@ -14,7 +14,7 @@
     "test:dev": "TEST_ENV=development playwright test"
   },
   "dependencies": {
-    "@cloudflare/ai-chat": "^0.10.0",
+    "@cloudflare/ai-chat": "latest",
     "@sentry/cloudflare": "^10.68.0",
     "@sentry/core": "^10.68.0",
     "agents": "latest",


### PR DESCRIPTION
They need to go together otherwise it just fails and makes 💥

Since `agents` is latest, `@cloudflare/ai-chat` should be latest too. It is only latest for now as they are in a v0 range and we want to know if an update of a minor breaks something.