### PR TITLE
fix(v10/browser-utils): Skip nullish LCP entries in vendored web-vitals

### DIFF
--- a/packages/browser-utils/src/metrics/web-vitals/README.md
+++ b/packages/browser-utils/src/metrics/web-vitals/README.md
@@ -27,6 +27,10 @@ web-vitals only report once per pageload.
 
 ## CHANGELOG
 
+- Guard against nullish entries in `onLCP`'s `handleEntries`, matching upstream
+
+  https://github.com/getsentry/sentry-javascript/issues/24278
+
 - Bumped from Web Vitals 5.0.2 to 5.1.0
   - Remove `visibilitychange` event listeners when no longer required [#627](https://github.com/GoogleChrome/web-vitals/pull/627)
   - Register visibility-change early [#637](https://github.com/GoogleChrome/web-vitals/pull/637)

--- a/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
@@ -58,6 +58,9 @@ export const onLCP = (onReport: (metric: LCPMetric) => void, opts: ReportOpts = 
       }
 
       for (const entry of entries) {
+        // Mirrors upstream web-vitals: a patched or non-conforming PerformanceObserver can yield nullish entries.
+        if (!entry) continue;
+
         lcpEntryManager._processEntry(entry);
 
         // Only report if the page wasn't hidden prior to LCP.

--- a/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
+++ b/packages/browser-utils/src/metrics/web-vitals/getLCP.ts
@@ -58,7 +58,7 @@ export const onLCP = (onReport: (metric: LCPMetric) => void, opts: ReportOpts = 
       }
 
       for (const entry of entries) {
-        // Mirrors upstream web-vitals: a patched or non-conforming PerformanceObserver can yield nullish entries.
+        // Upstream has this guard too; a patched PerformanceObserver can yield nullish entries.
         if (!entry) continue;
 
         lcpEntryManager._processEntry(entry);

--- a/packages/browser-utils/test/metrics/web-vitals/getLCP.test.ts
+++ b/packages/browser-utils/test/metrics/web-vitals/getLCP.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { onLCP } from '../../../src/metrics/web-vitals/getLCP';
+import type { LCPMetric } from '../../../src/metrics/web-vitals/types';
+
+function stubPerformanceObserver(): { emit: (entries: unknown[]) => Promise<void> } {
+  let observerCallback: ((list: PerformanceObserverEntryList) => void) | undefined;
+
+  class MockPerformanceObserver {
+    public static supportedEntryTypes = ['largest-contentful-paint'];
+
+    public constructor(callback: (list: PerformanceObserverEntryList) => void) {
+      observerCallback = callback;
+    }
+
+    public observe(): void {
+      // noop
+    }
+
+    public disconnect(): void {
+      // noop
+    }
+
+    public takeRecords(): PerformanceEntryList {
+      return [];
+    }
+  }
+
+  vi.stubGlobal('PerformanceObserver', MockPerformanceObserver);
+  vi.stubGlobal('addEventListener', vi.fn());
+  vi.stubGlobal('removeEventListener', vi.fn());
+  vi.stubGlobal('document', {
+    prerendering: false,
+    readyState: 'complete',
+    visibilityState: 'visible',
+  });
+
+  return {
+    emit: async entries => {
+      observerCallback?.({ getEntries: () => entries } as unknown as PerformanceObserverEntryList);
+      // `observe` defers the callback by a microtask.
+      await Promise.resolve();
+    },
+  };
+}
+
+function lcpEntry(startTime: number): unknown {
+  return { entryType: 'largest-contentful-paint', name: '', duration: 0, startTime, toJSON: () => ({}) };
+}
+
+describe('onLCP', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('skips nullish entries and still reports the valid ones', async () => {
+    const { emit } = stubPerformanceObserver();
+
+    const reported: LCPMetric[] = [];
+    onLCP(metric => reported.push(metric), { reportAllChanges: true });
+
+    await emit([undefined, lcpEntry(1234), null]);
+
+    expect(reported).toHaveLength(1);
+    expect(reported[0]?.value).toBe(1234);
+  });
+});


### PR DESCRIPTION
Ports upstream web-vitals' `if (!entry) continue` guard into `onLCP`'s `handleEntries`, so a nullish performance entry skips instead of throwing `Cannot read properties of undefined (reading 'startTime')` into the host page. 

develop (v11) already depends on `web-vitals@^6.1.1`, which ships the guard.

closes #24278
