### PR TITLE
fix(node): Don't recurse in logAndExitProcess on a broken stdio pipe

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
@@ -7,6 +7,6 @@ Sentry.init({
   dsn: 'https://public@127.0.0.1:1/1337',
 });
 
-// The test runner closes both stdio streams, so this write fails with EPIPE.
-// Node ignores SIGPIPE, so it surfaces as an uncaught exception.
+// The test runner closes both stdio streams, so this write raises EPIPE. Node ignores
+// SIGPIPE, so it arrives as an uncaught exception.
 setInterval(() => process.stdout.write('x'.repeat(4096)), 0);

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
@@ -1,0 +1,12 @@
+const Sentry = require('@sentry/node');
+
+// The DSN has to be unreachable rather than invalid, so that `client.close()` is
+// still pending while the broken pipe keeps producing errors.
+Sentry.init({
+  traceLifecycle: 'static',
+  dsn: 'https://public@127.0.0.1:1/1337',
+});
+
+// The test runner closes both stdio streams, so this write fails with EPIPE.
+// Node ignores SIGPIPE, so it surfaces as an uncaught exception.
+setInterval(() => process.stdout.write('x'.repeat(4096)), 0);

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
@@ -1,7 +1,7 @@
 const Sentry = require('@sentry/node');
 
-// The DSN has to be unreachable rather than invalid, so that `client.close()` is
-// still pending while the broken pipe keeps producing errors.
+// Unreachable rather than invalid, so `client.close()` is still pending while the
+// broken pipe keeps erroring.
 Sentry.init({
   traceLifecycle: 'static',
   dsn: 'https://public@127.0.0.1:1/1337',

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -47,6 +47,29 @@ describe('OnUncaughtException integration', () => {
       });
     }));
 
