### PR TITLE
fix(v10/node-core): Don't recurse in logAndExitProcess on a broken stdio pipe

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/broken-stdio-pipe-test-script.js
@@ -1,0 +1,11 @@
+const Sentry = require('@sentry/node');
+
+// Unreachable rather than invalid, so `client.close()` is still pending while the
+// broken pipe keeps erroring.
+Sentry.init({
+  dsn: 'https://public@127.0.0.1:1/1337',
+});
+
+// The test runner closes both stdio streams, so this write raises EPIPE. Node ignores
+// SIGPIPE, so it arrives as an uncaught exception.
+setInterval(() => process.stdout.write('x'.repeat(4096)), 0);

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -48,6 +48,26 @@ describe('OnUncaughtException integration', () => {
       });
     }));
 
+  test('should exit rather than recurse when stderr is a broken pipe', async () => {
+    const testScriptPath = path.resolve(__dirname, 'broken-stdio-pipe-test-script.js');
+
+    // The heap cap makes a regression fail in ~1s; at the default size it takes a minute
+    // and just looks like a hang.
+    const child = childProcess.spawn(process.execPath, ['--max-old-space-size=64', testScriptPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout.destroy();
+    child.stderr.destroy();
+
+    const exited = await new Promise<{ code: number | null; signal: string | null }>(resolve => {
+      child.on('exit', (code, signal) => resolve({ code, signal }));
+    });
+
+    // Unbounded recursion shows up as SIGABRT from the V8 OOM abort.
+    expect(exited).toEqual({ code: 1, signal: null });
+  });
+
   describe('with `exitEvenIfOtherHandlersAreRegistered` set to false', () => {
     test('should close process on uncaught error with no additional listeners registered', () =>
       new Promise<void>(done => {

--- a/packages/node-core/src/utils/errorhandling.ts
+++ b/packages/node-core/src/utils/errorhandling.ts
@@ -4,10 +4,19 @@ import type { NodeClient } from '../sdk/client';
 
 const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
 
+let isShuttingDown = false;
+
 /**
  * @hidden
  */
 export function logAndExitProcess(error: unknown): void {
+  // A broken stderr makes the console write below raise EPIPE, re-entering here. Return
+  // rather than exit, so the in-flight `client.close()` still flushes the fatal event.
+  if (isShuttingDown) {
+    return;
+  }
+  isShuttingDown = true;
+
   consoleSandbox(() => {
     // eslint-disable-next-line no-console
     console.error(error);
@@ -33,6 +42,7 @@ export function logAndExitProcess(error: unknown): void {
     },
     error => {
       DEBUG_BUILD && debug.error(error);
+      global.process.exit(1);
     },
   );
 }


### PR DESCRIPTION
Backport of: #24351

The only difference from the original: the test fixture drops `traceLifecycle: 'static'`, which doesn't exist on v10.