+  test('should exit rather than recurse when stderr is a broken pipe', async () => {
+    const testScriptPath = path.resolve(__dirname, 'broken-stdio-pipe-test-script.js');
+
+    // `logAndExitProcess` writes the error to stderr before shutting down. With stderr
+    // closed that write raises EPIPE too, which comes back as another uncaught exception
+    // and re-enters the handler. Each pass used to queue another console write and another
+    // `client.close()`, so the process died of heap exhaustion instead of exiting.
+    // The small heap cap turns that into a ~1s failure rather than a ~1min one.
+    const child = childProcess.spawn(process.execPath, ['--max-old-space-size=64', testScriptPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout.destroy();
+    child.stderr.destroy();
+
+    const exited = await new Promise<{ code: number | null; signal: string | null }>(resolve => {
+      child.on('exit', (code, signal) => resolve({ code, signal }));
+    });
+
+    // Unbounded recursion shows up as SIGABRT from the V8 out-of-memory abort.
+    expect(exited).toEqual({ code: 1, signal: null });
+  });
+
   describe('with `exitEvenIfOtherHandlersAreRegistered` set to false', () => {
     test('should close process on uncaught error with no additional listeners registered', () =>
       new Promise<void>(done => {

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -50,11 +50,8 @@ describe('OnUncaughtException integration', () => {
   test('should exit rather than recurse when stderr is a broken pipe', async () => {
     const testScriptPath = path.resolve(__dirname, 'broken-stdio-pipe-test-script.js');
 
-    // `logAndExitProcess` writes the error to stderr before shutting down. With stderr
-    // closed that write raises EPIPE too, which comes back as another uncaught exception
-    // and re-enters the handler. Each pass used to queue another console write and another
-    // `client.close()`, so the process died of heap exhaustion instead of exiting.
-    // The small heap cap turns that into a ~1s failure rather than a ~1min one.
+    // The heap cap is what makes a regression fail in ~1s. At the default heap size the
+    // runaway recursion takes about a minute to exhaust it and just looks like a hang.
     const child = childProcess.spawn(process.execPath, ['--max-old-space-size=64', testScriptPath], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -50,8 +50,8 @@ describe('OnUncaughtException integration', () => {
   test('should exit rather than recurse when stderr is a broken pipe', async () => {
     const testScriptPath = path.resolve(__dirname, 'broken-stdio-pipe-test-script.js');
 
-    // The heap cap is what makes a regression fail in ~1s. At the default heap size the
-    // runaway recursion takes about a minute to exhaust it and just looks like a hang.
+    // The heap cap makes a regression fail in ~1s; at the default size it takes a minute
+    // and just looks like a hang.
     const child = childProcess.spawn(process.execPath, ['--max-old-space-size=64', testScriptPath], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -63,7 +63,7 @@ describe('OnUncaughtException integration', () => {
       child.on('exit', (code, signal) => resolve({ code, signal }));
     });
 
-    // Unbounded recursion shows up as SIGABRT from the V8 out-of-memory abort.
+    // Unbounded recursion shows up as SIGABRT from the V8 OOM abort.
     expect(exited).toEqual({ code: 1, signal: null });
   });
 

--- a/packages/node/src/utils/errorhandling.ts
+++ b/packages/node/src/utils/errorhandling.ts
@@ -10,9 +10,8 @@ let isShuttingDown = false;
  * @hidden
  */
 export function logAndExitProcess(error: unknown): void {
-  // The console write below raises EPIPE when stderr is a broken pipe, which comes back as
-  // another uncaught exception and lands here again. Return rather than exit, so the shutdown
-  // already in flight keeps the `client.close()` flush that sends the fatal event.
+  // A broken stderr makes the console write below raise EPIPE, re-entering here. Return
+  // rather than exit, so the in-flight `client.close()` still flushes the fatal event.
   if (isShuttingDown) {
     return;
   }

--- a/packages/node/src/utils/errorhandling.ts
+++ b/packages/node/src/utils/errorhandling.ts
@@ -10,10 +10,9 @@ let isShuttingDown = false;
  * @hidden
  */
 export function logAndExitProcess(error: unknown): void {
-  // The console write below goes to stderr. When stderr is a broken pipe that write raises
-  // EPIPE, which surfaces as another uncaught exception and lands back here. Re-entering
-  // would queue another console write and another `client.close()` on every pass, exhausting
-  // the heap instead of exiting, so leave the shutdown already in flight to exit the process.
+  // The console write below raises EPIPE when stderr is a broken pipe, which comes back as
+  // another uncaught exception and lands here again. Return rather than exit, so the shutdown
+  // already in flight keeps the `client.close()` flush that sends the fatal event.
   if (isShuttingDown) {
     return;
   }

--- a/packages/node/src/utils/errorhandling.ts
+++ b/packages/node/src/utils/errorhandling.ts
@@ -4,10 +4,21 @@ import type { NodeClient } from '../sdk/client';
 
 const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
 
+let isShuttingDown = false;
+
 /**
  * @hidden
  */
 export function logAndExitProcess(error: unknown): void {
+  // The console write below goes to stderr. When stderr is a broken pipe that write raises
+  // EPIPE, which surfaces as another uncaught exception and lands back here. Re-entering
+  // would queue another console write and another `client.close()` on every pass, exhausting
+  // the heap instead of exiting, so leave the shutdown already in flight to exit the process.
+  if (isShuttingDown) {
+    return;
+  }
+  isShuttingDown = true;
+
   consoleSandbox(() => {
     // eslint-disable-next-line no-console
     console.error(error);
@@ -33,6 +44,7 @@ export function logAndExitProcess(error: unknown): void {
     },
     error => {
       DEBUG_BUILD && debug.error(error);
+      global.process.exit(1);
     },
   );
 }


### PR DESCRIPTION
A broken stdio pipe crashed Node with an OOM, fixed by making `logAndExitProcess` now guards against re-entry.

I added a broken pipe test that reproduces the issue before the fix.

closes #24337
